### PR TITLE
fix(vault): drain short os.write calls so bodies and index lines cannot truncate

### DIFF
--- a/creek-tools/creek/_fsio.py
+++ b/creek-tools/creek/_fsio.py
@@ -1,0 +1,124 @@
+"""Short-write-safe primitives for raw file-descriptor I/O (#987).
+
+``os.write`` is allowed to write *fewer* bytes than it was handed: the
+POSIX ``write(2)`` contract only promises some forward progress, so a
+signal, a nearly-full disk or a slow device can all cut a write short.
+Code that discards the returned count silently truncates its file.
+
+Both :mod:`creek.vault.writer` and :mod:`creek.save.writer` create notes
+by writing straight to the *final* path (``O_CREAT | O_EXCL``, with no
+tempfile + ``os.replace`` staging step), so a short write there does not
+merely spoil a scratch file — it files a half-written note under the
+real name, with no exception raised for anyone to notice. These two
+helpers live here instead of being triplicated across those call sites,
+so the drain loop and the partial-file cleanup have exactly one
+implementation to audit.
+
+Stdlib-only by design: this module sits underneath the writers and must
+not drag any of the package in behind it.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import errno
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_EXCLUSIVE_CREATE_FLAGS = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+"""Create-or-fail open flags: never truncates or clobbers an existing file."""
+
+_NEW_FILE_MODE = 0o644
+"""Permission bits requested for files created by :func:`create_exclusive`."""
+
+
+def write_all(fd: int, data: bytes) -> None:
+    """Write every byte of *data* to *fd*, looping over short writes.
+
+    Args:
+        fd: An open, writable file descriptor.
+        data: The payload to drain in full. An empty payload is a no-op
+            and issues no syscall.
+
+    Raises:
+        OSError: With ``errno.EIO`` when a single ``os.write`` reports no
+            forward progress, rather than spinning on a descriptor that
+            has stopped accepting bytes; or with the underlying errno
+            when the write itself fails. Either way the bytes already
+            written stay on the descriptor — a caller that owns a
+            freshly created file should discard it (see
+            :func:`create_exclusive`).
+    """
+    # The memoryview keeps ``view[offset:]`` O(1). Slicing ``data``
+    # directly would copy the unwritten remainder on every iteration,
+    # which turns a dribbling descriptor quadratic on the 35k-fragment
+    # write path.
+    view = memoryview(data)
+    total = len(view)
+    offset = 0
+    while offset < total:
+        # No ``InterruptedError`` branch on purpose: per PEP 475
+        # ``os.write`` retries the syscall itself on ``EINTR``, which the
+        # kernel reports only when *zero* bytes were transferred. A
+        # signal arriving after n > 0 bytes is reported instead as a
+        # short *success* — precisely the case this loop drains — so
+        # such a branch would be unreachable dead code. A genuine
+        # ``OSError`` (``ENOSPC`` on a later pass, say) must propagate.
+        written = os.write(fd, view[offset:])
+        if written <= 0:
+            msg = f"short write: {offset}/{total} bytes written"
+            raise OSError(errno.EIO, msg)
+        offset += written
+
+
+def create_exclusive(path: Path, data: bytes) -> None:
+    """Create *path* with ``O_CREAT|O_EXCL`` and write every byte of *data*.
+
+    One caveat, on errno fidelity rather than data safety: the
+    descriptor is closed in an inner ``finally``, so if :func:`write_all`
+    raises (an ``ENOSPC``, say) and ``os.close`` then *also* raises, the
+    close-time exception replaces the original and the caller sees the
+    close errno instead of the true root cause. ``os.close`` deliberately
+    does not retry on ``EINTR`` (PEP 475), so this is narrow but
+    reachable. The unlink cleanup still fires in that case — the handler
+    below catches any ``OSError`` subtype — so the guarantee that no
+    half-written file survives at the real path is unaffected.
+
+    A *successful* :func:`write_all` followed by a failing ``os.close``
+    likewise unlinks the (complete) file and raises. That is deliberate
+    fail-safe behaviour: a failing ``close`` can be the only signal of a
+    delayed write-back failure, so suppressing it would trade an
+    errno-fidelity gap for genuine silent data loss.
+
+    Args:
+        path: File to create; its parent directory must already exist.
+        data: Full contents to write.
+
+    Raises:
+        FileExistsError: When *path* already exists. Propagated
+            untouched: both writers' counter-suffix retry loops key on
+            it, and the cleanup below deliberately does not fire for a
+            file this call never created.
+        OSError: When the payload cannot be drained. The partial file is
+            unlinked before the error propagates, so a truncated body is
+            never promoted to the real path.
+    """
+    fd = os.open(str(path), _EXCLUSIVE_CREATE_FLAGS, _NEW_FILE_MODE)
+    try:
+        # Closing in the inner ``finally`` releases the descriptor
+        # before the cleanup unlink runs, however the drain ended.
+        try:
+            write_all(fd, data)
+        finally:
+            os.close(fd)
+    except OSError:
+        # Unlink failures are suppressed so the error already in flight
+        # is the one the caller sees — the drain's ``ENOSPC``, say, or
+        # the ``os.close`` failure that displaced it in the inner
+        # ``finally`` (see the docstring caveat).
+        with contextlib.suppress(OSError):
+            path.unlink()
+        raise

--- a/creek-tools/creek/save/writer.py
+++ b/creek-tools/creek/save/writer.py
@@ -13,19 +13,21 @@ path for fragments and rolled-up primitives; save needs to land notes
 at additional vault locations (``10-Liminal/Paradoxes/``,
 ``10-Liminal/Unnamed/``, ``07-Voice/Drafts/``) that VaultWriter does
 not own. Sharing the same atomic-create pattern keeps the on-disk
-behaviour consistent.
+behaviour consistent: the raw-descriptor create itself is
+:func:`creek._fsio.create_exclusive`, shared verbatim with
+:mod:`creek.vault.writer`.
 """
 
 from __future__ import annotations
 
 import hashlib
