### PR TITLE
fix(ralph): stop every merge to main invalidating every other lane

### DIFF
--- a/.claude/commands/ralph-tick.md
+++ b/.claude/commands/ralph-tick.md
@@ -175,14 +175,25 @@ Then act on `$STATUS`:
   ever covers a bump that was already current with `main` and already
   green — one nobody touched.
 - **`behind`** (`LGTM` + green but `mergeStateStatus` is `BEHIND`, **or** the
-  far more common case: `mergeStateStatus CLEAN` yet the compare API reports
-  `behind_by > 0`). `CLEAN` means only "no merge conflict" — GitHub computes
-  `BEHIND` solely when the base branch enforces strict/up-to-date status
-  checks, which this repo does not, so `CLEAN` routinely reports on a PR that
-  is dozens of commits stale (measured live: PR #943 reported
-  `MERGEABLE`/`UNSTABLE` while the compare API said `behind_by: 22`; PR #863
-  said `44`). **Do not merge stale — a branch's own green CI says nothing
-  about today's `main`.** Same remedy either way:
+  branch is behind `main` *for a reason that can invalidate its green*).
+  `CLEAN` means only "no merge conflict" — GitHub computes `BEHIND` solely when
+  the base branch enforces strict/up-to-date status checks, which this repo does
+  not, so `CLEAN` routinely reports on a PR that is dozens of commits stale
+  (measured live: PR #943 reported `MERGEABLE`/`UNSTABLE` while the compare API
+  said `behind_by: 22`; PR #863 said `44`). **Do not merge a branch whose green
+  says nothing about today's `main`.**
+
+  But **being behind is not by itself stale** (#1137). Requiring `behind_by == 0`
+  outright is quadratic in lane count — merging one lane pushes every *other*
+  lane behind, and each then pays a sync, a full CI round and a fresh review;
+  because that window is as long as the gap between merges, lanes went stale
+  again while re-proving themselves. Measured across that gate landing: CI runs
+  per PR 1.00 → 1.61 (max 5), p90 PR latency 15 → 104 min. `pr-ready.sh` now
+  prints `behind` only when the two changesets can actually interact: `main`
+  landed a cross-cutting change (lockfile, tool pin, workflow, check script,
+  root `conftest.py`), **or** this branch did, **or** the two touched a file in
+  common. Two fixes in unrelated modules no longer serialize. Same remedy when
+  it does fire:
   ```bash
   scripts/ralph/fleet.sh sync "$ISSUE_N" || echo "SYNC-CONFLICT $ISSUE_N"
   ```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,22 @@ on:
     branches: [ main, develop ]
   workflow_dispatch:
 
+# One in-flight run per ref. A Ralph lane pushes repeatedly to the same PR — a
+# sync merge, a review fix, a CI fix — and without this the superseded run keeps
+# burning a full ~15-minute 3-version matrix on a commit nobody will merge, while
+# the lane that needs a runner waits behind it (#1140). It also removes a real
+# ambiguity: `scripts/ralph/pr-ready.sh` keys CI state off `gh pr checks`, and a
+# stale in-flight run leaves the rollup reporting `pending` for a commit whose
+# answer no longer matters.
+#
+# `cancel-in-progress` is keyed off the EVENT, never a blanket `true`: cancelling
+# a `push` run on `main` would leave a merged commit unvalidated, and that run is
+# the backstop the relaxed pre-merge freshness gate depends on (#1138). Grouping
+# by `github.ref` keeps sibling lanes from cancelling each other.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   PYTHON_DEFAULT_VERSION: '3.12'
   COVERAGE_THRESHOLD: 90

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -10,6 +10,20 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+# One review per ref. This workflow only ever runs on `pull_request`, so an
+# unconditional cancel is correct here — but it is written the same way as
+# ci.yml's on purpose, so neither file grows a rule the other lacks if a
+# non-PR trigger is ever added.
+#
+# Why it matters: every push to a lane invalidates the previous LGTM under
+# pr-ready.sh's stale-verdict guard, so a superseded review is not merely
+# wasted Claude time — its verdict can never gate anything. Letting it run to
+# completion also posts a verdict comment against an already-dead HEAD, which
+# is noise on the very PR thread a human reads to see what happened (#1140).
+concurrency:
+  group: claude-review-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   claude-review:
     # Skip runs Dependabot itself TRIGGERED — keyed on the actor, not the PR's

--- a/scripts/ralph/pr-ready.sh
+++ b/scripts/ralph/pr-ready.sh
@@ -10,7 +10,12 @@
 #                    current with main, but this PR HAS no review gate: Dependabot
 #                    authored it AND pushed its HEAD commit, and `claude-review`
 #                    reported SKIPPED → the orchestrator decides (see ralph-tick.md)
-#   behind           LGTM (fresh) + CI green but the branch is not current → sync first
+#   behind           LGTM (fresh) + CI green, but `main` has landed something
+#                    since the merge base that can invalidate this branch's
+#                    green — a cross-cutting change (lockfile / tool pin /
+#                    workflow / check script / root conftest) or an edit to a
+#                    file this branch also touches → sync first. Merely being
+#                    behind is NOT enough; see the freshness guard below.
 #   pending          CI still running (or no checks registered yet) → wait for a later wake
 #   ci-failed        CI has a failing/errored check → Step 2 (ci-debugging)
 #   changes-requested CI green + a FRESH verdict (posted after HEAD) exists and is
@@ -54,7 +59,7 @@
 # `ready` path, so this token covers only the residual case of a bump already
 # green and already current, where nothing of ours is ever pushed. It is a
 # SEPARATE token rather than a looser `ready` on purpose: `ready` keeps its full
-# four-part meaning (fresh LGTM + green CI + CLEAN + `behind_by == 0`), so the
+# four-part meaning (fresh LGTM + green CI + CLEAN + verified current), so the
 # decision about what to do with a PR no reviewer ever saw is made visibly in
 # `ralph-tick.md` and never silently here — and in THIS repo ralph-tick.md's
 # Step 1 routing does not merge on this token, it hands the lane to a human.
@@ -101,11 +106,31 @@
 # `behind_by: 22`, and #863 says 44. #943 is a `ruff` bump, and the identical
 # situation upstream (a bump 17 behind carrying a ruff major) produced 144 lint
 # errors against the then-current tree — merging its stale green would have
-# turned `main` red. Freshness therefore comes from the compare API's
-# `behind_by`, and CLEAN is KEPT alongside it because DIRTY / CONFLICTING /
-# BLOCKED / DRAFT / UNKNOWN are invisible to `behind_by`. The probe is LAZY by
-# design — only a lane that would otherwise print `ready` pays for it, so the
-# orchestrator never burns a request per lane per wake on already-decided lanes.
+# turned `main` red. Freshness therefore comes from the compare API, and CLEAN
+# is KEPT alongside it because DIRTY / CONFLICTING / BLOCKED / DRAFT / UNKNOWN
+# are invisible to it. The probe is LAZY by design — only a lane that would
+# otherwise print `ready` pays for it, so the orchestrator never burns a request
+# per lane per wake on already-decided lanes.
+#
+# WHY IT IS `behind_by > 0` PLUS A REASON, NOT `behind_by > 0` ALONE (#1137):
+# requiring `behind_by == 0` outright is a self-imposed strict-up-to-date rule,
+# and it is quadratic in lane count — merging ONE lane pushes every OTHER open
+# lane behind, and each of them then pays a sync, a ~14-minute CI round, and
+# (because the new HEAD commit invalidates its LGTM under the stale-verdict
+# guard above) a full re-review. Because that window is comparable to the
+# interval between merges, lanes routinely went stale again WHILE re-proving
+# themselves. Measured across #1022 landing: CI runs per PR went 1.00 → 1.61
+# (max 5) and p90 PR latency went 15 → 104 minutes, with two of PR #1117's five
+# CI+review rounds spent on `Merge origin/main` commits that changed no code.
+#
+# So a branch that is behind is stale only for a REASON: `main` landed something
+# on the cross-cutting RISK_SURFACE_RE below (a lockfile, a tool pin, a workflow,
+# a check script, a root conftest — the class #943 actually belonged to), or it
+# touched a file this branch also touches, which is a genuine semantic
+# interaction. Otherwise the branch's green still describes the tree it would
+# merge into, and it merges. What backstops the residual risk is the full CI run
+# on `push: main` — every squash-merge re-proves the merged result, so a stale
+# green that slips through is caught on `main` rather than assumed away.
 #
 # Usage:  pr-ready.sh <PR_NUMBER> [--repo <owner/repo>]
 set -euo pipefail
@@ -144,6 +169,26 @@ readonly CURRENT_REPO_SLUG='{owner}/{repo}'
 # checks.
 readonly DEPENDABOT_AUTHOR="app/dependabot"
 readonly DEPENDABOT_COMMIT_AUTHOR="dependabot[bot]"
+
+# Paths on `main` that can turn ANY branch's green red no matter what that branch
+# touched, because they change how the whole tree is built, linted, typed or
+# tested. This is the list that keeps #1022's actual finding alive: PR #943 was a
+# `ruff` bump sitting 22 commits behind, and the identical situation upstream (a
+# bump 17 behind carrying a ruff major) produced 144 lint errors against the
+# then-current tree. A lockfile, a tool pin, a workflow, a check script or a root
+# `conftest.py` landing on `main` therefore still forces a full re-prove.
+#
+# Everything NOT on this list is inert with respect to a branch that does not
+# touch it: two bug fixes in different modules cannot invalidate each other's
+# CI run, and before this list existed each of them forced the other to re-run
+# ~14 minutes of CI and a full re-review (#1137).
+readonly RISK_SURFACE_RE='(^|/)(pyproject\.toml|uv\.lock|poetry\.lock|conftest\.py|\.pre-commit-config\.yaml|(requirements|constraints)[^/]*\.txt)$|^\.github/workflows/|^creek-tools/scripts/'
+
+# GitHub's compare API returns at most 300 entries in `.files`. AT the cap the
+# list is truncated, so "these two changesets are disjoint" is an answer we
+# cannot support — and the whole point of the disjointness test is to skip a
+# sync. Fail closed at the cap: a big merge re-proves itself the old way.
+readonly COMPARE_FILE_CAP=300
 
 # The `code-review.yml` job name as it appears in the status rollup (the job KEY;
 # that job declares no `name:` override, so the check name matches it), and the
@@ -347,12 +392,67 @@ review_gate_absent() {
   all_conclusions_skipped "$conclusions"
 }
 
-# True only when the compare API proves the head is 0 commits behind its base.
-# Fails CLOSED: an API error, an empty answer, or a non-integer all read as "not
-# current", because `behind`'s remedy (fleet.sh sync) is always safe and a false
-# `ready` is not.
+# The filenames a compare endpoint reports, one per line, or non-zero on any
+# failure — including the 300-entry cap, where GitHub has truncated the list and
+# a disjointness answer would be unsupportable. `grep -c` is guarded because it
+# exits 1 on an empty input, which is a legitimate answer (a range whose commits
+# changed no files) and not an error.
+compare_files() { # compare_files <slug> <range>
+  local out count
+  out="$(gh api "repos/$1/compare/$2?per_page=1" \
+    --jq '(.files // [])[].filename' 2>/dev/null)" || return 1
+  count="$(grep -c . <<<"$out" || true)"
+  [[ "$count" =~ ^[0-9]+$ ]] || return 1
+  [[ "$count" -lt "$COMPARE_FILE_CAP" ]] || return 1
+  printf '%s\n' "$out"
+}
+
+# True when everything `main` has landed since the merge base is inert with
+# respect to THIS branch: it touched no cross-cutting risk surface, and it
+# touched no file this branch also touches. Either of those is a real reason to
+# re-prove green; neither being present means the branch's existing green still
+# describes the tree it would merge into.
+#
+# Fails CLOSED on every failure path, exactly like the caller: an errored or
+# truncated compare reads as "not inert", whose remedy (a sync) is always safe.
+main_changes_are_inert() { # main_changes_are_inert <slug> <base> <head_oid> <merge_base>
+  local theirs ours f
+  # THEIRS first: it decides the risk-surface case on its own, so a lane that is
+  # behind a lockfile bump never pays for the second call.
+  theirs="$(compare_files "$1" "$4...$2")" || return 1
+  while IFS= read -r f; do
+    [[ -n "$f" ]] || continue
+    if [[ "$f" =~ $RISK_SURFACE_RE ]]; then return 1; fi
+  done <<<"$theirs"
+  ours="$(compare_files "$1" "$2...$3")" || return 1
+  while IFS= read -r f; do
+    [[ -n "$f" ]] || continue
+    # OUR side of the risk surface counts too, and for the sharper reason. A
+    # branch that changes how the tree is linted/built/typed/tested has proved
+    # that only against the tree AT ITS MERGE BASE; everything `main` has landed
+    # since is code the new tooling has never been run over. That is PR #943
+    # exactly — the ruff bump whose own green said nothing about the 22 commits
+    # that arrived after it — so a bump re-proves itself whenever `main` moves,
+    # which is the case #1022 was right about and this keeps.
+    if [[ "$f" =~ $RISK_SURFACE_RE ]]; then return 1; fi
+    # -x -F: whole line, literal. A path is not a pattern, and a prefix match
+    # would read `creek/vault.py` as overlapping `creek/vault_index.py`.
+    if grep -qxF "$f" <<<"$theirs"; then return 1; fi
+  done <<<"$ours"
+  return 0
+}
+
+# True when `main` has landed nothing since the merge base that could invalidate
+# this branch's green. `behind_by == 0` is the fast path and still short-circuits
+# on ONE call, so a lane that is already current costs exactly what it always
+# did; only a lane that is genuinely behind pays for the file comparison, and it
+# was otherwise about to pay for a sync plus a full CI round.
+#
+# Fails CLOSED: an API error, an empty answer, a non-integer, a malformed merge
+# base, or a truncated file list all read as "not current", because `behind`'s
+# remedy (fleet.sh sync) is always safe and a false `ready` is not.
 branch_is_current() {
-  local ref_line base head_oid slug behind
+  local ref_line base head_oid slug cmp behind merge_base cmp_rest
   ref_line="$(gh pr view "${gh_args[@]}" --json baseRefName,headRefOid \
     --jq '(.baseRefName // "") + "|" + (.headRefOid // "")' 2>/dev/null)" || return 1
   # Demand the separator before splitting on it. Without this, a separator-free
@@ -370,10 +470,22 @@ branch_is_current() {
   [[ "$head_oid" =~ ^[0-9a-f]{7,40}$ ]] || return 1
   slug="$CURRENT_REPO_SLUG"
   [[ -z "$repo_slug" ]] || slug="$repo_slug"
-  behind="$(gh api "repos/$slug/compare/$base...$head_oid?per_page=1" \
-    --jq '.behind_by' 2>/dev/null)" || return 1
+  # One call yields "<behind_by>|<merge base sha>". The merge base rides along
+  # because the "what did main land?" range is `<merge base>...<base>` and
+  # fetching it separately would be a second round trip for a value this
+  # response already carries.
+  cmp="$(gh api "repos/$slug/compare/$base...$head_oid?per_page=1" \
+    --jq '((.behind_by // "") | tostring) + "|" + (.merge_base_commit.sha // "")' \
+    2>/dev/null)" || return 1
+  # Split by FIELD COUNT for the same reason every other answer in this file is:
+  # neither an integer nor a SHA can contain `|`, so a surplus field means the
+  # answer is malformed and must fail closed rather than be seeked into.
+  IFS='|' read -r behind merge_base cmp_rest <<<"$cmp"
+  [[ -z "$cmp_rest" ]] || return 1
   [[ "$behind" =~ ^[0-9]+$ ]] || return 1
-  [[ "$behind" -eq 0 ]]
+  if [[ "$behind" -eq 0 ]]; then return 0; fi
+  [[ "$merge_base" =~ ^[0-9a-f]{7,40}$ ]] || return 1
+  main_changes_are_inert "$slug" "$base" "$head_oid" "$merge_base"
 }
 
 # Fresh LGTM ⇔ latest verdict is LGTM AND its createdAt is strictly newer than

--- a/scripts/ralph/test_pr_ready.sh
+++ b/scripts/ralph/test_pr_ready.sh
@@ -131,9 +131,25 @@ cat > "$BIN/gh" <<'STUB'
 args="$*"
 case "$args" in
   "api "*"compare"*)
-    [[ -n "${COMPARE_SENTINEL:-}" ]] && : > "$COMPARE_SENTINEL"
-    printf '%s\n' "${BEHIND_BY-0}"
-    exit "${COMPARE_EC:-0}" ;;
+    # Three compare calls now, told apart by the --jq the caller passes and by
+    # the range. The behind_by/merge-base probe is the only one a lane that is
+    # already current ever makes; the two file listings are paid only by a lane
+    # that is genuinely behind.
+    if [[ "$args" == *"behind_by"* ]]; then
+      [[ -n "${COMPARE_SENTINEL:-}" ]] && : > "$COMPARE_SENTINEL"
+      printf '%s|%s\n' "${BEHIND_BY-0}" "${MERGE_BASE-abc1234}"
+      exit "${COMPARE_EC:-0}"
+    fi
+    [[ -n "${FILES_SENTINEL:-}" ]] && : > "$FILES_SENTINEL"
+    # `<merge base>...<base>` is what MAIN landed; anything else is `<base>...<head>`,
+    # what THIS BRANCH changed. Both are comma-separated in the fixture and split
+    # to lines here, because a filename cannot contain a comma in these tests.
+    if [[ "$args" == *"compare/${MERGE_BASE-abc1234}..."* ]]; then
+      [[ -n "${THEIR_FILES-}" ]] && printf '%s' "${THEIR_FILES-}" | tr ',' '\n'
+      exit "${THEIR_FILES_EC:-0}"
+    fi
+    [[ -n "${OUR_FILES-}" ]] && printf '%s' "${OUR_FILES-}" | tr ',' '\n'
+    exit "${OUR_FILES_EC:-0}" ;;
   *"pr checks"*)
     if [[ "${CHECKS_NO_CHECKS:-0}" == "1" ]]; then
       echo "no checks reported on the 'feature-x' branch" >&2
@@ -399,15 +415,99 @@ check "changelog noise: hold on an upstream #456 is not ours → ready" "ready" 
 # main: GitHub only says BEHIND when the base branch requires strict up-to-date
 # merging. So `ready` must ask the compare API for `behind_by` directly, or the
 # loop merges branches that never ran against current main.
-check "green + CLEAN + fresh LGTM but 22 behind → behind" "behind" \
-  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=22 run 100)"
+check "green + CLEAN + fresh LGTM but 22 behind, overlapping file → behind" "behind" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=22 \
+     THEIR_FILES="creek/vault/writer.py" OUR_FILES="creek/vault/writer.py" run 100)"
 
 check "behind_by 0 → ready" "ready" \
   "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=0 run 100)"
 
