### PR TITLE
fix(scripts): make the ruff gate cache-free so Gate 2 cannot pass a tree CI fails

### DIFF
--- a/creek-tools/.pre-commit-config.yaml
+++ b/creek-tools/.pre-commit-config.yaml
@@ -33,11 +33,16 @@ repos:
     - main
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.15.13
+  # --no-cache: ruff's cache key is mtime-only, and these hooks seed the very
+  # cache check-all.sh would otherwise trust; CI has none (issue #1119).
   hooks:
   - id: ruff
     args:
     - --fix
+    - --no-cache
   - id: ruff-format
+    args:
+    - --no-cache
 - repo: https://github.com/pre-commit/mirrors-mypy
   # Kept in sync with uv.lock (mypy 2.1.0) and pyproject.toml's
   # [project.optional-dependencies].dev pin so all three install paths

--- a/creek-tools/CLAUDE.md
+++ b/creek-tools/CLAUDE.md
@@ -405,6 +405,14 @@ All code must meet these standards before merging to main:
 
 #### Linting and Formatting
 - **Ruff**: lint + format, configured in `pyproject.toml` (no `|| true`).
+- **Ruff cache**: `--no-cache` on every invocation — lint and format,
+  check and fix — in `scripts/lint.sh`, `scripts/format.sh`, and both
+  `astral-sh/ruff-pre-commit` hooks. Ruff's per-file cache key is
+  mtime-only, so a local gate must never trust a cache CI doesn't
+  have. Costs ~0.05s on this tree (477 files); don't drop it for
+  speed. Issue #1119; enforced by `tests/test_ruff_cache_poisoning.py`
+  and `tests/test_ruff_gate_parity.py`. Same hazard is open for mypy's
+  cache (#1186) and `__pycache__` (#1187).
 - **Pylint**: ≥9.0 (`pylint creek/ creek_mcp/ --fail-under=9.0`, in CI
   and `lint-extended.sh`; CI-002).
 - **Bandit**: zero medium-or-above findings

--- a/creek-tools/scripts/format.sh
+++ b/creek-tools/scripts/format.sh
@@ -66,18 +66,30 @@ fi
 
 echo "=== Formatting (Ruff) ==="
 
+# The --no-cache on all four calls below is deliberate and load-bearing
+# (issue #1119). Ruff keys its per-file cache on mtime alone -- no size, no
+# content hash -- so any content change that leaves the mtime unchanged or
+# restored poisons it: cp -p, rsync -t, tar -x, a checkout of an older tree,
+# an mtime-preserving editor. CI never has a .ruff_cache and always re-reads
+# the file, so a local gate that answers from one can clear a tree CI
+# rejects. That is not hypothetical: it cost a real CI failure on PR #1117.
+# The fixing calls carry it too, because a fix run that answers from a
+# poisoned cache silently declines to fix the file it was handed.
+# Running cold measures at ~0.05s over this tree (477 files) -- negligible --
+# so do not drop the flag to speed the gate up. tests/test_ruff_cache_poisoning.py
+# and tests/test_ruff_gate_parity.py fail if you do.
 if $CHECK; then
     # Check import sorting
     if $VERBOSE; then
         echo "Checking import sorting..."
     fi
-    ruff check --select I . || { echo "✗ Import sorting check failed" >&2; exit 1; }
+    ruff check --select I . --no-cache || { echo "✗ Import sorting check failed" >&2; exit 1; }
 
     # Check code formatting
     if $VERBOSE; then
         echo "Checking code formatting..."
     fi
-    ruff format --check . || { echo "✗ Code formatting check failed" >&2; exit 1; }
+    ruff format --check . --no-cache || { echo "✗ Code formatting check failed" >&2; exit 1; }
 
     echo "✓ Code formatting check passed"
 else
@@ -85,13 +97,13 @@ else
     if $VERBOSE; then
         echo "Sorting imports..."
     fi
-    ruff check --select I --fix . || { echo "✗ Import sorting failed" >&2; exit 1; }
+    ruff check --select I --fix . --no-cache || { echo "✗ Import sorting failed" >&2; exit 1; }
 
     # Format code
     if $VERBOSE; then
         echo "Formatting code..."
     fi
-    ruff format . || { echo "✗ Code formatting failed" >&2; exit 1; }
+    ruff format . --no-cache || { echo "✗ Code formatting failed" >&2; exit 1; }
 
     echo "✓ Code formatted successfully"
 fi

--- a/creek-tools/scripts/lint.sh
+++ b/creek-tools/scripts/lint.sh
@@ -66,17 +66,27 @@ fi
 
 echo "=== Linting (Ruff) ==="
 
+# The --no-cache below is deliberate and load-bearing (issue #1119).
+# Ruff keys its per-file cache on mtime alone -- no size, no content hash --
+# so any content change that leaves the mtime unchanged or restored poisons
+# it: cp -p, rsync -t, tar -x, a checkout of an older tree, an
+# mtime-preserving editor. CI never has a .ruff_cache and always re-reads the
+# file, so a local gate that answers from one can clear a tree CI rejects.
+# That is not hypothetical: it cost a real CI failure on PR #1117.
+# Running cold measures at ~0.05s over this tree (477 files) -- negligible --
+# so do not drop the flag to speed the gate up. tests/test_ruff_cache_poisoning.py
+# and tests/test_ruff_gate_parity.py fail if you do.
 if $FIX; then
     if $VERBOSE; then
         echo "Fixing linting issues..."
     fi
-    ruff check . --fix
+    ruff check . --fix --no-cache
     EXIT_CODE=$?
 else
     if $VERBOSE; then
         echo "Checking for linting issues..."
     fi
-    ruff check .
+    ruff check . --no-cache
     EXIT_CODE=$?
 fi
 

--- a/creek-tools/tests/shell_command_support.py
+++ b/creek-tools/tests/shell_command_support.py
@@ -1,0 +1,189 @@
+"""Parsing helpers for tests that assert on shell scripts and CI workflows.
+
+Several suites pin the *shape of the quality gates themselves* rather than
+the behaviour of ``creek/``: they read ``scripts/*.sh``,
+``.github/workflows/*.yml`` and ``.pre-commit-config.yaml`` and assert that
+the commands those files run are the ones the gate contract promises
+(``test_scanner_coverage.py`` for the issue #925 scanner widening,
+``test_ruff_gate_parity.py`` for the issue #1119 ruff cache-freedom).
+
+They all need the same three primitives, and they all need them to be
+comment-blind: these files habitually quote the very command they invoke
+inside an explanatory comment, so a naive substring scan would assert
+against prose rather than against the command that actually executes.
+
+``pyproject.toml`` sets ``python_files = ["test_*.py"]``, so this module is
+never collected as a test module -- it is a plain support module in the
+same spirit as ``tests/helpers.py``.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+CREEK_TOOLS_DIR = Path(__file__).resolve().parent.parent
+REPO_ROOT = CREEK_TOOLS_DIR.parent
+SCRIPTS_DIR = CREEK_TOOLS_DIR / "scripts"
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+CI_WORKFLOW = WORKFLOWS_DIR / "ci.yml"
+PRE_COMMIT_CONFIG = CREEK_TOOLS_DIR / ".pre-commit-config.yaml"
+
+
+def non_comment_lines(script: Path) -> list[str]:
+    """Return the lines of ``script`` that are not shell comments.
+
+    A line whose left-stripped form starts with ``#`` is a comment and is
+    dropped, so prose that quotes a command cannot satisfy an assertion
+    about the command that actually executes.
+
+    Args:
+        script: Path to the shell script to read.
+
+    Returns:
+        Every non-comment line, with original indentation preserved.
+    """
+    return [
+        line
+        for line in script.read_text(encoding="utf-8").splitlines()
+        if not line.lstrip().startswith("#")
+    ]
+
+
+def command_lines(script: Path, pattern: str) -> list[str]:
+    """Return non-comment lines of ``script`` matching ``pattern``.
+
+    Args:
+        script: Path to the shell script to read.
+        pattern: Regular expression searched against each raw (still
+            indented) non-comment line.
+
+    Returns:
+        The matching lines, stripped of surrounding whitespace.
+    """
+    regex = re.compile(pattern)
+    return [line.strip() for line in non_comment_lines(script) if regex.search(line)]
+
+
+def shell_tokens(command: str) -> list[str]:
+    """Split a shell command line into tokens, dropping any inline comment.
+
+    A trailing line-continuation backslash is stripped first so
+    :func:`shlex.split` does not choke on a dangling escape.
+
+    ``comments=True`` is load-bearing rather than tidiness. Callers use the
+    token list to assert that a gate command carries a required flag --
+    ``--no-cache`` for issue #1119, for instance. Without it, an unquoted
+    ``#`` and everything after it stay in the token stream, so a line such
+    as ``ruff check . --fix  # still needs --no-cache`` would satisfy a
+    ``"--no-cache" in shell_tokens(line)`` assertion while the flag itself
+    is gone from the command that actually runs. That is a gate check that
+    cannot fail -- the exact defect class these suites exist to prevent --
+    so tokenisation fails closed: prose naming a flag is never the flag.
+    :func:`shlex.split` stays quote-aware, so a ``#`` inside quotes
+    (``echo "a # b"``) is still ordinary text rather than a comment.
+
+    Args:
+        command: A single shell command line.
+
+    Returns:
+        The tokens of ``command`` up to any inline comment, quotes resolved.
+    """
+    return shlex.split(command.rstrip().rstrip("\\"), comments=True)
+
+
+def load_yaml(path: Path) -> dict[str, Any]:
+    """Parse a YAML document into a mapping.
+
+    Args:
+        path: Path to the YAML file.
+
+    Returns:
+        The parsed top-level mapping. Parsing (rather than scanning text)
+        is what drops YAML comments, several of which quote the command
+        the step actually runs.
+    """
+    document: dict[str, Any] = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return document
+
+
+def workflow_files() -> list[Path]:
+    """Return every GitHub Actions workflow file in the repository.
+
+    Returns:
+        Sorted ``.yml``/``.yaml`` paths under ``.github/workflows``.
+    """
+    found = [*WORKFLOWS_DIR.glob("*.yml"), *WORKFLOWS_DIR.glob("*.yaml")]
+    return sorted(found)
+
+
+def workflow_steps(workflow: Path) -> list[dict[str, Any]]:
+    """Return every step of every job in ``workflow``.
+
+    Jobs that delegate to a reusable workflow carry no ``steps`` key, and
+    are skipped rather than treated as an error.
+
+    Args:
+        workflow: Path to a GitHub Actions workflow file.
+
+    Returns:
+        The step mappings, in job-then-step order.
+    """
+    document = load_yaml(workflow)
+    steps: list[dict[str, Any]] = []
+    for job in document.get("jobs", {}).values():
+        if not isinstance(job, dict):
+            continue
+        steps.extend(
+            step for step in (job.get("steps") or []) if isinstance(step, dict)
+        )
+    return steps
+
+
+def all_workflow_steps() -> list[dict[str, Any]]:
+    """Return every step of every job of every workflow in the repository.
+
+    Returns:
+        The step mappings across all workflow files.
+    """
+    steps: list[dict[str, Any]] = []
+    for workflow in workflow_files():
+        steps.extend(workflow_steps(workflow))
+    return steps
+
+
+def ci_steps() -> list[dict[str, Any]]:
+    """Return every step of every job in the root CI workflow.
+
+    Returns:
+        The step mappings of ``.github/workflows/ci.yml``.
+    """
+    return workflow_steps(CI_WORKFLOW)
+
+
+def step_run_lines(steps: list[dict[str, Any]], pattern: str) -> list[str]:
+    """Return the ``run:`` lines of ``steps`` matching ``pattern``.
+
+    Args:
+        steps: Workflow step mappings, e.g. from :func:`ci_steps`.
+        pattern: Regular expression searched against each stripped line of
+            each step's ``run`` block.
+
+    Returns:
+        The matching command lines, stripped of surrounding whitespace.
+    """
+    regex = re.compile(pattern)
+    lines: list[str] = []
+    for step in steps:
+        run_block = step.get("run")
+        if not isinstance(run_block, str):
+            continue
+        for raw_line in run_block.splitlines():
+            line = raw_line.strip()
+            if regex.search(line):
+                lines.append(line)
+    return lines

--- a/creek-tools/tests/test_ruff_cache_poisoning.py
+++ b/creek-tools/tests/test_ruff_cache_poisoning.py
@@ -1,0 +1,314 @@
+"""The local ruff gate must not answer a check from a stale ``.ruff_cache``.
+
+Issue #1119. Ruff's per-file cache key is the file's **mtime** -- not its
+size, and not a content hash. Any workflow that changes a file's bytes
+while leaving its mtime unchanged or restored (``cp -p``, ``rsync -t``,
+``tar -x``, an mtime-preserving editor, a restored backup) therefore
+leaves ruff answering from a verdict it recorded for *different* content.
+CI never has a ``.ruff_cache``, so it re-reads the file and rejects the
+tree that ``./scripts/check-all.sh`` just cleared. That is not
+hypothetical: it cost a real CI failure on PR #1117.
+
+Each test here builds a throwaway project tree, seeds the cache with a
+clean verdict, rewrites the fixture module with dirty content while
+restoring the original mtime, and then runs the **real** gate script
+against that tree. The script is exposed to the fixture through a symlink
+so the file under test is byte-identical to ``creek-tools/scripts/<name>``:
+``lint.sh`` and ``format.sh`` both derive ``PROJECT_ROOT`` from the parent
+of ``${BASH_SOURCE[0]}``'s directory, so a symlink at
+``<tmp>/scripts/<name>`` makes the fixture tree the project root and ruff
+runs over the fixture instead of over this repository.
+
+The fix is ``--no-cache`` on every ruff invocation in those scripts.
+``--no-cache`` suppresses cache *writes* as well as reads, so no assertion
+here may depend on a ``.ruff_cache`` existing *after* a script has run.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from tests.shell_command_support import SCRIPTS_DIR
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# A frozen mtime, in nanoseconds, restamped after every write to the
+# fixture module -- that restamping is the whole mechanism under test.
+# ``os.utime(..., ns=...)`` is deliberate: ruff compares full-precision
+# mtimes, and the float ``times=`` form can round and miss the cache.
+_STAMP_NS = 1_700_000_000_000_000_000
+
+_SOURCE_NAME = "sample.py"
+_RUFF_CONFIG_NAME = "ruff.toml"
+_CACHE_NAME = ".ruff_cache"
+
+# A ``ruff.toml`` (rather than a ``pyproject.toml``) anchors ruff's config
+# discovery inside the fixture tree, so no ancestor configuration can leak
+# in and no repository setting can change what these fixtures mean.
+_RUFF_CONFIG = '[lint]\nselect = ["F", "I"]\n'
+
+_LINT_CLEAN = "import os\n\nprint(os.name)\n"
+# F401: ``sys`` is imported and never used. The imports stay correctly
+# sorted, so this unambiguously exercises the lint gate, not the sort gate.
+_LINT_POISONED = "import os\nimport sys\n\nprint(os.name)\n"
+
+_IMPORTS_CLEAN = "import os\nimport sys\n\nprint(os.name, sys.platform)\n"
+# I001: same bytes, same length, imports now out of order.
+_IMPORTS_POISONED = "import sys\nimport os\n\nprint(os.name, sys.platform)\n"
+
+_FORMAT_CLEAN = 'X = "a"\n'
+# Formatter-dirty under ruff's double-quote default, exactly as long as the
+# clean text, and import-clean so ``format.sh --check`` gets past its
+# import-sorting step and actually reaches the formatter.
+_FORMAT_POISONED = "X = 'a'\n"
+
+_CACHE_PREMISE = (
+    "ruff's cached verdict is no longer poisonable — if this fails after a "
+    "ruff version bump, upstream fixed the cache key and this test's premise "
+    "(not the repo) needs revisiting."
+)
+
+
+@dataclass(frozen=True)
+class _RuffTree:
+    """A throwaway project tree the real gate scripts can be pointed at.
+
+    Attributes:
+        root: The fixture project root; the scripts' ``PROJECT_ROOT``.
+        source: The single Python module ruff sees inside the tree.
+        env: Environment shared by every subprocess this test runs, so the
+            seeding run and the script run agree on the cache location.
+    """
+
+    root: Path
+    source: Path
+    env: dict[str, str]
+
+
+def _stamp(tree: _RuffTree, text: str) -> None:
+    """Write ``text`` to the fixture module and restore its frozen mtime.
+
+    Args:
+        tree: The fixture tree to write into.
+        text: New contents of the fixture module.
+    """
+    tree.source.write_text(text, encoding="utf-8")
+    os.utime(tree.source, ns=(_STAMP_NS, _STAMP_NS))
+
+
+def _make_tree(tmp_path: Path, *, script: str, source_text: str) -> _RuffTree:
+    """Assemble a fixture tree whose ``scripts/`` holds the real gate script.
+
+    ``scripts/`` is a real directory containing a *symlink* to the script
+    under test, so the file that executes is byte-identical to the one this
+    repository ships -- a copy could drift from it.
+
+    Args:
+        tmp_path: An empty directory to use as the project root.
+        script: File name under ``creek-tools/scripts`` to expose, e.g.
+            ``"lint.sh"``.
+        source_text: Initial (clean) contents of the fixture module.
+
+    Returns:
+        The assembled tree, with the fixture module already stamped.
+    """
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / script).symlink_to(SCRIPTS_DIR / script)
+    (tmp_path / _RUFF_CONFIG_NAME).write_text(_RUFF_CONFIG, encoding="utf-8")
+
+    env = dict(os.environ)
+    env.pop("RUFF_NO_CACHE", None)
+    env.pop("RUFF_OUTPUT_FORMAT", None)
+    # Pins the cache inside the fixture: it keeps the seeding run and the
+    # script run on one cache, and guarantees this test can never touch the
+    # developer's real creek-tools/.ruff_cache.
+    env["RUFF_CACHE_DIR"] = str(tmp_path / _CACHE_NAME)
+
+    tree = _RuffTree(root=tmp_path, source=tmp_path / _SOURCE_NAME, env=env)
+    _stamp(tree, source_text)
+    return tree
+
+
+def _run_ruff(tree: _RuffTree, argv: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run a bare ``ruff`` command inside the fixture tree.
+
+    These direct ``ruff`` calls are **fixture seeding and control probes,
+    not gate invocations**. ``creek-tools/CLAUDE.md`` §1.1 ("always use
+    ``./scripts/*``, never the tool directly") governs how this project's
+    quality gates are run; the point of these calls is to observe what the
+    cache does *underneath* a gate. The gate itself is only ever invoked
+    through the real script, by :func:`_run_script`.
+
+    The argv must mirror the script's own argv exactly: ruff's cache key
+    includes the settings hash, so seeding with ``ruff check --select I .``
+    and then running a script that issues ``ruff check .`` is a cache miss,
+    which would silently turn the whole demonstration vacuous.
+
+    Args:
+        tree: The fixture tree to run in.
+        argv: Full argument vector, starting with ``"ruff"``.
+
+    Returns:
+        The completed process.
+    """
+    return subprocess.run(
+        argv,
+        cwd=tree.root,
+        env=tree.env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=60,
+    )
+
+
+def _run_script(tree: _RuffTree, script: str) -> subprocess.CompletedProcess[str]:
+    """Run ``scripts/<script> --check`` against the fixture tree.
+
+    Args:
+        tree: The fixture tree to run in.
+        script: File name of the script exposed by :func:`_make_tree`.
+
+    Returns:
+        The completed process.
+    """
+    return subprocess.run(
+        ["bash", str(tree.root / "scripts" / script), "--check"],
+        cwd=tree.root,
+        env=tree.env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=60,
+    )
+
+
+def _assert_seeded(tree: _RuffTree, argv: list[str]) -> None:
+    """Seed the cache with ``argv`` and assert the seeding really happened.
+
+    A non-zero seed means the premise never held: the clean fixture was not
+    clean, or ``ruff`` is not on ``PATH`` at all (exit 127), either of which
+    would otherwise green the test for entirely the wrong reason.
+
+    Args:
+        tree: The fixture tree to seed.
+        argv: The ruff argv to seed with; must mirror the script's argv.
+    """
+    seed = _run_ruff(tree, argv)
+    assert seed.returncode == 0, (
+        f"seeding {argv!r} did not report a clean tree (exit {seed.returncode}); "
+        "the fixture premise never held.\n"
+        f"stdout:\n{seed.stdout}\nstderr:\n{seed.stderr}"
+    )
+    cache = tree.root / _CACHE_NAME
+    assert cache.is_dir(), (
+        f"{argv!r} wrote no cache directory at {cache}; there is nothing to "
+        "poison and the test below would pass vacuously."
+    )
+    assert any(entry.is_file() for entry in cache.rglob("*")), (
+        f"cache directory {cache} is empty after seeding with {argv!r}"
+    )
+
+
+def test_lint_check_fails_on_a_tree_whose_ruff_cache_says_clean(
+    tmp_path: Path,
+) -> None:
+    """``scripts/lint.sh --check`` must re-read a file the cache calls clean.
+
+    The fixture module gains an unused import (F401) at an unchanged mtime.
+    Cold ruff rejects it; ruff with the seeded cache does not; the gate must
+    side with cold ruff, because CI is always cold.
+    """
+    tree = _make_tree(tmp_path, script="lint.sh", source_text=_LINT_CLEAN)
+    argv = ["ruff", "check", "."]
+    _assert_seeded(tree, argv)
+
+    _stamp(tree, _LINT_POISONED)
+
+    control = _run_ruff(tree, argv)
+    assert control.returncode == 0, _CACHE_PREMISE
+    cold = _run_ruff(tree, [*argv, "--no-cache"])
+    assert cold.returncode != 0, (
+        "the poisoned fixture is not actually dirty; `ruff check --no-cache .` "
+        f"passed it.\nstdout:\n{cold.stdout}\nstderr:\n{cold.stderr}"
+    )
+
+    result = _run_script(tree, "lint.sh")
+    assert result.returncode != 0, (
+        "scripts/lint.sh --check cleared a tree carrying an unused import: it "
+        "answered from .ruff_cache instead of re-reading the file, so Gate 2 "
+        "can pass a tree CI rejects (#1119).\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+def test_format_check_fails_on_unsorted_imports_hidden_by_the_cache(
+    tmp_path: Path,
+) -> None:
+    """``scripts/format.sh --check`` must re-read imports the cache cleared.
+
+    ``format.sh --check`` runs ``ruff check --select I .`` first, so this
+    test owns its own tree: it short-circuits before the formatter step and
+    could not share a tree with the formatter test.
+    """
+    tree = _make_tree(tmp_path, script="format.sh", source_text=_IMPORTS_CLEAN)
+    argv = ["ruff", "check", "--select", "I", "."]
+    _assert_seeded(tree, argv)
+
+    _stamp(tree, _IMPORTS_POISONED)
+
+    control = _run_ruff(tree, argv)
+    assert control.returncode == 0, _CACHE_PREMISE
+    cold = _run_ruff(tree, [*argv, "--no-cache"])
+    assert cold.returncode != 0, (
+        "the poisoned fixture's imports are not actually unsorted; "
+        "`ruff check --select I --no-cache .` passed it.\n"
+        f"stdout:\n{cold.stdout}\nstderr:\n{cold.stderr}"
+    )
+
+    result = _run_script(tree, "format.sh")
+    assert result.returncode != 0, (
+        "scripts/format.sh --check cleared a tree whose imports are unsorted "
+        "(I001): it answered from .ruff_cache instead of re-reading the file "
+        "(#1119).\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+def test_format_check_fails_on_misformatted_code_hidden_by_the_cache(
+    tmp_path: Path,
+) -> None:
+    """``scripts/format.sh --check`` must re-read formatting the cache cleared.
+
+    Both of the script's ``--check`` steps are seeded: the import-sorting
+    check runs first and must pass for execution to reach the formatter, and
+    the formatter's own cached verdict is the one being poisoned.
+    """
+    tree = _make_tree(tmp_path, script="format.sh", source_text=_FORMAT_CLEAN)
+    imports_argv = ["ruff", "check", "--select", "I", "."]
+    format_argv = ["ruff", "format", "--check", "."]
+    _assert_seeded(tree, imports_argv)
+    _assert_seeded(tree, format_argv)
+
+    _stamp(tree, _FORMAT_POISONED)
+
+    control = _run_ruff(tree, format_argv)
+    assert control.returncode == 0, _CACHE_PREMISE
+    cold = _run_ruff(tree, [*format_argv, "--no-cache"])
+    assert cold.returncode != 0, (
+        "the poisoned fixture is already formatted; "
+        "`ruff format --check . --no-cache` passed it.\n"
+        f"stdout:\n{cold.stdout}\nstderr:\n{cold.stderr}"
+    )
+
+    result = _run_script(tree, "format.sh")
+    assert result.returncode != 0, (
+        "scripts/format.sh --check cleared a tree ruff would reformat: it "
+        "answered from .ruff_cache instead of re-reading the file (#1119).\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )

--- a/creek-tools/tests/test_ruff_gate_parity.py
+++ b/creek-tools/tests/test_ruff_gate_parity.py
@@ -1,0 +1,550 @@
+"""Local and CI ruff must run the same rules, with no cache in between.
+
+Issue #1119. ``test_ruff_cache_poisoning.py`` demonstrates the failure
+behaviourally, one script invocation at a time. This module pins the static
+contract, which catches what a behavioural suite structurally cannot: a
+*partial* revert that drops ``--no-cache`` from, say, only the ``--fix``
+path of ``format.sh``, or from the two pre-commit hooks, leaving the
+behavioural tests green while Gate 2 quietly goes back to answering from a
+cache CI does not have.
+
+"Gate-relevant" here means rule configuration, target scope, mutation and
+cache-freedom -- not output formatting:
+
+* Cosmetic, and free to differ between local and CI: ``--output-format=*``,
+  ``--exit-non-zero-on-fix``, ``--quiet`` / ``-q``, ``--no-cache``.
+* Gate-relevant, and therefore either absent from a gate line or identical
+  on both sides: ``--select``, ``--extend-select``, ``--ignore``,
+  ``--extend-ignore``, ``--per-file-ignores``, ``--config``, ``--isolated``,
+  ``--exclude``, ``--extend-exclude``, ``--preview`` / ``--no-preview``,
+  ``--fix``, ``--cache-dir``.
+
+``.github/workflows/ci.yml`` runs ruff **inline** rather than through
+``scripts/lint.sh`` / ``scripts/format.sh`` -- one ``ruff check`` step and
+one ``ruff format --check`` step. The rule-configuration and no-autofix
+tests below therefore intentionally pin that "exactly one inline CI ruff
+line per mode" shape. The follow-up that switches CI over to calling the
+scripts must update this module as part of that change: these assertions
+record what CI does today, they are not an argument that it should stay
+inline.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from tests.shell_command_support import (
+    PRE_COMMIT_CONFIG,
+    SCRIPTS_DIR,
+    all_workflow_steps,
+    ci_steps,
+    command_lines,
+    load_yaml,
+    non_comment_lines,
+    shell_tokens,
+    step_run_lines,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+_GATE_SCRIPTS = ("lint.sh", "format.sh")
+
+_RUFF_LINE = re.compile(r"^ruff\s")
+_IF_LINE = re.compile(r"^if .*; then$")
+# The mode switch of each gate script: ``lint.sh`` branches on ``$FIX``,
+# ``format.sh`` on ``$CHECK``.
+_MODE_IF = re.compile(r"^if \$(FIX|CHECK); then$")
+
+# Shell condition -> (branch entered when true, branch of the ``else`` arm).
+_MODE_BRANCHES = {"FIX": ("fix", "check"), "CHECK": ("check", "fix")}
+
+# Tokens after which the rest of the line is no longer part of the ruff
+# argv: ``format.sh`` spells every call as ``ruff … || { echo …; exit 1; }``.
+_SHELL_OPERATORS = frozenset({"||", "&&", "|", ";", "&"})
+
+# Flags whose value is a separate following token, so that value must not
+# be mistaken for a positional target.
+_VALUE_FLAGS = frozenset(
+    {
+        "--output-format",
+        "--select",
+        "--extend-select",
+        "--ignore",
+        "--extend-ignore",
+        "--per-file-ignores",
+        "--config",
+        "--exclude",
+        "--extend-exclude",
+        "--cache-dir",
+        "--target-version",
+        "--line-length",
+    }
+)
+
+# Differences that do not change which code is accepted.
+_COSMETIC_FLAGS = frozenset(
+    {"--output-format", "--exit-non-zero-on-fix", "--quiet", "-q", "--no-cache"}
+)
+# Flags that change the rule set or the file set, i.e. that stop the gate
+# taking its configuration from creek-tools/pyproject.toml.
+_RULE_CONFIG_FLAGS = frozenset(
+    {
+        "--select",
+        "--extend-select",
+        "--ignore",
+        "--extend-ignore",
+        "--per-file-ignores",
+        "--config",
+        "--isolated",
+        "--exclude",
+        "--extend-exclude",
+        "--cache-dir",
+    }
+)
+_PREVIEW_FLAGS = frozenset({"--preview", "--no-preview"})
+_MUTATION_FLAGS = frozenset({"--fix"})
+
+
+class _ModeBranchTracker:
+    """Tracks which mode branch of a gate script the current line sits in.
+
+    ``lint.sh`` branches on ``if $FIX; then … else … fi`` and ``format.sh``
+    on ``if $CHECK; then … else … fi``. Both nest ``if $VERBOSE`` blocks
+    inside those arms, so the tracker counts ``if``/``fi`` depth and reacts
+    only to the ``else``/``fi`` that close the mode branch itself.
+    """
+
+    def __init__(self) -> None:
+        """Start outside any mode branch."""
+        self.depth = 0
+        self.open_depth = -1
+        self.branch: str | None = None
+        self.branches: tuple[str, str] | None = None
+
+    def feed(self, line: str) -> str | None:
+        """Consume one stripped script line and report the branch it is in.
+
+        Args:
+            line: A stripped, non-comment line of the script.
+
+        Returns:
+            ``"check"``, ``"fix"``, or ``None`` outside the mode branch.
+        """
+        if _IF_LINE.match(line):
+            return self._open(line)
+        if line == "else":
+            return self._toggle()
+        if line == "fi":
+            return self._close()
+        return self.branch
+
+    def _open(self, line: str) -> str | None:
+        """Enter an ``if`` block, opening the mode branch if this is it."""
+        self.depth += 1
+        match = _MODE_IF.match(line)
+        if match is not None and self.branches is None:
+            self.branches = _MODE_BRANCHES[match.group(1)]
+            self.branch = self.branches[0]
+            self.open_depth = self.depth
+        return self.branch
+
+    def _toggle(self) -> str | None:
+        """Swap to the other arm, if this ``else`` closes the mode branch."""
+        if self.branches is not None and self.depth == self.open_depth:
+            self.branch = self.branches[1]
+        return self.branch
+
+    def _close(self) -> str | None:
+        """Leave an ``if`` block, closing the mode branch if this ends it."""
+        if self.depth == self.open_depth:
+            self.branch = None
+            self.branches = None
+            self.open_depth = -1
+        self.depth -= 1
+        return self.branch
+
+
+def _mode_branch_ruff_lines(script: Path) -> dict[str, list[str]]:
+    """Group ``script``'s ruff command lines by the mode branch they sit in.
+
+    Args:
+        script: A gate script that branches on ``$FIX`` or ``$CHECK``.
+
+    Returns:
+        ``{"check": [...], "fix": [...]}`` -- the ruff lines a ``--check``
+        run executes, and the ones a mutating run executes.
+    """
+    grouped: dict[str, list[str]] = {"check": [], "fix": []}
+    tracker = _ModeBranchTracker()
+    for raw_line in non_comment_lines(script):
+        line = raw_line.strip()
+        branch = tracker.feed(line)
+        if branch is not None and _RUFF_LINE.match(line):
+            grouped[branch].append(line)
+    return grouped
+
+
+def _ruff_argv(command: str) -> list[str]:
+    """Return the ruff argument vector at the head of ``command``.
+
+    Everything from the first shell operator or redirection onwards is
+    dropped, so the ``|| { echo …; exit 1; }`` tail that ``format.sh``
+    appends to each call is not mistaken for ruff arguments.
+
+    Args:
+        command: A single shell command line beginning with ``ruff``.
+
+    Returns:
+        The tokens ruff itself receives.
+    """
+    argv: list[str] = []
+    for token in shell_tokens(command):
+        if token in _SHELL_OPERATORS or token.startswith(">"):
+            break
+        argv.append(token)
+    return argv
+
+
+def _flag_names(argv: list[str]) -> set[str]:
+    """Return the flag names in ``argv``, with any ``=value`` suffix dropped.
+
+    Args:
+        argv: A ruff argument vector from :func:`_ruff_argv`.
+
+    Returns:
+        Flag names such as ``{"--output-format", "--exit-non-zero-on-fix"}``.
+    """
+    return {token.partition("=")[0] for token in argv if token.startswith("-")}
+
+
+def _has_flag(command: str, flag: str) -> bool:
+    """Return whether ``command``'s ruff argv carries ``flag``.
+
+    Args:
+        command: A single shell command line beginning with ``ruff``.
+        flag: The exact flag name to look for.
+
+    Returns:
+        ``True`` if the flag is present as its own token.
+    """
+    return flag in _flag_names(_ruff_argv(command))
+
+
+def _targets(argv: list[str]) -> list[str]:
+    """Return the positional targets of a ruff argv.
+
+    The program name and the subcommand are dropped, as is the value of any
+    flag spelled ``--flag value`` rather than ``--flag=value``.
+
+    Args:
+        argv: A ruff argument vector of the form ``["ruff", "<sub>", …]``.
+
+    Returns:
+        The positional path arguments, in order.
+    """
+    targets: list[str] = []
+    skip = False
+    for token in argv[2:]:
+        if skip:
+            skip = False
+        elif token.startswith("-"):
+            skip = token in _VALUE_FLAGS
+        else:
+            targets.append(token)
+    return targets
+
+
+def _local_ruff_lines() -> list[str]:
+    """Return every non-comment ruff command line in the two gate scripts.
+
+    Returns:
+        The stripped command lines, ``lint.sh`` first.
+    """
+    lines: list[str] = []
+    for script in _GATE_SCRIPTS:
+        lines.extend(command_lines(SCRIPTS_DIR / script, r"^\s*ruff\s"))
+    return lines
+
+
+def _ci_ruff_lines() -> list[str]:
+    """Return every ruff command line in the root CI workflow's run blocks.
+
+    Returns:
+        The stripped command lines, in workflow order.
+    """
+    return step_run_lines(ci_steps(), r"^ruff\s")
+
+
+def _is_checking_ruff_check(line: str) -> bool:
+    """Return whether ``line`` is the gate's plain, whole-tree ``ruff check``.
+
+    The gate scripts also spell a mutating ``ruff check … --fix`` and an
+    import-sorting ``ruff check --select I …``; neither is the line CI's
+    inline ``ruff check`` corresponds to.
+
+    Args:
+        line: A stripped shell command line from a gate script.
+
+    Returns:
+        ``True`` for the non-mutating, unnarrowed ``ruff check`` line.
+    """
+    return (
+        line.startswith("ruff check ")
+        and not _has_flag(line, "--fix")
+        and not _has_flag(line, "--select")
+    )
+
+
+def _single_gate_line(
+    lines: list[str], predicate: Callable[[str], bool], description: str
+) -> str:
+    """Return the one line of ``lines`` matching ``predicate``.
+
+    The gate-parity assertions compare one local line against one CI line,
+    so "exactly one match" is part of the contract, not a convenience: two
+    matches would mean the comparison silently ignores a second gate line,
+    and zero would make it vacuous.
+
+    Args:
+        lines: Candidate command lines.
+        predicate: Test applied to each line.
+        description: Human-readable name of the line being looked for,
+            used in the failure message.
+
+    Returns:
+        The single matching line.
+    """
+    matching = [line for line in lines if predicate(line)]
+    assert len(matching) == 1, f"expected exactly one {description}, got {matching!r}"
+    return matching[0]
+
+
+def _assert_same_rule_configuration(local: str, ci: str, label: str) -> None:
+    """Assert a local gate line and its CI twin accept exactly the same code.
+
+    Both sides must take their rule set from ``creek-tools/pyproject.toml``:
+    neither may narrow it on the command line, both must target the whole
+    tree, they must agree on preview rules, and the only flags they may
+    disagree on are cosmetic ones.
+
+    Args:
+        local: The gate line from ``scripts/``.
+        ci: The corresponding inline line from ``ci.yml``.
+        label: Human-readable name of the gate, used in failure messages.
+    """
+    local_argv = _ruff_argv(local)
+    ci_argv = _ruff_argv(ci)
+    for source, line, argv in (
+        ("scripts/", local, local_argv),
+        ("ci.yml", ci, ci_argv),
+    ):
+        narrowing = sorted(_flag_names(argv) & _RULE_CONFIG_FLAGS)
+        assert not narrowing, (
+            f"{source} {label} narrows the rule set with {narrowing!r} instead "
+            f"of taking it from pyproject.toml: {line!r}"
+        )
+        assert _targets(argv) == ["."], (
+            f"{source} {label} no longer checks the whole tree: {line!r}"
+        )
+
+    local_flags = _flag_names(local_argv)
+    ci_flags = _flag_names(ci_argv)
+    assert (local_flags & _PREVIEW_FLAGS) == (ci_flags & _PREVIEW_FLAGS), (
+        f"{label} disagrees on preview rules between local and CI: {local!r} vs {ci!r}"
+    )
+    difference = sorted((local_flags ^ ci_flags) - _COSMETIC_FLAGS)
+    assert not difference, (
+        f"{label} differs between local and CI by non-cosmetic flag(s) "
+        f"{difference!r}: {local!r} vs {ci!r}"
+    )
+
+
+def test_every_local_ruff_invocation_is_cache_free() -> None:
+    """Every ruff call in the gate scripts must pass ``--no-cache`` (#1119).
+
+    Ruff's per-file cache key is mtime-only, so a content change that leaves
+    the mtime alone leaves a cached verdict standing. CI has no cache and
+    re-reads the file, which is how ``check-all.sh`` can exit 0 on a tree CI
+    rejects. Every invocation is covered, not just the checking ones: a
+    ``--fix`` run that answers from a poisoned cache silently declines to
+    fix the file it was asked to fix.
+
+    The flag must sit in ruff's own argv, not merely somewhere on the line:
+    a mention in the ``|| { echo …; exit 1; }`` tail, or in a trailing
+    comment, does not make the invocation cache-free.
+    """
+    lines = _local_ruff_lines()
+    assert len(lines) >= 6, (
+        "expected at least the six ruff invocations of scripts/lint.sh (2) "
+        f"and scripts/format.sh (4); found {lines!r}"
+    )
+    for line in lines:
+        assert _has_flag(line, "--no-cache"), (
+            "this ruff invocation may answer from .ruff_cache, which CI never "
+            f"has, so Gate 2 can pass a tree CI rejects (#1119): {line!r}"
+        )
+
+
+def test_a_commented_flag_cannot_satisfy_the_cache_free_gate() -> None:
+    """Prose naming ``--no-cache`` must not count as passing ``--no-cache``.
+
+    The gate above asks whether each ruff invocation carries the flag. If
+    tokenisation kept inline comments, an edit that dropped the real flag
+    but left a comment mentioning it would keep that gate green -- a check
+    that cannot fail, which is the exact defect class of issue #1119 (a
+    local gate that answers a question CI never asked). So the tokeniser
+    must fail closed. Quoting still wins: a ``#`` inside quotes is text,
+    not the start of a comment.
+    """
+    commented = "ruff check . --fix  # mentions --no-cache"
+    assert shell_tokens(commented) == ["ruff", "check", ".", "--fix"], (
+        "an inline comment survived tokenisation, so a comment naming a flag "
+        f"could satisfy a flag-presence gate: {shell_tokens(commented)!r}"
+    )
+    assert not _has_flag(commented, "--no-cache"), (
+        "the cache-freedom gate accepted an invocation that only mentions "
+        f"--no-cache in a comment: {commented!r}"
+    )
+
+    genuine = "ruff check . --no-cache"
+    assert shell_tokens(genuine) == ["ruff", "check", ".", "--no-cache"], (
+        f"a genuine --no-cache invocation no longer tokenises: {genuine!r}"
+    )
+    assert _has_flag(genuine, "--no-cache"), (
+        f"the cache-freedom gate rejected a genuinely cache-free line: {genuine!r}"
+    )
+
+    quoted = 'echo "a # not a comment" --no-cache'
+    assert shell_tokens(quoted) == ["echo", "a # not a comment", "--no-cache"], (
+        "a # inside quotes was mistaken for a comment, so tokenisation is "
+        f"no longer quote-aware: {shell_tokens(quoted)!r}"
+    )
+
+
+def test_pre_commit_ruff_hooks_are_cache_free() -> None:
+    """Both ruff pre-commit hooks must pass ``--no-cache`` too (#1119).
+
+    The hooks run the same two tools over the same tree, from a cache the
+    developer's machine keeps between commits; leaving them cached would
+    reopen the same gap one layer earlier than ``check-all.sh``.
+    """
+    config = load_yaml(PRE_COMMIT_CONFIG)
+    repos = [
+        repo
+        for repo in config["repos"]
+        if "astral-sh/ruff-pre-commit" in str(repo.get("repo", ""))
+    ]
+    assert len(repos) == 1, (
+        "expected exactly one astral-sh/ruff-pre-commit repo entry in "
+        f"{PRE_COMMIT_CONFIG.name}, found {len(repos)}"
+    )
+    hooks = {str(hook.get("id")): hook for hook in repos[0].get("hooks", [])}
+    for hook_id in ("ruff", "ruff-format"):
+        assert hook_id in hooks, (
+            f"the {hook_id!r} hook is gone from the ruff-pre-commit entry; "
+            f"found {sorted(hooks)!r}"
+        )
+        args = [str(arg) for arg in hooks[hook_id].get("args", [])]
+        assert "--no-cache" in args, (
+            f"pre-commit hook {hook_id!r} may answer from .ruff_cache "
+            f"(#1119); args are {args!r}"
+        )
+
+
+def test_ci_does_not_restore_a_ruff_cache() -> None:
+    """CI must stay cold: no restored ``.ruff_cache``, no ``--cache-dir``.
+
+    The whole value of the CI ruff run is that it re-reads every file.
+    Caching ``.ruff_cache`` across runs, or pointing ruff at a shared cache
+    directory, would import the exact staleness ``--no-cache`` removes
+    locally -- and would do it on the side that is meant to be the backstop.
+    """
+    steps = all_workflow_steps()
+    cache_steps = [
+        step for step in steps if str(step.get("uses", "")).startswith("actions/cache")
+    ]
+    assert cache_steps, (
+        "no actions/cache step was found in any workflow, so the workflow "
+        "parse is not seeing steps and the assertions below are vacuous"
+    )
+    for step in cache_steps:
+        cached_path = str((step.get("with") or {}).get("path", ""))
+        assert ".ruff_cache" not in cached_path, (
+            "a CI cache step restores ruff's cache, which is exactly the "
+            f"staleness this gate exists to prevent: {step.get('name')!r} "
+            f"caches {cached_path!r}"
+        )
+
+    ruff_lines = step_run_lines(steps, r"^ruff\s")
+    assert ruff_lines, "no ruff command line was found in any workflow run block"
+    for line in ruff_lines:
+        assert not _has_flag(line, "--cache-dir"), (
+            f"a CI ruff invocation points at a cache directory: {line!r}"
+        )
+
+
+def test_ci_and_local_ruff_share_the_same_rule_configuration() -> None:
+    """The local gate and CI must accept exactly the same code.
+
+    Both sides must read their rules from ``creek-tools/pyproject.toml``.
+    If either narrows the rule set on the command line, or checks a smaller
+    target, ``--no-cache`` alone would not close the gap this issue is
+    about: the local gate would still be answering a different question
+    than CI asks.
+    """
+    lint_local = _single_gate_line(
+        _local_ruff_lines(),
+        _is_checking_ruff_check,
+        "checking `ruff check` line in the gate scripts",
+    )
+    lint_ci = _single_gate_line(
+        _ci_ruff_lines(),
+        lambda line: line.startswith("ruff check "),
+        "inline `ruff check` line in ci.yml",
+    )
+    _assert_same_rule_configuration(lint_local, lint_ci, "ruff check")
+
+    format_local = _single_gate_line(
+        _mode_branch_ruff_lines(SCRIPTS_DIR / "format.sh")["check"],
+        lambda line: line.startswith("ruff format "),
+        "`ruff format` line in format.sh's --check branch",
+    )
+    format_ci = _single_gate_line(
+        _ci_ruff_lines(),
+        lambda line: line.startswith("ruff format "),
+        "inline `ruff format` line in ci.yml",
+    )
+    _assert_same_rule_configuration(format_local, format_ci, "ruff format --check")
+
+
+def test_gate_ruff_invocations_do_not_autofix() -> None:
+    """No checking ruff invocation may rewrite the tree to make itself pass.
+
+    ``ruff check . --fix`` edits the offending file and exits 0, so an
+    autofixing gate is a gate that cannot fail. Mutation belongs on the
+    scripts' ``--fix`` path and in pre-commit, never on the path
+    ``check-all.sh`` and CI take.
+    """
+    lint_check = _mode_branch_ruff_lines(SCRIPTS_DIR / "lint.sh")["check"]
+    assert len(lint_check) == 1, (
+        f"expected exactly one ruff line in lint.sh's check branch, got {lint_check!r}"
+    )
+    format_check = _mode_branch_ruff_lines(SCRIPTS_DIR / "format.sh")["check"]
+    assert len(format_check) == 2, (
+        "expected the import-sorting and formatter lines in format.sh's "
+        f"--check branch, got {format_check!r}"
+    )
+    ci_lines = _ci_ruff_lines()
+    assert len(ci_lines) == 2, (
+        f"expected exactly the two inline ruff lines in ci.yml, got {ci_lines!r}"
+    )
+
+    for line in [*lint_check, *format_check, *ci_lines]:
+        mutating = sorted(_flag_names(_ruff_argv(line)) & _MUTATION_FLAGS)
+        assert not mutating, (
+            f"a gate ruff invocation autofixes with {mutating!r}, so it can "
+            f"never fail: {line!r}"
+        )

--- a/creek-tools/tests/test_scanner_coverage.py
+++ b/creek-tools/tests/test_scanner_coverage.py
@@ -27,16 +27,20 @@ from __future__ import annotations
 import re
 import shlex
 import tomllib
-from pathlib import Path
 from typing import Any
 
 import yaml
 
-CREEK_TOOLS_DIR = Path(__file__).resolve().parent.parent
-REPO_ROOT = CREEK_TOOLS_DIR.parent
-SCRIPTS_DIR = CREEK_TOOLS_DIR / "scripts"
-CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
-PRE_COMMIT_CONFIG = CREEK_TOOLS_DIR / ".pre-commit-config.yaml"
+from tests.shell_command_support import (
+    CI_WORKFLOW,
+    CREEK_TOOLS_DIR,
+    PRE_COMMIT_CONFIG,
+    SCRIPTS_DIR,
+)
+from tests.shell_command_support import ci_steps as _ci_steps
+from tests.shell_command_support import command_lines as _command_lines
+from tests.shell_command_support import non_comment_lines as _non_comment_lines
+
 PYPROJECT = CREEK_TOOLS_DIR / "pyproject.toml"
 
 # ``\bcreek\b`` deliberately does NOT match inside ``creek_mcp`` (``_`` is a
@@ -70,26 +74,6 @@ _MYPY_DISABLING_SETTINGS: dict[str, Any] = {
     "disallow_untyped_defs": False,
     "check_untyped_defs": False,
 }
-
-
-def _non_comment_lines(script: Path) -> list[str]:
-    """Return the lines of ``script`` that are not shell comments.
-
-    A line whose left-stripped form starts with ``#`` is a comment and is
-    dropped, so prose that quotes a command cannot satisfy an assertion
-    about the command that actually executes.
-    """
-    return [
-        line
-        for line in script.read_text(encoding="utf-8").splitlines()
-        if not line.lstrip().startswith("#")
-    ]
-
-
-def _command_lines(script: Path, pattern: str) -> list[str]:
-    """Return non-comment lines of ``script`` matching ``pattern``."""
-    regex = re.compile(pattern)
-    return [line.strip() for line in _non_comment_lines(script) if regex.search(line)]
 
 
 def _exclusion_values(command: str) -> list[str]:
@@ -141,15 +125,6 @@ def _as_list(value: Any) -> list[str]:
     if isinstance(value, str):
         return [value]
     return [str(item) for item in value]
-
-
-def _ci_steps() -> list[dict[str, Any]]:
-    """Return every step of every job in the root CI workflow."""
-    workflow: dict[str, Any] = yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
-    steps: list[dict[str, Any]] = []
-    for job in workflow["jobs"].values():
-        steps.extend(job.get("steps", []))
-    return steps
 
 
 def _ci_bandit_run_lines() -> list[str]:


### PR DESCRIPTION
## Summary

- **The local quality gate could pass on code CI rejects.** `./scripts/check-all.sh` consulted `.ruff_cache`; CI never has one. Root cause, verified by experiment: **ruff's per-file cache key is mtime-only** — not size, not a content hash. Any content change leaving the mtime unchanged or restored (`cp -p`, `rsync -t`, `tar -x`, a checkout of an older tree, an mtime-preserving editor) leaves a stale verdict standing. This cost a real CI failure on PR #1117 plus a `ci-debugging` lane to diagnose.
- **Fix:** `--no-cache` on all six ruff invocations in `scripts/lint.sh` and `scripts/format.sh`, plus both `astral-sh/ruff-pre-commit` hooks. **Fix paths as well as check paths** — I verified a `--fix` run answering from a poisoned cache prints "All checks passed!" and *leaves the file unfixed*, which is worse than a false green because the developer then commits it. The pre-commit hooks are included because they are one of the things that *seeds* the cache the gate later trusts.
- **Two regression suites**, one behavioural and one static — see the test plan.

### Design decisions, with the measurements behind them

**Performance.** Measured on this tree (477 tracked `.py` files, median of 3, `/usr/bin/time -p`):

| invocation | cached | `--no-cache` |
|---|---|---|
| `ruff check .` | 0.01s | 0.04s |
| `ruff format --check .` | 0.01s | 0.03s |

**~0.05s total.** There is no trade-off to make, which is why check *and* fix paths are covered uniformly rather than split — "ruff always reads the real bytes" is an invariant a test can pin; "check paths are cache-free, fix paths aren't" is a rule someone gets wrong later.

**Hardcoded flag, no env override.** Ruff honours `RUFF_NO_CACHE` natively, but routing the gate through an env var builds an off switch for a gate. The flag is greppable, visible under `set -x`, and shlex-parseable by the parity test.

**CI unification deferred.** `ci.yml` runs ruff inline while calling `./scripts/*.sh` for every other gate — ruff is the lone exception to the workflow's own stated CI-004 principle, and ruff is exactly where the drift bit us. Changing what runs in CI on a P0 about restoring trust in the gate is risk visible only after push, so `test_ruff_gate_parity.py` pins the invariant instead and the switch is filed as #1188.

### Other tools checked for the same hazard

I probed each empirically rather than assuming:

| tool | vulnerable? | evidence |
|---|---|---|
| **ruff** | **yes** | key is mtime-only — even a *different-length* rewrite at a restored mtime stayed cached-clean |
| **mypy** | **yes** | same mtime + same size → `Success: no issues found` on a file cold mypy rejects with `[return-value]`. **Not free to close: 1.22s incremental vs 17.82s `--no-incremental`.** Filed #1186 |
| **`__pycache__`** | **yes** | `assert 1 == 1` → `assert 1 == 2` at same mtime+size still **passed** — stale bytecode. Filed #1187 |
| `.pytest_cache` | no | stores `lastfailed`/`nodeids`, not verdicts |
| refurb, vulture, interrogate | no | no cache options |
| pylint, bandit | no | no persistent result cache in the gate invocation |

**`$?`-after-pipe defect class: not present.** I grepped `creek-tools/scripts/*.sh` and `scripts/ralph/*.sh` — no instance of a tool being piped and then `$?` checked. The ralph scripts all use the safe `|| rc=$?` idiom. The one adjacent smell is `lint.sh`'s `EXIT_CODE=$?`, which is *unreachable* under `set -euo pipefail` rather than wrong (the gate still fails correctly via `set -e`); filed as #1189 and deliberately left untouched to keep this P0's diff to pure argv appends.

## Test plan

**RED was real and non-vacuous.** Against unfixed HEAD, the *real* gate scripts cleared trees CI would reject:

```
scripts/lint.sh --check   -> exit 0   "✓ Linting checks passed"        (unused import present)
scripts/format.sh --check -> exit 0   "✓ Code formatting check passed" (I001 unsorted / misformatted)
ruff check --no-cache .   -> exit 1   on the identical bytes
```
5 failed / 16 passed before the fix; 22 passed after.

- **`tests/test_ruff_cache_poisoning.py`** (behavioural, 3 tests) — builds a temp tree, seeds a real `.ruff_cache` with argv **mirroring the script's own**, rewrites the source with a violation at a restored mtime (`os.utime(ns=...)`), symlinks the **real** gate script into `<tmp>/scripts/` so `PROJECT_ROOT` retargets, then asserts the script fails. `RUFF_CACHE_DIR` is pinned inside `tmp_path`, and ambient `RUFF_NO_CACHE`/`RUFF_OUTPUT_FORMAT` are stripped, so it can never touch the real cache.
  - Anti-vacuity is the point: I deliberately broke the seed argv (a cache-key mismatch) and confirmed the test **fails loudly on its guard** rather than passing green — that exact mistake nearly cost the whole demonstration while prototyping.
- **`tests/test_ruff_gate_parity.py`** (static, 6 tests) — pins `--no-cache` on every invocation (catches a *partial* revert the behavioural suite structurally cannot see), pins that local and CI ruff take the same rule set from `pyproject.toml`, that CI never restores a `.ruff_cache`, and that no gate line auto-fixes.
- **Independently reproduced outside pytest**, before and after, using the real scripts via symlink; and confirmed `format.sh --fix` now actually sorts a file it previously left untouched under a poisoned cache.
- **Gate 2:** `cd creek-tools && ./scripts/check-all.sh` → **exit 0**, 12/12 checks, 7476 tests passed, coverage 94.13%, per-file gate 224 files ≥80%.
- **Gate 2.5:** `code-review-orchestrator` returned FIX_REQUIRED on the first pass (one blocker), then **CLEAN** after fixes.
- Repo-root shell suites (`scripts/ralph/test_*.sh`) all pass — 6/6.

### Gate 2.5 findings fixed before push

1. **Complexity C(15)** on a new parity test, over the ≤10 threshold — extracted `_single_gate_line`/`_is_checking_ruff_check` helpers; `xenon --max-absolute B` now exits 0 with all four singleton assertions preserved. (It escaped `check-all.sh` only because the complexity gate never scans `tests/` — filed #1191, along with the 20 *pre-existing* C-rank test functions it hides.)
2. **The cache-freedom guard could itself pass vacuously** — it tokenised the raw line, so a trailing comment naming `--no-cache` would satisfy it even if the real flag were gone. That is the same defect class as this issue: a gate that cannot fail. Fixed with quote-aware `shlex.split(..., comments=True)` plus an assertion against ruff's actual argv, and pinned by a new regression test. I verified the fix bites by reverting it (the new test fails) and verified it truncates none of the 8 command lines actually parsed.

`tests/test_scanner_coverage.py` (merged, gate-bearing, from #925) changes by **import substitution only** — I verified with `git diff -U0` that no line inside any `def test_*` changed and no assertion was altered, and confirmed the relocated `ci_steps()` returns results byte-identical to the original implementation (43 steps, `old == new`).

## Follow-ups filed rather than scope-creeping this P0

#1186 (mypy stale cache) · #1187 (`__pycache__` stale bytecode) · #1188 (CI ruff inline vs scripts) · #1189 (`lint.sh` unreachable `EXIT_CODE=$?`) · #1190 (`creek-tools/CLAUDE.md` truncated on `main` — §§7–10 and all appendices missing, which is why the doc entry landed in §6.1) · #1191 (complexity/docstring gates never scan `tests/`)

Closes #1119
