### PR TITLE
fix(classify): escalate the tier on new evidence, not on tier ownership

### DIFF
--- a/creek-tools/creek/classify/classify_engine.py
+++ b/creek-tools/creek/classify/classify_engine.py
@@ -53,9 +53,19 @@ call it:
 * **Escalate-only, never auto-downgrade.** ``--force`` may raise a tier
   that is too light, and the post-classification reassess may raise one
   the classifier just hardened, but neither ever lowers a tier —
-  lowering is the one direction that leaks content. An explicit
-  non-``unclassified`` tier on disk also survives any non-``--force``
-  run untouched: the operator's decision outranks the heuristic.
+  lowering is the one direction that leaks content.
+* **A settled tier moves only on new evidence** (#1105). A concrete
+  non-``unclassified`` tier on disk survives a non-``--force`` run
+  *assignment* untouched — :func:`~creek.classify.privacy_pass.apply_tier`
+  will not overwrite it. The post-classification reassess can still raise
+  it, but only when *this run's* classification made the privacy
+  heuristic strictly more restrictive than it was on the fragment as
+  loaded (:attr:`_PreparedFragment.tier_baseline`). So a re-run over
+  unchanged evidence never disturbs a tier the operator chose, while a
+  freshly-revealed INTIMATE signal is no longer discarded just because
+  some tier was already on record. A fragment the resume short-circuit
+  preserves is not reassessed at all: this run produced no evidence
+  about it.
 
 Praxis pass (issue #877)
 ------------------------
@@ -708,18 +718,19 @@ class _PreparedFragment:
             keys are preserved through the rewrite).
         llm: The classifier the fragment's tier resolved to, or ``None``
             on the rules path.
-        owns_tier: Whether *this* run owns the fragment's tier — true
-            when the frontmatter carried none (or ``unclassified``), or
-            when ``--force`` was passed. Gates the post-classification
-            reassess so a hand-set tier is never silently escalated
-            either.
+        tier_baseline: The privacy heuristic's verdict on the fragment
+            **as loaded**, taken before this run classified anything.
+            :func:`~creek.classify.privacy_pass.reassess` compares its
+            own verdict against this to answer the only question that
+            licenses touching a settled tier: did *this run* make the
+            heuristic stricter? (#1105)
     """
 
     fragment: Fragment
     body: str
     raw: dict[str, object]
     llm: LLMClassifier | None
-    owns_tier: bool
+    tier_baseline: PrivacyTier
 
 
 def _prepare_fragment(
@@ -741,6 +752,15 @@ def _prepare_fragment(
     ``llm``/``manual``-stamped fragments that make up a mature vault can
     acquire a tier without ``--force`` re-paying for their classification.
 
+    One more ordering is load-bearing (issue #1105):
+    :attr:`_PreparedFragment.tier_baseline` is captured *first of all*, on
+    the fragment exactly as loaded. It is the reference point
+    :func:`~creek.classify.privacy_pass.reassess` needs to judge whether
+    this run learned anything new about the fragment's privacy, so any
+    mutation taken before it — the tier stamp here, the classifier's voice
+    verdict later — would fold this run's own output back into the
+    baseline and blind the gate to it.
+
     Args:
         md_file: The file to consider.
         force: Whether to re-derive settled classifications and tiers.
@@ -760,8 +780,22 @@ def _prepare_fragment(
         return None
     fragment, body, raw = record
 
+    # #1105: record the heuristic's verdict on the fragment as loaded, BEFORE
+    # ``apply_tier`` (and the classifier below) change anything it reads. The
+    # post-classification reassess needs this to tell "the model just revealed
+    # something new" from "the model echoed what was already on disk"; only the
+    # former licenses raising a tier that is already on record.
+    tier_baseline = privacy.classify_tier(fragment, content=body)
+
     # #876: stamp a real tier before anything else looks at one. ``force``
     # merges escalate-only, so an existing ``intimate`` is never lowered.
+    #
+    # Since #1105 this answers only "did this run *assign* the tier?", and its
+    # two remaining consumers are the ``privacy_tiers_assigned`` counter just
+    # below and the preserved-path :func:`_persist_tier_only` write. It no
+    # longer gates the post-classification reassess — ``tier_baseline`` does
+    # that — because "a tier is already on record" turned out to say nothing
+    # about whether a *person* put it there.
     owns_tier = needs_tier(raw) or force
     fragment = apply_tier(fragment, body, raw=raw, force=force, classifier=privacy)
     if owns_tier:
@@ -797,7 +831,7 @@ def _prepare_fragment(
         body=body,
         raw=raw,
         llm=llm,
-        owns_tier=owns_tier,
+        tier_baseline=tier_baseline,
     )
 
 
@@ -914,10 +948,21 @@ def _process_file(
     # #876: classification may have hardened the fragment's voice signals
     # (confessional + conviction is one of the INTIMATE triggers), which the
     # pre-pass could not see. Take the stricter of the two verdicts —
-    # escalate-only, and only when this run owns the tier, so a deliberate
-    # operator tier is never silently raised either.
-    if prepared.owns_tier:
-        new_fragment = reassess(new_fragment, body, classifier=privacy)
+    # escalate-only, so nothing here can lower a tier.
+    #
+    # #1105: unconditional, because ``reassess`` now carries its own gate.
+    # Its ``baseline`` is the heuristic's verdict on the fragment as loaded,
+    # so it fires only where this run's classification made the heuristic
+    # strictly stricter — new evidence, which no tier on disk predates. The
+    # gate this replaces asked "does this run own the tier?", which is False
+    # for every already-tiered fragment, i.e. for the whole of a mature
+    # vault; that answer discarded exactly the verdicts it was here to catch.
+    new_fragment = reassess(
+        new_fragment,
+        body,
+        baseline=prepared.tier_baseline,
+        classifier=privacy,
+    )
 
     with lock:
         _record_praxis(praxis_before, new_fragment, counts)

--- a/creek-tools/creek/classify/privacy_pass.py
+++ b/creek-tools/creek/classify/privacy_pass.py
@@ -12,15 +12,26 @@ close that hole:
 * :func:`escalate` — merge two candidate tiers, never lowering.
 * :func:`apply_tier` — stamp a tier, honouring a manual override.
 * :func:`reassess` — re-run the check after classification hardened the
-  fragment's voice signals; escalate-only. Both entry points call it,
-  each as its last mutation before the write (#974).
+  fragment's voice signals; escalate-only, and only on new evidence.
+  Both entry points call it, each as its last mutation before the write
+  (#974).
 
-Two rules hold across every function here:
+Three rules hold across every function here:
 
 **Never auto-downgrade.** Lowering a tier is the only direction that
 leaks content, so both the ``--force`` merge and the post-classification
 reassess take the *more* restrictive of the two candidates. An operator
 who wants a tier relaxed edits the frontmatter by hand.
+
+**Act only on new evidence** (#1105). A tier already on record is
+re-litigated only when *this run's* classification made the heuristic
+strictly more restrictive than it was on the fragment as loaded —
+:func:`reassess` compares its own verdict against the caller's
+``baseline`` and returns the fragment untouched when nothing hardened.
+That is why the pass needs no notion of *who* wrote the tier (the
+frontmatter carries no such provenance): it acts only on evidence that
+did not exist when the tier was written, so a settled decision cannot be
+overturned by a re-run over unchanged input.
 
 **Never yield ``unclassified``.**
 :meth:`~creek.classify.privacy.PrivacyClassifier.classify_tier` always
@@ -163,9 +174,10 @@ def reassess(
     fragment: Fragment,
     body: str,
     *,
+    baseline: PrivacyTier,
     classifier: PrivacyClassifier,
 ) -> Fragment:
-    """Re-derive the tier after classification and keep the stricter one.
+    """Re-derive the tier after classification, on new evidence only.
 
     The pre-pass runs *before* the classifier so the per-tier router sees
     a real tier, which means it can only read the axes already on the
@@ -176,20 +188,49 @@ def reassess(
     third INTIMATE trigger — this second look promotes the tier before
     the write, so the harder signal is not thrown away.
 
-    Escalate-only: a lighter post-classification verdict can never demote
-    the tier the pre-pass chose.
+    Two independent guards, in this order (#1105):
+
+    1. **The gate.** Compare the heuristic's verdict *now* against
+       *baseline*, its verdict on the fragment as loaded. Act only when
+       the verdict got **strictly more restrictive**; otherwise this run
+       learned nothing new about the fragment's privacy and has no
+       standing to disturb a tier already on record.
+    2. **The merge.** Escalate-only against ``tier_of(fragment)``, so
+       passing the gate is never licence to *lower* what is stored.
+
+    The gate is deliberately "strictly more restrictive" and not "merely
+    different". A different verdict includes a *weaker* one, and acting
+    on a weakening verdict would let a flip-flopping model raise a tier
+    off evidence that pointed the other way — ratcheting a vault tighter
+    every run.
+
+    Known limitation, stated plainly. A run that escalates also persists
+    the voice axes that justified it, so an operator who then lowers the
+    tier by hand keeps it: the next run reads that same voice off disk,
+    the baseline moves up with it, and nothing hardens. But if the
+    model's verdict is *unstable* — the axes are rewritten weaker on one
+    run and confessional again on the next — that later re-hardening is
+    genuine new evidence and will raise the tier again. Each flip
+    terminates in one step, and the alternative (trusting a tier's
+    provenance the frontmatter does not record) is the bug this replaced.
 
     Args:
         fragment: The classified fragment. Never mutated.
         body: The fragment's markdown body.
+        baseline: The heuristic's tier for this fragment *before* this
+            run classified anything. Callers compute it on the fragment
+            as loaded, so "hardened" means "hardened by this run".
         classifier: The shared :class:`PrivacyClassifier`.
 
     Returns:
-        The fragment at the merged tier — the same object when nothing
-        escalated.
+        The fragment at the merged tier — the same object when this run
+        hardened nothing, or when the merge changed nothing.
     """
+    candidate = classifier.classify_tier(fragment, content=body)
+    if escalate(baseline, candidate) is baseline:
+        return fragment
     current = tier_of(fragment)
-    merged = escalate(current, classifier.classify_tier(fragment, content=body))
+    merged = escalate(current, candidate)
     if merged is current:
         return fragment
     return classifier.enforce_tier(fragment, merged)

--- a/creek-tools/creek/pipeline.py
+++ b/creek-tools/creek/pipeline.py
@@ -42,12 +42,7 @@ from creek.classify.classify_engine import build_tier_classifiers
 from creek.classify.praxis_pass import apply_praxis
 from creek.classify.privacy import PrivacyClassifier
 from creek.classify.privacy_filter import tier_of
-from creek.classify.privacy_pass import (
-    PRIVACY_TIER_KEY,
-    apply_tier,
-    needs_tier,
-    reassess,
-)
+from creek.classify.privacy_pass import PRIVACY_TIER_KEY, apply_tier, reassess
 from creek.classify.review import ReviewQueueGenerator
 from creek.classify.rules import RuleClassifier
 from creek.config import CreekConfig
@@ -570,20 +565,32 @@ class Pipeline:
         voice-proxy eligible. Running it last is safe because it is
         escalate-only (:func:`~creek.classify.privacy_pass.escalate`): it
         can never lower a tier, so it can never regress the tier→router
-        ordering above. It is guarded on ``owns_tier`` to mirror
-        ``_prepare_fragment`` (``creek/classify/classify_engine.py:765``
-        and ``:919-920``), so the two entry points stay ordered and gated
-        identically — which is the whole point of an issue about those
-        two disagreeing. ``force`` is always ``False`` on this path, so
-        the engine's ``needs_tier(raw) or force`` reduces here to
-        ``needs_tier(raw)``; the guard earns its place because
-        ``apply_tier`` itself already declines to overwrite a tier that
-        is on record when ``force`` is ``False``
-        (``creek/classify/privacy_pass.py:153-155``), and an unguarded
-        reassess would therefore have the pipeline honour a pre-set tier
-        before the model runs and override it after. No production
-        ingester sets ``privacy_tier`` today, so in practice
-        ``owns_tier`` is always ``True`` here.
+        ordering above.
+
+        That second look is unconditional, because ``reassess`` carries
+        its own gate (#1105): it acts only when *this run's*
+        classification made the privacy heuristic **strictly more
+        restrictive** than it was on the fragment as ingested. So a tier
+        already on record — which ``apply_tier`` correctly declines to
+        overwrite when ``force`` is ``False`` — is disturbed only by
+        evidence that did not exist when it was set, never by a re-run
+        over the same input. The predicate replaces an ``owns_tier``
+        guard that asked "did this frontmatter still owe us a tier?";
+        that proxy answered ``False`` for every already-tiered fragment,
+        so it discarded exactly the confessional verdicts the second look
+        exists to catch.
+
+        The ``baseline`` handed to ``reassess`` is computed on
+        ``item.fragment`` *before* the rule classifier runs, mirroring the
+        engine, which computes it on the fragment as loaded from disk
+        before any of its own classification
+        (``creek.classify.classify_engine._prepare_fragment``). Both
+        therefore mean "the heuristic's verdict on untouched input", and
+        the two entry points stay gated identically — which is the whole
+        point of an issue about them disagreeing. Taking it *after* the
+        rules pass here would make a rules-derived confessional register
+        count as new evidence on this path but not on the engine's, and
+        re-open the divergence in a subtler place.
 
         Classification operates on the inner :class:`Fragment`; the body
         is preserved unchanged on the returned :class:`IngestedFragment`.
@@ -603,6 +610,15 @@ class Pipeline:
 
         classified: list[IngestedFragment] = []
         for item in ingested:
+            # Issue #1105: the heuristic's verdict on the fragment as ingested,
+            # taken before ANY of this run's classification touches the axes it
+            # reads. The reassess below compares against it to tell new evidence
+            # from an echo of what was already there. Mirrors the point at which
+            # the classify engine takes its own baseline.
+            baseline = self.privacy_classifier.classify_tier(
+                item.fragment,
+                content=item.body,
+            )
             frag = self.rule_classifier.classify(item.fragment, content=item.body)
             # Issue #876: assign a real privacy tier BEFORE ``for_tier`` picks
             # a provider, or an Intimate fragment routes to the cloud on the
@@ -610,10 +626,6 @@ class Pipeline:
             # There is no frontmatter on disk yet, so the fragment's own tier
             # is the "raw" state a manual override would have to come through.
             raw: dict[str, object] = {PRIVACY_TIER_KEY: frag.privacy_tier}
-            # Read the ownership question BEFORE ``apply_tier`` answers it by
-            # stamping a tier, mirroring the engine's ``_prepare_fragment``
-            # (``force`` is always False here, so its ``or force`` drops out).
-            owns_tier = needs_tier(raw)
             frag = apply_tier(
                 frag,
                 item.body,
@@ -643,10 +655,16 @@ class Pipeline:
             frag = apply_praxis(frag, item.body)
             # Issue #974: the tier pass above had to run before the LLM, so it
             # never saw the voice axes Pass 3 just filled in. Look once more,
-            # last and escalate-only, exactly where the engine looks — only
-            # when this run owns the tier, so a pre-set one is never raised.
-            if owns_tier:
-                frag = reassess(frag, item.body, classifier=self.privacy_classifier)
+            # last and escalate-only, exactly where the engine looks. Issue
+            # #1105: unconditional — ``reassess`` compares against ``baseline``
+            # itself and declines unless this run made the heuristic stricter,
+            # so a tier already on record moves only on new evidence.
+            frag = reassess(
+                frag,
+                item.body,
+                baseline=baseline,
+                classifier=self.privacy_classifier,
+            )
             classified.append(IngestedFragment(fragment=frag, body=item.body))
 
         self.review_generator.generate_queue(

--- a/creek-tools/tests/test_classify_engine.py
+++ b/creek-tools/tests/test_classify_engine.py
@@ -1875,6 +1875,426 @@ def test_tier_only_write_failure_lands_on_errors_without_aborting(
     assert _tier_map(vault)["frag-tierio-ok001"] == "personal"
 
 
+# ---- Post-classification reassess on an already-tiered vault (issue #1105) --
+#
+# ``_prepare_fragment`` gated the post-classification reassess on ``owns_tier``
+# (``needs_tier(raw) or force``), which is ``False`` for every fragment that
+# already carries a concrete tier. A mature vault is *entirely* such fragments,
+# so on a non-``--force`` LLM run the second look never ran: a fragment stamped
+# ``personal`` whose LLM verdict came back ``confessional`` + ``conviction``
+# stayed ``personal`` and — because ``voice_proxy_eligible`` is derived from the
+# tier — stayed a legitimate input to voice-proxy generation.
+#
+# The replacement predicate is "did THIS run's classification make the privacy
+# heuristic **strictly more restrictive** than it was on the fragment as
+# loaded?". Strictly, not merely-differently: a weakened verdict must not raise
+# an operator's tier either. The tests below pin both halves plus the two
+# guarantees the old proxy was standing in for (an operator tier survives a
+# signal-free run; a preserved fragment is not re-tiered at all).
+
+
+def _field_map(vault: Path, key: str) -> dict[str, object]:
+    """Return ``{fragment_id: frontmatter[key]}`` read back off disk.
+
+    The sibling of :func:`_tier_map` for the other frontmatter keys these
+    tests assert on (``voice_proxy_eligible``, ``classification_method``),
+    kept separate so ``_tier_map``'s ``dict[str, str]`` contract — which
+    several existing tests compare against string literals — is untouched.
+    Reads EVERY markdown file under ``01-Fragments`` and keys the result by
+    fragment id, never by ``rglob`` position.
+
+    Args:
+        vault: Vault root to read back.
+        key: Frontmatter key to project.
+
+    Returns:
+        Mapping of fragment id to that key's value, ``"<absent>"`` when the
+        key is missing.
+    """
+    out: dict[str, object] = {}
+    for path in (vault / "01-Fragments").rglob("*.md"):
+        meta = frontmatter.load(str(path)).metadata
+        if meta.get("type") != "fragment":
+            continue
+        out[str(meta["id"])] = meta.get(key, "<absent>")
+    return out
+
+
+def test_a_confessional_verdict_escalates_an_already_tiered_fragment(
+    tmp_path: Path,
+) -> None:
+    """An LLM verdict hardens the tier of a fragment that already had one.
+
+    The #1105 reproduction. Both fragments are pre-stamped
+    ``privacy_tier: personal`` — the shape of every fragment in a vault
+    that has been classified once — and neither carries a
+    ``classification_method``, so the OPS-001 preserved short-circuit does
+    not fire and both really do reach the model on this non-``--force``
+    run. One comes back ``confessional`` + ``conviction``, which is
+    ``PrivacyClassifier.classify_tier``'s third INTIMATE trigger; before
+    #1105 the reassess was gated on "does this run own the tier?", which
+    is false here, so that verdict was silently discarded and the fragment
+    stayed ``personal`` / ``voice_proxy_eligible: true``.
+
+    ``voice_proxy_eligible`` is asserted alongside the tier because it is
+    the actual cost: it is what admits a confessional fragment into
+    voice-proxy generation, where private material can be echoed back out
+    in generated prose.
+
+    The second fragment — same starting tier, an ``analytical`` /
+    ``musing`` verdict — must stay ``personal``, so an implementation that
+    escalates every already-tiered fragment fails here rather than passing
+    the reproduction by accident.
+    """
+    from creek.models import (
+        Authorship,
+        Confidence,
+        PrivacyTier,
+        VoiceClassification,
+        VoiceRegister,
+    )
+
+    vault = tmp_path / "vault"
+    for frag_id in ("frag-owned-conf01", "frag-owned-calm01"):
+        _write_fragment(
+            vault=vault,
+            fragment=Fragment(
+                id=frag_id,
+                title="A hard thing",
+                source=FragmentSource(
+                    platform=SourcePlatform.MARKDOWN,
+                    author=Authorship.SELF,
+                ),
+                privacy_tier=PrivacyTier.PERSONAL,
+            ),
+            body=_TIER_NEUTRAL_BODY,
+        )
+    # Precondition: the tier really is on record before the run, so this is
+    # the already-tiered path and not a first classification.
+    assert _tier_map(vault) == {
+        "frag-owned-conf01": "personal",
+        "frag-owned-calm01": "personal",
+    }
+
+    verdicts = {
+        "frag-owned-conf01": VoiceClassification(
+            voice_register=VoiceRegister.CONFESSIONAL,
+            confidence=Confidence.CONVICTION,
+        ),
+        "frag-owned-calm01": VoiceClassification(
+            voice_register=VoiceRegister.ANALYTICAL,
+            confidence=Confidence.MUSING,
+        ),
+    }
+
+    def _verdict(fragment: Fragment, content: str = "") -> LLMClassificationResult:
+        """Return this test's scripted voice verdict for *fragment*."""
+        _ = content
+        return LLMClassificationResult(
+            fragment=fragment.model_copy(update={"voice": verdicts[fragment.id]}),
+            reasoning="",
+        )
+
+    config = CreekConfig()
+    config.classification.confidence_threshold = 1.0  # force the LLM path
+
+    with patch(
+        "creek.classify.classify_engine.LLMClassifier.classify_with_reasoning",
+        side_effect=_verdict,
+    ):
+        run_classify(vault_path=vault, config=config, method="llm", force=False)
+
+    assert _tier_map(vault) == {
+        "frag-owned-conf01": "intimate",  # the LLM's verdict hardened the tier
+        "frag-owned-calm01": "personal",  # a light verdict moves nothing
+    }
+    assert _field_map(vault, "voice_proxy_eligible") == {
+        "frag-owned-conf01": False,
+        "frag-owned-calm01": True,
+    }
+    # The verdicts really landed, so the tiers above cannot be passing for
+    # want of an LLM call.
+    assert _field_map(vault, "classification_method") == {
+        "frag-owned-conf01": "llm",
+        "frag-owned-calm01": "llm",
+    }
+
+
+def test_an_operator_tier_survives_when_the_run_produces_no_new_signal(
+    tmp_path: Path,
+) -> None:
+    """A deliberate tier is not raised by a signal that was already on disk.
+
+    The guarantee the deleted ``owns_tier`` gate was standing in for, and
+    the reason #1105 is not fixed by reassessing unconditionally. This
+    journal fragment already reads INTIMATE to the heuristic *as loaded*
+    (self-authored journal, and confessional + conviction already in its
+    frontmatter), and the operator nonetheless set ``privacy_tier: open``.
+    The model returns exactly the verdict already on disk, so this run
+    hardened nothing — and a tier the operator chose may only be relaxed
+    or tightened by the operator, never by a re-run over unchanged
+    evidence.
+
+    The contrast fragment is an untiered journal entry: it must acquire
+    ``intimate`` on the same run, so a "never touch any tier" regression
+    cannot pass this test.
+    """
+    from creek.models import (
+        Authorship,
+        Confidence,
+        PrivacyTier,
+        VoiceClassification,
+        VoiceRegister,
+    )
+
+    confessional = VoiceClassification(
+        voice_register=VoiceRegister.CONFESSIONAL,
+        confidence=Confidence.CONVICTION,
+    )
+    vault = tmp_path / "vault"
+    _write_fragment(
+        vault=vault,
+        fragment=Fragment(
+            id="frag-opertr-open1",
+            title="Morning pages",
+            source=FragmentSource(
+                platform=SourcePlatform.JOURNAL,
+                author=Authorship.SELF,
+            ),
+            privacy_tier=PrivacyTier.OPEN,
+            voice=confessional,
+        ),
+        body=_TIER_NEUTRAL_BODY,
+    )
+    _write_fragment(
+        vault=vault,
+        fragment=Fragment(
+            id="frag-opertr-fresh",
+            title="Morning pages",
+            source=FragmentSource(
+                platform=SourcePlatform.JOURNAL,
+                author=Authorship.SELF,
+            ),
+        ),
+        body=_TIER_NEUTRAL_BODY,
+    )
+
+    def _echo(fragment: Fragment, content: str = "") -> LLMClassificationResult:
+        """Return the fragment with the confessional verdict it already had."""
+        _ = content
+        return LLMClassificationResult(
+            fragment=fragment.model_copy(update={"voice": confessional}),
+            reasoning="",
+        )
+
+    config = CreekConfig()
+    config.classification.confidence_threshold = 1.0  # force the LLM path
+
+    with patch(
+        "creek.classify.classify_engine.LLMClassifier.classify_with_reasoning",
+        side_effect=_echo,
+    ):
+        run_classify(vault_path=vault, config=config, method="llm", force=False)
+
+    assert _tier_map(vault) == {
+        "frag-opertr-open1": "open",  # the operator's call, kept
+        "frag-opertr-fresh": "intimate",  # a fresh fragment still gets tiered
+    }
+    # Both fragments really went through the model, so "open" above is a
+    # decision the pass made, not a fragment it never looked at.
+    assert _field_map(vault, "classification_method") == {
+        "frag-opertr-open1": "llm",
+        "frag-opertr-fresh": "llm",
+    }
+
+
+def test_a_weakened_verdict_does_not_raise_an_operator_tier(tmp_path: Path) -> None:
+    """A verdict that softens the signal may not raise a tier either.
+
+    The engine-level companion to
+    ``TestReassess.test_declines_when_the_candidate_weakened_from_the_baseline``:
+    it separates the decided "strictly more restrictive" predicate from a
+    naive "merely different" one. This markdown fragment is loaded looking
+    INTIMATE to the heuristic (confessional + conviction in its
+    frontmatter) with an operator tier of ``open``; the model then answers
+    ``analytical`` / ``musing``, so the post-classification candidate is
+    ``personal`` — different from the baseline, but different downwards.
+    Acting on that difference would raise the operator's ``open`` to
+    ``personal`` on evidence that pointed the other way, and a
+    flip-flopping model would ratchet a vault tighter every run.
+
+    The contrast fragment (untiered markdown, same weakened verdict) must
+    still land ``personal``, so this cannot pass by never tiering anything.
+    """
+    from creek.models import (
+        Authorship,
+        Confidence,
+        PrivacyTier,
+        VoiceClassification,
+        VoiceRegister,
+    )
+
+    vault = tmp_path / "vault"
+    _write_fragment(
+        vault=vault,
+        fragment=Fragment(
+            id="frag-weaken-open1",
+            title="A hard thing",
+            source=FragmentSource(
+                platform=SourcePlatform.MARKDOWN,
+                author=Authorship.SELF,
+            ),
+            privacy_tier=PrivacyTier.OPEN,
+            voice=VoiceClassification(
+                voice_register=VoiceRegister.CONFESSIONAL,
+                confidence=Confidence.CONVICTION,
+            ),
+        ),
+        body=_TIER_NEUTRAL_BODY,
+    )
+    _write_fragment(
+        vault=vault,
+        fragment=Fragment(
+            id="frag-weaken-fresh",
+            title="A hard thing",
+            source=FragmentSource(
+                platform=SourcePlatform.MARKDOWN,
+                author=Authorship.SELF,
+            ),
+        ),
+        body=_TIER_NEUTRAL_BODY,
+    )
+
+    analytical = VoiceClassification(
+        voice_register=VoiceRegister.ANALYTICAL,
+        confidence=Confidence.MUSING,
+    )
+
+    def _soften(fragment: Fragment, content: str = "") -> LLMClassificationResult:
+        """Return a verdict weaker than the one already on the fragment."""
+        _ = content
+        return LLMClassificationResult(
+            fragment=fragment.model_copy(update={"voice": analytical}),
+            reasoning="",
+        )
+
+    config = CreekConfig()
+    config.classification.confidence_threshold = 1.0  # force the LLM path
+
+    with patch(
+        "creek.classify.classify_engine.LLMClassifier.classify_with_reasoning",
+        side_effect=_soften,
+    ):
+        run_classify(vault_path=vault, config=config, method="llm", force=False)
+
+    assert _tier_map(vault) == {
+        "frag-weaken-open1": "open",  # weakened evidence raises nothing
+        "frag-weaken-fresh": "personal",
+    }
+    # The weakened verdict really was written, so the tier above is the
+    # pass's decision about it and not a fragment the model never saw.
+    assert _field_map(vault, "voice") == {
+        "frag-weaken-open1": {
+            "voice_register": "analytical",
+            "confidence": "musing",
+        },
+        "frag-weaken-fresh": {
+            "voice_register": "analytical",
+            "confidence": "musing",
+        },
+    }
+
+
+def test_a_preserved_fragment_is_not_retiered(tmp_path: Path) -> None:
+    """The OPS-001 short-circuit still means "this run did not look".
+
+    A fragment carrying ``classification_method: llm`` from a prior paid
+    run is skipped before any classifier sees it, so this run produces no
+    new signal about it at all — even though the confessional voice
+    already in its frontmatter means the heuristic *would* answer
+    ``intimate`` if asked. #1105 widens when the reassess runs, and the
+    risk is that it widens into this path and starts silently re-tiering
+    the whole of a mature vault off evidence no run of this command
+    produced. The preserved counter is asserted alongside the tier so the
+    test cannot pass by the fragment being skipped for the wrong reason.
+
+    The contrast fragment is an untiered journal entry that does classify
+    normally on the same run.
+    """
+    from creek.models import (
+        Authorship,
+        Confidence,
+        PrivacyTier,
+        VoiceClassification,
+        VoiceRegister,
+    )
+
+    vault = tmp_path / "vault"
+    _write_fragment(
+        vault=vault,
+        fragment=Fragment(
+            id="frag-presrv-conf1",
+            title="A hard thing",
+            source=FragmentSource(
+                platform=SourcePlatform.MARKDOWN,
+                author=Authorship.SELF,
+            ),
+            privacy_tier=PrivacyTier.PERSONAL,
+            voice=VoiceClassification(
+                voice_register=VoiceRegister.CONFESSIONAL,
+                confidence=Confidence.CONVICTION,
+            ),
+        ),
+        body=_TIER_NEUTRAL_BODY,
+        method="llm",
+    )
+    _write_fragment(
+        vault=vault,
+        fragment=Fragment(
+            id="frag-presrv-fresh",
+            title="Morning pages",
+            source=FragmentSource(
+                platform=SourcePlatform.JOURNAL,
+                author=Authorship.SELF,
+            ),
+        ),
+        body=_TIER_NEUTRAL_BODY,
+    )
+
+    seen: list[str] = []
+
+    def _record(fragment: Fragment, content: str = "") -> LLMClassificationResult:
+        """Record which fragments reached the model; echo them back unchanged."""
+        _ = content
+        seen.append(fragment.id)
+        return LLMClassificationResult(fragment=fragment, reasoning="")
+
+    config = CreekConfig()
+    config.classification.confidence_threshold = 1.0  # force the LLM path
+
+    with patch(
+        "creek.classify.classify_engine.LLMClassifier.classify_with_reasoning",
+        side_effect=_record,
+    ):
+        summary = run_classify(
+            vault_path=vault,
+            config=config,
+            method="llm",
+            force=False,
+        )
+
+    assert summary.preserved_llm == 1
+    assert seen == ["frag-presrv-fresh"]  # the preserved fragment never ran
+    assert _tier_map(vault) == {
+        "frag-presrv-conf1": "personal",  # untouched: this run never looked
+        "frag-presrv-fresh": "intimate",
+    }
+    assert _field_map(vault, "voice_proxy_eligible") == {
+        "frag-presrv-conf1": True,
+        "frag-presrv-fresh": False,
+    }
+
+
 # ---- Praxis-potential pass (issue #877) ------------------------------------
 #
 # Same discipline as the #876 tier block above: seed fragments with known

--- a/creek-tools/tests/test_pipeline.py
+++ b/creek-tools/tests/test_pipeline.py
@@ -1534,31 +1534,34 @@ class TestPipelinePrivacyReassess:
             "frag-reassess006": True,
         }
 
-    def test_a_preset_ingester_tier_is_not_silently_raised(
+    def test_a_preset_tier_is_raised_only_when_the_verdict_hardens_it(
         self,
         vault_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """A tier already on record survives a heavier LLM verdict.
+        """A tier on record yields to a verdict that hardens the signal.
 
-        :func:`~creek.classify.privacy_pass.apply_tier`
-        (``creek/classify/privacy_pass.py:153-155``) declines to overwrite
-        a tier that is already on record when ``force=False`` — the
-        operator's call outranks the heuristic. The second look has to
-        decline for the same reason, keyed on the same "did this
-        frontmatter still owe us a tier?" question
-        (:func:`~creek.classify.privacy_pass.needs_tier`), or the
-        pipeline would half-honour a pre-set tier: respected before the
-        model runs, overridden after.
+        **Supersedes the ``owns_tier`` seam contract, by decision of
+        issue #1105.** This test previously asserted the opposite — that
+        a pre-set tier is never raised, because the second look was gated
+        on :func:`~creek.classify.privacy_pass.needs_tier` ("did this
+        frontmatter still owe us a tier?"). That proxy answered ``False``
+        for every fragment carrying a concrete tier, i.e. for the whole of
+        a vault that has been classified once, so a confessional verdict
+        on an already-tiered fragment was silently discarded and the
+        fragment stayed voice-proxy eligible. #1105 replaces the proxy
+        with the predicate it was standing in for: escalate when *this
+        run's* classification made the privacy heuristic **strictly more
+        restrictive** than it was on the fragment as loaded.
 
-        This is a **seam contract**, not a live content path: no
-        production ingester sets ``privacy_tier`` today, so the fragment
-        below is constructed by hand. Note the resulting test polarity —
-        it passes both before and after the #974 fix, and fails only if
-        the fix drops the ``owns_tier`` guard and reassesses
-        unconditionally (which reads ``intimate`` here). Deleting it
-        because "it was never red" removes the only thing pinning that
-        guard.
+        The original observation still holds and still matters: this is a
+        **seam contract**, not a live content path — no production
+        ingester sets ``privacy_tier`` today, so both fragments below are
+        constructed by hand. What it pins now is the discrimination, not a
+        blanket refusal. Both start at ``open``; the confessional +
+        conviction verdict raises one to ``intimate`` while the analytical
+        verdict leaves the other at ``open``, so neither "never raise a
+        pre-set tier" nor "always reassess" can pass.
         """
         from creek.models import Confidence, PrivacyTier, VoiceRegister
 
@@ -1574,6 +1577,7 @@ class TestPipelinePrivacyReassess:
                     VoiceRegister.CONFESSIONAL,
                     Confidence.CONVICTION,
                 ),
+                "frag-reassess012": (VoiceRegister.ANALYTICAL, Confidence.MUSING),
             },
         )
 
@@ -1584,19 +1588,33 @@ class TestPipelinePrivacyReassess:
                     "markdown",
                     tier=PrivacyTier.OPEN,
                 ),
+                self._ingested(
+                    "frag-reassess012",
+                    "markdown",
+                    tier=PrivacyTier.OPEN,
+                ),
             ],
             vault_path,
             PipelineResult(),
         )
 
         assert self._tiers(classified) == {
-            "frag-reassess007": PrivacyTier.OPEN.value,
+            "frag-reassess007": PrivacyTier.INTIMATE.value,
+            "frag-reassess012": PrivacyTier.OPEN.value,
         }
-        # The verdict that *would* have escalated an untiered fragment did
-        # land, so the assertion above is not passing for want of an LLM call.
-        assert classified[0].fragment.voice.voice_register == (
-            VoiceRegister.CONFESSIONAL.value
-        )
+        assert self._eligibility(classified) == {
+            "frag-reassess007": False,
+            "frag-reassess012": True,
+        }
+        # The verdicts did land, so the tiers above are not passing for want
+        # of an LLM call. Keyed by id, never by list position.
+        landed = {
+            item.fragment.id: item.fragment.voice.voice_register for item in classified
+        }
+        assert landed == {
+            "frag-reassess007": VoiceRegister.CONFESSIONAL.value,
+            "frag-reassess012": VoiceRegister.ANALYTICAL.value,
+        }
 
     def test_a_no_llm_run_changes_no_tier(self, vault_path: Path) -> None:
         """With no LLM in the run, the second look is a strict no-op.

--- a/creek-tools/tests/test_privacy_pass.py
+++ b/creek-tools/tests/test_privacy_pass.py
@@ -256,7 +256,19 @@ class TestApplyTier:
 
 
 class TestReassess:
-    """``reassess`` re-runs the check post-classification and only escalates."""
+    """``reassess`` re-runs the check post-classification and only escalates.
+
+    Since issue #1105 the pass is gated on a required ``baseline`` —
+    the heuristic's verdict on the fragment as it was loaded, *before*
+    this run classified anything. The pass acts only when this run's
+    classification made the heuristic **strictly more restrictive** than
+    that baseline, and returns the very same fragment object otherwise.
+
+    The predicate is deliberately ``>`` and not ``!=``: a merely
+    *different* verdict includes a **weaker** one, and acting on a
+    weakening verdict would let a flip-flopping model raise an
+    operator's deliberate tier off evidence that pointed the other way.
+    """
 
     def test_escalates_when_classification_hardens_the_signal(self) -> None:
         """Confessional + conviction from the classifier lifts personal → intimate."""
@@ -269,7 +281,14 @@ class TestReassess:
             ),
         )
 
-        result = reassess(fragment, _NEUTRAL_BODY, classifier=PrivacyClassifier())
+        # baseline: pre-classification this fragment carried no voice, so the
+        # heuristic answered PERSONAL — the verdict below genuinely hardens it.
+        result = reassess(
+            fragment,
+            _NEUTRAL_BODY,
+            baseline=PrivacyTier.PERSONAL,
+            classifier=PrivacyClassifier(),
+        )
 
         assert PrivacyTier(result.privacy_tier) is PrivacyTier.INTIMATE
 
@@ -280,7 +299,15 @@ class TestReassess:
             tier=PrivacyTier.INTIMATE,
         )
 
-        result = reassess(fragment, _NEUTRAL_BODY, classifier=PrivacyClassifier())
+        # baseline: no prior heuristic verdict, so the essay's OPEN candidate
+        # counts as hardening and the escalate-only merge really runs — which
+        # is what keeps this test's "never lowers" claim under test.
+        result = reassess(
+            fragment,
+            _NEUTRAL_BODY,
+            baseline=PrivacyTier.UNCLASSIFIED,
+            classifier=PrivacyClassifier(),
+        )
 
         assert PrivacyTier(result.privacy_tier) is PrivacyTier.INTIMATE
 
@@ -291,7 +318,14 @@ class TestReassess:
             tier=PrivacyTier.PERSONAL,
         )
 
-        result = reassess(fragment, _NEUTRAL_BODY, classifier=PrivacyClassifier())
+        # baseline: as above — UNCLASSIFIED lets the OPEN candidate through the
+        # gate so the merge, not the gate, is what refuses to lower the tier.
+        result = reassess(
+            fragment,
+            _NEUTRAL_BODY,
+            baseline=PrivacyTier.UNCLASSIFIED,
+            classifier=PrivacyClassifier(),
+        )
 
         assert PrivacyTier(result.privacy_tier) is PrivacyTier.PERSONAL
 
@@ -302,6 +336,151 @@ class TestReassess:
             tier=PrivacyTier.OPEN,
         )
 
-        result = reassess(fragment, _NEUTRAL_BODY, classifier=PrivacyClassifier())
+        # baseline: the heuristic said OPEN before classification and says OPEN
+        # after, so nothing hardened and the pass has nothing to do.
+        result = reassess(
+            fragment,
+            _NEUTRAL_BODY,
+            baseline=PrivacyTier.OPEN,
+            classifier=PrivacyClassifier(),
+        )
 
         assert result.model_dump(mode="json") == fragment.model_dump(mode="json")
+
+    def test_hardened_signal_also_flips_voice_proxy_eligibility(self) -> None:
+        """The escalation carries the derived eligibility flag with it (#1105).
+
+        ``voice_proxy_eligible`` is a computed field over ``privacy_tier``
+        + ``source.author``, and it is the actual damage of the bug: a
+        confessional fragment left at ``personal`` advertises itself as a
+        legitimate input to voice-proxy generation, so private material
+        can be echoed back out in generated prose. Pinning the flag as
+        well as the tier means an implementation that escalates without
+        going through ``enforce_tier`` cannot pass.
+        """
+        fragment = _fragment(
+            platform=SourcePlatform.MARKDOWN,
+            tier=PrivacyTier.PERSONAL,
+            voice=VoiceClassification(
+                voice_register=VoiceRegister.CONFESSIONAL,
+                confidence=Confidence.CONVICTION,
+            ),
+        )
+        assert fragment.voice_proxy_eligible is True
+
+        result = reassess(
+            fragment,
+            _NEUTRAL_BODY,
+            baseline=PrivacyTier.PERSONAL,
+            classifier=PrivacyClassifier(),
+        )
+
+        assert result is not fragment
+        assert PrivacyTier(result.privacy_tier) is PrivacyTier.INTIMATE
+        assert result.voice_proxy_eligible is False
+        # The input is never mutated: the caller's copy still reads personal.
+        assert PrivacyTier(fragment.privacy_tier) is PrivacyTier.PERSONAL
+
+    def test_declines_when_the_candidate_matches_the_baseline(self) -> None:
+        """An unchanged signal leaves an operator's lighter tier alone (#1105).
+
+        This journal fragment reads INTIMATE to the heuristic both before
+        and after classification — the run produced no *new* privacy
+        signal — while the tier on record is the operator's deliberate
+        ``personal``. Without the baseline gate the escalate-only merge
+        would raise it, which is how the previous ``owns_tier`` proxy
+        earned its place; the gate has to keep that guarantee while
+        dropping the proxy. Identity (``is``) is asserted rather than
+        equality because the contract is "the same object back", which no
+        accidental re-stamp can satisfy.
+        """
+        fragment = _fragment(
+            platform=SourcePlatform.JOURNAL,
+            tier=PrivacyTier.PERSONAL,
+        )
+
+        result = reassess(
+            fragment,
+            _NEUTRAL_BODY,
+            baseline=PrivacyTier.INTIMATE,
+            classifier=PrivacyClassifier(),
+        )
+
+        assert result is fragment
+        assert PrivacyTier(result.privacy_tier) is PrivacyTier.PERSONAL
+
+    def test_declines_when_the_candidate_weakened_from_the_baseline(self) -> None:
+        """A *weaker* verdict may not raise a tier either (#1105).
+
+        This is the case that separates the decided ``>`` predicate from
+        a naive ``!=`` one. The fragment was loaded looking INTIMATE to
+        the heuristic (self-authored, confessional + conviction on disk);
+        this run's classification came back merely analytical, so the
+        candidate is PERSONAL — *different* from the baseline, but
+        different in the weakening direction. Under ``!=`` the pass would
+        fire and the escalate-only merge would raise the operator's
+        ``open`` to ``personal`` on evidence that pointed the other way.
+        Under ``>`` it declines, and the operator's tier survives.
+        """
+        fragment = _fragment(
+            platform=SourcePlatform.MARKDOWN,
+            tier=PrivacyTier.OPEN,
+            voice=VoiceClassification(
+                voice_register=VoiceRegister.ANALYTICAL,
+                confidence=Confidence.MUSING,
+            ),
+        )
+        # Precondition: this fixture's candidate really is PERSONAL — markdown
+        # is neither the ESSAY nor the DISCORD branch, and an analytical /
+        # musing voice misses the third INTIMATE trigger, so ``classify_tier``
+        # falls through to its PERSONAL default.
+        assert (
+            PrivacyClassifier().classify_tier(fragment, content=_NEUTRAL_BODY)
+            is PrivacyTier.PERSONAL
+        )
+
+        result = reassess(
+            fragment,
+            _NEUTRAL_BODY,
+            baseline=PrivacyTier.INTIMATE,
+            classifier=PrivacyClassifier(),
+        )
+
+        assert result is fragment
+        assert PrivacyTier(result.privacy_tier) is PrivacyTier.OPEN
+
+    def test_a_hardened_signal_still_never_lowers_the_stored_tier(self) -> None:
+        """Passing the gate is not licence to lower what is on disk (#1105).
+
+        The gate compares the *heuristic's* two verdicts; the merge that
+        follows compares against the tier actually on the fragment. Those
+        are different quantities, and this fragment holds them apart: the
+        candidate (PERSONAL) hardens relative to the baseline (OPEN), so
+        the pass runs — but the stored tier is INTIMATE, so the merge
+        must keep INTIMATE. An implementation that assigned the candidate
+        outright once the gate opened would silently downgrade intimate
+        content, the one direction that leaks it.
+
+        The platform is ``markdown``, not the ``essay`` an earlier sketch
+        of this case used: a self-authored essay derives OPEN, which does
+        not harden past an OPEN baseline, so that shape would never have
+        opened the gate at all and the test would have been vacuous.
+        """
+        fragment = _fragment(
+            platform=SourcePlatform.MARKDOWN,
+            tier=PrivacyTier.INTIMATE,
+            voice=VoiceClassification(
+                voice_register=VoiceRegister.ANALYTICAL,
+                confidence=Confidence.MUSING,
+            ),
+        )
+
+        result = reassess(
+            fragment,
+            _NEUTRAL_BODY,
+            baseline=PrivacyTier.OPEN,
+            classifier=PrivacyClassifier(),
+        )
+
+        assert PrivacyTier(result.privacy_tier) is PrivacyTier.INTIMATE
+        assert result.voice_proxy_eligible is False


### PR DESCRIPTION
## Summary

- **The bug.** `classify_engine._prepare_fragment` computed `owns_tier = needs_tier(raw) or force` and gated the post-classification privacy reassess on it. `needs_tier` is `False` for any concrete tier, so on a non-`--force` run over an already-tiered fragment the reassess never ran — even when that same run had just produced `voice_register: confessional` + `confidence: conviction`, which is `PrivacyClassifier.classify_tier`'s third INTIMATE trigger. **The run wrote the intimate trigger to disk and discarded the tier verdict in the same pass.** Verified on unfixed HEAD: `privacy_tier: personal` next to `voice: {confidence: conviction, voice_register: confessional}` and `voice_proxy_eligible: True`. That `true` is the damage — it admits confessional material into voice-proxy generation.
- **The design decision, and why this option.** The guard's stated rationale was "never silently raise a deliberate operator tier", but **there is no tier provenance in the frontmatter**: the engine cannot tell an operator's considered `personal` from one `_retier_after_rewrite` or `Pipeline._run_classification` stamped a millisecond earlier. This PR replaces the ownership *proxy* with the predicate it was standing in for: `privacy_pass.reassess` gains a required `baseline` — the heuristic's verdict on the fragment **as loaded** — and escalates only when *this run's* classification made the heuristic **strictly more restrictive**. We never need to know who wrote the tier, because we act only on evidence that did not exist when it was written.
- **Strictly-more-restrictive, not merely-different.** A different candidate includes a *weaker* one; acting on a weakening verdict would let a flip-flopping model ratchet an operator's tier up off evidence pointing the other way. Implemented by reusing `escalate` (`escalate(baseline, candidate) is baseline` → decline), so no new rank table and no fourth tier reader.
- **Settled repo-wide.** `creek/pipeline.py` carried the identical gate (added by #1113 to mirror the engine). It is changed the same way, so `creek process` and `creek classify` remain one decision rather than two — this is the fifth instance of the "wired into one entry point but not the other" class, and fixing it in one place only would have produced the sixth.
- **Strictly additive semantics.** For every case the old gate *permitted*, the new predicate is provably a no-op: on the assigning path `apply_tier` already stamped `candidate_pre == baseline`; on the `--force` path it already merged `escalate(on-disk, baseline)`. The only behaviour change is the bug case.

### Two options considered and rejected (the issue body offered both)

**Unconditional reassess.** `reassess` re-derives from the *same* platform/author/body evidence `apply_tier`'s pre-pass just declined to act on, so this makes `apply_tier`'s operator-override branch dead in practice — honoured before the model runs, overridden milliseconds later. And because `privacy_tier` is a one-way ratchet, the operator could then **never durably hold a tier below the heuristic**: hand-edit back to `open`, next run re-buries it at `intimate`, forever. That matters because `RECOVERY_KEYWORDS` documents itself as *"intentionally errs on the side of high-recall: false positives land in INTIMATE"* — false-positive INTIMATE verdicts are a designed-in property, and the operator's override is their **only** correction mechanism. "Raising is non-destructive" is true for privacy but false for utility: `intimate` permanently removes voice-proxy eligibility and cloud routing, with no tooling path back.

**A `privacy_tier_source: heuristic | operator` key.** The information is unobtainable without operator cooperation, so the key lies in both default directions. Default-to-`operator` leaves every already-mis-stamped vault broken forever; machine-self-stamps-`heuristic` means a human who edits a machine-stamped `personal` down to `open` leaves the stale marker in place and gets overridden anyway. Only greenfield hand-written frontmatter would be protected — a schema change buying an unreliable signal.

### What happens to a genuinely hand-set tier

Unchanged in the case that matters, and it now self-corrects in the case that does not. A hand-set `open` on a journal fragment survives **every** run: platform is not new evidence, so baseline and candidate are both `INTIMATE` and the pass declines (`test_manual_tier_override_survives_a_non_force_run` passes unmodified). When the machine *does* raise a tier on a genuinely new signal, it persists the voice axes that justified it — so the operator, having now seen the evidence, can hand-edit the tier back down and it **sticks**: on the next run those axes are already on the loaded fragment, the baseline moves with them, and nothing hardens. The operator overrules the machine once they have seen its reasoning. `reassess`'s docstring records the honest residual: if the model's verdict is *unstable*, a later re-hardening is genuine new evidence and will raise again — one step per flip.

### Callers affected

| Caller | Behaviour |
|---|---|
| `creek fill --upgrade` (`cli.py:2342`, `method="llm", force=False`) | **Changes** — the headline case; its whole purpose is re-running over already-tiered fragments |
| `creek sync` Tier B (`cli.py:750` → `_sync_classify(..., "llm")`, `force=False`) | **Changes** — biggest real-world beneficiary; re-runs over an already-tiered vault every cycle |
| `creek classify` (`cli.py:1698`) | **Changes** when non-force + concrete tier + not preserved + the verdict hardens. `--force`: provably identical |
| MCP `creek.classify` (`creek_mcp/tools/classify.py:54`) | **Changes** identically; no MCP-side edit needed |
| `creek process` (`Pipeline._run_classification`) | **No production change** — no ingester sets `privacy_tier`, so `owns_tier` was always `True`. Seam contract only |
| Preserved short-circuit (`classification_method: llm`/`manual`) | **Unchanged** — classification never runs, so there is no new evidence; `_persist_tier_only` is untouched |
| `creek ingest`, `creek fill` without `--upgrade`, `VaultWriter._retier_after_rewrite` | Unchanged |

### Sibling issues — stated honestly, not overclaimed

- **#1106 (mis-stamped vaults): this PR does NOT remediate them.** I probed it directly. A fragment carrying `personal` + confessional/conviction already on disk stays `personal` / `voice_proxy_eligible: true` after a non-force run, because that evidence is no longer new — the design working as intended, not a gap. (The same probe confirms `--force` still fixes it, even on the free `--method rules` path, so #1106 is a *targeting* problem rather than a capability gap.) #1106's `retierable` gap detector remains needed and unaffected: `_scan_fill_gaps` still counts only `needs_tier(raw)` (`cli.py:2184`), so a wrongly-`personal` fragment is still invisible.
- **#1107 (parity detector blind to the LLM path): this PR does NOT make widening it cheap.** The two new reproduction tests stub the model through two *different* idioms — `patch("...LLMClassifier.classify_with_reasoning")` in `test_classify_engine.py` vs `monkeypatch.setattr(classifier, "classify")` in `test_pipeline.py`. That is direct evidence the shared deterministic-model harness #1107 needs does not fall out of this work; we add two more instances of the divergence it exists to unify. Left to #1107.

### One existing test's expectation deliberately changed

`tests/test_pipeline.py::TestPipelinePrivacyReassess::test_a_preset_ingester_tier_is_not_silently_raised` was the only thing pinning the `owns_tier` guard on the pipeline side, and its own docstring warned against removing it. **It is rewritten, not deleted**, as `test_a_preset_tier_is_raised_only_when_the_verdict_hardens_it`, and is strictly stronger: two fragments, both directions (one hardening verdict raises `open`→`intimate`, one analytical verdict leaves `open` alone), plus `voice_proxy_eligible` and keyed-by-id landed-verdict assertions the original lacked. Its docstring states that it supersedes the old contract by decision of #1105 and preserves the original's still-true "seam contract, not a live content path" observation. This is the **only** existing expectation that changed; the other four test edits are mechanical `baseline=` additions to `TestReassess` with every pre-existing assertion surviving verbatim.

## Test plan

Gate 1 RED verified against unfixed HEAD before implementing — the headline reproduction failed with `{'frag-owned-conf01': 'personal'} != {'frag-owned-conf01': 'intimate'}`, and the pipeline test with `{'frag-reassess007': 'open'} != {'frag-reassess007': 'intimate'}`.

New tests:
- `tests/test_privacy_pass.py::TestReassess` — 4 new (hardened signal flips `voice_proxy_eligible`; declines when the candidate matches the baseline; **declines when the candidate weakened** — the test a `!=` predicate fails; a hardened signal still never lowers the stored tier) + 4 mechanical `baseline=` migrations.
- `tests/test_classify_engine.py` — `test_a_confessional_verdict_escalates_an_already_tiered_fragment` (the reproduction, with a second pre-stamped `personal` fragment on an analytical verdict so blanket escalation also fails), `test_an_operator_tier_survives_when_the_run_produces_no_new_signal` (fails under the unconditional-reassess option), `test_a_weakened_verdict_does_not_raise_an_operator_tier`, `test_a_preserved_fragment_is_not_retiered`.
- `tests/test_pipeline.py` — the rewritten preset-tier test above.

Pins confirmed still green **unmodified**: `test_classification_signals_escalate_the_tier`, `test_an_existing_intimate_tier_is_never_lowered` (both params), `test_manual_tier_override_survives_a_non_force_run`, `test_second_classify_run_assigns_no_tiers_and_changes_none`, `test_reatomized_children_carry_a_concrete_tier`, all of `tests/test_process_classify_parity.py`, and the rest of `TestPipelinePrivacyReassess`.

Gates run locally from `creek-tools/`:
- `./scripts/check-all.sh` → **exit 0**, 12/12 checks, **7463 passed** (up from 7455 on unmodified HEAD), 94.13% branch coverage, per-file gate 224 files ≥80%.
- `ruff check --no-cache .` with `.ruff_cache` deleted → clean (cold verification, per #1119).
- `code-review-orchestrator` over the diff → **CLEAN**, no blocking findings. Its one non-blocking nit (the now-narrowed `owns_tier` local reads like the seam it replaced) was applied as a clarifying comment.
- No `# noqa`, `# type: ignore`, `skip`/`xfail`, or threshold change anywhere in the diff. `pyproject.toml`, `uv.lock`, `creek/vault/writer.py` and `creek_mcp/` untouched.

Closes #1105
Refs #974, #1106, #1107