-# One commit is enough: "nearly current" is still not current.
-check "behind_by 1 → behind" "behind" \
-  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=1 run 100)"
+# --- behind ≠ stale: the #1137 regression ----------------------------------
+# Requiring `behind_by == 0` outright made every merge to `main` invalidate every
+# OTHER open lane: each paid a sync, a ~14-minute CI round and a full re-review,
+# and because that window is as long as the gap between merges, lanes went stale
+# again WHILE re-proving themselves. Two bug fixes in different modules cannot
+# turn each other red, so being behind is stale only for a REASON.
+check "behind but disjoint, inert files → ready" "ready" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=22 \
+     THEIR_FILES="creek/classify/privacy.py,tests/test_privacy.py" \
+     OUR_FILES="creek/vault/writer.py,tests/test_writer.py" run 100)"
+
+# One shared file IS a semantic interaction, even buried in a longer list.
+check "behind + one overlapping file among many → behind" "behind" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=3 \
+     THEIR_FILES="creek/a.py,creek/shared.py,creek/b.py" \
+     OUR_FILES="creek/c.py,creek/d.py,creek/shared.py" run 100)"
+
+# A prefix match would read `creek/vault.py` as overlapping `creek/vault_index.py`
+# and re-impose the very serialization this change removes.
+check "behind + merely prefix-similar paths → ready" "ready" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=2 \
+     THEIR_FILES="creek/vault.py" OUR_FILES="creek/vault_index.py" run 100)"
+
+# --- the risk surface: what #1022 was actually right about ------------------
+# PR #943 was a `ruff` bump 22 commits behind, and a bump 17 behind carrying a
+# ruff major produced 144 lint errors against the then-current tree. A change to
+# how the tree is built/linted/typed/tested invalidates EVERY branch's green,
+# overlap or not — so each of these must still force a sync.
+for risky in "creek-tools/uv.lock" "creek-tools/pyproject.toml" \
+             "crawdad/requirements-dev.txt" ".pre-commit-config.yaml" \
+             "creek-tools/tests/conftest.py" ".github/workflows/ci.yml" \
+             "creek-tools/scripts/check-all.sh"; do
+  check "risk surface on main ($risky) → behind" "behind" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=4 \
+       THEIR_FILES="creek/unrelated.py,$risky" OUR_FILES="creek/mine.py" run 100)"
+done
+
+# OUR side of the risk surface counts too, and the reason is sharper: a branch
+# that changes the tooling has proved it only against the tree at its merge base,
+# so everything main landed after that is code the new tooling never ran over.
+check "risk surface on OUR side, inert main → behind" "behind" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=4 \
+     THEIR_FILES="creek/unrelated.py" OUR_FILES="creek/mine.py,creek-tools/uv.lock" run 100)"
+
+# The twin: a path that merely LOOKS like the risk surface is not it. Without
+# this, `docs/pyproject.toml.md` or `creek/scripts/helper.py` would silently
+# re-serialize the fleet.
+check "risk-surface look-alikes are inert → ready" "ready" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=4 \
+     THEIR_FILES="docs/pyproject.toml.md,creek/scripts/helper.py,docs/workflows/ci.yml" \
+     OUR_FILES="creek/mine.py" run 100)"
+
+# --- fail closed on every unusable answer ----------------------------------
+# The file listings decide whether to SKIP a sync, so an answer we cannot trust
+# has to read as "sync anyway" — the remedy is always safe, a false `ready` is not.
+check "main-side file listing errors → behind" "behind" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=5 \
+     THEIR_FILES="creek/a.py" THEIR_FILES_EC=1 OUR_FILES="creek/b.py" run 100)"
+
+check "branch-side file listing errors → behind" "behind" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=5 \
+     THEIR_FILES="creek/a.py" OUR_FILES="creek/b.py" OUR_FILES_EC=1 run 100)"
+
+# GitHub caps `.files` at 300. AT the cap the list is truncated, so "disjoint" is
+# an answer the data cannot support.
+TRUNCATED="$(seq 1 300 | sed 's|^|creek/f|; s|$|.py|' | paste -sd, -)"
+check "300-file (capped) main listing → behind" "behind" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=6 \
+     THEIR_FILES="$TRUNCATED" OUR_FILES="creek/mine.py" run 100)"
+
+# 299 is under the cap and therefore a complete, usable list — the non-vacuity
+# twin proving the check above is about truncation, not about list length.
+UNDER_CAP="$(seq 1 299 | sed 's|^|creek/f|; s|$|.py|' | paste -sd, -)"
+check "299-file (uncapped) main listing → ready" "ready" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=6 \
+     THEIR_FILES="$UNDER_CAP" OUR_FILES="creek/mine.py" run 100)"
+
+# The merge base comes from the same call as behind_by and builds the main-side
+# compare range; a malformed one would compare against a garbage ref.
+check "malformed merge base → behind" "behind" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=7 \
+     MERGE_BASE="not-a-sha" THEIR_FILES="creek/a.py" OUR_FILES="creek/b.py" run 100)"
+
+check "empty merge base → behind" "behind" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=7 \
+     MERGE_BASE="" THEIR_FILES="creek/a.py" OUR_FILES="creek/b.py" run 100)"
 
 # Fail CLOSED. A compare call that errors (rate limit, 404 on a force-pushed OID)
 # must not inherit the happy answer that happens to be on stdout.
