### PR TITLE
fix(models): enforce the "never naive" timestamp contract on Fragment

### DIFF
--- a/creek-tools/creek/models.py
+++ b/creek-tools/creek/models.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Literal, TypeVar, get_args
 from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator
 
 from creek.compile.provenance import CompileMethod, ProvenanceEntry
-from creek.time import now_la, today_la
+from creek.time import ensure_aware, now_la, today_la
 
 logger = logging.getLogger(__name__)
 
@@ -729,6 +729,23 @@ class Fragment(BaseModel):
         source: Source metadata. Its ``author_slug`` names the
             ``11-Other-Authors/<slug>/`` folder a borrowed fragment came from
             (``None`` for a native fragment), distinct from ``source.author``.
+        created: When the fragment came into being on the vault side.
+            Normalised like every timestamp below.
+        ingested: The wall-clock moment the vault wrote the fragment.
+            Never naive when the fragment was built through the normal
+            constructor or ``model_validate`` path.
+        authored_at: The timestamp the source itself records, or ``None``
+            when none is extractable — the model never invents one.
+            ``created`` / ``ingested`` / ``authored_at`` are all
+            normalised at validation time by
+            :meth:`_normalise_timestamp` (#976), which *anchors* rather
+            than converts: a naive value keeps its wall clock and gains
+            the America/Los_Angeles offset, while an already-aware value
+            — a Sydney ``authored_at``, say — passes through untouched
+            with its ``tzinfo`` and microseconds intact. A ``None``
+            ``authored_at`` stays ``None``. See
+            :meth:`_normalise_timestamp` for exactly which construction
+            paths this normalisation covers, and which bypass it.
     """
 
     model_config = ConfigDict(use_enum_values=True)
@@ -751,6 +768,8 @@ class Fragment(BaseModel):
     # until the audience classifier runs — additive and backward-compatible,
     # and fails closed to ``mixed`` so a corrupt value never crashes a scan.
     audience: Audience = "mixed"
+    # All three timestamps below are anchored to LA when they arrive
+    # naive — see ``_normalise_timestamp`` for the contract (#976).
     created: datetime = Field(default_factory=now_la)
     ingested: datetime = Field(default_factory=now_la)
     # Timestamp the source itself records (a Substack post's publish
@@ -816,6 +835,58 @@ class Fragment(BaseModel):
             return value
         _warn_fail_closed("Fragment audience", value, "mixed")
         return "mixed"
+
+    @field_validator("created", "ingested", "authored_at", mode="after")
+    @classmethod
+    def _normalise_timestamp(cls, value: datetime | None) -> datetime | None:
+        """Anchor a naive timestamp to LA; leave an aware one untouched (#976).
+
+        Vault frontmatter routinely serialises timestamps without an
+        offset (``ingested: 2024-01-01 12:00:00``), which PyYAML parses
+        into a *naive* datetime. Stored verbatim, it raises ``TypeError:
+        can't compare offset-naive and offset-aware datetimes`` at
+        whichever consumer first compares it against a neighbouring
+        aware timestamp. Repairing it here — the chokepoint every
+        ``Fragment`` load crosses via the constructor or
+        ``model_validate`` — is what lets the downstream surfaces
+        (synchronicity, temporal linking, wavelength bucketing) treat
+        "never naive" as an invariant on those paths, instead of
+        re-repairing it site by site. The invariant does not reach
+        ``Fragment.model_construct``, ``model_copy(update=...)``, or a
+        direct attribute assignment on an existing ``Fragment``: none
+        of those routes through Pydantic field validators, so a caller
+        that builds or mutates a fragment that way can still hand a
+        naive datetime downstream. No production caller assigns a
+        timestamp that way today, but a future one should not assume
+        this validator ran.
+
+        ``mode="after"`` is load-bearing rather than stylistic: a
+        before-validator sees the raw input, which on the
+        ``model_validate`` path can still be an offsetless ISO-8601
+        ``str`` Pydantic has yet to parse into a ``datetime``. This
+        function calls ``ensure_aware(value)``, which reads
+        ``value.utcoffset()`` — handed that raw string, a
+        before-validator would raise ``AttributeError``, not silently
+        return a naive result. ``mode="after"`` guarantees Pydantic has
+        already parsed the value into a real ``datetime`` before this
+        validator runs.
+
+        Deliberately silent, unlike the sibling ``_coerce_*``
+        validators: those warn because they *discard* a malformed value
+        the operator needs to know about, whereas this repair is
+        lossless and expected of every legacy vault. Warning per field
+        would emit six figures of noise on a 35k-fragment scan.
+
+        Args:
+            value: The supplied timestamp; ``None`` only for the
+                optional ``authored_at``.
+
+        Returns:
+            ``None`` unchanged, otherwise the value with an offset
+            guaranteed — attached, never converted, per
+            :func:`creek.time.ensure_aware`.
+        """
+        return None if value is None else ensure_aware(value)
 
     # BUG-009: the ``[prop-decorator]`` suppression below is a known
     # mypy / Pydantic-v2 limitation when stacking ``@computed_field``

--- a/creek-tools/creek/time.py
+++ b/creek-tools/creek/time.py
@@ -9,9 +9,12 @@ produce naive datetimes that fail to compare against tz-aware ones with
 values that arrive from outside that discipline — persisted frontmatter,
 legacy callers — making them safe to compare without moving the clock.
 
-The constant :data:`LA_TZ` is re-exported from
-:mod:`creek.ingest.base` to preserve the historical import path while
-giving callers a dependency-free home for the helper.
+The constant :data:`LA_TZ` is defined here as a dependency-free home
+for the timezone helpers; :mod:`creek.ingest.base` independently
+defines its own equal constant of the same name to preserve the
+historical import path some callers still use. Neither re-exports the
+other — each module owns its own definition, and the two simply agree
+on the same ``ZoneInfo("America/Los_Angeles")`` value.
 """
 
 from __future__ import annotations
@@ -45,6 +48,15 @@ def ensure_aware(value: datetime) -> datetime:
     failure mode this module exists to prevent. Callers that mix a
     pipeline-generated clock with timestamps read back off disk route
     through this helper first.
+
+    The primary production caller is
+    :class:`~creek.models.Fragment`'s field validator over ``created`` /
+    ``ingested`` / ``authored_at`` (#976), which makes every fragment
+    load through the constructor or ``model_validate`` — the paths
+    ingest and vault reads use — the enforcement point for the "never
+    naive" invariant. See
+    :meth:`~creek.models.Fragment._normalise_timestamp` for the
+    construction paths that bypass it.
 
     The contract is deliberately asymmetric:
 
@@ -93,7 +105,14 @@ def effective_authored_at(fragment: Fragment) -> datetime:
        source-side timestamp (a Substack post's ``post_date``, a
        Discord message's ``timestamp``, an EXIF ``DateTimeOriginal``).
     2. :attr:`Fragment.ingested` — the wall-clock moment the vault
-       wrote the fragment. Always present, never naive.
+       wrote the fragment. Never naive when the fragment was built
+       through the normal constructor or ``model_validate`` path:
+       :class:`~creek.models.Fragment` normalises ``created`` /
+       ``ingested`` / ``authored_at`` through :func:`ensure_aware` at
+       validation time (#976), so a frontmatter timestamp serialised
+       without an offset is anchored to LA before it ever reaches this
+       helper. (See :meth:`~creek.models.Fragment._normalise_timestamp`
+       for which construction paths this covers.)
 
     :attr:`Fragment.created` is deliberately not in the chain:
     historically it conflated "source authored date" and "filesystem

--- a/creek-tools/tests/test_synchronicity.py
+++ b/creek-tools/tests/test_synchronicity.py
@@ -8,8 +8,9 @@ and create_synchronicity_note (writing reflection notes to
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, cast
+from zoneinfo import ZoneInfo
 
 import frontmatter
 import pytest
@@ -575,6 +576,82 @@ class TestEffectiveAuthoredAtPrecedence:
         assert "2025-01-05" in body
         assert "2025-04-20" in body
         assert ingest_moment.date().isoformat() not in body
+
+
+# ---- Issue #976: mixed naive / aware vaults ----
+
+
+class TestMixedNaiveAndAwareTimestamps:
+    """A vault mixing offsetless and offset-carrying timestamps still detects.
+
+    This is the consumer-side regression for issue #976. The fixtures
+    above feed naive datetimes on *both* sides of every pair, so they
+    never compare a naive value against an aware one and the suite stayed
+    green while the defect was live. A real vault is not so tidy: journal
+    frontmatter written as ``ingested: 2024-01-01 09:00:00`` (naive, per
+    PyYAML) sits next to a Substack fragment whose ``authored_at`` was
+    extracted with a real offset. Detection then walked into
+    ``TypeError: can't compare offset-naive and offset-aware datetimes``
+    in :meth:`SynchronicityDetector._chronological_pair`, killing the
+    whole ``creek report --type synchronicity`` run rather than one pair.
+
+    ``detect_synchronicities`` is the cheapest public entry point that
+    reproduces it: it accepts the legacy ``(id_a, id_b, similarity)``
+    tuple, so two fragments and one tuple exercise the crash with no
+    embeddings, no LLM, and no I/O.
+    """
+
+    def test_mixed_naive_and_aware_vault_yields_synchronicity(
+        self,
+        detector: SynchronicityDetector,
+    ) -> None:
+        """A naive-``ingested`` fragment pairs with an aware-``authored_at`` one.
+
+        Asserts the *result*, not merely that nothing raised: a
+        "does not raise" test would be exactly the vacuousness issue
+        #976 is about. The expected gap is computed from the coerced
+        instants — 2024-01-01 09:00 anchored to LA (17:00Z) against
+        2024-06-01 09:00 in Sydney (2024-05-31 23:00Z) — which is 151
+        days and 6 hours, so ``time_gap_days`` is 151.
+
+        The gap alone does *not* separate the correct
+        ``replace(tzinfo=LA_TZ)`` coercion from an ``astimezone``-based
+        one: the ``astimezone`` variant only shifts this gap to 152 on
+        hosts at UTC+12 or further east (Pacific/Auckland,
+        Pacific/Kiritimati), so it survives here on every realistic dev
+        or CI host. That variant is killed instead by
+        ``test_naive_coercion_preserves_the_wall_clock`` in
+        ``tests/test_time.py``, which pins the wall-clock fields rather
+        than an elapsed gap.
+        """
+        sydney = ZoneInfo("Australia/Sydney")
+        naive_journal = _make_fragment(
+            frag_id="frag-naive-ingested",
+            title="the kettle boils in an empty kitchen",
+            platform=SourcePlatform.JOURNAL,
+            created=datetime(2024, 1, 1, 9, 0, 0),
+        )
+        aware_substack = _authored_fragment(
+            frag_id="frag-aware-authored",
+            title="a bell rung twice at the edge of sleep",
+            platform=SourcePlatform.SUBSTACK,
+            ingest_moment=datetime(2024, 6, 2, 12, 0, 0, tzinfo=UTC),
+            authored_at=datetime(2024, 6, 1, 9, 0, 0, tzinfo=sydney),
+        )
+        fragments = {
+            naive_journal.id: naive_journal,
+            aware_substack.id: aware_substack,
+        }
+        resonances = [("frag-naive-ingested", "frag-aware-authored", 0.95)]
+
+        result = detector.detect_synchronicities(resonances, fragments)
+
+        assert len(result) == 1
+        # The naive-timestamped fragment is the earlier of the two once
+        # both sides are comparable, so it lands in ``fragment_a_id``.
+        assert result[0].fragment_a_id == "frag-naive-ingested"
+        assert result[0].fragment_b_id == "frag-aware-authored"
+        assert result[0].time_gap_days == 151
 
 
 # ---- FEAT-024 cross-level ranking ----

--- a/creek-tools/tests/test_time.py
+++ b/creek-tools/tests/test_time.py
@@ -1,6 +1,6 @@
 """Regression tests for ``creek.time`` and the BUG-002 timezone sweep.
 
-These tests pin two facts that earlier code regressed on:
+These tests pin the facts that earlier code regressed on:
 
 1. The :func:`creek.time.now_la` helper returns a tz-aware datetime
    anchored to America/Los_Angeles.
@@ -11,6 +11,10 @@ These tests pin two facts that earlier code regressed on:
 4. :func:`creek.time.effective_authored_at` codifies the FEAT-031
    precedence (``authored_at`` → ``ingested``) that every time-bucket
    surface routes through.
+5. :class:`creek.models.Fragment` anchors a naive ``created`` /
+   ``ingested`` / ``authored_at`` to America/Los_Angeles at validation
+   time (issue #976), so offsetless YAML frontmatter cannot smuggle a
+   naive datetime into a vault that also holds tz-aware ones.
 """
 
 from __future__ import annotations
@@ -108,14 +112,24 @@ class TestFragmentDefaultTimestamps:
         assert frag.ingested.tzinfo is not None
 
     def test_fragment_default_timestamps_are_la(self) -> None:
-        """Fragment defaults agree with the LA timezone."""
+        """Fragment defaults agree with the LA timezone.
+
+        Post-#976 this is the only test pinning the default path:
+        ``default_factory=now_la`` values never reach
+        ``Fragment._normalise_timestamp`` because Pydantic does not run
+        field validators over defaults. The defaults therefore have to
+        be LA-aware on their own, and a future change that moved the LA
+        anchoring *into* the validator would leave them naive with
+        nothing else to catch it.
+        """
         frag = Fragment(
             id="frag-test1234",
             title="t",
             source=FragmentSource(platform=SourcePlatform.OTHER),
         )
-        la_offset = ZoneInfo("America/Los_Angeles").utcoffset(frag.created)
-        assert frag.created.utcoffset() == la_offset
+        la = ZoneInfo("America/Los_Angeles")
+        assert frag.created.utcoffset() == la.utcoffset(frag.created)
+        assert frag.ingested.utcoffset() == la.utcoffset(frag.ingested)
 
 
 class TestThreadEddyDecisionDefaults:
@@ -223,18 +237,28 @@ class TestEffectiveAuthoredAt:
     def test_result_is_always_tz_aware(self) -> None:
         """Neither branch produces a naive datetime — invariant for downstream.
 
-        Fragment validates that ``ingested`` and ``authored_at`` (when
-        present) are tz-aware via Pydantic's datetime parsing for both
-        defaults and round-tripped YAML values, so this helper inherits
-        the invariant. Pin it here so a future change to the model can't
-        silently break temporal-linker comparisons.
+        The enforcer is :class:`~creek.models.Fragment`'s field
+        validator over ``created`` / ``ingested`` / ``authored_at``
+        (issue #976), **not** Pydantic's datetime parsing: Pydantic
+        happily accepts an offsetless value and stores it naive, which
+        is exactly what PyYAML hands back for a frontmatter line like
+        ``ingested: 2024-01-01 12:00:00``. So both branches are fed
+        *naive* inputs here — the shape that actually reaches the model
+        off disk — and both must come back anchored to LA. Asserting
+        only ``tzinfo is not None`` off an already-aware input would be
+        vacuous; the offset assertion pins where it lands.
         """
-        authored = datetime(2024, 3, 15, tzinfo=UTC)
-        ingested = datetime(2026, 5, 24, tzinfo=UTC)
+        authored = datetime(2024, 3, 15)
+        ingested = datetime(2026, 5, 24)
         with_authored = self._frag(authored_at=authored, ingested=ingested)
         without_authored = self._frag(authored_at=None, ingested=ingested)
-        assert effective_authored_at(with_authored).tzinfo is not None
-        assert effective_authored_at(without_authored).tzinfo is not None
+        from_authored = effective_authored_at(with_authored)
+        from_ingested = effective_authored_at(without_authored)
+        la = ZoneInfo("America/Los_Angeles")
+        assert from_authored.tzinfo is not None
+        assert from_ingested.tzinfo is not None
+        assert from_authored.utcoffset() == la.utcoffset(from_authored)
+        assert from_ingested.utcoffset() == la.utcoffset(from_ingested)
 
 
 class TestEffectiveAuthoredDate:
@@ -337,6 +361,202 @@ class TestEnsureAware:
         assert future >= reference
         assert reference >= past
         assert reference < future
+
+
+class TestFragmentTimestampNormalisation:
+    """``Fragment`` anchors naive timestamps to LA at validation (issue #976).
+
+    Vault frontmatter routinely carries offsetless timestamps
+    (``ingested: 2024-01-01 12:00:00``), which PyYAML parses into a
+    *naive* :class:`~datetime.datetime`. Before #976 the model stored
+    that verbatim, so a vault mixing offsetless and offset-carrying
+    timestamps raised ``TypeError: can't compare offset-naive and
+    offset-aware datetimes`` at whichever consumer compared them first
+    (:class:`~creek.generate.synchronicity.SynchronicityDetector` is the
+    reproducer). :func:`creek.time.ensure_aware` was the repair valve
+    but had no caller on the load path; the model is now the chokepoint,
+    so no downstream surface has to remember to repair anything.
+
+    The contract inherits ``ensure_aware``'s asymmetry: naive in →
+    *attach* LA (wall clock preserved); aware in → untouched, zone and
+    microseconds intact; ``None`` in → still ``None``.
+    """
+
+    def test_naive_ingested_is_anchored_to_la(self) -> None:
+        """A naive ``ingested`` comes back anchored to America/Los_Angeles."""
+        frag = Fragment(
+            id="frag-tznorm0001",
+            title="t",
+            source=FragmentSource(platform=SourcePlatform.OTHER),
+            ingested=datetime(2025, 4, 20, 10, 0, 0),
+        )
+        la = ZoneInfo("America/Los_Angeles")
+        assert frag.ingested.tzinfo is not None
+        assert frag.ingested.utcoffset() == la.utcoffset(frag.ingested)
+
+    def test_naive_created_is_anchored_to_la(self) -> None:
+        """A naive ``created`` comes back anchored to America/Los_Angeles."""
+        frag = Fragment(
+            id="frag-tznorm0002",
+            title="t",
+            source=FragmentSource(platform=SourcePlatform.OTHER),
+            created=datetime(2025, 4, 20, 10, 0, 0),
+        )
+        la = ZoneInfo("America/Los_Angeles")
+        assert frag.created.tzinfo is not None
+        assert frag.created.utcoffset() == la.utcoffset(frag.created)
+
+    def test_naive_authored_at_is_anchored_to_la(self) -> None:
+        """A naive ``authored_at`` comes back anchored to America/Los_Angeles.
+
+        ``authored_at`` needs its own case because it is the only one of
+        the three that is ``datetime | None`` — a validator written for
+        the two non-optional fields could easily be left off it, and it
+        is the field :func:`effective_authored_at` prefers.
+        """
+        frag = Fragment(
+            id="frag-tznorm0003",
+            title="t",
+            source=FragmentSource(platform=SourcePlatform.OTHER),
+            authored_at=datetime(2025, 4, 20, 10, 0, 0),
+        )
+        la = ZoneInfo("America/Los_Angeles")
+        assert frag.authored_at is not None
+        assert frag.authored_at.tzinfo is not None
+        assert frag.authored_at.utcoffset() == la.utcoffset(frag.authored_at)
+
+    def test_naive_coercion_preserves_the_wall_clock(self) -> None:
+        """The zone is *attached*, never converted — 23:00 stays 23:00.
+
+        This is the assertion that catches an ``astimezone()``
+        implementation. ``astimezone`` on a naive value interprets it in
+        the host timezone and then shifts the clock, so 23:00 on the
+        28th becomes 16:00 on the 28th (or 06:00 on the 29th, depending
+        on the host) — silently moving fragments across a day boundary
+        and corrupting every date-bucketed surface. Only the
+        wall-clock-preserving ``replace(tzinfo=...)`` behaviour of
+        :func:`creek.time.ensure_aware` satisfies both halves of this
+        test.
+        """
+        frag = Fragment(
+            id="frag-tznorm0004",
+            title="t",
+            source=FragmentSource(platform=SourcePlatform.OTHER),
+            ingested=datetime(2026, 7, 28, 23, 0, 0, 123456),
+        )
+        ingested = frag.ingested
+        la = ZoneInfo("America/Los_Angeles")
+        assert ingested.utcoffset() == la.utcoffset(ingested)
+        assert (ingested.year, ingested.month, ingested.day) == (2026, 7, 28)
+        assert (ingested.hour, ingested.minute, ingested.second) == (23, 0, 0)
+        assert ingested.microsecond == 123456
+
+    def test_iso_string_without_offset_is_anchored_to_la(self) -> None:
+        """An offsetless ISO-8601 *string* is anchored too — after, not before.
+
+        Load-bearing: this is the only case that distinguishes a
+        ``mode="after"`` validator from a ``mode="before"`` one. A
+        before-validator runs on the raw ``str`` and never sees a
+        :class:`~datetime.datetime` at all, so it would hand the string
+        to Pydantic untouched and the parsed result would stay naive.
+        Frontmatter quoted as ``ingested: "2025-04-20T10:00:00"`` (or
+        any JSON round-trip of a fragment) arrives in exactly this shape.
+        """
+        frag = Fragment.model_validate(
+            {
+                "type": "fragment",
+                "id": "frag-tznorm0005",
+                "title": "t",
+                "source": {"platform": "other"},
+                "ingested": "2025-04-20T10:00:00",
+            },
+        )
+        la = ZoneInfo("America/Los_Angeles")
+        assert frag.ingested.tzinfo is not None
+        assert frag.ingested.utcoffset() == la.utcoffset(frag.ingested)
+
+    def test_naive_datetime_from_yaml_mapping_is_anchored_to_la(self) -> None:
+        """A naive ``datetime`` inside a validated mapping is anchored.
+
+        The PyYAML shape: ``creek.vault.reader.try_load_fragment`` calls
+        ``Fragment.model_validate`` on the parsed frontmatter mapping,
+        in which an unquoted ``ingested: 2025-04-20 10:00:00`` has
+        already become a naive ``datetime`` object. Pinned separately
+        from the keyword-constructor cases so a validator that somehow
+        only fires on one entry point cannot pass.
+        """
+        frag = Fragment.model_validate(
+            {
+                "type": "fragment",
+                "id": "frag-tznorm0006",
+                "title": "t",
+                "source": {"platform": "other"},
+                "ingested": datetime(2025, 4, 20, 10, 0, 0),
+            },
+        )
+        la = ZoneInfo("America/Los_Angeles")
+        assert frag.ingested.tzinfo is not None
+        assert frag.ingested.utcoffset() == la.utcoffset(frag.ingested)
+
+    def test_aware_sydney_authored_at_is_untouched(self) -> None:
+        """An already-aware ``authored_at`` keeps its own zone, not LA.
+
+        The other half of the asymmetric contract: coercion must not
+        become normalisation. A Substack post authored in Sydney keeps
+        its Sydney rendering, matching the promise
+        :func:`effective_authored_at` already makes to callers that
+        display source-local time.
+        """
+        sydney = ZoneInfo("Australia/Sydney")
+        authored = datetime(2024, 3, 15, 8, 30, 45, 123456, tzinfo=sydney)
+        frag = Fragment(
+            id="frag-tznorm0007",
+            title="t",
+            source=FragmentSource(platform=SourcePlatform.OTHER),
+            authored_at=authored,
+        )
+        assert frag.authored_at is not None
+        assert frag.authored_at == authored
+        assert frag.authored_at.tzinfo == sydney
+        assert frag.authored_at.hour == 8
+        assert frag.authored_at.microsecond == 123456
+
+    def test_aware_utc_ingested_is_untouched(self) -> None:
+        """An already-aware ``ingested`` passes straight through in UTC.
+
+        Covers the aware branch on a non-optional field (the Sydney case
+        covers it on the optional one), so both sides of the validator's
+        branch are exercised rather than only the naive path.
+        """
+        moment = datetime(2026, 5, 24, 6, 0, 0, 654321, tzinfo=UTC)
+        frag = Fragment(
+            id="frag-tznorm0008",
+            title="t",
+            source=FragmentSource(platform=SourcePlatform.OTHER),
+            ingested=moment,
+        )
+        assert frag.ingested == moment
+        assert frag.ingested.tzinfo == UTC
+        assert frag.ingested.hour == 6
+        assert frag.ingested.microsecond == 654321
+
+    def test_authored_at_none_is_preserved(self) -> None:
+        """``authored_at=None`` stays ``None`` — the validator never invents one.
+
+        ``None`` is the honest answer when no source date is
+        extractable. A validator that reached for ``now_la()`` on the
+        ``None`` branch would fabricate an authored date for every
+        fragment whose source has none, which
+        :func:`effective_authored_at` would then prefer over the real
+        ``ingested`` value — silently re-dating the whole vault.
+        """
+        frag = Fragment(
+            id="frag-tznorm0009",
+            title="t",
+            source=FragmentSource(platform=SourcePlatform.OTHER),
+            authored_at=None,
+        )
+        assert frag.authored_at is None
 
 
 @pytest.mark.parametrize("tz_env", ["UTC", "Asia/Tokyo", "America/New_York"])

--- a/creek-tools/tests/test_vault_reader.py
+++ b/creek-tools/tests/test_vault_reader.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -132,6 +133,56 @@ def test_try_load_fragment_without_hierarchy_keys_defaults_to_root(
     # files and explode the audit diff on the next pass).
     assert "parent_id" not in raw
     assert "level" not in raw
+
+
+def test_fragment_with_offsetless_frontmatter_timestamp_loads_tz_aware(
+    tmp_path: Path,
+) -> None:
+    """An offsetless ``ingested:`` loads coerced to LA — and is not dropped.
+
+    PyYAML parses the unquoted frontmatter line
+    ``ingested: 2024-01-01 12:00:00`` into a *naive* datetime, which
+    before issue #976 flowed straight through
+    :meth:`Fragment.model_validate` and detonated later, at whichever
+    consumer first compared it against a tz-aware timestamp from a
+    neighbouring fragment. This is the on-disk round trip: the frontmatter
+    is hand-written rather than dumped from a :class:`Fragment`, because a
+    dumped model would already carry an offset and prove nothing.
+
+    Assertion (a) — ``record is not None`` — is deliberate, not padding.
+    :func:`try_load_fragment` swallows ``ValidationError`` and returns
+    ``None`` at DEBUG level, so "hardening" the model to *reject* naive
+    timestamps rather than coerce them would silently delete every
+    offsetless fragment from every vault scan with no error surfaced
+    anywhere. This test pins coerce-over-reject.
+    """
+    fragment_file = tmp_path / "offsetless.md"
+    fragment_file.write_text(
+        "---\n"
+        "type: fragment\n"
+        "id: frag-offsetless01\n"
+        "title: Offsetless timestamp\n"
+        "source:\n"
+        "  platform: journal\n"
+        "ingested: 2024-01-01 12:00:00\n"
+        "---\n"
+        "Body of the offsetless fragment.\n",
+        encoding="utf-8",
+    )
+
+    record = try_load_fragment(fragment_file)
+
+    # (a) The fragment survives the load — naive timestamps are repaired,
+    # never grounds for silently discarding vault content.
+    assert record is not None
+    fragment, _body, _raw = record
+    # (b) …and it is repaired to LA, not merely stamped with some offset.
+    la = ZoneInfo("America/Los_Angeles")
+    assert fragment.ingested.tzinfo is not None
+    assert fragment.ingested.utcoffset() == la.utcoffset(fragment.ingested)
+    # Attached, not converted: the wall clock the file recorded survives.
+    assert fragment.ingested.hour == 12
+    assert fragment.ingested.date().isoformat() == "2024-01-01"
 
 
 def test_try_load_fragment_round_trips_hierarchy_fields(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- **Makes the "never naive" contract real.** `creek/time.py::effective_authored_at` documented that
  `Fragment.ingested` is "Always present, never naive" — but nothing enforced it. `Fragment` had
  `field_validator`s for `voice_weight` / `representativeness` / `audience` and none for the three
  datetime fields, so a vault frontmatter timestamp serialised without an offset flowed straight in and
  the contract was a comment, not an invariant. This adds one
  `@field_validator("created", "ingested", "authored_at", mode="after")` on `Fragment` delegating to the
  existing `creek.time.ensure_aware` (added by #938), and rewrites the docstrings so every "never naive"
  claim **names its enforcer** instead of asserting an unowned property.
- **Root cause, not another call site.** #938 hardened `compost.py`'s call site only; the issue listed
  ~15 more unguarded consumers. Fixing the one constructor makes every present and future consumer
  inherit the invariant, instead of playing whack-a-mole down the pipeline. No consumer file is touched.
- **Coercion is at the model boundary and is lossless** — naive in, LA *attached* (wall clock preserved,
  never converted); aware in, returned untouched with `tzinfo` and microseconds intact; `None`
  `authored_at` stays `None`.

## What actually happens today (measured, not predicted)

A naive `ingested` does **not** crash `effective_authored_at` — that returns the naive value verbatim,
and `effective_authored_date` works fine (a `date` carries no tzinfo). The `TypeError` fires at the
*consumer*, the moment a naive-derived value meets an aware one. Reproduced through a public API:

```
SynchronicityDetector().detect_synchronicities(...)
  -> TypeError: can't compare offset-naive and offset-aware datetimes
     at creek/generate/synchronicity.py:306   (_chronological_pair's comparison)
```

It aborts at the **comparison** on line 306, not the subtraction on 257 — so hardening only the
arithmetic would have left the crash in place. An all-naive vault works today, which is exactly why
the suite was green: `tests/test_synchronicity.py`'s fixtures fed naive datetimes on *both* sides and
never mixed the two.

## Coerce, not reject — and why

Both designs were measured on the real suite before choosing:

| design | result |
| --- | --- |
| coerce (`ensure_aware`) | **7427 passed, 0 failed** |
| reject (`raise` on naive) | **204 failed + 73 errors across 17 test files** |

The deciding argument is not the count, though — it is that
`creek/vault/reader.py::try_load_fragment` catches `ValidationError` and returns `None`, logging at
DEBUG. **A rejecting validator would be fail-*silent*, not fail-closed:** an operator's existing
offsetless fragments would quietly vanish from every vault scan with no error surfaced anywhere. That
is strictly worse than today's loud `TypeError`. `tests/test_vault_reader.py`'s new test asserts
`record is not None` specifically to pin coerce-over-reject against a future "hardening".

LA is the right anchor, not UTC: ontology §8.3 normalises every timestamp this pipeline writes to LA,
so a naive value is an LA wall clock that lost its offset in YAML transit. The value is *attached*, so
no instant moves and no fragment crosses a day boundary — verified for `2024-01-01 00:30`.

**An operator with an existing naive-datetime vault sees no breakage:** the vault that loads today
still loads, every fragment's effective date is unchanged, and nothing is logged (deliberately — this
repair is lossless and universal for legacy vaults; warning per field would emit six figures of noise
on a 35k-fragment scan, unlike the sibling `_coerce_*` validators, which warn because they *discard* a
malformed value).

## Why all three fields

`effective_authored_at` excludes `created` from its *precedence* chain for a semantic reason (it
conflates authored-date with fs-mtime), which is orthogonal to tz-awareness — and
`creek/atomize/aggregate.py:173,183,215,268,300,301` sorts, `min`/`max`es and subtracts on
`Fragment.created`, the identical crash surface. `authored_at` is the only optional one, so the
validator returns `None` unchanged; a dedicated test pins that it never invents a date.

## Scope

Deliberately **not** changed: every consumer (`link/*`, `generate/*`, `atomize/*`);
`compost.py:437`'s now-redundant `ensure_aware` (harmless, aware-in/aware-out); `Thread` / `Eddy` /
`Decision` date fields (typed `date`, structurally immune); `AuthorManifest` (no datetime field).

## Behaviour change worth knowing about

Because `Fragment` timestamps now arrive LA-aware, `creek/clean/validator.py`'s **UTC**-assuming
private `_ensure_aware` becomes a no-op for fragments, so `creek clean`'s `future_date` verdict shifts
by the LA offset — a naive wall clock in a ~7-8 hour band that was not flagged before is flagged now.
Measured, and the new verdict is the more correct one (an LA wall clock 3 hours ahead of LA-now really
is in the future; the old UTC reading silently accepted it). The verdict is `review`, not deletion.
No test covered that band either way — recorded on #1115 with the boundary test to write.

## Follow-ups filed

- **#1115** — two `ensure_aware` helpers disagree (`creek.time` anchors to LA, `clean/validator`
  assumes UTC); includes the `future_date` measurement above.
- **#1116** — the invariant is bypassable via `model_construct` / `model_copy(update=…)` / direct
  attribute assignment (`validate_assignment` is off). No production caller exploits it today (all ~25
  `model_copy`/`model_construct` sites on `Fragment` were checked), so this PR documents the real scope
  rather than expanding its blast radius.

## Test plan

- **Gate 1 RED verified twice** (once against the final test files, by reverting only `creek/` and
  re-running): 9 tests fail at `89a5b79`, each for its intended reason — including the `TypeError` from
  `synchronicity.py:306`.
- **GREEN:** all 9 pass. New coverage: naive→LA for each of the three fields; wall-clock preservation
  (kills an `astimezone` implementation); the offsetless-ISO-**string** path (the only test that
  distinguishes `mode="after"` from `mode="before"`); the raw-naive-`datetime` mapping path; Sydney
  `authored_at` preserved with `tzinfo` and microseconds; UTC `ingested` untouched; `None` preserved;
  the on-disk `try_load_fragment` frontmatter round trip; and the mixed naive/aware
  `detect_synchronicities` regression asserting the *result* (`len == 1`, earlier fragment first,
  `time_gap_days == 151` — re-derived by hand, not reverse-engineered from a run).
- `tests/test_time.py::test_result_is_always_tz_aware` was **vacuous** (its docstring claimed Fragment
  validated tz-awareness "via Pydantic's datetime parsing", which was false, and it only ever fed
  tz-aware inputs). It now feeds naive inputs on both branches and asserts the LA offset; both original
  assertions are retained. No live assertion was removed anywhere in the diff.
- `cd creek-tools && ./scripts/check-all.sh` → **exit 0**, 12/12 (ruff, ruff-format, mypy strict,
  pylint 9.69, bandit + pip-audit, xenon, refurb, tryceratops, interrogate 99.4%, unit tests,
  coverage 94.13%, per-file gate).
- Full suite incl. integration/e2e: **7463 passed, 5 skipped**, stable across repeated
  randomised-order runs.
- Gate 2.5 `code-review-orchestrator` run to `CLEAN`; its one blocker (docstrings promising more than a
  field validator can deliver — the same defect class as the issue itself) was fixed by scoping the
  claims to the constructor / `model_validate` paths.

Closes #976
Refs #938
