### PR TITLE
fix(crawdad): make the workflow privacy ceiling real and stop calling it a floor

### DIFF
--- a/crawdad/README.md
+++ b/crawdad/README.md
@@ -110,11 +110,59 @@ message, so the Sonnet composer wraps the tool results in your voice.
 | `/crawdad surface` | Surface paradoxes / liminal content via `creek.lint`. |
 | `/crawdad draft <topic>` | Mine + draft on the supplied topic (`creek.mine` → `creek.draft`). |
 | `/crawdad save <content>` | File the supplied content back to the vault (`creek.save`). |
-| `/crawdad workflow [list]` | v1.0 stub — full workflow DSL ships in v1.1. |
+| `/crawdad workflow [list\|run <name>]` | List registered workflows, or walk one. See [Workflow files](#workflow-files). |
 
 Full grammar reference (including the developer-side `/creek` surface
 for Claude Code) is in
 [`creek-tools/docs/slash-commands.md`](../creek-tools/docs/slash-commands.md).
+
+### Workflow files
+
+`/crawdad workflow run <name>` executes a `*.workflow.yaml` file: a
+deterministic, router-free walk over an ordered list of MCP tool
+calls (DSL reference — interpolation syntax, per-step error handling —
+is the module docstring in `crawdad/crawdad/workflows.py`). Files are
+discovered from two sources, in order, a user `name` beating a
+built-in of the same name: `crawdad/crawdad/builtin_workflows/`
+(shipped, version-controlled) and `<vault>/00-Creek-Meta/Workflows/`
+(your own, outside version control — see
+`crawdad/docs/adr/2026-05-24_workflow-file-location.md`).
+
+| Key | Required | Default | Notes |
+|---|---|---|---|
+| `name` | yes | — | Unique id; the argument to `workflow run <name>`. |
+| `description` | yes | — | Shown by `/crawdad workflow list`. |
+| `trigger` | no | — | Documentation only; not read by the walker. |
+| `phase_aware` | no | `false` | If `true`, refuses to run with no session phase. |
+| `allowed_phases` | no | any | Non-empty list narrows `phase_aware` to specific phases. |
+| `privacy_tier_ceiling` | no | `open` | See below. |
+| `inputs` | no | — | Names the caller must supply, or the run is refused. |
+| `steps` | yes | — | Ordered `{id, tool, args}` list; one MCP tool call each. |
+
+**The ceiling, ordered least-to-most permissive:** `open` <
+`personal` < `intimate` < `all` — despite its name, `open` is the
+*most restrictive* tier, not "no restriction"; that inversion is what
+the old key name got backwards. Only `open`/`personal` may be
+declared: a workflow requesting `intimate` or `all` still parses and
+still shows up in `/crawdad workflow list`, but `run` refuses it in
+Discord at run time, because every tool result is relayed to a cloud
+LLM composer and posted straight into a Discord message.
+
+**Renamed from `privacy_tier_floor`**, which was inverted (raising the
+"floor" widened access). The old key still works, value-preserving,
+with a `WARNING` naming the workflow (removal tracked in
+[#1151](https://github.com/Geoffe-Ga/Creek-Vault/issues/1151)); both
+keys in one file is a parse error. For an existing file:
+`open`/`personal` values run unchanged —
+rename at your leisure; `intimate`/`all` values now get refused at
+`run` (intended — that value was granting intimate reads, never
+requiring intimate protection); both keys present fails to parse and
+the workflow drops out of the listing.
+
+**No per-step ceilings** — a step's `args:` may not set its own
+`privacy_tier_ceiling` (or the deprecated `privacy_tier_floor`); the
+workflow-level value applies to every step, and a step that tries is
+refused at run time, naming the step.
 
 ## Development
 

--- a/crawdad/crawdad/builtin_workflows/compost-surfacing.workflow.yaml
+++ b/crawdad/crawdad/builtin_workflows/compost-surfacing.workflow.yaml
@@ -19,7 +19,7 @@ description: |
   the structured seed list into a short, voice-faithful summary.
 trigger: "/crawdad workflow run compost-surfacing"
 phase_aware: true
-privacy_tier_floor: personal
+privacy_tier_ceiling: personal
 steps:
   - id: read
     tool: creek.state.read

--- a/crawdad/crawdad/builtin_workflows/substack-draft-phase-transitions.workflow.yaml
+++ b/crawdad/crawdad/builtin_workflows/substack-draft-phase-transitions.workflow.yaml
@@ -12,7 +12,7 @@ description: |
   drafts the top-ranked seed via ``creek.draft``.
 trigger: "/crawdad workflow run substack-draft-phase-transitions"
 phase_aware: true
-privacy_tier_floor: personal
+privacy_tier_ceiling: personal
 inputs: []
 steps:
   - id: read

--- a/crawdad/crawdad/builtin_workflows/wavelength-checkin.workflow.yaml
+++ b/crawdad/crawdad/builtin_workflows/wavelength-checkin.workflow.yaml
@@ -11,7 +11,7 @@ description: |
   user's voice register.
 trigger: "/crawdad workflow run wavelength-checkin"
 phase_aware: false
-privacy_tier_floor: open
+privacy_tier_ceiling: open
 steps:
   - id: read
     tool: creek.state.read

--- a/crawdad/crawdad/workflows.py
+++ b/crawdad/crawdad/workflows.py
@@ -4,7 +4,29 @@ CrawDad composite commands compile down to a deterministic walk over
 authored YAML files. Each file declares a named workflow: a list of
 :class:`WorkflowStep` entries that map one-to-one to MCP tool calls,
 plus first-class constraint metadata (``phase_aware`` /
-``privacy_tier_floor``) the walker enforces before any tool fires.
+``privacy_tier_ceiling``).
+
+Pre-flight enforcement
+----------------------
+
+:meth:`WorkflowWalker._check_constraints` runs before the MCP session is
+opened, so a refusal costs zero tool calls. It enforces exactly five
+things, raising :class:`WorkflowConstraintError` on the first that
+fails — in this order, privacy first:
+
+1. ``privacy_tier_ceiling`` is inside :data:`WORKFLOW_ADMITTED_CEILINGS`;
+2. no step's ``args`` declares a ``privacy_tier_ceiling`` of its own —
+   per-step ceilings are not a supported feature;
+3. every name in ``inputs:`` was supplied by the caller;
+4. every step's ``tool:`` is advertised by the live MCP server;
+5. when ``phase_aware: true``, a session phase exists and (if
+   ``allowed_phases`` is non-empty) is one of the allowed ones.
+
+Note what is *not* enforced here: the admitted ceiling value itself is
+merely forwarded, verbatim, as a sibling argument on every tool call.
+The MCP server is what actually applies it when selecting content. The
+walker's only privacy job is to refuse the ceilings CrawDad must never
+request at all — see :data:`WORKFLOW_ADMITTED_CEILINGS`.
 
 File format
 -----------
@@ -17,7 +39,7 @@ looks like::
     trigger: "/crawdad workflow run substack-draft-phase-transitions"
     phase_aware: true
     allowed_phases: [rising, peak]
-    privacy_tier_floor: personal
+    privacy_tier_ceiling: personal
     inputs: [topic]
     steps:
       - id: read
@@ -75,10 +97,17 @@ from __future__ import annotations
 import logging
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Final, cast
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
 
 from crawdad.dispatcher import ToolResult
 from crawdad.intents import PrivacyTierCeiling
@@ -102,6 +131,44 @@ BUILTIN_WORKFLOWS_DIR: Path = Path(__file__).resolve().parent / "builtin_workflo
 VAULT_WORKFLOWS_SUBPATH: Path = Path("00-Creek-Meta") / "Workflows"
 
 _WORKFLOW_FILE_SUFFIX = ".workflow.yaml"
+
+# The canonical privacy-ceiling key. The YAML key, the
+# :class:`WorkflowDefinition` field, and the sibling argument the MCP
+# server reads all share this one spelling by design, so the author
+# reads the same word in the file, the model, and the wire call.
+_CEILING_KEY = "privacy_tier_ceiling"
+
+# The pre-#1051 spelling of that key. Still accepted, value-preserving,
+# with a deprecation warning — see
+# :meth:`WorkflowDefinition._migrate_privacy_tier_floor`.
+_LEGACY_CEILING_KEY = "privacy_tier_floor"
+
+# The only privacy tier ceilings an authored workflow may request.
+#
+# CrawDad relays every :class:`~crawdad.dispatcher.ToolResult` body to a
+# cloud LLM composer and then posts the reply into a Discord message, so
+# ``intimate`` / ``all`` must never be requestable by a workflow file.
+# ``ALL`` subsumes ``intimate``, so the admitted set is the complement.
+#
+# The value coincides with ``creek_mcp.policy.REMOTE_ADMITTED_CEILINGS``
+# (``{OPEN, PERSONAL}`` — "intimate content is not reachable over the
+# network") but is NOT derived from it, and the two are not canonical
+# for each other: that cap draws the line at the network, this one at
+# the cloud composer. The reasoning above stands on its own if the
+# server-side set ever changes.
+#
+# This walker check is the ONLY gate on this path, not a redundant second
+# copy of the server's: CrawDad reaches the MCP server over **stdio**,
+# which ``creek_mcp/server.py::_caller_identity`` classifies as a LOCAL
+# caller (``is_remote=False``), so the server-side remote cap never fires
+# here. (Prose reference only — crawdad has no Python dependency on
+# creek-tools.)
+#
+# Membership (``in``), never a rank comparison: ``crawdad.loop`` owns the
+# single tier-ordering table and a second one must not exist.
+WORKFLOW_ADMITTED_CEILINGS: Final[frozenset[PrivacyTierCeiling]] = frozenset(
+    {PrivacyTierCeiling.OPEN, PrivacyTierCeiling.PERSONAL}
+)
 
 # ``\w`` matches the YAML-friendly subset we accept inside placeholder
 # tokens (alphanumerics, underscore). Dotted access is the only nesting
@@ -135,7 +202,15 @@ class WorkflowConstraintError(RuntimeError):
 
     Raised for any of: missing required input, missing session-state
     phase when ``phase_aware: true``, current phase not in
-    ``allowed_phases``, or a step referencing an unadvertised MCP tool.
+    ``allowed_phases``, a step referencing an unadvertised MCP tool, a
+    ``privacy_tier_ceiling`` outside :data:`WORKFLOW_ADMITTED_CEILINGS`,
+    or a step whose ``args`` tries to declare its own
+    ``privacy_tier_ceiling``.
+
+    Every one of these is checked pre-flight, before the MCP session is
+    opened. Keep this list in sync with
+    :meth:`WorkflowWalker._check_constraints` — stale prose here is how
+    the ceiling gap of #1051 hid in plain sight.
     """
 
 
@@ -220,10 +295,28 @@ class WorkflowStep(BaseModel):
 class WorkflowDefinition(BaseModel):
     """An authored workflow loaded from a ``*.workflow.yaml`` file.
 
-    ``phase_aware`` and ``privacy_tier_floor`` are the AC's first-class
-    constraint attributes. The walker treats them as soft-fail gates
-    rather than runtime errors so the slash-command surface can return
-    a clean user-facing message instead of a stack trace.
+    ``phase_aware`` and ``privacy_tier_ceiling`` are the AC's
+    first-class constraint attributes. Both are soft-fail gates: the
+    walker raises :class:`WorkflowConstraintError`, which the
+    slash-command surface turns into a clean user-facing message rather
+    than a stack trace. That mechanism is unchanged.
+
+    What they cover, precisely (#1051 — the previous wording implied the
+    ceiling was enforced when nothing read it at all):
+
+    * ``phase_aware`` / ``allowed_phases`` gate *when* the workflow may
+      run.
+    * ``privacy_tier_ceiling`` is capped at walk time to
+      :data:`WORKFLOW_ADMITTED_CEILINGS`; an admitted value is then
+      forwarded verbatim to the MCP server, which is what applies it.
+      A ceiling above the cap is refused loudly at run time and
+      deliberately NOT at parse time — see
+      :meth:`WorkflowWalker._check_privacy_ceiling`.
+
+    ``privacy_tier_floor`` is the deprecated spelling of
+    ``privacy_tier_ceiling``. It is still accepted, value-preserving,
+    with a WARNING; declaring both keys is an error. See
+    :meth:`_migrate_privacy_tier_floor`.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -233,9 +326,67 @@ class WorkflowDefinition(BaseModel):
     trigger: str | None = None
     phase_aware: bool = False
     allowed_phases: tuple[str, ...] = ()
-    privacy_tier_floor: PrivacyTierCeiling = PrivacyTierCeiling.OPEN
+    privacy_tier_ceiling: PrivacyTierCeiling = PrivacyTierCeiling.OPEN
     inputs: tuple[str, ...] = ()
     steps: tuple[WorkflowStep, ...]
+
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_privacy_tier_floor(cls, data: Any) -> Any:
+        """Accept the deprecated ``privacy_tier_floor`` key, warning once.
+
+        The field was misnamed (#1051): ``open`` is the MOST restrictive
+        tier and ``all`` the broadest, so raising the so-called "floor"
+        *widened* what the MCP server returned. The key always was a
+        ceiling. The migration is therefore value-preserving — a file
+        declaring ``privacy_tier_floor: personal`` keeps requesting
+        exactly ``personal``, it just stops lying about the direction.
+
+        ``mode="before"`` so both entry points are covered:
+        :func:`load_workflow_from_yaml`'s ``model_validate(dict)`` and
+        direct ``WorkflowDefinition(privacy_tier_floor=...)`` kwargs
+        construction.
+
+        Declaring both spellings is ambiguous — silently picking a
+        winner could ship a different effective ceiling than the author
+        last read — so it raises :class:`ValueError`. That type is
+        deliberate: pydantic converts only ``ValueError`` /
+        ``AssertionError`` into a ``ValidationError``, which
+        :func:`load_workflow_from_yaml` already maps to
+        :class:`WorkflowParseError`.
+        """
+        # Pydantic hands non-dict payloads to "before" validators in
+        # some construction modes; nothing to migrate in those.
+        if not isinstance(data, dict):
+            return data
+        if _LEGACY_CEILING_KEY not in data:
+            return data
+        raw_name = data.get("name")
+        name = raw_name if isinstance(raw_name, str) else "<unnamed>"
+        if _CEILING_KEY in data:
+            msg = (
+                f"workflow {name!r} declares both {_LEGACY_CEILING_KEY!r} and "
+                f"{_CEILING_KEY!r}; the former is the deprecated spelling of "
+                f"the latter — keep only {_CEILING_KEY!r}"
+            )
+            raise ValueError(msg)
+        # Copy rather than mutate: the caller may still own this dict.
+        # The legacy key is popped, not merely shadowed, so no stale
+        # spelling survives into the model payload.
+        migrated = dict(data)
+        migrated[_CEILING_KEY] = migrated.pop(_LEGACY_CEILING_KEY)
+        _LOGGER.warning(
+            "workflow %r uses the deprecated key %r; rename it to %r. The "
+            "value is unchanged: the key always was a ceiling, not a floor "
+            "(%r is the most restrictive tier, %r the broadest). The alias "
+            "will be removed — see issue #1151.",
+            name,
+            _LEGACY_CEILING_KEY,
+            _CEILING_KEY,
+            PrivacyTierCeiling.OPEN.value,
+            PrivacyTierCeiling.ALL.value,
+        )
+        return migrated
 
     @field_validator("steps")
     @classmethod
@@ -590,7 +741,9 @@ class WorkflowWalker:
 
         Raises:
             WorkflowConstraintError: a declared constraint refused the
-                run — missing input, wrong phase, unknown tool, etc.
+                run — missing input, unknown tool, a privacy ceiling
+                above the cap, a step-level ceiling, or the wrong
+                phase. Always raised before the MCP session opens.
             WorkflowStepError: a step failed mid-walk — either its
                 ``args`` reference an unresolvable upstream step or
                 its MCP tool call raised. The error names the failing
@@ -609,7 +762,21 @@ class WorkflowWalker:
         state: SessionState | None,
         inputs: dict[str, str],
     ) -> None:
-        """Validate phase, inputs, and tool surface before any tool fires."""
+        """Validate privacy ceilings, inputs, tools, and phase pre-flight.
+
+        Every check here runs before :meth:`run` opens the MCP session,
+        so a refusal costs zero tool calls. Kept as a flat sequence of
+        guards — each non-trivial rule lives in its own ``_check_*``
+        helper so this stays readable as the rule set grows.
+
+        The privacy guards run FIRST, and that order is deliberate:
+        only the first failure is reported, so putting the missing-input
+        or unknown-tool checks ahead of them would walk an author with
+        several problems up to the privacy refusal one round trip at a
+        time. The privacy rule must never be the second thing said.
+        """
+        self._check_privacy_ceiling(workflow)
+        self._check_step_arg_ceilings(workflow)
         missing_inputs = [name for name in workflow.inputs if name not in inputs]
         if missing_inputs:
             msg = (
@@ -628,6 +795,84 @@ class WorkflowWalker:
             raise WorkflowConstraintError(msg)
         if workflow.phase_aware:
             self._check_phase(workflow, state)
+
+    def _check_privacy_ceiling(self, workflow: WorkflowDefinition) -> None:
+        """Refuse a workflow ceiling outside :data:`WORKFLOW_ADMITTED_CEILINGS`.
+
+        The cap is enforced HERE, at walk time, and deliberately not as
+        a pydantic validator. Two reasons, and the second is the one
+        that must stop a future editor from "improving" this into a
+        validator:
+
+        1. :func:`_absorb_dir` catches :class:`WorkflowParseError` and
+           does ``warning(); continue``, so a parse-time rejection would
+           make the workflow vanish from ``/crawdad workflow list`` with
+           no user-visible reason. Fail-invisible is worse than the bug
+           this closes.
+        2. A validator only guards *validated* construction.
+           ``model_construct`` and ``model_copy(update=...)`` sail
+           straight past one — both verified to produce an ``all``-tier
+           definition. This check sits on the only path to
+           ``session.call_tool``, so it holds for every construction
+           route, not just the parsed one.
+
+        The message lands verbatim in a Discord reply (see
+        :func:`crawdad.slash_commands._reply_workflow_run`), so it names
+        the workflow, the refused tier, the allowed set, and why. Every
+        token it interpolates is operator-*authored* — a workflow name,
+        a tier the author typed, a module constant. Keep it that way:
+        interpolating a tool result or any vault-derived value would
+        turn a refusal into an oracle over content the caller never had
+        (the #1090 hazard), which is exactly what this refusal is free
+        of today.
+        """
+        tier = workflow.privacy_tier_ceiling
+        if tier not in WORKFLOW_ADMITTED_CEILINGS:
+            allowed = ", ".join(sorted(t.value for t in WORKFLOW_ADMITTED_CEILINGS))
+            msg = (
+                f"workflow {workflow.name!r} declares {_CEILING_KEY} "
+                f"{tier.value!r}, which CrawDad refuses to request: every tool "
+                "result is relayed to a cloud LLM composer and then posted "
+                "into a Discord message, so material above the cap must never "
+                f"be asked for on this path. Allowed ceilings: {allowed}."
+            )
+            raise WorkflowConstraintError(msg)
+
+    def _check_step_arg_ceilings(self, workflow: WorkflowDefinition) -> None:
+        """Refuse any step whose ``args`` declares its own privacy ceiling.
+
+        ANY step-level declaration is refused, not just a widening one.
+        Deciding "is this wider?" would need a tier-ordering comparison
+        (``crawdad.loop`` owns the only such table), and admitting a
+        narrowing value would teach authors that per-step ceilings are a
+        supported feature when they are not.
+
+        Today such a key is silently overwritten by
+        :func:`_build_call_arguments`. That is safe, but it gives the
+        author neither the tier they asked for nor any signal their line
+        was discarded — the same false-assurance defect as the headline
+        bug of #1051, one level down.
+
+        Both spellings are refused. Scoping this to :data:`_CEILING_KEY`
+        alone would leave a step's ``privacy_tier_floor: all`` silently
+        accepted — that name is dead everywhere else, no MCP tool reads
+        it, and a line that does nothing while looking like a privacy
+        control is the very shape #1051 exists to close.
+        """
+        offenders = [
+            step.id
+            for step in workflow.steps
+            if _CEILING_KEY in step.args or _LEGACY_CEILING_KEY in step.args
+        ]
+        if offenders:
+            msg = (
+                f"workflow {workflow.name!r} sets {_CEILING_KEY!r} (or its "
+                f"deprecated spelling {_LEGACY_CEILING_KEY!r}) in the args of "
+                f"step(s) {offenders}: per-step privacy ceilings are not "
+                "supported — the workflow-level ceiling applies to every step. "
+                "Remove the key from those steps."
+            )
+            raise WorkflowConstraintError(msg)
 
     def _check_phase(
         self, workflow: WorkflowDefinition, state: SessionState | None
@@ -695,7 +940,7 @@ class WorkflowWalker:
                 step.args, state=state, inputs=inputs, step_results=step_results
             )
             arguments = _build_call_arguments(
-                resolved_args, workflow.privacy_tier_floor
+                resolved_args, workflow.privacy_tier_ceiling
             )
             body = await session.call_tool(step.tool, arguments)
         except (_StepRefError, WorkflowStepError) as exc:
@@ -705,7 +950,7 @@ class WorkflowWalker:
         return ToolResult(
             intent_type=step.tool,
             body=body,
-            privacy_tier_ceiling=workflow.privacy_tier_floor,
+            privacy_tier_ceiling=workflow.privacy_tier_ceiling,
         )
 
 
@@ -766,20 +1011,31 @@ def _wrap_step_failure(
 
 
 def _build_call_arguments(
-    resolved_args: Any, floor: PrivacyTierCeiling
+    resolved_args: Any, ceiling: PrivacyTierCeiling
 ) -> dict[str, Any]:
-    """Merge interpolated args with the privacy floor, matching dispatcher semantics.
+    """Merge interpolated args with the privacy ceiling, dispatcher-style.
 
     The MCP server reads ``privacy_tier_ceiling`` as a sibling argument
     on every tool call (see :mod:`crawdad.dispatcher._build_arguments`).
-    The workflow's declared floor is the contract; any colliding key
-    in the user-authored args is overwritten so a workflow author
-    cannot accidentally smuggle a looser tier in through the args dict.
+    The workflow's declared ceiling is the contract, so any colliding
+    key in the resolved args is overwritten rather than honoured.
+
+    :meth:`WorkflowWalker._check_step_arg_ceilings` now refuses that
+    collision up front, loudly, before the session opens. This
+    overwrite stays as defence in depth for a future programmatic
+    caller that reaches this helper without having gone through
+    :meth:`WorkflowWalker._check_constraints`. Never remove the belt
+    because braces were added.
+
+    It is NOT a guard against a ceiling appearing during interpolation:
+    :func:`interpolate` recurses over dict *values* only, so no new
+    top-level key can materialise. Saying otherwise would be exactly
+    the kind of overclaiming prose #1051 is a postmortem about.
     """
     payload: dict[str, Any] = (
         dict(resolved_args) if isinstance(resolved_args, dict) else {}
     )
-    payload["privacy_tier_ceiling"] = floor.value
+    payload[_CEILING_KEY] = ceiling.value
     return payload
 
 
@@ -820,9 +1076,10 @@ async def run_workflow_and_compose(
 
     Raises:
         WorkflowConstraintError: a declared constraint refused the run
-            (missing required input, wrong phase, unknown MCP tool).
-            Callers map these to a Discord soft error rather than
-            crashing the bot.
+            (missing required input, wrong phase, unknown MCP tool, a
+            privacy ceiling outside :data:`WORKFLOW_ADMITTED_CEILINGS`,
+            or a step declaring its own ceiling). Callers map these to
+            a Discord soft error rather than crashing the bot.
         WorkflowStepError: the walker aborted mid-walk because a step
             failed — either its interpolation references an
             unresolvable upstream step or its MCP tool call raised.

--- a/crawdad/tests/test_workflows.py
+++ b/crawdad/tests/test_workflows.py
@@ -3,7 +3,8 @@
 Covers:
 
 * Workflow model validation (parser happy + malformed)
-* Constraint enforcement (phase-aware refusal, privacy floor propagation)
+* Constraint enforcement (phase-aware refusal, privacy ceiling cap +
+  propagation, deprecated ``privacy_tier_floor`` alias migration)
 * Step-walker semantics (deterministic walk + interpolation)
 * Registry file discovery (built-in + vault)
 * The three reference workflows shipped with the package
@@ -11,6 +12,7 @@ Covers:
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from textwrap import dedent
 from typing import Any
@@ -24,6 +26,7 @@ from crawdad.state import SessionState
 from crawdad.workflows import (
     BUILTIN_WORKFLOWS_DIR,
     VAULT_WORKFLOWS_SUBPATH,
+    WORKFLOW_ADMITTED_CEILINGS,
     WorkflowConstraintError,
     WorkflowDefinition,
     WorkflowNotFoundError,
@@ -32,6 +35,7 @@ from crawdad.workflows import (
     WorkflowStep,
     WorkflowStepError,
     WorkflowWalker,
+    _build_call_arguments,
     _StepRefError,
     _synthesize_user_message,
     interpolate,
@@ -39,6 +43,35 @@ from crawdad.workflows import (
     resolve_phase,
     run_workflow_and_compose,
 )
+
+# The three reference workflows shipped in ``BUILTIN_WORKFLOWS_DIR``,
+# paired with the privacy ceiling each declares. The values are the
+# ones the files carried under the old ``privacy_tier_floor`` key — the
+# #1051 rename is value-preserving, so a drift here means a builtin's
+# effective MCP ceiling moved during the rename.
+_REFERENCE_WORKFLOW_CEILINGS: tuple[tuple[str, PrivacyTierCeiling], ...] = (
+    ("wavelength-checkin.workflow.yaml", PrivacyTierCeiling.OPEN),
+    ("compost-surfacing.workflow.yaml", PrivacyTierCeiling.PERSONAL),
+    (
+        "substack-draft-phase-transitions.workflow.yaml",
+        PrivacyTierCeiling.PERSONAL,
+    ),
+)
+
+_REFERENCE_WORKFLOW_IDS: list[str] = [
+    filename.removesuffix(".workflow.yaml")
+    for filename, _ in _REFERENCE_WORKFLOW_CEILINGS
+]
+
+
+def _workflow_warnings(caplog: pytest.LogCaptureFixture) -> list[str]:
+    """Return WARNING+ messages emitted by the ``crawdad.workflows`` logger."""
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "crawdad.workflows" and record.levelno >= logging.WARNING
+    ]
+
 
 # ---------------------------------------------------------------------------
 # Models + parser
@@ -54,7 +87,7 @@ def test_workflow_definition_minimal() -> None:
     )
 
     assert wf.phase_aware is False
-    assert wf.privacy_tier_floor == PrivacyTierCeiling.OPEN
+    assert wf.privacy_tier_ceiling == PrivacyTierCeiling.OPEN
     assert wf.allowed_phases == ()
     assert wf.inputs == ()
     assert wf.trigger is None
@@ -102,7 +135,7 @@ def test_load_workflow_from_yaml_round_trip(tmp_path: Path) -> None:
             trigger: "/crawdad workflow run demo"
             phase_aware: true
             allowed_phases: [rising, peak]
-            privacy_tier_floor: personal
+            privacy_tier_ceiling: personal
             inputs: [topic]
             steps:
               - id: read
@@ -125,7 +158,7 @@ def test_load_workflow_from_yaml_round_trip(tmp_path: Path) -> None:
     assert wf.trigger == "/crawdad workflow run demo"
     assert wf.phase_aware is True
     assert wf.allowed_phases == ("rising", "peak")
-    assert wf.privacy_tier_floor == PrivacyTierCeiling.PERSONAL
+    assert wf.privacy_tier_ceiling == PrivacyTierCeiling.PERSONAL
     assert wf.inputs == ("topic",)
     assert len(wf.steps) == 2
     assert wf.steps[0].id == "read"
@@ -179,6 +212,157 @@ def test_load_workflow_from_yaml_empty_file_raises(tmp_path: Path) -> None:
     path.write_text("", encoding="utf-8")
 
     with pytest.raises(WorkflowParseError):
+        load_workflow_from_yaml(path)
+
+
+# ---------------------------------------------------------------------------
+# Deprecated ``privacy_tier_floor`` alias (#1051)
+# ---------------------------------------------------------------------------
+#
+# The field was misnamed: ``OPEN`` is the MOST restrictive tier and
+# ``ALL`` the broadest, so raising the so-called "floor" WIDENED what
+# the MCP server returned. The rename to ``privacy_tier_ceiling`` is
+# value-preserving — an existing file keeps the exact tier it declared,
+# it just stops lying about the direction.
+
+
+def _ceiling_workflow_yaml(key: str | None, value: str = "personal") -> str:
+    """Return a minimal workflow document declaring *key* = *value*.
+
+    ``key`` of ``None`` omits the privacy declaration entirely so the
+    default-path test exercises the same document shape as the rest.
+    """
+    declaration = "" if key is None else f"{key}: {value}\n"
+    return (
+        "name: aliased\n"
+        "description: exercises the privacy tier key\n"
+        f"{declaration}"
+        "steps:\n"
+        "  - id: read\n"
+        "    tool: creek.state.read\n"
+    )
+
+
+def test_yaml_legacy_privacy_tier_floor_key_migrates(tmp_path: Path) -> None:
+    """A file still using ``privacy_tier_floor`` loads under the new field name.
+
+    Value-preserving: ``personal`` in, ``PERSONAL`` out. The legacy key
+    must NOT survive as a second attribute — the model exposes exactly
+    one privacy attribute, ``privacy_tier_ceiling``.
+    """
+    path = tmp_path / "legacy.workflow.yaml"
+    path.write_text(
+        _ceiling_workflow_yaml("privacy_tier_floor", "personal"), encoding="utf-8"
+    )
+
+    wf = load_workflow_from_yaml(path)
+
+    assert wf.privacy_tier_ceiling == PrivacyTierCeiling.PERSONAL
+    assert not hasattr(wf, "privacy_tier_floor")
+
+
+def test_yaml_legacy_privacy_tier_floor_key_warns_naming_workflow(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The legacy key is accepted but logs a WARNING that names the workflow.
+
+    A silent migration would leave every authored file on a deprecated
+    key forever. The warning has to name the offending workflow or the
+    operator cannot find the file to edit.
+    """
+    path = tmp_path / "legacy-warn.workflow.yaml"
+    path.write_text(
+        _ceiling_workflow_yaml("privacy_tier_floor", "personal"), encoding="utf-8"
+    )
+
+    with caplog.at_level(logging.WARNING, logger="crawdad.workflows"):
+        wf = load_workflow_from_yaml(path)
+
+    messages = _workflow_warnings(caplog)
+    assert len(messages) == 1
+    assert "privacy_tier_floor" in messages[0]
+    assert "privacy_tier_ceiling" in messages[0]
+    assert "aliased" in messages[0]
+    assert wf.privacy_tier_ceiling == PrivacyTierCeiling.PERSONAL
+
+
+def test_kwargs_legacy_privacy_tier_floor_migrates() -> None:
+    """Direct kwargs construction migrates too, not just ``model_validate``.
+
+    The alias lives in a ``mode="before"`` model validator precisely so
+    both entry points are covered: :func:`load_workflow_from_yaml` goes
+    through ``model_validate(dict)``, but in-process callers (and the
+    walker tests) construct ``WorkflowDefinition(...)`` directly.
+    """
+    wf = WorkflowDefinition(
+        name="kwargs-legacy",
+        description="constructed with the deprecated keyword",
+        privacy_tier_floor=PrivacyTierCeiling.PERSONAL,
+        steps=(WorkflowStep(id="read", tool="creek.state.read"),),
+    )
+
+    assert wf.privacy_tier_ceiling == PrivacyTierCeiling.PERSONAL
+
+
+def test_canonical_privacy_tier_ceiling_key_emits_no_warning(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A file already on the canonical key is silent — no deprecation noise."""
+    path = tmp_path / "canonical.workflow.yaml"
+    path.write_text(
+        _ceiling_workflow_yaml("privacy_tier_ceiling", "personal"), encoding="utf-8"
+    )
+
+    with caplog.at_level(logging.WARNING, logger="crawdad.workflows"):
+        wf = load_workflow_from_yaml(path)
+
+    assert wf.privacy_tier_ceiling == PrivacyTierCeiling.PERSONAL
+    assert _workflow_warnings(caplog) == []
+
+
+def test_absent_privacy_tier_key_defaults_to_open_without_warning(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Omitting the key falls back to ``OPEN`` and warns about nothing.
+
+    ``OPEN`` is the most restrictive tier, so the default is the safe
+    one. A workflow that never mentioned the legacy key must not be
+    accused of using it.
+    """
+    path = tmp_path / "defaulted.workflow.yaml"
+    path.write_text(_ceiling_workflow_yaml(None), encoding="utf-8")
+
+    with caplog.at_level(logging.WARNING, logger="crawdad.workflows"):
+        wf = load_workflow_from_yaml(path)
+
+    assert wf.privacy_tier_ceiling == PrivacyTierCeiling.OPEN
+    assert _workflow_warnings(caplog) == []
+
+
+def test_both_privacy_tier_keys_raise_workflow_parse_error(tmp_path: Path) -> None:
+    """Declaring both the legacy and canonical keys is ambiguous — refuse it.
+
+    Silently picking a winner would let a half-finished migration ship a
+    different effective ceiling than the author last read. The
+    ``ValueError`` the validator raises reaches the caller as a
+    :class:`WorkflowParseError` via the loader's ``ValidationError``
+    mapping.
+    """
+    path = tmp_path / "both.workflow.yaml"
+    path.write_text(
+        (
+            "name: ambiguous\n"
+            "description: declares the privacy tier twice\n"
+            "privacy_tier_floor: open\n"
+            "privacy_tier_ceiling: personal\n"
+            "steps:\n"
+            "  - id: read\n"
+            "    tool: creek.state.read\n"
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(WorkflowParseError, match="privacy_tier_floor"):
         load_workflow_from_yaml(path)
 
 
@@ -643,18 +827,29 @@ class _FakeMCPClient:
     ignore[arg-type]`` at every call site. Both fakes implement the
     same ``call_tool`` shape; the walker only ever invokes that one
     method.
+
+    ``connect_calls`` / ``entered`` exist so pre-flight tests can prove
+    a constraint fired *before any tool could fire* (#1051). Asserting
+    only that ``run()`` raised is not enough: a check placed inside the
+    step loop would raise too, after the session was already open and
+    (for a multi-step workflow) after earlier tools had already run.
     """
 
     def __init__(self, session: Any) -> None:
         """Stash the session that ``connect()`` will yield."""
         self._session = session
+        self.connect_calls = 0
+        self.entered = False
 
     def connect(self) -> Any:
         """Async-context-manager that yields the wrapped session."""
         from contextlib import asynccontextmanager
 
+        self.connect_calls += 1
+
         @asynccontextmanager
         async def _ctx() -> Any:
+            self.entered = True
             yield self._session
 
         return _ctx()
@@ -698,19 +893,41 @@ async def test_walker_runs_each_step_in_order() -> None:
     assert results[0].body == "phase: rising"
 
 
-async def test_walker_propagates_privacy_floor_to_each_call() -> None:
-    """Every step receives ``privacy_tier_ceiling`` = the workflow's floor."""
+async def test_walker_propagates_privacy_ceiling_to_each_call() -> None:
+    """Every step receives ``privacy_tier_ceiling`` = the workflow's ceiling."""
     session = _FakeSession()
     walker = WorkflowWalker(
         mcp_client=_FakeMCPClient(session),
         known_tools=("creek.state.read", "creek.mine"),
     )
-    wf = _simple_workflow(privacy_tier_floor=PrivacyTierCeiling.PERSONAL)
+    wf = _simple_workflow(privacy_tier_ceiling=PrivacyTierCeiling.PERSONAL)
 
     await walker.run(wf, state=None, inputs={})
 
     for _name, args in session.calls:
         assert args["privacy_tier_ceiling"] == "personal"
+
+
+async def test_walker_propagates_privacy_ceiling_to_each_tool_result() -> None:
+    """The declared ceiling also lands on every returned ``ToolResult``.
+
+    Downstream, :func:`crawdad.loop._max_ceiling_from` reads
+    ``ToolResult.privacy_tier_ceiling`` to decide how sensitive the
+    composed reply may be. If the walker stamped the wrong attribute
+    the loop would under- or over-classify the whole batch.
+    """
+    session = _FakeSession()
+    walker = WorkflowWalker(
+        mcp_client=_FakeMCPClient(session),
+        known_tools=("creek.state.read", "creek.mine"),
+    )
+    wf = _simple_workflow(privacy_tier_ceiling=PrivacyTierCeiling.PERSONAL)
+
+    results = await walker.run(wf, state=None, inputs={})
+
+    assert len(results) == 2
+    for result in results:
+        assert result.privacy_tier_ceiling == PrivacyTierCeiling.PERSONAL
 
 
 async def test_walker_refuses_phase_aware_without_state() -> None:
@@ -990,6 +1207,318 @@ async def test_walker_step_error_carries_step_and_tool_metadata() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Walker — privacy ceiling cap (#1051)
+# ---------------------------------------------------------------------------
+#
+# CrawDad relays every ToolResult body to a cloud LLM composer and then
+# posts it to Discord. ``intimate`` / ``all`` content must therefore
+# never be *requestable* by an authored workflow file, no matter what
+# the file declares. The cap is enforced at WALK time, not parse time,
+# deliberately: a parse error would make the workflow vanish from
+# ``/crawdad workflow list`` via ``_absorb_dir``'s warn-and-skip, which
+# is a worse silent failure than a loud refusal at run time.
+
+_ADMITTED_TIERS = (PrivacyTierCeiling.OPEN, PrivacyTierCeiling.PERSONAL)
+_ADMITTED_TIER_IDS = [tier.value for tier in _ADMITTED_TIERS]
+_REFUSED_TIERS = (PrivacyTierCeiling.INTIMATE, PrivacyTierCeiling.ALL)
+_REFUSED_TIER_IDS = [tier.value for tier in _REFUSED_TIERS]
+
+
+def test_workflow_admitted_ceilings_is_open_and_personal() -> None:
+    """The cap is exactly ``{open, personal}`` — an immutable frozenset.
+
+    Mirrors ``creek_mcp.policy.REMOTE_ADMITTED_CEILINGS``. Pinned as an
+    exact set (not a membership spot-check) so widening the cap is a
+    deliberate, reviewable edit to this assertion rather than a silent
+    addition nobody notices.
+    """
+    assert (
+        frozenset({PrivacyTierCeiling.OPEN, PrivacyTierCeiling.PERSONAL})
+        == WORKFLOW_ADMITTED_CEILINGS
+    )
+    assert isinstance(WORKFLOW_ADMITTED_CEILINGS, frozenset)
+    assert PrivacyTierCeiling.INTIMATE not in WORKFLOW_ADMITTED_CEILINGS
+    assert PrivacyTierCeiling.ALL not in WORKFLOW_ADMITTED_CEILINGS
+
+
+@pytest.mark.parametrize("tier", _REFUSED_TIERS, ids=_REFUSED_TIER_IDS)
+async def test_walker_refuses_ceiling_above_cap_before_any_tool_fires(
+    tier: PrivacyTierCeiling,
+) -> None:
+    """A workflow declaring ``intimate`` / ``all`` is refused pre-flight.
+
+    "Pre-flight" is the load-bearing word: the MCP session must never be
+    opened, so no tool has a chance to return over-broad content that
+    the walker would then have to discard. Asserting only on the raised
+    exception would pass even if the check lived inside the step loop.
+    """
+    session = _FakeSession()
+    client = _FakeMCPClient(session)
+    walker = WorkflowWalker(
+        mcp_client=client,
+        known_tools=("creek.state.read", "creek.mine"),
+    )
+    wf = _simple_workflow(privacy_tier_ceiling=tier)
+
+    with pytest.raises(WorkflowConstraintError):
+        await walker.run(wf, state=None, inputs={})
+
+    assert client.connect_calls == 0
+    assert client.entered is False
+    assert session.calls == []
+
+
+@pytest.mark.parametrize("tier", _ADMITTED_TIERS, ids=_ADMITTED_TIER_IDS)
+async def test_walker_admits_ceilings_within_cap(tier: PrivacyTierCeiling) -> None:
+    """``open`` and ``personal`` still walk to completion — the cap is not a ban."""
+    session = _FakeSession()
+    client = _FakeMCPClient(session)
+    walker = WorkflowWalker(
+        mcp_client=client,
+        known_tools=("creek.state.read", "creek.mine"),
+    )
+    wf = _simple_workflow(privacy_tier_ceiling=tier)
+
+    results = await walker.run(wf, state=None, inputs={})
+
+    assert len(results) == 2
+    assert client.entered is True
+    assert [name for name, _ in session.calls] == ["creek.state.read", "creek.mine"]
+    for _name, args in session.calls:
+        assert args["privacy_tier_ceiling"] == tier.value
+
+
+async def test_walker_ceiling_refusal_names_workflow_tier_and_allowed_set() -> None:
+    """The refusal message is actionable: which workflow, which tier, what's allowed.
+
+    The operator sees this text in Discord. Without the workflow name
+    they cannot find the file; without the allowed set they cannot tell
+    what to change it to.
+    """
+    session = _FakeSession()
+    client = _FakeMCPClient(session)
+    walker = WorkflowWalker(
+        mcp_client=client,
+        known_tools=("creek.state.read", "creek.mine"),
+    )
+    wf = _simple_workflow(
+        name="leaky-flow", privacy_tier_ceiling=PrivacyTierCeiling.ALL
+    )
+
+    with pytest.raises(WorkflowConstraintError) as excinfo:
+        await walker.run(wf, state=None, inputs={})
+
+    message = str(excinfo.value)
+    assert "'leaky-flow'" in message
+    assert "'all'" in message
+    assert "open" in message
+    assert "personal" in message
+    assert session.calls == []
+
+
+async def test_ceiling_refusal_reported_before_other_constraint_failures() -> None:
+    """The privacy refusal wins when several constraints fail at once.
+
+    ``_check_constraints`` reports the FIRST failure it finds, so check
+    order decides what the operator sees. A workflow that is over the
+    cap *and* names an unadvertised tool *and* is missing an input must
+    report the ceiling: fix-the-tool-then-rerun would otherwise walk the
+    author up to the privacy refusal one round trip at a time, and the
+    privacy rule is the one that must never be the second thing said.
+    """
+    wf = WorkflowDefinition(
+        name="multi-fail",
+        description="over the cap, unknown tool, and missing an input",
+        privacy_tier_ceiling=PrivacyTierCeiling.INTIMATE,
+        inputs=("topic",),
+        steps=(WorkflowStep(id="read", tool="creek.not.a.real.tool"),),
+    )
+    session = _FakeSession()
+    client = _FakeMCPClient(session)
+    walker = WorkflowWalker(mcp_client=client, known_tools=("creek.state.read",))
+
+    with pytest.raises(WorkflowConstraintError) as excinfo:
+        await walker.run(wf, state=None, inputs={})
+
+    message = str(excinfo.value)
+    assert "'intimate'" in message
+    assert "not.a.real.tool" not in message
+    assert "topic" not in message
+    assert client.connect_calls == 0
+
+
+async def test_workflow_over_cap_stays_visible_in_registry(tmp_path: Path) -> None:
+    """An over-cap workflow is refused at WALK time, not hidden at PARSE time.
+
+    This is the whole reason the cap is not a validator. If the parse
+    rejected it, ``_absorb_dir`` would log-and-skip and the workflow
+    would simply be absent from ``/crawdad workflow list`` — the author
+    would see no workflow and no reason. Instead it stays listed and
+    gettable, and refuses loudly when run.
+    """
+    user_dir = tmp_path / VAULT_WORKFLOWS_SUBPATH
+    _write_workflow(
+        user_dir / "too-private.workflow.yaml",
+        name="too-private",
+        body=dedent(
+            """\
+            name: too-private
+            description: declares a ceiling above the cap
+            privacy_tier_ceiling: intimate
+            steps:
+              - id: read
+                tool: creek.state.read
+            """
+        ),
+    )
+    registry = WorkflowRegistry(vault_path=tmp_path)
+
+    # Still discoverable — the file parsed, it just cannot be walked.
+    assert "too-private" in {wf.name for wf in registry.list()}
+    wf = registry.get("too-private")
+    assert wf.privacy_tier_ceiling == PrivacyTierCeiling.INTIMATE
+
+    session = _FakeSession()
+    client = _FakeMCPClient(session)
+    walker = WorkflowWalker(mcp_client=client, known_tools=("creek.state.read",))
+
+    with pytest.raises(WorkflowConstraintError, match="'too-private'"):
+        await walker.run(wf, state=None, inputs={})
+
+    assert client.connect_calls == 0
+    assert session.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Walker — step-arg ceiling smuggling (#1051)
+# ---------------------------------------------------------------------------
+#
+# ``_build_call_arguments`` overwrites any ``privacy_tier_ceiling`` key
+# a step's ``args`` carries. That backstop stays, but a silent
+# overwrite means an author who wrote ``privacy_tier_ceiling: all`` in
+# a step gets neither the tier they asked for nor any indication that
+# their line was discarded. Refuse it up front instead.
+
+
+async def test_walker_refuses_step_arg_ceiling_naming_the_step() -> None:
+    """A step ``args`` block declaring ``privacy_tier_ceiling`` is refused.
+
+    The message must name the offending step id — a workflow can have
+    many steps and the author needs to know which line to delete.
+    """
+    wf = WorkflowDefinition(
+        # Deliberately does NOT contain the step id as a substring, so
+        # the "names the step" assertion cannot be satisfied by the
+        # workflow name leaking into the message.
+        name="tier-override-flow",
+        description="a step tries to set its own ceiling",
+        privacy_tier_ceiling=PrivacyTierCeiling.OPEN,
+        steps=(
+            WorkflowStep(id="benign", tool="creek.state.read"),
+            WorkflowStep(
+                id="smuggle",
+                tool="creek.mine",
+                args={"strategy": "thread-terminus", "privacy_tier_ceiling": "all"},
+            ),
+        ),
+    )
+    session = _FakeSession()
+    client = _FakeMCPClient(session)
+    walker = WorkflowWalker(
+        mcp_client=client,
+        known_tools=("creek.state.read", "creek.mine"),
+    )
+
+    with pytest.raises(WorkflowConstraintError) as excinfo:
+        await walker.run(wf, state=None, inputs={})
+
+    message = str(excinfo.value)
+    assert "smuggle" in message
+    assert "privacy_tier_ceiling" in message
+    # Pre-flight: even the *earlier*, innocent step never ran.
+    assert client.connect_calls == 0
+    assert session.calls == []
+
+
+async def test_walker_refuses_step_arg_legacy_ceiling_key() -> None:
+    """The DEPRECATED spelling in a step's ``args`` is refused too.
+
+    Scoping the step-arg check to the canonical key alone would leave
+    ``privacy_tier_floor: all`` in a step silently accepted — the exact
+    false-assurance shape #1051 exists to close, one key over. No MCP
+    tool reads the legacy name, so nothing leaks either way; what is at
+    stake is that the author's line does something or says so.
+    """
+    wf = WorkflowDefinition(
+        name="tier-override-flow",
+        description="a step tries to set its own ceiling, old spelling",
+        privacy_tier_ceiling=PrivacyTierCeiling.OPEN,
+        steps=(
+            WorkflowStep(
+                id="smuggle",
+                tool="creek.mine",
+                args={"privacy_tier_floor": "all"},
+            ),
+        ),
+    )
+    session = _FakeSession()
+    client = _FakeMCPClient(session)
+    walker = WorkflowWalker(mcp_client=client, known_tools=("creek.mine",))
+
+    with pytest.raises(WorkflowConstraintError) as excinfo:
+        await walker.run(wf, state=None, inputs={})
+
+    message = str(excinfo.value)
+    assert "smuggle" in message
+    assert "privacy_tier_floor" in message
+    assert client.connect_calls == 0
+    assert session.calls == []
+
+
+async def test_walker_allows_steps_without_a_ceiling_arg() -> None:
+    """Ordinary steps are untouched by the step-arg refusal.
+
+    Guards against an over-broad check that trips on any arg key, or on
+    the walker-injected ``privacy_tier_ceiling`` it adds itself.
+    """
+    session = _FakeSession()
+    client = _FakeMCPClient(session)
+    walker = WorkflowWalker(
+        mcp_client=client,
+        known_tools=("creek.state.read", "creek.mine"),
+    )
+
+    results = await walker.run(_simple_workflow(), state=None, inputs={})
+
+    assert len(results) == 2
+    assert client.entered is True
+    assert [name for name, _ in session.calls] == ["creek.state.read", "creek.mine"]
+
+
+def test_build_call_arguments_still_overwrites_colliding_key() -> None:
+    """The ``_build_call_arguments`` backstop survives the pre-flight refusal.
+
+    Defence in depth: the constraint check is the loud gate, but the
+    merge helper must still clamp any ``privacy_tier_ceiling`` that
+    reaches it — e.g. from a future programmatic caller that never ran
+    ``_check_constraints``. (It is NOT reachable via interpolation:
+    ``interpolate`` recurses over dict values only, so no new top-level
+    key can appear.)
+
+    The tier parameter is passed positionally on purpose: it is being
+    renamed ``floor`` -> ``ceiling`` and this test pins behaviour, not
+    the parameter's spelling.
+    """
+    payload = _build_call_arguments(
+        {"strategy": "thread-terminus", "privacy_tier_ceiling": "all"},
+        PrivacyTierCeiling.OPEN,
+    )
+
+    assert payload["privacy_tier_ceiling"] == "open"
+    assert payload["strategy"] == "thread-terminus"
+
+
+# ---------------------------------------------------------------------------
 # Reference workflows
 # ---------------------------------------------------------------------------
 
@@ -1000,6 +1529,7 @@ def test_substack_draft_reference_workflow_parses() -> None:
     wf = load_workflow_from_yaml(path)
     assert wf.phase_aware is True
     assert any(step.tool == "creek.draft" for step in wf.steps)
+    assert wf.privacy_tier_ceiling == PrivacyTierCeiling.PERSONAL
 
 
 def test_wavelength_checkin_reference_workflow_parses() -> None:
@@ -1007,6 +1537,56 @@ def test_wavelength_checkin_reference_workflow_parses() -> None:
     path = BUILTIN_WORKFLOWS_DIR / "wavelength-checkin.workflow.yaml"
     wf = load_workflow_from_yaml(path)
     assert any(step.tool == "creek.state.read" for step in wf.steps)
+    assert wf.privacy_tier_ceiling == PrivacyTierCeiling.OPEN
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected_ceiling"),
+    _REFERENCE_WORKFLOW_CEILINGS,
+    ids=_REFERENCE_WORKFLOW_IDS,
+)
+def test_reference_workflows_use_canonical_ceiling_key(
+    filename: str,
+    expected_ceiling: PrivacyTierCeiling,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Every shipped workflow is migrated: canonical key, same tier, no warning.
+
+    Three things at once, because they are one property:
+
+    * the file parses under ``privacy_tier_ceiling``;
+    * its tier is *unchanged* by the #1051 rename (value-preserving —
+      a shifted value here would silently move what the MCP server
+      returns for a workflow nobody edited);
+    * loading it emits no deprecation warning, i.e. the builtins do not
+      ride the legacy alias they are meant to replace.
+    """
+    path = BUILTIN_WORKFLOWS_DIR / filename
+
+    with caplog.at_level(logging.WARNING, logger="crawdad.workflows"):
+        wf = load_workflow_from_yaml(path)
+
+    assert wf.privacy_tier_ceiling == expected_ceiling
+    assert _workflow_warnings(caplog) == []
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected_ceiling"),
+    _REFERENCE_WORKFLOW_CEILINGS,
+    ids=_REFERENCE_WORKFLOW_IDS,
+)
+def test_reference_workflows_sit_inside_the_ceiling_cap(
+    filename: str, expected_ceiling: PrivacyTierCeiling
+) -> None:
+    """No shipped workflow declares a tier the walker would refuse.
+
+    A builtin that trips the cap would ship broken out of the box —
+    listed by ``/crawdad workflow list`` and guaranteed to fail on run.
+    """
+    wf = load_workflow_from_yaml(BUILTIN_WORKFLOWS_DIR / filename)
+
+    assert wf.privacy_tier_ceiling in WORKFLOW_ADMITTED_CEILINGS
+    assert expected_ceiling in WORKFLOW_ADMITTED_CEILINGS
 
 
 def test_compost_surfacing_reference_workflow_parses() -> None:
@@ -1039,6 +1619,7 @@ def test_compost_surfacing_reference_workflow_parses() -> None:
     assert any(
         "{{state.phase}}" in str(value) for value in mine_steps[0].args.values()
     ), "compost-surfacing's creek.mine step must scope to the current phase"
+    assert wf.privacy_tier_ceiling == PrivacyTierCeiling.PERSONAL
 
 
 async def test_compost_surfacing_refuses_when_session_state_unavailable() -> None:


### PR DESCRIPTION
## Summary

`crawdad/crawdad/workflows.py` declared the workflow DSL's only privacy knob as
`privacy_tier_floor: PrivacyTierCeiling = OPEN` and wrote its value verbatim into the
MCP `privacy_tier_ceiling` call argument. But `open` is the **most** restrictive tier and
`all` the broadest, so raising the "floor" *widened* what the server returned. An author
writing `privacy_tier_floor: intimate` believing they were asserting a minimum protection
was in fact granting the workflow intimate reads.

The second half is the dangerous one: **nothing enforced it.**

### What the walker did with the value, empirically (unfixed HEAD)

```
'privacy' in inspect.getsource(_check_constraints): False
'tier'    in inspect.getsource(_check_constraints): False

declared privacy_tier_floor='open'     -> WALK SUCCEEDED, call arg privacy_tier_ceiling='open'
declared privacy_tier_floor='personal' -> WALK SUCCEEDED, call arg privacy_tier_ceiling='personal'
declared privacy_tier_floor='intimate' -> WALK SUCCEEDED, call arg privacy_tier_ceiling='intimate'
declared privacy_tier_floor='all'      -> WALK SUCCEEDED, call arg privacy_tier_ceiling='all'

step args declared 'all', workflow declared 'open' -> sent 'open' (silently overwritten, no error, no log)
```

So: it passed the value straight through to the wire and to `ToolResult`, and **never read
it as a constraint at all** — while the module docstring advertised it as metadata "the
walker enforces before any tool fires" and `WorkflowDefinition` called it a "soft-fail gate".
This is the same defect class as #1037, #1068, #1078, #1084, #1090, #976 and #1105: a named
privacy property nothing enforces. The fix makes the property real rather than softening the
name to match the broken behaviour.

### Changes

- **Renamed** `privacy_tier_floor` -> `privacy_tier_ceiling` (field, both use sites, the
  `_build_call_arguments` parameter, the three shipped builtin YAMLs — values unchanged).
- **Deprecated alias.** A `model_validator(mode="before")` accepts the legacy key,
  **value-preservingly**, pops it, and logs exactly one WARNING naming the workflow and
  pointing at #1151. Declaring both keys raises `ValueError` -> `WorkflowParseError`.
- **A real pre-flight cap.** `WORKFLOW_ADMITTED_CEILINGS = frozenset({OPEN, PERSONAL})`,
  enforced by `WorkflowWalker._check_privacy_ceiling`, called **first** from
  `_check_constraints`. Every `ToolResult` body is relayed to a cloud LLM composer and then
  posted into a Discord message, so `intimate`/`all` must never be requestable on this path.
- **No per-step ceilings.** `_check_step_arg_ceilings` refuses any step whose `args` declares
  either spelling of the key. The `_build_call_arguments` overwrite is **kept** as a backstop.
- **Prose corrected** at six sites, plus a new `### Workflow files` section in
  `crawdad/README.md` documenting the schema, the ordering, the cap and the migration.

## Answers to the three questions this fix had to settle

### 1. Which fix for the name, and what does an operator with an existing file experience?

**Deprecated alias, value-preserving, with a WARNING** — not a bare rename and not a hard
error. Both alternatives were rejected on evidence:

- A **bare rename** is a *new* silent-failure mode. `WorkflowDefinition` has no
  `extra="forbid"`, so I verified that an unrecognised key is silently dropped — the workflow
  would quietly fall back to the `open` default. Fail-closed, but silent.
- A **hard error** is worse than it looks: `_absorb_dir` catches `WorkflowParseError` and does
  `warning(); continue`, so the workflow would **vanish** from `/crawdad workflow list`
  entirely. Fail-invisible.

Value-preserving is the only defensible alias semantics: a "floor" has no well-defined inverse
into a ceiling, so we cannot guess intent — we preserve observed behaviour and let the warning
correct the author's understanding.

| Existing file | After this change |
|---|---|
| `privacy_tier_floor: open` / `: personal` | Runs **exactly as before**. One WARNING naming the workflow. Rename at leisure. |
| `privacy_tier_floor: intimate` / `: all` | Still parses, still listed by `/crawdad workflow list`. `run` now refuses with an explicit Discord message. **Intended breakage** — that value was granting intimate reads, never requiring intimate protection. |
| Both keys present | Parse error; the workflow drops out of the listing. Fail-closed, and the only case that fails quietly (see #1153). |
| New file on the canonical key | Parses, no warning. |
| No key | `open`, no warning. Unchanged. |

### 2. Is the walker's enforcement additive to the server-side cap, or redundant?

**Additive — it is the only cap on this path.** The premise that CrawDad is a remote consumer
is wrong for the shipped transport, and I verified it rather than assuming:
`crawdad/crawdad/mcp_client.py` connects over **stdio**, and
`creek_mcp/server.py::_caller_identity` returns `CallerIdentity(consumer=None, is_remote=False)`
whenever there is no MCP access token. `creek_mcp.policy.admitted_ceiling` then returns an
unconditional `Admission` for a local caller — its own docstring says "Local callers are not
capped: the *network* is the boundary, not the tier."

So `REMOTE_ADMITTED_CEILINGS` **never fires for CrawDad**. This is not defence in depth; it is
the only door. The cap's value coincides with the server's but is **not derived from it** and
neither is canonical for the other — that one draws the line at the network, this one at the
cloud composer. The comment on the constant says so explicitly so a future editor does not
treat them as one rule.

The knob should not be removed: it is load-bearing on a path nothing else guards.

### 3. Why walk time rather than parse time?

Two reasons, both in the code:

1. A parse-time rejection makes the workflow **vanish** from `/crawdad workflow list` via
   `_absorb_dir`'s warn-and-skip. `test_workflow_over_cap_stays_visible_in_registry` pins that
   an over-cap workflow stays listed and refuses loudly on `run`.
2. A validator only guards *validated* construction. I probed the fixed code: `model_construct`
   and `model_copy(update=...)` both sail past the validator and produce an `all`-tier
   definition — **and the walk-time cap still refuses both with `connect_calls == 0`.** The
   check sits on the only path to `session.call_tool`.

## Test plan

- **RED evidence** captured against unfixed HEAD (the block at the top of this description) —
  an above-ceiling workflow walking to completion and sending `intimate`/`all` to the server.
  After adding the tests, the suite failed at collection on the missing
  `WORKFLOW_ADMITTED_CEILINGS`; the two later additions were confirmed RED individually
  (`DID NOT RAISE WorkflowConstraintError`).
- **Gate 2:** `cd crawdad && ./scripts/check-all.sh` -> **exit 0**, 7/7 (lint, format,
  typecheck, security, docstrings, complexity, tests). 579 passed, branch coverage 94.60%
  overall, 98%+ on `workflows.py`. Lint re-verified **cold** with `ruff check --no-cache`
  (per #1119). This change does not touch `creek-tools/`, so crawdad's gate is the only one
  that applies.
- **Gate 2.5:** `code-review-orchestrator` returned **CLEAN**, no blockers. A dedicated
  security pass also returned no blockers; every finding it raised was either fixed in this PR
  (legacy spelling in step args, privacy-checks-first ordering, two overclaiming docstrings,
  the "mirrors" wording) or filed as a follow-up.
- **Assertion count: 90 -> 148, zero removed.** The only deleted `assert` lines are the two
  renamed ones, both re-added under the new name; the only deleted `def` is the renamed test.
- New tests pin *properties*, not messages: the cap tests assert `connect_calls == 0`,
  `entered is False` and `session.calls == []`, so moving the check inside the step loop would
  fail them. `test_ceiling_refusal_reported_before_other_constraint_failures` pins that the
  privacy refusal wins over a simultaneous unknown-tool and missing-input failure.

## Deviations and scope notes

- The issue's Scope paragraph says it does not "add a new enforcement mechanism". Task 3 offers
  "Alternatively, add the pre-flight check the docstring promises", and this PR takes that
  branch deliberately: leaving the knob unenforced and only fixing the prose would keep a
  privacy control that does nothing.
- The cap is **hard-coded, not configurable**. A knob whose failure mode is "set to `all` once
  to unblock, never reset" is silent permanent relaxation.
- Membership (`frozenset`), never a rank comparison — `crawdad/crawdad/loop.py:329` owns the
  single tier-ordering table and a second one must not exist. No new privacy-tier reader was
  added (#1079): this ranks nothing on disk and reads no fragment.
- `privacy_tier` one-way ratchet: **untouched**. This change writes no tier anywhere; the only
  mutations are an in-memory call-args dict and an explicit copy of the input dict.
- `crawdad/docs/adr/2026-05-24_workflow-file-location.md` is deliberately unmodified — it is
  about file *location* and names no schema key.
- No suppressions of any kind (`# noqa`, `# type: ignore`, `skip`, `xfail`, `--no-verify`).

## Follow-ups filed

- **#1152** (`priority-high`) — the LLM router path is still uncapped: `Intent.privacy_tier_ceiling`
  accepts all four values, `build_intents_schema` publishes all four to the router, and
  `dispatcher._build_arguments` forwards them with no cap. Injection-reachable, because raw tool
  bodies are rendered verbatim into the router prompt. This PR closes one of two doors.
- **#1153** (`priority-medium`) — an unparseable workflow file vanishes from `workflow list`.
- **#1154** (`priority-medium`) — `extra="forbid"`; blocked by #1153.
- **#1155** (`priority-low`) — MCP-derived exception text reaches Discord replies.
- **#1156** (`priority-low`, `needs-spec`) — the workflow runner has no channel context.
- **#1151** (`priority-low`) — remove the `privacy_tier_floor` alias; referenced by the
  deprecation warning.

Closes #1051

🤖 Generated with [Claude Code](https://claude.com/claude-code)