@@ -487,6 +587,30 @@ tok="$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" \
 check "lazy compare: would-be-ready lane token" "ready" "$tok"
 probed "lazy compare: would-be-ready lane DOES probe" "yes" "$S_READY"
 
+# The file listings are lazy INSIDE the compare probe as well: `behind_by == 0`
+# is the overwhelmingly common answer and must still cost exactly ONE request,
+# or the fix for #1137 would tax every already-current lane on every wake.
+S_F_CURRENT="$WORK/probe-files-current"
+tok="$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" \
+       BEHIND_BY=0 FILES_SENTINEL="$S_F_CURRENT" run 100)" || tok="exit-$?"
+check "lazy files: current lane token" "ready" "$tok"
+probed "lazy files: current lane does not list files" "no" "$S_F_CURRENT"
+
+S_F_BEHIND="$WORK/probe-files-behind"
+tok="$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=9 \
+       THEIR_FILES="creek/a.py" OUR_FILES="creek/b.py" \
+       FILES_SENTINEL="$S_F_BEHIND" run 100)" || tok="exit-$?"
+check "lazy files: behind lane token" "ready" "$tok"
+probed "lazy files: behind lane DOES list files" "yes" "$S_F_BEHIND"
+
+# And a lane behind a RISK-SURFACE change never pays for the branch-side listing:
+# the main-side answer already decided it.
+S_F_RISK="$WORK/probe-files-risk"
+tok="$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=9 \
+       THEIR_FILES="creek-tools/uv.lock" OUR_FILES="creek/b.py" OUR_FILES_EC=1 \
+       FILES_SENTINEL="$S_F_RISK" run 100)" || tok="exit-$?"
+check "lazy files: risk-surface lane short-circuits" "behind" "$tok"
+
 S_OPTOUT="$WORK/probe-optout"
 tok="$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" \
        BEHIND_BY=22 PR_LABELS="$OPTOUT" COMPARE_SENTINEL="$S_OPTOUT" run 100)" || tok="exit-$?"