-import os
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 import frontmatter
 
+from creek._fsio import create_exclusive
 from creek.classify.privacy_filter import pre_save_filter
 from creek.models import (
     Authorship,
@@ -236,20 +238,32 @@ def _compose_base_name(title: str) -> str:
 
 
 def _atomic_create(target_dir: Path, base_name: str, content: str) -> Path:
-    """Create ``target_dir/{base_name}.md`` atomically; retry on collision."""
-    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    """Create ``target_dir/{base_name}.md`` atomically; retry on collision.
+
+    Args:
+        target_dir: Directory the note will land in.
+        base_name: Filename stem (without ``.md``).
+        content: Full note contents to write.
+
+    Returns:
+        The path of the created note.
+
+    Raises:
+        RuntimeError: If a unique filename cannot be obtained within
+            :data:`_MAX_COLLISION_RETRIES` attempts.
+        OSError: If the note was created but its contents could not be
+            written in full. The partial file is unlinked, so a
+            truncated answer is never filed under the operator's title
+            (#987).
+    """
     encoded = content.encode("utf-8")
     for counter in range(_MAX_COLLISION_RETRIES):
         suffix = "" if counter == 0 else f"-{counter}"
         candidate = target_dir / f"{base_name}{suffix}.md"
         try:
-            fd = os.open(candidate, flags, 0o644)
+            create_exclusive(candidate, encoded)
         except FileExistsError:
             continue
-        try:
-            os.write(fd, encoded)
-        finally:
-            os.close(fd)
         return candidate
     msg = (
         f"Could not allocate a unique filename for '{base_name}.md' in "

--- a/creek-tools/creek/vault/writer.py
+++ b/creek-tools/creek/vault/writer.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING
 import frontmatter
 import yaml
 
+from creek._fsio import create_exclusive, write_all
 from creek.audit import AuditLog
 from creek.models import (
     Authorship,
@@ -1233,6 +1234,39 @@ class VaultWriter:
         before the write to make a regression (e.g. an unusually long
         fragment ID or filename) fail loudly rather than risk silent
         interleaving.
+
+        The line is drained through :func:`creek._fsio.write_all`, so an
+        ordinary short ``write(2)`` no longer leaves half a JSON line at
+        the tail (#987). If the line is genuinely un-drainable the
+        ``OSError`` propagates and a partial line survives at the tail.
+        That residual is worse than a single lost entry: ``O_APPEND``
+        writes always land at EOF with no separator of their own — the
+        trailing newline is part of the payload — so a remnant left
+        *without* its trailing newline is silently concatenated onto the
+        next successful append. The merged line is not valid JSON, so
+        :meth:`_load_index_file` skips it wholesale at
+        ``json.JSONDecodeError`` and **both** the failed entry and the
+        next legitimate one drop out of the index.
+
+        ``ftruncate``-back is not a safe alternative: under concurrent
+        ``O_APPEND`` writers the write offset is chosen atomically inside
+        the syscall, so we never reliably learn our own start offset, and
+        another appender may already have landed a complete line past
+        ours that the truncation would destroy. Tracked as issue #1120 —
+        a real fix needs a rewrite-under-lock or a framing change, both
+        out of scope for #987.
+
+        Args:
+            target_dir: Directory holding the index file.
+            model_id: ID of the model being recorded.
+            filename: Name of the markdown file that holds it.
+
+        Raises:
+            ValueError: If the encoded line exceeds :data:`_PIPE_BUF_BYTES`,
+                which would void the ``O_APPEND`` atomicity guarantee.
+            OSError: If the line cannot be written in full. A
+                newline-less partial line may survive at the tail, taking
+                the next appended entry down with it (#1120, above).
         """
         target_dir.mkdir(parents=True, exist_ok=True)
         index_path = target_dir / INDEX_FILENAME
@@ -1249,7 +1283,7 @@ class VaultWriter:
         flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
         fd = os.open(str(index_path), flags, 0o644)
         try:
-            os.write(fd, encoded)
+            write_all(fd, encoded)
         finally:
             os.close(fd)
 
@@ -1272,6 +1306,10 @@ class VaultWriter:
         contention pattern surfaces as a loud ``RuntimeError`` rather
         than spinning forever.
 
+        The create-and-drain step is :func:`creek._fsio.create_exclusive`,
+        which writes the whole body even when ``write(2)`` goes short
+        and unlinks the file if it cannot (#987).
+
         Args:
             target_dir: Directory the file will live in.
             base_name: Filename stem (without ``.md``).
@@ -1283,20 +1321,18 @@ class VaultWriter:
         Raises:
             RuntimeError: If a unique filename cannot be obtained within
                 :data:`_MAX_FILENAME_COLLISION_RETRIES` attempts.
+            OSError: If the file was created but its contents could not
+                be written in full. The partial file is unlinked, so a
+                truncated note is never promoted to the real path.
         """
-        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
         encoded = content.encode("utf-8")
         for counter in range(_MAX_FILENAME_COLLISION_RETRIES):
             suffix = "" if counter == 0 else f"-{counter}"
             candidate = target_dir / f"{base_name}{suffix}.md"
             try:
-                fd = os.open(str(candidate), flags, 0o644)
+                create_exclusive(candidate, encoded)
             except FileExistsError:
                 continue
-            try:
-                os.write(fd, encoded)
-            finally:
-                os.close(fd)
             return candidate
         msg = (
             f"Could not allocate a unique filename for '{base_name}.md' in "

--- a/creek-tools/tests/conftest.py
+++ b/creek-tools/tests/conftest.py
@@ -6,10 +6,15 @@ Provides auto-use fixtures that:
   models or require GPU access, and
 - pin the terminal width so Rich/Typer CLI output renders deterministically
   regardless of the ambient terminal or whether stdout is a TTY (GAP-013).
+
+Also provides the opt-in :func:`short_write` fixture (issue #987), which
+simulates partial ``os.write`` returns so the vault/save writers can be
+pinned against silent truncation.
 """
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
 
@@ -17,7 +22,7 @@ import numpy as np
 import pytest
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
 
 # Pin a wide terminal so Rich/Typer never wrap CLI output mid-word. Rich
 # defaults to 80 columns whenever stdout is not a TTY (pipes, fresh
@@ -75,3 +80,181 @@ def mock_sentence_transformer() -> Iterator[MagicMock]:
         return_value=mock_model,
     ) as mock_load:
         yield mock_load
+
+
+class ShortWriteController:
+    """Stand-in for ``os.write`` that simulates partial (short) writes.
+
+    Installed by the :func:`short_write` fixture. Only descriptors handed
+    out by ``os.open`` *while the fixture is active* are shortened; every
+    other descriptor is delegated verbatim to the pristine ``os.write``,
+    so pytest's capture pipes and coverage's data files are untouched.
+
+    Until one of the installer methods runs, the shim is a pure
+    pass-through — requesting the fixture therefore never perturbs
+    fixture set-up or unrelated I/O.
+
+    Attributes:
+        calls: How many ``os.write`` calls have targeted a tracked fd.
+    """
+
+    def __init__(
+        self,
+        real_write: Callable[[int, bytes | memoryview], int],
+        tracked: set[int],
+    ) -> None:
+        """Store the pristine ``os.write`` and the shared tracked-fd set.
+
+        Args:
+            real_write: The unpatched ``os.write``.
+            tracked: Mutable set of descriptors opened through the
+                patched ``os.open``; shared with (and filled by) the
+                :func:`short_write` fixture.
+        """
+        self._real_write = real_write
+        self._tracked = tracked
+        self._strategy: Callable[[int, bytes | memoryview], int] | None = None
+        self.calls = 0
+
+    def __call__(self, fd: int, data: bytes | memoryview) -> int:
+        """Serve as the monkeypatched ``os.write``.
+
+        Args:
+            fd: Target file descriptor.
+            data: Payload buffer. Callers under test hand over a
+                ``memoryview``, so only ``len()`` and slicing are used.
+
+        Returns:
+            The number of bytes actually written.
+        """
+        if fd not in self._tracked:
+            return self._real_write(fd, data)
+        self.calls += 1
+        if self._strategy is None:
+            return self._real_write(fd, data)
+        return self._strategy(fd, data)
+
+    def halve(self) -> None:
+        """Write only ``max(1, len(data) // 2)`` bytes per call."""
+
+        def _halve(fd: int, data: bytes | memoryview) -> int:
+            """Write the first half of *data* and report that count."""
+            return self._real_write(fd, data[: max(1, len(data) // 2)])
+
+        self._strategy = _halve
+
+    def one_byte(self) -> None:
+        """Write exactly one byte per call."""
+
+        def _one_byte(fd: int, data: bytes | memoryview) -> int:
+            """Write the first byte of *data* and report that count."""
+            return self._real_write(fd, data[:1])
+
+        self._strategy = _one_byte
+
+    def passthrough(self) -> None:
+        """Delegate every write verbatim again, clearing any strategy.
+
+        Restores the controller's initial (pure pass-through) state so a
+        test can stage a failure, observe the damage it left behind, and
+        then let a follow-up write succeed *in full* — without reaching
+        into private attributes. The ``calls`` counter deliberately
+        keeps running across the reset, so the total number of tracked
+        writes stays observable.
+        """
+        self._strategy = None
+
+    def stall(self) -> None:
+        """Report zero bytes written, having written nothing."""
+
+        def _stall(_fd: int, _data: bytes | memoryview) -> int:
+            """Make no forward progress at all."""
+            return 0
+
+        self._strategy = _stall
+
+    def fail_after_half(self, error_number: int) -> None:
+        """Write half of the first payload, then fail on every later call.
+
+        Args:
+            error_number: ``errno`` value carried by the raised
+                :class:`OSError`.
+        """
+
+        def _fail_after_half(fd: int, data: bytes | memoryview) -> int:
+            """Half-write once, then raise ``OSError(error_number)``."""
+            if self.calls == 1:
+                return self._real_write(fd, data[: max(1, len(data) // 2)])
+            raise OSError(error_number, os.strerror(error_number))
+
+        self._strategy = _fail_after_half
+
+
+@pytest.fixture
+def short_write(monkeypatch: pytest.MonkeyPatch) -> ShortWriteController:
+    """Shorten ``os.write`` for descriptors opened during the test (#987).
+
+    Deliberately **not** auto-use: a test opts in and then selects a
+    failure mode via one of the controller's installers
+    (:meth:`~ShortWriteController.halve`,
+    :meth:`~ShortWriteController.one_byte`,
+    :meth:`~ShortWriteController.stall`,
+    :meth:`~ShortWriteController.fail_after_half`);
+    :meth:`~ShortWriteController.passthrough` resets to plain
+    delegation. ``os.open`` is wrapped only to record the descriptors it
+    hands out, so the shortening stays confined to files the code under
+    test opened itself, and ``os.close`` is wrapped only to *forget*
+    them again: the kernel recycles descriptor numbers, so a stale entry
+    in the tracked set would silently shorten writes to an unrelated
+    file that happened to inherit the number. Both wrappers are total
+    pass-throughs — every call reaches the pristine function with the
+    same arguments and the same exceptions propagate — so the rest of
+    the suite's descriptor traffic is unaffected.
+
+    Args:
+        monkeypatch: Restores ``os.open`` / ``os.write`` / ``os.close``
+            at teardown.
+
+    Returns:
+        The controller, exposing the installers and a ``calls`` counter.
+    """
+    real_open = os.open
+    real_write = os.write
+    real_close = os.close
+    tracked: set[int] = set()
+
+    def _tracking_open(
+        path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        """Open via the pristine ``os.open`` and record the new fd."""
+        fd = real_open(path, flags, mode, dir_fd=dir_fd)
+        tracked.add(fd)
+        return fd
+
+    def _tracking_close(fd: int) -> None:
+        """Close via the pristine ``os.close`` and stop tracking the fd.
+
+        Args:
+            fd: Descriptor to close. Descriptors this fixture never
+                handed out pass through untouched — ``set.discard``
+                cannot raise on a member that was never recorded — and
+                any error from the real ``os.close`` propagates
+                unchanged.
+        """
+        try:
+            real_close(fd)
+        finally:
+            # Untrack even when the close failed: the number is no
+            # longer a descriptor this fixture can claim either way, and
+            # leaving it behind is exactly the recycling hazard above.
+            tracked.discard(fd)
+
+    controller = ShortWriteController(real_write, tracked)
+    monkeypatch.setattr(os, "open", _tracking_open)
+    monkeypatch.setattr(os, "write", controller)
+    monkeypatch.setattr(os, "close", _tracking_close)
+    return controller

--- a/creek-tools/tests/test_fsio.py
+++ b/creek-tools/tests/test_fsio.py
@@ -1,0 +1,189 @@
+"""Tests for :mod:`creek._fsio` — the short-write-safe I/O primitives (#987).
+
+``os.write`` is allowed to write fewer bytes than it was handed. Every
+raw ``os.write`` call site in the vault/save writers ignored the returned
+count, so a short write silently truncated the file at its *final* path
+(there is no tempfile + ``os.replace`` in those paths). These tests pin
+the two primitives that close that hole:
+
+* :func:`creek._fsio.write_all` — loops until the whole buffer is drained,
+  and raises rather than spinning when the descriptor stops making
+  forward progress.
+* :func:`creek._fsio.create_exclusive` — ``O_CREAT | O_EXCL`` create plus
+  a fully-drained write, unlinking the partial file if anything goes
+  wrong so a truncated body is never promoted to the real path.
+
+No ``InterruptedError`` test lives here on purpose: per PEP 475 a signal
+that arrives after ``n > 0`` bytes is reported as a short *success*, so
+``os.write`` cannot surface ``InterruptedError`` for a partial write.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+from typing import TYPE_CHECKING
+
+import pytest
+
+from creek._fsio import create_exclusive, write_all
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from conftest import ShortWriteController
+
+# A distinctive tail makes a halved write unmistakable: a truncated file
+# keeps the leading ``x`` run but loses ``TAIL``.
+_PAYLOAD = b"x" * 400 + b"TAIL"
+
+
+def _open_new(path: Path) -> int:
+    """Create *path* exclusively and return the writable descriptor."""
+    return os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+
+
+def test_write_all_drains_short_writes(
+    tmp_path: Path,
+    short_write: ShortWriteController,
+) -> None:
+    """Every byte lands on disk even when each ``os.write`` writes half."""
+    short_write.halve()
+    path = tmp_path / "halved.bin"
+
+    fd = _open_new(path)
+    try:
+        write_all(fd, _PAYLOAD)
+    finally:
+        os.close(fd)
+
+    assert path.read_bytes() == _PAYLOAD
+    assert short_write.calls > 1
+
+
+def test_write_all_drains_one_byte_at_a_time(
+    tmp_path: Path,
+    short_write: ShortWriteController,
+) -> None:
+    """A one-byte-per-call descriptor still yields the exact payload.
+
+    Pins the offset arithmetic: exactly ``len(payload)`` calls are needed,
+    so an off-by-one advance or a wrong loop condition changes the count.
+    """
+    short_write.one_byte()
+    path = tmp_path / "dribble.bin"
+
+    fd = _open_new(path)
+    try:
+        write_all(fd, _PAYLOAD)
+    finally:
+        os.close(fd)
+
+    assert path.read_bytes() == _PAYLOAD
+    assert short_write.calls == len(_PAYLOAD)
+
+
+def test_write_all_raises_when_no_progress(
+    tmp_path: Path,
+    short_write: ShortWriteController,
+) -> None:
+    """A descriptor that writes nothing raises ``EIO`` instead of spinning."""
+    short_write.stall()
+    path = tmp_path / "stalled.bin"
+
+    fd = _open_new(path)
+    try:
+        with pytest.raises(OSError) as excinfo:
+            write_all(fd, _PAYLOAD)
+    finally:
+        os.close(fd)
+
+    assert excinfo.value.errno == errno.EIO
+    assert path.read_bytes() == b""
+
+
+def test_write_all_accepts_empty_payload(
+    tmp_path: Path,
+    short_write: ShortWriteController,
+) -> None:
+    """An empty payload is a no-op: the loop is never entered.
+
+    ``stall`` is installed so a spurious ``os.write(fd, b"")`` would be
+    seen as zero forward progress and raise — the test would then fail
+    loudly rather than quietly tolerate the wasted syscall.
+    """
+    short_write.stall()
+    path = tmp_path / "empty.bin"
+
+    fd = _open_new(path)
+    try:
+        write_all(fd, b"")
+    finally:
+        os.close(fd)
+
+    assert short_write.calls == 0
+    assert path.read_bytes() == b""
+
+
+def test_create_exclusive_writes_all_bytes_under_short_writes(
+    tmp_path: Path,
+    short_write: ShortWriteController,
+) -> None:
+    """``create_exclusive`` drains the whole payload despite short writes."""
+    short_write.halve()
+    path = tmp_path / "created.md"
+
+    create_exclusive(path, _PAYLOAD)
+
+    assert path.read_bytes() == _PAYLOAD
+    assert short_write.calls > 1
+
+
+def test_create_exclusive_propagates_file_exists_when_path_taken(
+    tmp_path: Path,
+) -> None:
+    """``FileExistsError`` propagates untouched and the old file survives.
+
+    Both writers' collision-retry loops key on ``FileExistsError``, so
+    swallowing or re-wrapping it would turn a counter-suffix retry into a
+    hard failure. The existing bytes must also be left alone — the
+    unlink-on-failure cleanup must not fire on a create that never
+    happened.
+    """
+    path = tmp_path / "taken.md"
+    path.write_bytes(b"original contents")
+
+    with pytest.raises(FileExistsError):
+        create_exclusive(path, _PAYLOAD)
+
+    assert path.read_bytes() == b"original contents"
+
+
+def test_create_exclusive_unlinks_partial_file_when_write_raises_midway(
+    tmp_path: Path,
+    short_write: ShortWriteController,
+) -> None:
+    """A mid-write ``ENOSPC`` leaves no half-written file at the real path."""
+    short_write.fail_after_half(errno.ENOSPC)
+    path = tmp_path / "nospace.md"
+
+    with pytest.raises(OSError) as excinfo:
+        create_exclusive(path, _PAYLOAD)
+
+    assert excinfo.value.errno == errno.ENOSPC
+    assert not path.exists()
+
+
+def test_create_exclusive_unlinks_when_write_makes_no_progress(
+    tmp_path: Path,
+    short_write: ShortWriteController,
+) -> None:
+    """A stalled descriptor raises ``EIO`` and leaves no empty file behind."""
+    short_write.stall()
+    path = tmp_path / "stalled.md"
+
+    with pytest.raises(OSError) as excinfo:
+        create_exclusive(path, _PAYLOAD)
+
+    assert excinfo.value.errno == errno.EIO
+    assert not path.exists()

--- a/creek-tools/tests/test_save.py
+++ b/creek-tools/tests/test_save.py
@@ -7,6 +7,8 @@ and the ``creek save`` CLI command itself.
 
 from __future__ import annotations
 
+import errno
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -28,6 +30,8 @@ from creek.save import (
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+
+    from conftest import ShortWriteController
 
 
 @pytest.fixture
@@ -770,12 +774,55 @@ def test_atomic_create_raises_when_collision_retries_exhausted(
     def always_exists(*_args: object, **_kwargs: object) -> int:
         raise FileExistsError
 
-    monkeypatch.setattr(writer_module.os, "open", always_exists)
+    monkeypatch.setattr(os, "open", always_exists)
     with pytest.raises(RuntimeError) as excinfo:
         writer_module._atomic_create(vault, "stuck", "content")
     message = str(excinfo.value)
     assert "stuck.md" in message
     assert str(writer_module._MAX_COLLISION_RETRIES) in message
+
+
+def test_save_writes_full_body_under_short_writes(
+    vault: Path,
+    short_write: ShortWriteController,
+) -> None:
+    """A short ``os.write`` must not truncate a saved note's body (#987).
+
+    ``_atomic_create`` writes directly to the final path, so a discarded
+    byte count silently files half an answer under the operator's title —
+    the most dangerous shape of this bug, because the note looks saved.
+    """
+    short_write.halve()
+    body = "x" * 400 + "TAIL"
+
+    path = save_to_vault(
+        _make_request(SaveTarget.THREAD, body=body),
+        vault_path=vault,
+    )
+
+    # Assert on the raw bytes first: a truncated note may lose its closing
+    # frontmatter delimiter, and a parser error would obscure the real
+    # failure (the missing tail).
+    assert path.read_text(encoding="utf-8").rstrip("\n").endswith("TAIL")
+    post = frontmatter.load(str(path))
+    assert post.content.strip() == body
+
+
+def test_save_atomic_create_leaves_no_file_when_write_makes_no_progress(
+    vault: Path,
+    short_write: ShortWriteController,
+) -> None:
+    """A stalled descriptor raises instead of filing an empty note."""
+    short_write.stall()
+
+    with pytest.raises(OSError) as excinfo:
+        save_to_vault(
+            _make_request(SaveTarget.THREAD, body="x" * 400 + "TAIL"),
+            vault_path=vault,
+        )
+
+    assert excinfo.value.errno == errno.EIO
+    assert not list(target_directory(vault, SaveTarget.THREAD).glob("*.md"))
 
 
 # ---- Shared slugify helper ----

--- a/creek-tools/tests/test_vault_writer.py
+++ b/creek-tools/tests/test_vault_writer.py
@@ -9,6 +9,7 @@ via write_any.
 
 from __future__ import annotations
 
+import errno
 import json
 from datetime import date, datetime
 from typing import TYPE_CHECKING, Any
@@ -33,6 +34,8 @@ from creek.vault.writer import VaultWriter
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from conftest import ShortWriteController
 
 
 # ---- Fixtures ----
@@ -1525,6 +1528,202 @@ class TestAtomicWriteHardening:
                 "2025-01-15-collide",
                 "irrelevant",
             )
+
+    def test_atomic_create_writes_full_body_under_short_writes(
+        self,
+        vault_path: Path,
+        short_write: ShortWriteController,
+    ) -> None:
+        """A short ``os.write`` must not truncate the created note (#987).
+
+        ``_atomic_create`` writes straight to the final path — there is no
+        tempfile + rename — so a discarded byte count lands a half-written
+        note at the real filename with no exception raised.
+        """
+        short_write.halve()
+        target_dir = vault_path / "01-Fragments" / "Conversations"
+        content = "x" * 400 + "TAIL"
+
+        path = VaultWriter._atomic_create(target_dir, "demo", content)
+
+        assert path.read_text(encoding="utf-8") == content
+
+    def test_atomic_create_leaves_no_file_when_write_makes_no_progress(
+        self,
+        vault_path: Path,
+        short_write: ShortWriteController,
+    ) -> None:
+        """A stalled descriptor raises instead of returning an empty note.
+
+        Today the zero-byte return is ignored: the caller receives a path
+        to a 0-byte file and indexes it as a real fragment.
+        """
+        short_write.stall()
+        target_dir = vault_path / "01-Fragments" / "Conversations"
+
+        with pytest.raises(OSError) as excinfo:
+            VaultWriter._atomic_create(target_dir, "demo", "x" * 400 + "TAIL")
+
+        assert excinfo.value.errno == errno.EIO
+        assert not list(target_dir.glob("demo*.md"))
+
+    def test_append_index_entry_writes_complete_line_under_short_writes(
+        self,
+        vault_path: Path,
+        short_write: ShortWriteController,
+    ) -> None:
+        """A short append writes the whole JSON line, not half of one.
+
+        Half a line is not valid JSON, so ``_load_index_file`` skips it and
+        the id-to-filename mapping is silently dropped — the fragment
+        becomes invisible to duplicate detection and to ``update_fragment``.
+        """
+        from creek.vault.writer import INDEX_FILENAME
+
+        short_write.halve()
+        target_dir = vault_path / "01-Fragments" / "Conversations"
+        model_id = "frag-short-write"
+        filename = "2025-01-15-demo.md"
+
+        VaultWriter._append_index_entry(target_dir, model_id, filename)
+
+        index_path = target_dir / INDEX_FILENAME
+        expected = (
+            json.dumps({"id": model_id, "filename": filename}, sort_keys=True) + "\n"
+        )
+        assert index_path.read_text(encoding="utf-8") == expected
+        assert VaultWriter._load_index_file(index_path) == {model_id: filename}
+
+    def test_append_index_entry_raises_when_write_makes_no_progress(
+        self,
+        vault_path: Path,
+        short_write: ShortWriteController,
+    ) -> None:
+        """A stalled index append fails loudly rather than dropping the entry."""
+        from creek.vault.writer import INDEX_FILENAME
+
+        short_write.stall()
+        target_dir = vault_path / "01-Fragments" / "Conversations"
+
+        with pytest.raises(OSError) as excinfo:
+            VaultWriter._append_index_entry(
+                target_dir,
+                "frag-stalled",
+                "2025-01-15-demo.md",
+            )
+
+        assert excinfo.value.errno == errno.EIO
+        assert VaultWriter._load_index_file(target_dir / INDEX_FILENAME) == {}
+
+    def test_failed_index_append_also_swallows_the_next_entry(
+        self,
+        vault_path: Path,
+        short_write: ShortWriteController,
+    ) -> None:
+        """A half-written index line takes the *next* entry down with it.
+
+        KNOWN DEFECT, tracked as issue #1120. This is a characterization
+        test: it pins the behaviour the code has **today**, not the
+        behaviour anybody wants. ``_append_index_entry`` opens with
+        ``O_APPEND``, so every line lands at EOF with no separator of its
+        own — the trailing newline is part of the payload. When a drain
+        fails part-way (``ENOSPC`` here, after half the bytes are on
+        disk) the remnant survives *without* that newline, and the next
+        successful append is concatenated straight onto it. The merged
+        line is not valid JSON, so ``_load_index_file`` skips it wholesale
+        at ``json.JSONDecodeError`` and **both** the failed entry and the
+        innocent next one drop out of the index.
+
+        ``ftruncate``-back is not a safe repair under concurrent
+        ``O_APPEND`` writers, so a real fix needs a rewrite-under-lock or
+        a framing change — out of scope for #987. When #1120 lands, this
+        test must be **inverted** (``frag-next`` at minimum, ideally both
+        entries, must survive), never deleted.
+        """
+        from creek.vault.writer import INDEX_FILENAME
+
+        target_dir = vault_path / "01-Fragments" / "Conversations"
+        index_path = target_dir / INDEX_FILENAME
+        next_line = json.dumps(
+            {"id": "frag-next", "filename": "2025-01-16-next.md"},
+            sort_keys=True,
+        )
+
+        # First append: half the encoded line reaches disk (the payload
+        # is ~60 bytes, so the cut lands deep inside the JSON, far short
+        # of the terminating newline), then the drain hits ENOSPC.
+        short_write.fail_after_half(errno.ENOSPC)
+        with pytest.raises(OSError) as excinfo:
+            VaultWriter._append_index_entry(
+                target_dir,
+                "frag-partial",
+                "2025-01-15-partial.md",
+            )
+        assert excinfo.value.errno == errno.ENOSPC
+
+        # Second append: an entirely healthy, complete write.
+        short_write.passthrough()
+        VaultWriter._append_index_entry(
+            target_dir,
+            "frag-next",
+            "2025-01-16-next.md",
+        )
+
+        raw = index_path.read_text(encoding="utf-8")
+        # Both halves of the scenario are genuinely on disk, so neither
+        # write can have silently become a no-op: the file is non-empty,
+        # the second entry landed complete at the tail, and something
+        # (the remnant) precedes it.
+        assert raw
+        assert raw.endswith(next_line + "\n")
+        assert len(raw) > len(next_line) + 1
+        # ...and the remnant carried no newline of its own, so the two
+        # collided into a single, unparseable line.
+        assert len(raw.splitlines()) == 1
+
+        index = VaultWriter._load_index_file(index_path)
+        # State both absences explicitly: the failed entry is gone (bad
+        # but expected) and so is the *successful* one (the defect).
+        assert "frag-partial" not in index
+        assert "frag-next" not in index
+        assert index == {}
+
+    def test_write_fragment_survives_short_writes_end_to_end(
+        self,
+        writer: VaultWriter,
+        vault_path: Path,
+        short_write: ShortWriteController,
+    ) -> None:
+        """The public write path keeps both the body and the index intact.
+
+        Exercises the full blast radius of #987 in one pass: the note body
+        goes through ``_atomic_create`` and the id mapping goes through
+        ``_append_index_entry``, and a short write corrupts both.
+        """
+        import frontmatter as fm_mod
+
+        from creek.vault.writer import INDEX_FILENAME
+
+        fragment = Fragment(
+            id="frag-short-e2e",
+            title="Short write end to end",
+            source=FragmentSource(platform=SourcePlatform.CLAUDE),
+            created=datetime(2025, 1, 15, 10, 0, 0),
+        )
+        body = "x" * 400 + "TAIL"
+        short_write.halve()
+
+        path = writer.write_fragment(fragment, body=body)
+
+        # Raw bytes first: a truncated note can lose its closing ``---``
+        # delimiter, and a parser error would obscure the real failure.
+        assert path.read_text(encoding="utf-8").rstrip("\n").endswith("TAIL")
+        post = fm_mod.load(str(path))
+        assert post.content.strip() == body
+        assert post["id"] == "frag-short-e2e"
+        index_path = vault_path / "01-Fragments" / "Conversations" / INDEX_FILENAME
+        index = VaultWriter._load_index_file(index_path)
+        assert index == {"frag-short-e2e": path.name}
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Summary

- **Fixes a silent data-loss bug in the vault write path.** Three raw `os.write(fd, encoded)` call sites discarded the byte count `write(2)` returns. POSIX permits a short write on a regular file (`ENOSPC` writes what fits and returns that count with no error; a signal arriving after *n* > 0 bytes returns a partial count — PEP 475 only auto-retries `EINTR` when *zero* bytes were written), so a fragment body or an id-index JSON line could be truncated with no exception, no log and no trace. Reproduced at `c63befc`: **404 intended bytes, 202 on disk, no exception raised.**
- Adds one stdlib-only module `creek/_fsio.py` with `write_all(fd, data)` (drains the buffer, raising `OSError(EIO)` if a write makes zero forward progress rather than spinning) and `create_exclusive(path, data)` (`O_CREAT|O_EXCL` open + full drain + **unlink-the-partial-file on failure**). All three sites now call into it, so the raw-fd pattern has exactly one implementation to audit instead of three copies.
- The unlink matters because these sites are **not** tempfile+`os.replace` staged — they `os.open` the *final* path directly, so a truncated write lands at the real filename. Without cleanup the fix would only have converted "silently truncated file" into "truncated file plus an exception". `FileExistsError` still propagates untouched, because both callers' counter-suffix retry loops key on it.
- Blast radius closed end-to-end: `_atomic_create` used to return the path as if the write succeeded, after which `VaultWriter` appended an index entry claiming a complete fragment existed — and `_append_index_entry` had the identical defect, writing half a JSON line that `_load_index_file` then discarded at `json.JSONDecodeError`, silently dropping the fragment from the id index.

## What changed

| Site | Before | After |
|---|---|---|
| `creek/vault/writer.py` `VaultWriter._atomic_create` | `os.open` / `os.write` / `os.close` | `create_exclusive(candidate, encoded)` |
| `creek/vault/writer.py` `VaultWriter._append_index_entry` | `os.write(fd, encoded)` | `write_all(fd, encoded)` |
| `creek/save/writer.py` `_atomic_create` | `os.open` / `os.write` / `os.close` | `create_exclusive(candidate, encoded)` |

`_MAX_FILENAME_COLLISION_RETRIES` / `_MAX_COLLISION_RETRIES`, the counter-suffix scheme, the `RuntimeError` messages and the `O_APPEND` `_PIPE_BUF_BYTES` guard are all byte-identical — only the write itself changed. `import os` was dropped from `creek/save/writer.py` (no longer referenced).

Deliberately **not** done, per the issue text: `fsync` / durability on these paths is out of scope.

## Notes on the design

- **`EINTR` needs no explicit handling.** Per PEP 475 `os.write` retries the syscall itself on `EINTR`, which the kernel reports only when *zero* bytes were transferred; a signal after *n* > 0 bytes is reported as a short **success** — precisely the case the loop drains. An `except InterruptedError: continue` branch would be unreachable dead code, so `write_all` carries a comment explaining why it is absent rather than a branch nobody can cover.
- **The `O_APPEND` site cannot be fully repaired here.** Retrying the remaining slice is the right call (the issue sanctions it explicitly), but if a line proves genuinely un-drainable, a remnant without its trailing newline survives and the *next* successful append is concatenated onto it — the merged line fails `json.loads`, so `_load_index_file` drops **both** entries. `ftruncate`-back is not a safe alternative: with `O_APPEND` the write offset is chosen atomically inside the syscall, so we never reliably learn our own start offset and a concurrent appender may already have landed a complete line past ours. This is now documented in the docstring, pinned by a characterization test that says it must be *inverted* rather than deleted, and filed as **#1120** for a rewrite-under-lock or framing fix.

## Test plan

Gate 1 (RED verified against unfixed HEAD before implementing — every one of these failed on an assertion, not an import error):

```
FAILED test_vault_writer.py::TestAtomicWriteHardening::test_atomic_create_writes_full_body_under_short_writes
    AssertionError: assert 'xxxx...xxxx' == 'xxxx...TAIL'
FAILED test_vault_writer.py::TestAtomicWriteHardening::test_atomic_create_leaves_no_file_when_write_makes_no_progress
    Failed: DID NOT RAISE <class 'OSError'>
FAILED test_vault_writer.py::TestAtomicWriteHardening::test_append_index_entry_writes_complete_line_under_short_writes
    assert '{"filename":...5-01-15-demo.' == '{"filename":...ort-write"}\n'
FAILED test_vault_writer.py::TestAtomicWriteHardening::test_append_index_entry_raises_when_write_makes_no_progress
    Failed: DID NOT RAISE <class 'OSError'>
FAILED test_vault_writer.py::TestAtomicWriteHardening::test_write_fragment_survives_short_writes_end_to_end
FAILED test_save.py::test_save_writes_full_body_under_short_writes
FAILED test_save.py::test_save_atomic_create_leaves_no_file_when_write_makes_no_progress
7 failed, 1 passed
```

(`tests/test_fsio.py` failed collection with `ModuleNotFoundError: No module named 'creek._fsio'` — the correct RED for a module that does not exist yet. The 1 pass is the pre-existing collision-retry test, confirming it was not disturbed.)

The tests **force** the short write rather than exercising a happy path: a `short_write` fixture in `tests/conftest.py` wraps `os.open` to record the descriptors the code under test opens, then shortens `os.write` for *only* those descriptors (`.halve()`, `.one_byte()`, `.stall()`, `.fail_after_half(errno)`, `.passthrough()`), delegating verbatim for everything else so pytest's capture and coverage writes are untouched. `os.close` is wrapped to untrack the fd so a recycled descriptor number cannot be shortened by accident.

Gate 1 GREEN — 16 new tests:

- `tests/test_fsio.py` (8): full drain under halving writes; one-byte-per-call (pins the offset arithmetic — exactly `len(payload)` calls, so an off-by-one or a mutant that re-writes the whole buffer each iteration fails); zero-progress raises `EIO` instead of spinning; empty payload issues no syscall; `create_exclusive` drains fully; `FileExistsError` propagates and leaves a pre-existing file's bytes untouched; mid-write `ENOSPC` unlinks the partial file; zero-progress unlinks. Every `OSError` test asserts `excinfo.value.errno`, so a bare or wrong-errno raise still fails.
- `tests/test_vault_writer.py` (6, in `TestAtomicWriteHardening`): both raw sites, a `write_fragment` end-to-end case asserting the body round-trips *and* `_load_index_file` resolves the fragment id, and the #1120 characterization test.
- `tests/test_save.py` (2): through the public `save_to_vault`.

One pre-existing test changed by exactly one expression — `monkeypatch.setattr(writer_module.os, ...)` → `monkeypatch.setattr(os, ...)`, mechanically required because `creek/save/writer.py` dropped its now-unused `import os`. Both targets are the same `os` module singleton; all three of its assertions are byte-identical. `git diff -U0 tests/ | grep '^-'` shows only that line and a widened `TYPE_CHECKING` import — no assertion anywhere was deleted or loosened.

Gate 2 — `cd creek-tools && ./scripts/check-all.sh`: **12/12 checks passed, 7455 tests passed, 94.13% aggregate branch coverage**, per-file gate 224 files ≥80%. `creek/_fsio.py` sits at 94.59% per-file. `ruff check --no-cache .` re-verified clean (imports changed, and a cached verdict would not be trustworthy — see #1119).

Gate 2.5 — `code-review-orchestrator` over the diff. Round 1 returned FIX_REQUIRED on one MAJOR (the `O_APPEND` residual was under-documented and untested); fixed via the docstring correction, the characterization test and issue #1120, along with its two non-blocking findings (the `close()`-errno caveat and the fd-tracking hygiene). Round 2 returned CLEAN.

## Audit of the rest of the codebase

`grep -rn 'os\.write|os\.read|os\.pwrite|os\.sendfile'` over `creek/`, `creek_mcp/` and `crawdad/` returns **exactly these three sites and nothing else** — there is no fourth instance to file a follow-up for. Every other `os.open` in the tree (`creek/ingest/gdrive.py:479`, `creek/confidential/keyvault.py:364`, `creek/redact/cli_commands.py:417`, `creek/vault/writer.py:391`) immediately wraps the descriptor in `os.fdopen`, whose buffered `.write()` already drains, so none of them are affected.

## Detecting damage that already happened

A vault written by an earlier version could already contain a truncated fragment, and **nothing in the tree can detect it.** There is no content checksum or byte-length record anywhere on the fragment write path: the hash-chained provenance log (`creek.audit.AuditLog`) records only `{id, type, path, written_at}`, and it chains *log lines*, not file contents. None of the ten `creek lint` checks (broken-links, compost, draft-grounding, orphan-compiled, paradox, skill-size-budget, synchronicity, tags, unnamed, voice-fidelity) verify body completeness. A note truncated *after* its closing frontmatter delimiter parses cleanly and simply has a shorter body — indistinguishable from a short note. A note truncated *inside* the frontmatter loses its `id` and falls out of the index, which is at least noticeable as an absence, but is never reported as corruption. This PR stops new damage; it cannot find old damage, and detecting it would need a content-integrity feature that does not exist today.

Closes #987
Refs #1120