@@ -524,9 +648,23 @@ check "reviewless setup WITH a fresh LGTM → ready" "ready" \
      PR_AUTHOR="$DEPENDABOT" HEAD_AUTHOR="$DEPENDABOT_COMMIT" \
      REVIEW_CONCLUSIONS="$SKIPPED" run 100)"
 
-# Skipping review does NOT skip freshness or mergeability.
-check "reviewless but 22 behind → behind" "behind" \
+# Skipping review does NOT skip freshness or mergeability. A bump changes the
+# risk surface BY DEFINITION — its lockfile is the thing that decides how the
+# whole tree lints and builds — so it re-proves itself every time `main` moves,
+# no matter how unrelated main's commits look. This is PR #943's case: a `ruff`
+# bump 22 behind, whose own green said nothing about the 22 commits after it.
+check "reviewless bump 22 behind (its own lockfile) → behind" "behind" \
   "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$NO_VERDICT" BEHIND_BY=22 \
+     THEIR_FILES="creek/unrelated.py" OUR_FILES="creek-tools/uv.lock,creek-tools/pyproject.toml" \
+     PR_AUTHOR="$DEPENDABOT" HEAD_AUTHOR="$DEPENDABOT_COMMIT" \
+     REVIEW_CONCLUSIONS="$SKIPPED" run 100)"
+
+# The twin, so the check above is provably about the risk surface and not about
+# `ready-unreviewed` losing its freshness gate: the same reviewless lane, equally
+# far behind, touching only ordinary source, still clears.
+check "reviewless bump 22 behind, inert both sides → ready-unreviewed" "ready-unreviewed" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$NO_VERDICT" BEHIND_BY=22 \
+     THEIR_FILES="creek/unrelated.py" OUR_FILES="creek/other.py" \
      PR_AUTHOR="$DEPENDABOT" HEAD_AUTHOR="$DEPENDABOT_COMMIT" \
      REVIEW_CONCLUSIONS="$SKIPPED" run 100)"
 


### PR DESCRIPTION
PR throughput collapsed after #1022 landed the `behind_by == 0` merge gate.
That gate is a self-imposed strict-up-to-date rule -- `main` does not enforce
one -- and it is quadratic in lane count: merging ONE lane pushes every OTHER
open lane behind, and each of them then pays a sync, a ~14-minute CI round and
(because the sync's new HEAD invalidates its LGTM under the stale-verdict
guard) a full re-review. That window is as long as the interval between
merges, so lanes routinely went stale again WHILE re-proving themselves.

Measured across #1022's merge commit, from the Actions API:

                        before      after
  CI runs per PR        1.00        1.61  (max 5)
  review runs per PR    1.00        1.61  (max 5)
  p90 PR CI span        15 min      104 min
  one CI run            13.9 min    13.2 min
  merges/hour           ~1.0        ~0.88   -- with TWICE the lanes

The duration of a CI run did not move. What moved is how many times each PR
has to run it. Per-lane throughput fell 1.0/hr to 0.44/hr; two lanes produce
less than one lane did. Confirmed on PR #1117: five CI+review rounds over 156
minutes, two of them spent on `Merge origin/main` commits that changed no
code, each triggered by a sibling that touched none of its files.

pr-ready.sh now prints `behind` only when `main` has landed something that can
actually invalidate this branch's green:

  * a cross-cutting change on either side -- lockfile, tool pin, workflow,
    check script, root conftest. This keeps what #1022 was right about. PR #943
    was a ruff bump 22 commits behind, and a bump 17 behind carrying a ruff
    major produced 144 lint errors against the then-current tree.
  * a file both changesets touch, which is a genuine semantic interaction.

OUR side of the risk surface counts as well as theirs, and for the sharper
reason: a branch that changes how the tree is linted or built has proved that
only against the tree at its merge base, so everything main landed since is
code the new tooling never ran over. That is PR #943 exactly -- an existing
test caught this and it is now pinned in both directions.

`behind_by == 0` stays the fast path and still short-circuits on one API call,
so an already-current lane costs exactly what it always did. Only a lane that
is genuinely behind pays for the file listings, and it was otherwise about to
pay for a sync plus a full CI round. Every failure path fails CLOSED as before
-- an errored call, a malformed answer, a bad merge base, or a file list at
GitHub's 300-entry cap (where "disjoint" is unsupportable) all read as behind,
whose remedy is always safe.

What backstops the residual risk is the full CI run on `push: main`, which was
considered for removal as redundant and deliberately kept: it re-proves every
squash-merge, so a stale green that slips through is caught on main rather
than assumed away.

Also adds `concurrency` groups to ci.yml and code-review.yml. A lane pushes
repeatedly to the same PR, and the superseded run was burning a full matrix
and a full Claude review on a commit nobody will merge. `cancel-in-progress`
is keyed off `github.event_name` rather than a blanket true, so a `push` run
on main -- the backstop above -- is never cancelled, and grouping by
`github.ref` keeps sibling lanes from cancelling each other.

Tests: 112 pr-ready assertions (up from 97), covering disjoint-inert to ready,
overlap to behind, each risk-surface path to behind with a look-alike twin
proving the regex is not merely matching everything, both file-listing error
paths, the 300-file cap with a 299-file twin, malformed and empty merge bases,
and laziness assertions that a current lane still makes exactly one call.
Full ralph tooling suite green: 267 shell assertions + 65 recap tests.

Refs #1137, #1138, #1140