### PR TITLE
docs(creek-tools): repair truncated CLAUDE.md and gate Markdown integrity

### DIFF
--- a/creek-tools/CLAUDE.md
+++ b/creek-tools/CLAUDE.md
@@ -1,19 +1,14 @@
 # Claude Code Project Context: creek-tools
 
 **Table of Contents**
+- [0. Repo topology](#0-repo-topology)
 - [1. Critical Principles](#1-critical-principles)
 - [2. Project Overview](#2-project-overview)
 - [3. The Maximum Quality Engineering Mindset](#3-the-maximum-quality-engineering-mindset)
 - [4. Stay Green Workflow](#4-stay-green-workflow)
 - [5. Architecture](#5-architecture)
 - [6. Quality Standards](#6-quality-standards)
-- [7. Development Workflow](#7-development-workflow)
-- [8. Testing Strategy](#8-testing-strategy)
-- [9. Tool Usage & Code Standards](#9-tool-usage--code-standards)
-- [10. Common Pitfalls & Troubleshooting](#10-common-pitfalls--troubleshooting)
-- [Appendix A: AI Subagent Guidelines](#appendix-a-ai-subagent-guidelines)
-- [Appendix B: Key Files](#appendix-b-key-files)
-- [Appendix C: External References](#appendix-c-external-references)
+- [7. Where the rest lives](#7-where-the-rest-lives)
 
 ---
 
@@ -54,7 +49,7 @@ Always invoke tools through `./scripts/*` instead of directly.
 | All checks | *(run each tool)* | `./scripts/check-all.sh` |
 | Security scan | `bandit -r src/` | `./scripts/security.sh` |
 
-See [9.1 Tool Invocation Patterns](#91-tool-invocation-patterns) for complete list.
+See [`scripts/`](scripts/) and the gate list in `scripts/check-all.sh` for the complete list.
 
 ---
 
@@ -89,7 +84,7 @@ Never bypass quality checks or suppress errors without justification.
 - ✅ Always run pre-commit checks
 - ✅ Refactor complex functions into smaller ones
 
-See [10.1 No Shortcuts Policy](#101-no-shortcuts-policy) for detailed examples.
+See [6.2 Forbidden Patterns](#62-forbidden-patterns) for detailed examples.
 
 ---
 
@@ -155,7 +150,7 @@ Run `./scripts/check-all.sh` before every commit. Only commit if exit code is 0.
 - [ ] No failing tests
 - [ ] Conventional commit message ready
 
-See [10. Common Pitfalls & Troubleshooting](#10-common-pitfalls--troubleshooting) for complete list.
+See [4.2 Quick Checklist](#42-quick-checklist) for complete list.
 
 ---
 
@@ -467,3 +462,46 @@ The following patterns are NEVER allowed without explicit justification and issu
    ```python
    # ❌ FORBIDDEN
    # TODO: optimize
+
+   # ✅ ALLOWED (with issue reference)
+   # TODO: optimize this query (Issue #N)
+
+   # ❌ FORBIDDEN
+   # FIXME: broken
+
+   # ✅ ALLOWED (with issue reference)
+   # FIXME: broken on empty input (Issue #N)
+   ```
+
+---
+
+## 7. Where the rest lives
+
+Until issue #1190 this file's table of contents promised six further
+sections — Development Workflow, Testing Strategy, Tool Usage & Code
+Standards, Common Pitfalls & Troubleshooting, and three appendices —
+that were never written: the file was truncated mid-code-fence in the
+repository's initial commit and every revision since ended on that same
+line. Rather than invent standards nobody agreed to, those entries were
+retired in favour of pointers to the artifacts that actually define each
+topic. A restatement is a second copy, and per §1.2 second copies drift
+from their source. Existing drift between this file and the sources
+below is tracked in issue #1194; this section only points, it does not
+describe.
+
+- **Development workflow**: [`../.claude/agents/shared/house-rules.md`](../.claude/agents/shared/house-rules.md)
+  (the four gates, commit/PR conventions); [`.pre-commit-config.yaml`](.pre-commit-config.yaml).
+- **Testing strategy**: [`scripts/test.sh`](scripts/test.sh); the
+  `[tool.pytest.ini_options]` table in [`pyproject.toml`](pyproject.toml)
+  for markers and testpaths.
+- **Tool usage & code standards**: [`scripts/check-all.sh`](scripts/check-all.sh)
+  for the gates, in order; the tool sections of [`pyproject.toml`](pyproject.toml).
+- **Common pitfalls & troubleshooting**: the Troubleshooting section of
+  [`docs/mcp.md`](docs/mcp.md); [`../.claude/skills/ci-debugging/`](../.claude/skills/ci-debugging/)
+  and [`../.claude/skills/stay-green/`](../.claude/skills/stay-green/).
+- **AI subagent guidelines**: [`../.claude/agents/README.md`](../.claude/agents/README.md)
+  and [`../.claude/agents/shared/house-rules.md`](../.claude/agents/shared/house-rules.md);
+  [`../scripts/ralph/PROMPT.md`](../scripts/ralph/PROMPT.md).
+- **Key files**: [`docs/README.md`](docs/README.md) (the docs index) and
+  §5.2 above.
+- **External references**: [`docs/architecture/ADR/`](docs/architecture/ADR/).

--- a/creek-tools/tests/markdown-integrity-exceptions.txt
+++ b/creek-tools/tests/markdown-integrity-exceptions.txt
@@ -1,0 +1,31 @@
+# Fence-integrity exceptions (issue #1190).
+#
+# Format: "<path> <reason>", mirroring scripts/coverage-waivers.txt.
+# Blank lines and lines whose stripped form starts with "#" are ignored;
+# every other line is partitioned on its FIRST space. Paths are
+# repo-relative POSIX paths as `git ls-files` emits them from the
+# repository root, so the canonical form is "creek-tools/<file>.md" for
+# anything inside the Python subproject and "<file>.md" for anything at
+# the repo root.
+#
+# An entry exempts its file from the UNCLOSED-FENCE check only. The
+# trailing-newline check and the same-file-anchor check in
+# tests/test_markdown_integrity.py still apply to every file listed here.
+#
+# The list is itself verified, so it cannot rot into permanent cover:
+# an entry naming a file git no longer tracks fails the suite, an entry
+# whose file now has balanced fences fails the suite, an entry with no
+# issue reference in its reason fails the suite, and adding a path not in
+# KNOWN_FENCE_EXCEPTIONS in tests/test_markdown_integrity.py fails the
+# suite. Fix the fence and delete the line; do not add new entries here
+# to make a red gate go green.
+#
+# All three files below are broken by the same CommonMark trap: fences do
+# not nest, so a ```markdown block that demonstrates an inner ```json (or
+# ```bash) block ends early at the inner block's bare closer, and the
+# outer block's intended closer then opens a fence that is never closed.
+# Repairing them means re-fencing the outer block with a longer run of
+# backticks, which is documentation surgery rather than a test fix.
+.claude/skills/architectural-decisions/references/examples.md nested-fence trap: inner block's closer ends the outer example block; repair tracked by issue #1193
+.claude/skills/spec-decomposition/references/templates.md nested-fence trap: inner block's closer ends the outer template block; repair tracked by issue #1193
+creek-tools/.claude/skills/architectural-decisions.md nested-fence trap: inner block's closer ends the outer example block; repair tracked by issue #1193

--- a/creek-tools/tests/markdown_integrity_support.py
+++ b/creek-tools/tests/markdown_integrity_support.py
@@ -1,0 +1,402 @@
+"""Markdown structure parsing for the integrity gate (issue #1190).
+
+``tests/test_markdown_integrity.py`` asserts that every tracked Markdown
+file closes the code fences it opens, ends with exactly one newline, and
+only links to anchors that exist. The parsing those assertions need is
+here, hand-rolled against the subset of CommonMark the repository
+actually exercises.
+
+Hand-rolled rather than delegated. ``markdown-it-py`` is on the tree only
+as a transitive of ``rich``, and it auto-closes an unclosed fence at end
+of input -- so it cannot answer the one question this gate exists to ask.
+The naive alternative (``grep -c '^```'``) is worse: it counts ``6`` on
+``creek-tools/CLAUDE.md``, an even number, because the broken opener is
+indented three spaces inside an ordered-list item and never touches
+column zero. An indent-tolerant count returns ``11``.
+
+Three rules carry the whole gate, and each has a live counter-example in
+this repository:
+
+* A fence opener may be indented **0-3 spaces**; a fourth space makes the
+  line an indented code block instead. This is the
+  ``creek-tools/CLAUDE.md`` defect.
+* A closer must use the **same** fence character, run **at least as
+  long** as the opener's, and carry **no info string**.
+* Fences do not **nest**. Inside an open fence every line is content, so
+  a ``markdown`` block demonstrating a ``json`` block ends early at the
+  inner block's bare closer, and the outer block's intended closer then
+  opens a fresh fence that is never closed. Three skill files are broken
+  exactly this way; they are listed in
+  ``tests/markdown-integrity-exceptions.txt`` under issue #1193.
+
+``pyproject.toml`` sets ``python_files = ["test_*.py"]``, so this module
+is never collected as a test module -- it is a plain support module in
+the same spirit as ``tests/shell_command_support.py``.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Collection, Iterable, Iterator
+    from pathlib import Path
+
+# A fence line: up to three spaces of indent, then a run of three or more
+# backticks or tildes, then (for an opener) an info string. Written
+# verbose so the 0-3 indent allowance -- the crux of issue #1190 -- is
+# documented where it is enforced rather than buried in a literal.
+_FENCE_LINE = re.compile(
+    r"""
+    ^\ {0,3}                # 0-3 spaces; a 4th makes an indented code block
+    (?P<run>`{3,}|~{3,})    # three or more of a single fence character
+    (?P<info>.*)$           # info string; disqualifies the line as a closer
+    """,
+    re.VERBOSE,
+)
+
+# An ATX heading: 0-3 spaces of indent, one to six hashes, then at least
+# one space. Setext headings are deliberately unsupported -- see
+# :func:`heading_slugs`.
+_ATX_HEADING = re.compile(
+    r"""
+    ^\ {0,3}
+    (?P<hashes>\#{1,6})     # `#` needs escaping: re.VERBOSE reads it as a comment
+    [\ \t]+
+    (?P<text>.*)$
+    """,
+    re.VERBOSE,
+)
+
+# An optional closing run of hashes, which GitHub strips before slugging.
+# The run must be preceded by whitespace (or be the whole line), so a
+# trailing hash inside a word -- ``## C#`` -- survives.
+_CLOSING_HASHES = re.compile(r"(?:^|\s)#+[ \t]*$")
+
+# Everything GitHub's slugger deletes outright: anything that is not a
+# word character (alphanumeric or underscore), a hyphen or a space.
+# Deleted, never replaced -- ``## Generic (`generic`)`` slugs to
+# ``generic-generic``, not ``generic---generic--``.
+_SLUG_DROP = re.compile(r"[^\w\- ]")
+
+# An inline link whose target is a same-file anchor. The target must
+# start with ``#``, which is what puts ``other.md#frag`` and
+# ``https://host/page#frag`` out of scope.
+_ANCHOR_LINK = re.compile(r"\[[^\]]*\]\(#(?P<anchor>[^)\s]+)\)")
+
+
+@dataclass(frozen=True)
+class _Fence:
+    """A parsed fence line.
+
+    Attributes:
+        char: The fence character, either a backtick or a tilde.
+        length: How many fence characters the run contains.
+        info: The info string that followed the run, stripped. Non-empty
+            only on an opener: an info string disqualifies a line from
+            closing anything.
+    """
+
+    char: str
+    length: int
+    info: str
+
+
+def _parse_fence(line: str) -> _Fence | None:
+    """Parse ``line`` as a code fence.
+
+    Args:
+        line: A single line of Markdown, without its terminator.
+
+    Returns:
+        The parsed fence, or ``None`` when the line is not a fence --
+        including when it is indented four or more spaces, which makes it
+        an indented code block.
+    """
+    match = _FENCE_LINE.match(line)
+    if match is None:
+        return None
+    run = match["run"]
+    return _Fence(char=run[0], length=len(run), info=match["info"].strip())
+
+
+def _closes(opener: _Fence, candidate: _Fence) -> bool:
+    """Report whether ``candidate`` closes the block ``opener`` started.
+
+    Args:
+        opener: The fence that opened the currently open block.
+        candidate: A fence found while that block is open.
+
+    Returns:
+        ``True`` when ``candidate`` uses the same fence character, runs at
+        least as long as ``opener``, and carries no info string.
+    """
+    return (
+        candidate.char == opener.char
+        and candidate.length >= opener.length
+        and not candidate.info
+    )
+
+
+def _scan_fences(text: str) -> tuple[list[bool], int | None]:
+    """Walk ``text`` once, tracking fenced-code state.
+
+    The single scan behind all three of :func:`find_unclosed_fence`,
+    :func:`heading_slugs` and :func:`same_file_anchor_links`, so those
+    three can never disagree about what counts as code.
+
+    Fences do not nest: while a block is open, a fence line either closes
+    it or is content, and can never open a second block.
+
+    Args:
+        text: A Markdown document.
+
+    Returns:
+        A ``(flags, opener)`` pair. ``flags`` has one entry per line of
+        ``text``, ``True`` when the line belongs to a fenced code block
+        (its opener and closer included). ``opener`` is the 1-based line
+        number of the fence still open at end of input, or ``None``.
+    """
+    flags: list[bool] = []
+    open_fence: _Fence | None = None
+    opener_line: int | None = None
+
+    for number, line in enumerate(text.splitlines(), start=1):
+        fence = _parse_fence(line)
+        if open_fence is None:
+            if fence is not None:
+                open_fence, opener_line = fence, number
+            flags.append(fence is not None)
+            continue
+        flags.append(True)
+        if fence is not None and _closes(open_fence, fence):
+            open_fence, opener_line = None, None
+
+    return flags, opener_line
+
+
+def _lines_outside_code(text: str) -> Iterator[tuple[int, str]]:
+    """Yield the lines of ``text`` that are not inside a fenced block.
+
+    Args:
+        text: A Markdown document.
+
+    Yields:
+        ``(1-based line number, line)`` for each line outside fenced code,
+        in document order.
+    """
+    flags, _ = _scan_fences(text)
+    numbered = enumerate(zip(text.splitlines(), flags, strict=True), start=1)
+    for number, (line, in_code) in numbered:
+        if not in_code:
+            yield number, line
+
+
+def find_unclosed_fence(text: str) -> int | None:
+    """Locate the code fence that ``text`` opens and never closes.
+
+    Args:
+        text: A Markdown document.
+
+    Returns:
+        The 1-based line number of the opener still open at end of input,
+        or ``None`` when every fence in the document is closed.
+    """
+    return _scan_fences(text)[1]
+
+
+def _slug(heading_text: str) -> str:
+    """Convert heading text into a GitHub anchor slug.
+
+    Lowercase, delete every character that is not alphanumeric, a space, a
+    hyphen or an underscore, then map spaces to hyphens. Deletion (rather
+    than replacement) is what makes ``9. Tool Usage & Code Standards``
+    slug to ``9-tool-usage--code-standards``: the ampersand vanishes and
+    the two spaces that surrounded it each become a hyphen.
+
+    Args:
+        heading_text: The heading's text, with any closing run of hashes
+            already stripped.
+
+    Returns:
+        The anchor slug, before de-duplication.
+    """
+    return _SLUG_DROP.sub("", heading_text.lower()).replace(" ", "-")
+
+
+def _atx_headings(text: str) -> list[tuple[int, str]]:
+    """Return the level and bare slug of every ATX heading in ``text``.
+
+    Args:
+        text: A Markdown document.
+
+    Returns:
+        ``(level, slug)`` pairs in document order, for headings outside
+        fenced code. The slugs are not yet de-duplicated.
+    """
+    headings: list[tuple[int, str]] = []
+    for _, line in _lines_outside_code(text):
+        match = _ATX_HEADING.match(line)
+        if match is None:
+            continue
+        title = _CLOSING_HASHES.sub("", match["text"]).strip()
+        headings.append((len(match["hashes"]), _slug(title)))
+    return headings
+
+
+def _deduplicate(slugs: Iterable[str]) -> list[str]:
+    """Suffix repeated slugs the way GitHub does.
+
+    Args:
+        slugs: Bare slugs in document order.
+
+    Returns:
+        The same slugs with ``-1``, ``-2``, ... appended to the second and
+        later occurrences of each value; the first keeps the bare slug.
+    """
+    seen: dict[str, int] = {}
+    unique: list[str] = []
+    for slug in slugs:
+        occurrence = seen.get(slug, 0)
+        seen[slug] = occurrence + 1
+        unique.append(slug if occurrence == 0 else f"{slug}-{occurrence}")
+    return unique
+
+
+def heading_slugs(text: str, *, levels: Collection[int] | None = None) -> list[str]:
+    """Return the GitHub anchor slugs of ``text``'s ATX headings.
+
+    Only ATX headings (``^ {0,3}#{1,6} ``) are recognised. Setext support
+    is deliberately absent: there are no ``^=+$`` lines in the tracked
+    Markdown, so it could only ever fire on ``---`` -- turning every
+    horizontal rule in the repository into a phantom anchor minted from
+    whatever prose preceded it. Headings inside fenced code are skipped
+    for the same reason, using the same scanner as
+    :func:`find_unclosed_fence`.
+
+    Args:
+        text: A Markdown document.
+        levels: When given, keep only headings of these levels. The filter
+            is applied *after* de-duplication, so a heading's slug is the
+            one GitHub would mint for it in the whole document rather than
+            in the filtered subset.
+
+    Returns:
+        The slugs, in document order.
+    """
+    headings = _atx_headings(text)
+    unique = _deduplicate(slug for _, slug in headings)
+    return [
+        slug
+        for (level, _), slug in zip(headings, unique, strict=True)
+        if levels is None or level in levels
+    ]
+
+
+def same_file_anchor_links(text: str) -> list[tuple[int, str]]:
+    """Return every same-file anchor link in ``text``.
+
+    Links inside fenced code are excluded. Several skill files in this
+    repository are *examples of Markdown* and show a sample table of
+    contents inside a ``markdown`` block; resolving those against the
+    enclosing document's headings would manufacture failures nobody can
+    fix.
+
+    Args:
+        text: A Markdown document.
+
+    Returns:
+        ``(1-based line number, anchor without its leading "#")`` for each
+        ``[label](#anchor)`` link, in document order and left to right
+        within a line.
+    """
+    return [
+        (number, match["anchor"])
+        for number, line in _lines_outside_code(text)
+        for match in _ANCHOR_LINK.finditer(line)
+    ]
+
+
+def tracked_markdown_files(repo_root: Path) -> list[Path]:
+    """Return every ``*.md`` file git tracks under ``repo_root``.
+
+    Always shells out with an explicit ``-C repo_root``. The CI ``quality``
+    job runs with ``working-directory: creek-tools``, so a bare ``git
+    ls-files`` would quietly enumerate one subtree and the gate would miss
+    most of the repository. ``-z`` because git otherwise quotes paths
+    containing unusual bytes. Whether ``.git`` is a directory is never
+    probed: in a linked worktree it is a *file*, and that probe would
+    false-negative into an empty sweep.
+
+    Args:
+        repo_root: Directory to run git in, and the base the returned
+            paths are joined onto.
+
+    Returns:
+        The tracked Markdown paths, joined onto ``repo_root`` and sorted.
+
+    Raises:
+        RuntimeError: If the ``git`` binary cannot be run, if git exits
+            non-zero, or if the sweep comes back empty. Every failure mode
+            is loud: a discovery step that can return ``[]`` turns every
+            assertion downstream into a pass over nothing.
+    """
+    command = ["git", "-C", str(repo_root), "ls-files", "-z", "--", "*.md"]
+    try:
+        completed = subprocess.run(command, capture_output=True, check=False)
+    except OSError as error:
+        raise RuntimeError(f"Could not run `git ls-files`: {error}") from error
+
+    if completed.returncode != 0:
+        detail = completed.stderr.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(
+            f"`git ls-files` exited {completed.returncode} in {repo_root}: "
+            f"{detail or 'no diagnostic on stderr'}"
+        )
+
+    entries = completed.stdout.decode("utf-8").split("\0")
+    files = sorted(repo_root / entry for entry in entries if entry)
+    if not files:
+        raise RuntimeError(f"git tracks no Markdown files under {repo_root}")
+    return files
+
+
+def load_fence_exceptions(path: Path) -> dict[str, str]:
+    """Parse the fence-exception list at ``path``.
+
+    The format mirrors ``scripts/coverage-waivers.txt``: blank lines and
+    lines whose stripped form starts with ``#`` are ignored, and every
+    other line is partitioned on its first space into a repo-relative
+    POSIX path and a reason. Listed files are exempt from the fence check
+    **only**; the trailing-newline and anchor checks still apply.
+
+    Args:
+        path: The exception file to read.
+
+    Returns:
+        Path to reason, in file order.
+
+    Raises:
+        ValueError: If an entry carries no reason -- an exemption nobody
+            has to justify is a permanent one -- or if a path is listed
+            twice, which a plain dict would silently resolve last-one-wins
+            and take the first reason's issue reference with it.
+    """
+    exceptions: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        entry, _, reason = stripped.partition(" ")
+        if not reason.strip():
+            raise ValueError(
+                f"Fence exception {entry!r} in {path} has no reason; every "
+                "entry needs one, citing the issue that will remove it."
+            )
+        if entry in exceptions:
+            raise ValueError(f"Fence exception {entry!r} is listed twice in {path}")
+        exceptions[entry] = reason.strip()
+    return exceptions

--- a/creek-tools/tests/test_markdown_integrity.py
+++ b/creek-tools/tests/test_markdown_integrity.py
@@ -1,0 +1,778 @@
+"""Mechanical integrity gate for every tracked Markdown file (issue #1190).
+
+``creek-tools/CLAUDE.md`` shipped with a code fence that is opened and never
+closed, a table of contents listing seven sections that do not exist, and
+three internal links pointing at absent anchors. None of it was caught by
+anything: CI does not run ``pre-commit``, and the obvious hand-rolled check
+(``grep -c '^```'``) returns ``6`` on that file -- an even number, so the
+fences look balanced. An indent-tolerant count returns ``11``. The bug is
+invisible to the naive checker precisely because the broken opener is
+indented three spaces inside an ordered-list item.
+
+This module therefore does two things. Sections A/C/D prove the checker is
+*capable of failing* by driving it against synthetic documents whose verdict
+is known; section B applies it to the repository. Both halves matter: a
+repo-wide sweep that silently parses nothing would be a gate that cannot
+fail.
+
+Parsing lives in ``tests/markdown_integrity_support.py`` (a non-``test_*``
+module, so ``python_files = ["test_*.py"]`` never collects it). Its contract,
+which this module is written against:
+
+``find_unclosed_fence(text: str) -> int | None``
+    Return the 1-based line number of the fenced-code-block opener that is
+    still open at end of input, or ``None`` when every fence is closed.
+    CommonMark rules, and only these:
+
+    * An *opener* is a line indented 0-3 spaces followed by a run of three
+      or more backticks or three or more tildes, optionally followed by an
+      info string. Four or more spaces of indentation makes an indented code
+      block, not a fence.
+    * A *closer* is a line indented 0-3 spaces consisting solely of a run of
+      the **same** fence character, **at least as long** as the opener's
+      run, followed only by whitespace. An info string disqualifies a line
+      from closing anything.
+    * Fences do not nest. Inside an open fence every other line is content,
+      including a line that would otherwise open a fence -- which is why a
+      ``markdown`` block containing a ``json`` block ends early at the
+      inner block's bare closer, and why the outer block's intended closer
+      then opens a fresh, unclosed fence.
+    * The CommonMark rule that a backtick info string may not itself
+      contain a backtick is out of scope; no file in this repository
+      exercises it.
+
+``heading_slugs(text, *, levels=None) -> list[str]``
+    Return GitHub anchor slugs for the ATX headings of ``text``, in document
+    order. ``levels`` is a ``Collection[int] | None``; when given, the result
+    is filtered to headings of those levels *after* de-duplication, so
+    suffixes stay consistent with the whole document.
+
+    * ATX only (``^ {0,3}#{1,6} ``). Setext headings are deliberately not
+      recognised: there are zero ``^=+$`` lines across the tracked Markdown,
+      so honouring ``---`` as a setext underline would only manufacture a
+      bogus anchor out of every horizontal rule in the repository.
+    * Headings inside a fenced code block are skipped, using the same fence
+      scanner as :func:`find_unclosed_fence`.
+    * An optional closing run of ``#`` is stripped, then the text is
+      slugged: lowercase, drop every character that is not alphanumeric,
+      space, hyphen or underscore, then map spaces to hyphens.
+    * Repeated slugs get ``-1``, ``-2``, ... in order of appearance; the
+      first occurrence keeps the bare slug.
+
+``same_file_anchor_links(text) -> list[tuple[int, str]]``
+    Return ``(1-based line number, anchor without its "#")`` for every
+    inline ``[label](#anchor)`` link that is not inside a fenced code block,
+    in document order, left to right within a line. Only same-file targets
+    qualify -- a target must start with ``#``, so ``path.md#frag`` and
+    ``https://host/#frag`` are out of scope.
+
+``tracked_markdown_files(repo_root: Path) -> list[Path]``
+    Return the absolute path of every ``*.md`` file tracked by git, sorted.
+    Must shell out as ``git -C <repo_root> ls-files -z -- '*.md'``: the CI
+    ``quality`` job runs with ``working-directory: creek-tools``, so a bare
+    ``git ls-files`` would quietly scan one subtree and the gate would miss
+    most of the repository. ``-z`` because paths are otherwise quoted. It
+    must **not** probe whether ``.git`` is a directory -- in a linked git
+    worktree, which is where this branch is being developed, ``.git`` is a
+    file, and that probe false-negatives. A missing ``git`` binary or a
+    non-zero exit raises ``RuntimeError`` naming the cause; it must never
+    return an empty list, and this module must never skip.
+
+``load_fence_exceptions(path: Path) -> dict[str, str]``
+    Parse ``tests/markdown-integrity-exceptions.txt``, whose format mirrors
+    ``scripts/coverage-waivers.txt``: blank lines and lines whose stripped
+    form starts with ``#`` are ignored; every other line is partitioned on
+    its first space into a repo-relative POSIX path and a reason. Returns
+    path -> reason, insertion-ordered. A non-comment line carrying no reason
+    raises ``ValueError`` naming the offending path, as does a repeated
+    path. The listed files are exempt from the fence check **only** -- the
+    trailing-newline and anchor checks still apply to them.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.markdown_integrity_support import (
+    find_unclosed_fence,
+    heading_slugs,
+    load_fence_exceptions,
+    same_file_anchor_links,
+    tracked_markdown_files,
+)
+from tests.shell_command_support import CREEK_TOOLS_DIR, REPO_ROOT
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+EXCEPTIONS_FILE = CREEK_TOOLS_DIR / "tests" / "markdown-integrity-exceptions.txt"
+CREEK_TOOLS_CLAUDE_MD = CREEK_TOOLS_DIR / "CLAUDE.md"
+
+# The tracked-Markdown count was 251 when this gate was written. The floor is
+# an anti-vacuity guard, not a census: it fails loudly if discovery ever
+# collapses to a subtree (or to nothing) instead of passing on an empty sweep.
+MINIMUM_TRACKED_MARKDOWN_FILES = 200
+
+# The only files allowed in the fence-exception list. Every one of them is
+# broken by the same CommonMark nesting trap and is tracked by issue #1193.
+# Growing this set is a deliberate edit to a test, not a config tweak.
+KNOWN_FENCE_EXCEPTIONS = frozenset(
+    {
+        ".claude/skills/architectural-decisions/references/examples.md",
+        ".claude/skills/spec-decomposition/references/templates.md",
+        "creek-tools/.claude/skills/architectural-decisions.md",
+    }
+)
+
+_ISSUE_REFERENCE = re.compile(r"#\d+")
+_H2_HEADING = re.compile(r"^## +\S")
+
+
+def _doc(*lines: str) -> str:
+    """Join ``lines`` into a Markdown document with a trailing newline.
+
+    Written out line by line rather than as a triple-quoted block because
+    leading whitespace is load-bearing in most of these cases and
+    :func:`textwrap.dedent` would eat it.
+
+    Args:
+        *lines: The lines of the document, without line terminators.
+
+    Returns:
+        The document text, newline-separated and newline-terminated.
+    """
+    return "\n".join(lines) + "\n"
+
+
+def _tracked_markdown() -> list[Path]:
+    """Return every tracked Markdown file, refusing a vacuous result.
+
+    Returns:
+        Absolute paths of the tracked ``*.md`` files.
+
+    Raises:
+        AssertionError: If discovery found implausibly few files, which
+            would let every repo-wide assertion below pass by scanning
+            nothing.
+    """
+    files = tracked_markdown_files(REPO_ROOT)
+    assert len(files) >= MINIMUM_TRACKED_MARKDOWN_FILES, (
+        f"Found only {len(files)} tracked Markdown file(s) under {REPO_ROOT}; "
+        f"expected at least {MINIMUM_TRACKED_MARKDOWN_FILES}. Discovery has "
+        "collapsed to a subtree (a bare `git ls-files` run from creek-tools/ "
+        "does exactly this) and the gate is scanning almost nothing."
+    )
+    return files
+
+
+def _relative(path: Path) -> str:
+    """Return ``path`` as a repo-relative POSIX string.
+
+    Args:
+        path: An absolute path inside the repository.
+
+    Returns:
+        The path relative to :data:`REPO_ROOT`, POSIX-separated, which is
+        the form the exception file and every failure message use.
+    """
+    return path.relative_to(REPO_ROOT).as_posix()
+
+
+def _table_of_contents_anchors(text: str) -> list[str]:
+    """Return the anchors of the table-of-contents list at the top of ``text``.
+
+    The table of contents is the run of same-file anchor links that precedes
+    the document's first ``## `` heading. That region contains no code
+    fences in the file this is applied to, so no fence handling beyond what
+    :func:`same_file_anchor_links` already does is needed.
+
+    Args:
+        text: The full Markdown document.
+
+    Returns:
+        The anchors (without their leading ``#``) listed before the first
+        level-2 heading, in document order.
+    """
+    lines = text.splitlines()
+    first_section = len(lines)
+    for index, line in enumerate(lines):
+        if _H2_HEADING.match(line):
+            first_section = index
+            break
+    return [
+        anchor
+        for line_number, anchor in same_file_anchor_links(text)
+        if line_number <= first_section
+    ]
+
+
+# --------------------------------------------------------------------------
+# A. Parser self-tests -- prove the checker can fail
+# --------------------------------------------------------------------------
+
+_FENCE_CASES = [
+    pytest.param(
+        _doc("1. Item", "", "   ```python", "   x = 1"),
+        3,
+        id="opener-indented-three-spaces-is-a-fence",
+    ),
+    pytest.param(
+        _doc("1. Item", "", "   ```python", "   x = 1", "   ```"),
+        None,
+        id="indented-fence-closed-by-indented-closer",
+    ),
+    pytest.param(
+        _doc("Prose.", "", "    ```python", "    x = 1"),
+        None,
+        id="opener-indented-four-spaces-is-an-indented-code-block",
+    ),
+    pytest.param(
+        _doc("~~~", "code", "~~~"),
+        None,
+        id="tilde-fence-closed-by-tildes",
+    ),
+    pytest.param(
+        _doc("~~~", "code", "```", "more"),
+        1,
+        id="tilde-fence-not-closed-by-backticks",
+    ),
+    pytest.param(
+        _doc("```", "code", "~~~", "more"),
+        1,
+        id="backtick-fence-not-closed-by-tildes",
+    ),
+    pytest.param(
+        _doc("````", "code", "```", "more"),
+        1,
+        id="four-backtick-opener-not-closed-by-three",
+    ),
+    pytest.param(
+        _doc("````", "code", "````"),
+        None,
+        id="four-backtick-opener-closed-by-four",
+    ),
+    pytest.param(
+        _doc("```", "code", "````"),
+        None,
+        id="three-backtick-opener-closed-by-a-longer-run",
+    ),
+    pytest.param(
+        _doc("```", "code", "```python", "more"),
+        1,
+        id="closer-may-not-carry-an-info-string",
+    ),
+    pytest.param(
+        _doc("```", "code", "```   "),
+        None,
+        id="closer-may-carry-trailing-whitespace",
+    ),
+    pytest.param(
+        _doc(
+            "```markdown",
+            "# Example",
+            "",
+            "```json",
+            '{"a": 1}',
+            "```",
+            "",
+            "More prose.",
+            "```",
+        ),
+        9,
+        id="inner-fence-terminates-the-outer-block-early",
+    ),
+    pytest.param(
+        _doc("# Title", "", "```bash", "ls", "```", "", "Done."),
+        None,
+        id="balanced-backtick-document",
+    ),
+    pytest.param(
+        _doc("# Title", "", "~~~text", "hi", "~~~", "", "Done."),
+        None,
+        id="balanced-tilde-document",
+    ),
+    pytest.param(
+        _doc("# Title", "", "No fences here."),
+        None,
+        id="document-with-no-fences",
+    ),
+    pytest.param("", None, id="empty-document"),
+]
+
+
+@pytest.mark.parametrize(("document", "expected"), _FENCE_CASES)
+def test_find_unclosed_fence_matches_commonmark(
+    document: str, expected: int | None
+) -> None:
+    """The fence scanner agrees with CommonMark on every known-verdict case.
+
+    Two cases carry the whole issue. ``opener-indented-three-spaces-is-a-
+    fence`` is the shape that broke ``creek-tools/CLAUDE.md``: the opener
+    sits inside an ordered-list item at three spaces, so a checker anchored
+    on ``^`` never sees it and reports a balanced file.
+    ``inner-fence-terminates-the-outer-block-early`` is the shape that broke
+    three skill files (issue #1193): fences do not nest, so the inner block's
+    bare closer ends the outer block and the outer block's intended closer
+    opens a fence that is never closed.
+
+    Args:
+        document: A synthetic Markdown document.
+        expected: 1-based line number of the unclosed opener, or ``None``
+            when the document is balanced.
+    """
+    assert find_unclosed_fence(document) == expected
+
+
+_SLUG_CASES = [
+    pytest.param(
+        _doc("## 9. Tool Usage & Code Standards"),
+        ["9-tool-usage--code-standards"],
+        id="ampersand-is-dropped-leaving-a-double-hyphen",
+    ),
+    pytest.param(
+        _doc("### 9.1 Tool Invocation Patterns"),
+        ["91-tool-invocation-patterns"],
+        id="dot-is-dropped-from-a-numbered-subsection",
+    ),
+    pytest.param(
+        _doc("## Generic (`generic`)"),
+        ["generic-generic"],
+        id="parentheses-and-backticks-are-dropped-not-replaced",
+    ),
+    pytest.param(
+        _doc("## What `--apply` does"),
+        ["what---apply-does"],
+        id="backticks-vanish-leaving-the-literal-double-hyphen",
+    ),
+    pytest.param(
+        _doc("# Title", "", "## Section", "", "### Subsection"),
+        ["title", "section", "subsection"],
+        id="every-level-in-document-order",
+    ),
+    pytest.param(
+        _doc("## Setup", "", "## Setup", "", "## Setup"),
+        ["setup", "setup-1", "setup-2"],
+        id="repeated-headings-get-numeric-suffixes",
+    ),
+    pytest.param(
+        _doc("Some prose", "---", "", "## Real Heading"),
+        ["real-heading"],
+        id="triple-hyphen-is-a-horizontal-rule-not-a-setext-underline",
+    ),
+    pytest.param(
+        _doc("```bash", "# not a heading", "```", "", "## Real Heading"),
+        ["real-heading"],
+        id="headings-inside-a-fence-are-ignored",
+    ),
+    pytest.param(
+        _doc("## Foo ##"),
+        ["foo"],
+        id="closing-hash-run-is-stripped",
+    ),
+    pytest.param(
+        _doc("## a_b-c d"),
+        ["a_b-c-d"],
+        id="underscore-and-hyphen-survive-spaces-become-hyphens",
+    ),
+    pytest.param(
+        _doc("Prose.", "", "    # Indented"),
+        [],
+        id="four-space-indent-is-not-a-heading",
+    ),
+    pytest.param(
+        _doc("#NoSpace"),
+        [],
+        id="hash-without-a-following-space-is-not-a-heading",
+    ),
+]
+
+
+@pytest.mark.parametrize(("document", "expected"), _SLUG_CASES)
+def test_heading_slugs_match_github_anchors(document: str, expected: list[str]) -> None:
+    """Slugging reproduces GitHub's anchors for known headings.
+
+    The first two cases are lifted verbatim from ``creek-tools/CLAUDE.md``'s
+    own table of contents, so they pin the two characters that trip people
+    up: ``&`` is deleted rather than replaced, leaving the two spaces around
+    it to become a *double* hyphen, and ``.`` is deleted outright so
+    ``9.1`` slugs to ``91``. The next two are live headings from
+    ``docs/ingestion.md`` and ``docs/redaction.md`` that already have links
+    pointing at them; both would break if punctuation were replaced with a
+    hyphen instead of deleted.
+
+    ``triple-hyphen-is-a-horizontal-rule-not-a-setext-underline`` is the
+    negative case that keeps the anchor gate honest. There are zero ``^=+$``
+    lines in the tracked Markdown, so setext support could only ever fire on
+    ``---`` -- and every horizontal rule in the repository would then mint a
+    heading anchor out of whatever prose happened to precede it.
+
+    Args:
+        document: A synthetic Markdown document.
+        expected: The slugs the document should yield, in order.
+    """
+    assert heading_slugs(document) == expected
+
+
+def test_heading_slugs_dedupe_across_levels_then_filter() -> None:
+    """``levels`` filters after de-duplication, not before.
+
+    De-duplication is a property of the whole document -- GitHub numbers the
+    second ``Alpha`` ``alpha-1`` no matter what level it sits at. Filtering
+    first would hand back ``alpha`` for a heading whose real anchor is
+    ``alpha-1``, which is exactly the silent mis-resolution the anchor gate
+    exists to catch.
+    """
+    document = _doc("# Title", "", "## Alpha", "", "### Alpha", "", "## Alpha")
+
+    assert heading_slugs(document) == ["title", "alpha", "alpha-1", "alpha-2"]
+    assert heading_slugs(document, levels={2}) == ["alpha", "alpha-2"]
+    assert heading_slugs(document, levels={3}) == ["alpha-1"]
+    assert heading_slugs(document, levels={1, 3}) == ["title", "alpha-1"]
+
+
+_ANCHOR_CASES = [
+    pytest.param(
+        _doc("See [X](#x-y) and [Y](#z)."),
+        [(1, "x-y"), (1, "z")],
+        id="two-links-on-one-line-left-to-right",
+    ),
+    pytest.param(
+        _doc("```", "[X](#x)", "```", "", "[Y](#y)"),
+        [(5, "y")],
+        id="links-inside-a-fence-are-ignored",
+    ),
+    pytest.param(
+        _doc("```markdown", "- [A](#a)", "```"),
+        [],
+        id="sample-toc-inside-a-fence-is-ignored",
+    ),
+    pytest.param(
+        _doc("[X](other.md#x)"),
+        [],
+        id="cross-file-anchor-is-out-of-scope",
+    ),
+    pytest.param(
+        _doc("[X](https://example.com/page#x)"),
+        [],
+        id="external-anchor-is-out-of-scope",
+    ),
+    pytest.param(
+        _doc("- [1. A Section](#1-a-section)"),
+        [(1, "1-a-section")],
+        id="table-of-contents-entry",
+    ),
+    pytest.param(
+        _doc("no links here"),
+        [],
+        id="document-with-no-links",
+    ),
+]
+
+
+@pytest.mark.parametrize(("document", "expected"), _ANCHOR_CASES)
+def test_same_file_anchor_links_are_located(
+    document: str, expected: list[tuple[int, str]]
+) -> None:
+    """Only live, same-file anchor links are reported, with their line numbers.
+
+    Fenced content is excluded because this repository's skill files are
+    largely *examples of Markdown*: several show a sample table of contents
+    inside a ``markdown`` block. Resolving those against the enclosing
+    document's headings would produce failures nobody can fix.
+
+    Args:
+        document: A synthetic Markdown document.
+        expected: ``(line number, anchor)`` pairs, in document order.
+    """
+    assert same_file_anchor_links(document) == expected
+
+
+# --------------------------------------------------------------------------
+# B. Repo-wide assertions over tracked Markdown
+# --------------------------------------------------------------------------
+
+
+def test_tracked_markdown_discovery_covers_the_whole_repository() -> None:
+    """Discovery reaches both the repo root and the ``creek-tools`` subtree.
+
+    ``CLAUDE.md`` and ``creek-tools/CLAUDE.md`` are named explicitly because
+    they sit on opposite sides of the CI ``working-directory: creek-tools``
+    boundary. If the helper ever drops ``-C REPO_ROOT``, the root file
+    disappears from the sweep and every gate below narrows silently.
+    """
+    files = _tracked_markdown()
+    relative = {_relative(path) for path in files}
+
+    assert "CLAUDE.md" in relative
+    assert "creek-tools/CLAUDE.md" in relative
+    assert files == sorted(files)
+
+
+def test_tracked_markdown_discovery_fails_loudly_without_a_repository(
+    tmp_path: Path,
+) -> None:
+    """Discovery raises instead of returning an empty list when git cannot run.
+
+    A directory that does not exist is used rather than merely a non-repo
+    directory, so the outcome does not depend on whether the temp root
+    happens to sit inside some other checkout. The point is the failure
+    *mode*: a gate whose discovery step can return ``[]`` -- or skip -- is a
+    gate that cannot fail.
+    """
+    with pytest.raises(RuntimeError):
+        tracked_markdown_files(tmp_path / "definitely-not-a-repository")
+
+
+def test_every_tracked_markdown_file_has_balanced_code_fences() -> None:
+    """No tracked Markdown file leaves a code fence open at end of file.
+
+    Files named in ``tests/markdown-integrity-exceptions.txt`` are exempt
+    from *this* check only; the trailing-newline and anchor checks below
+    still cover them.
+    """
+    exceptions = load_fence_exceptions(EXCEPTIONS_FILE)
+    broken: list[str] = []
+    for path in _tracked_markdown():
+        relative = _relative(path)
+        if relative in exceptions:
+            continue
+        opener = find_unclosed_fence(path.read_text(encoding="utf-8"))
+        if opener is not None:
+            broken.append(f"{relative}:{opener}")
+
+    assert not broken, (
+        "Code fence opened and never closed (path:line of the opener): "
+        + ", ".join(broken)
+        + ". Close the fence; do not add it to "
+        "tests/markdown-integrity-exceptions.txt."
+    )
+
+
+def test_every_tracked_markdown_file_ends_with_exactly_one_newline() -> None:
+    """Every non-empty tracked Markdown file ends with a single ``\\n``.
+
+    All 251 tracked files satisfy this today, so this is pure regression
+    protection -- deliberately so. ``.github/workflows/ci.yml`` has no
+    ``pre-commit run`` step, which makes the ``end-of-file-fixer`` hook a
+    local convenience rather than a merge gate. Empty files are exempt
+    because an empty file has no last line to terminate.
+    """
+    offenders: list[str] = []
+    for path in _tracked_markdown():
+        raw = path.read_bytes()
+        if not raw:
+            continue
+        if not raw.endswith(b"\n"):
+            offenders.append(f"{_relative(path)} (no trailing newline)")
+        elif raw.endswith(b"\n\n"):
+            offenders.append(f"{_relative(path)} (blank line at end of file)")
+
+    assert not offenders, "Bad file ending: " + ", ".join(offenders)
+
+
+def test_every_same_file_anchor_link_resolves_to_a_heading() -> None:
+    """Every ``[...](#anchor)`` link points at a heading in its own file.
+
+    Cross-file ``path.md#fragment`` links are out of scope: resolving them
+    is a different check with different failure modes, and
+    ``creek clean broken-links`` already owns the vault-side equivalent.
+    """
+    dangling: list[str] = []
+    for path in _tracked_markdown():
+        text = path.read_text(encoding="utf-8")
+        slugs = set(heading_slugs(text))
+        dangling.extend(
+            f"{_relative(path)}:{line_number} -> #{anchor}"
+            for line_number, anchor in same_file_anchor_links(text)
+            if anchor not in slugs
+        )
+
+    assert not dangling, (
+        "Anchor link with no matching heading in the same file: " + ", ".join(dangling)
+    )
+
+
+# --------------------------------------------------------------------------
+# C. Exception-file semantics
+# --------------------------------------------------------------------------
+
+
+def test_fence_exceptions_file_exists_and_is_not_empty() -> None:
+    """The exception file exists and parses to at least one entry.
+
+    Without this, deleting the file (or emptying it) would turn the
+    "entries must still be broken" and "reasons must cite an issue" tests
+    below into no-ops that pass by iterating nothing.
+    """
+    assert EXCEPTIONS_FILE.is_file(), f"Missing {EXCEPTIONS_FILE}"
+    assert load_fence_exceptions(EXCEPTIONS_FILE)
+
+
+def test_no_fence_exception_names_an_untracked_file() -> None:
+    """Every exception entry names a file git still tracks.
+
+    Mirrors the orphan-waiver detector in ``scripts/coverage-per-file.sh``:
+    a stale entry is dead weight that quietly exempts nothing, and it hides
+    a path-format drift (``creek-tools/...`` vs ``...``) that would exempt
+    nothing either.
+    """
+    exceptions = load_fence_exceptions(EXCEPTIONS_FILE)
+    tracked = {_relative(path) for path in _tracked_markdown()}
+    orphans = sorted(set(exceptions) - tracked)
+
+    assert not orphans, (
+        "tests/markdown-integrity-exceptions.txt lists path(s) that are not "
+        "tracked Markdown files: " + ", ".join(orphans) + ". Remove them."
+    )
+
+
+def test_every_fence_exception_still_has_an_unclosed_fence() -> None:
+    """No exception entry names a file that now passes the fence check.
+
+    This is what stops the list becoming permanent cover. The moment issue
+    #1193 repairs a file, its entry has to go -- and the failure message
+    says so, rather than leaving a silent exemption behind.
+    """
+    exceptions = load_fence_exceptions(EXCEPTIONS_FILE)
+    now_passing: list[str] = []
+    for entry in exceptions:
+        target = REPO_ROOT / entry
+        if not target.is_file():
+            continue  # the orphan test above owns this failure mode
+        if find_unclosed_fence(target.read_text(encoding="utf-8")) is None:
+            now_passing.append(entry)
+
+    now_passing.sort()
+    assert not now_passing, (
+        "These file(s) now have balanced fences and no longer need an "
+        "exception: " + ", ".join(now_passing) + ". Delete their lines from "
+        "tests/markdown-integrity-exceptions.txt."
+    )
+
+
+def test_every_fence_exception_reason_cites_an_issue() -> None:
+    """Every exception reason references an issue number.
+
+    Same rule the coverage waivers carry: an exemption without a tracked
+    owner is a permanent one.
+    """
+    exceptions = load_fence_exceptions(EXCEPTIONS_FILE)
+    unsourced = sorted(
+        entry
+        for entry, reason in exceptions.items()
+        if not _ISSUE_REFERENCE.search(reason)
+    )
+
+    assert not unsourced, (
+        "Fence exception(s) with no issue reference in the reason: "
+        + ", ".join(unsourced)
+    )
+
+
+def test_fence_exceptions_cannot_grow_without_a_test_change() -> None:
+    """The exception list is a subset of the three files issue #1193 owns.
+
+    Shrinking is free; growing requires editing
+    :data:`KNOWN_FENCE_EXCEPTIONS`, which puts a new exemption in the diff
+    a reviewer is already reading rather than in a text file nobody opens.
+    """
+    exceptions = load_fence_exceptions(EXCEPTIONS_FILE)
+    unexpected = sorted(set(exceptions) - KNOWN_FENCE_EXCEPTIONS)
+
+    assert not unexpected, (
+        "Unexpected fence exception(s): "
+        + ", ".join(unexpected)
+        + ". Fix the fence instead; if an exemption really is warranted, "
+        "add the path to KNOWN_FENCE_EXCEPTIONS in this file with an issue."
+    )
+
+
+def test_load_fence_exceptions_ignores_comments_and_blank_lines(
+    tmp_path: Path,
+) -> None:
+    """Comments, indented comments and blank lines are not entries.
+
+    Args:
+        tmp_path: pytest-provided temporary directory.
+    """
+    path = tmp_path / "exceptions.txt"
+    path.write_text(
+        "# Fence-integrity exceptions.\n"
+        "\n"
+        "a/b.md nested-fence trap; issue #1193\n"
+        "   # an indented comment\n"
+        "c/d.md same trap; issue #1193\n",
+        encoding="utf-8",
+    )
+
+    assert load_fence_exceptions(path) == {
+        "a/b.md": "nested-fence trap; issue #1193",
+        "c/d.md": "same trap; issue #1193",
+    }
+
+
+def test_load_fence_exceptions_rejects_an_entry_without_a_reason(
+    tmp_path: Path,
+) -> None:
+    """A bare path with no reason is an error, not a reasonless exemption.
+
+    Args:
+        tmp_path: pytest-provided temporary directory.
+    """
+    path = tmp_path / "exceptions.txt"
+    path.write_text("a/b.md\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"a/b\.md"):
+        load_fence_exceptions(path)
+
+
+def test_load_fence_exceptions_rejects_a_duplicate_path(tmp_path: Path) -> None:
+    """A repeated path is an error rather than a last-one-wins overwrite.
+
+    Two entries for one file means two reasons, and a dict would silently
+    drop the first -- taking its issue reference with it.
+
+    Args:
+        tmp_path: pytest-provided temporary directory.
+    """
+    path = tmp_path / "exceptions.txt"
+    path.write_text(
+        "a/b.md first reason; issue #1193\na/b.md second reason; issue #1193\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=r"a/b\.md"):
+        load_fence_exceptions(path)
+
+
+# --------------------------------------------------------------------------
+# D. creek-tools/CLAUDE.md table of contents
+# --------------------------------------------------------------------------
+
+
+def test_creek_tools_claude_md_table_of_contents_is_bidirectional() -> None:
+    """Every section is in the TOC and every TOC entry names a real heading.
+
+    The anchor gate above only catches one direction. ``## 0. Repo topology``
+    exists in the body of ``creek-tools/CLAUDE.md`` and is absent from the
+    table of contents -- a real defect that no dangling-anchor check can
+    see, because there is no link to dangle.
+    """
+    text = CREEK_TOOLS_CLAUDE_MD.read_text(encoding="utf-8")
+    listed = _table_of_contents_anchors(text)
+    assert listed, "No table of contents found in creek-tools/CLAUDE.md"
+
+    all_slugs = set(heading_slugs(text))
+    sections = heading_slugs(text, levels={2})
+
+    missing_from_toc = [slug for slug in sections if slug not in set(listed)]
+    dangling = [anchor for anchor in listed if anchor not in all_slugs]
+
+    assert not missing_from_toc and not dangling, (
+        "creek-tools/CLAUDE.md table of contents is out of sync -- sections "
+        f"with no TOC entry: {missing_from_toc}; TOC entries with no such "
+        f"heading: {dangling}"
+    )


### PR DESCRIPTION
## Summary

- **The sections were never written — so nothing was invented.** I bisected the full history of `creek-tools/CLAUDE.md`: it was **born truncated** in the repository's initial commit (`1c47c9b`, already 396 lines ending at `# TODO: optimize`) and ended on that same line through all 14 later revisions. There is no revision to restore from; the table of contents was aspirational. Rather than fabricate standards nobody agreed to — which agents would then follow as project law — the seven absent TOC entries are retired in favour of pointers to the artifacts that actually define each topic.
- **Closes the truncation.** §6.2 item 3 is completed by mirroring the `❌ FORBIDDEN` / `✅ ALLOWED` shape items 1 and 2 already establish, and the fence is closed. It states a convention and claims no enforcement: ruff's `select` is `E,W,F,I,N,UP,B,C4,SIM,TCH,RUF`, so `TD`/`FIX` are not enabled and no pre-commit hook covers TODOs.
- **Reconciles the TOC in both directions.** Drops the seven entries with no section, and adds the missing `0. Repo topology` entry — that section existed in the body but not the TOC, a mismatch in the opposite direction that the issue did not mention. The two dangling body links (`#101-no-shortcuts-policy`, `#10-common-pitfalls--troubleshooting`) are retargeted to headings that exist; the third becomes an anchorless path, which cannot rot.
- **Adds `## 7. Where the rest lives`** — a pointer block to twelve artifacts, each verified to exist. It states no policy, applying this file's own §1.2 DRY rule ("Never duplicate content. Always reference the canonical source."). Every one of the eight pre-existing factual errors in this file is a restatement that drifted, so pointers are the shape that does not repeat the mistake.
- **Adds a mechanical gate** (`tests/test_markdown_integrity.py`, 50 tests) over every tracked `*.md`: balanced code fences, exactly one trailing newline, resolvable same-file anchors, plus a bidirectional TOC check on `CLAUDE.md`.

### Why the gate is indent-tolerant, and why that is the whole point

The broken fence was indented three spaces inside an ordered-list item. `grep -c '^```'` returns **6** on the pre-fix file — an even number, so the fences look balanced and a naive checker passes on the very file that motivated this issue. A CommonMark-correct scan returns **11**. The checker therefore implements real fence semantics: openers indented 0–3 spaces (4+ is an indented code block), closers matching the opener's character and length with no info string, and **no nesting** — a ```` ```markdown ```` block containing an inner ```` ```json ```` block ends early at the inner bare closer, and the outer's intended closer then opens a fresh unclosed fence.

Two further deliberate properties, because a gate that cannot fail is worse than no gate:
- **Anti-vacuity floor.** Discovery is `git -C <repo_root> ls-files -z -- '*.md'`, never a bare `git ls-files` — CI's `quality` job runs with `working-directory: creek-tools`, which would silently scan one subtree. It asserts ≥200 files (currently 251) and that both `CLAUDE.md` files are found, and **hard-fails rather than skipping** if git is unavailable.
- **A self-expiring exception list.** `tests/markdown-integrity-exceptions.txt` (format mirroring `scripts/coverage-waivers.txt`) exempts three files from the **fence check only** — newline and anchor checks still apply. Tests fail if an entry names a missing file, if an entry's file now passes, or if a reason cites no issue; growing the list requires a reviewed test diff.

## Test plan

- `pytest tests/test_markdown_integrity.py` → **50 passed**. Verified the RED→GREEN sequence at each step rather than only the end state: collection `ImportError` → **47 passed / 3 failed** after the parser landed, failing on the three genuine defects (unclosed fence at `CLAUDE.md:467`, 9 dangling anchors, TOC out of sync) → 50 passed after the document repair.
- `./scripts/check-all.sh` → **exit 0**, 12/12 checks, 7527 tests passed, 94.13% coverage. Baseline on this branch before any change was also exit 0, so the delta is attributable.
- Confirmed the repaired file: fences balanced (12, even under an indent-tolerant scan), last byte `0x0a`, zero dangling anchors.
- Scanned all 251 tracked `*.md`: exactly four files had unclosed fences and none had trailing-newline problems. The three files that are not this one are filed, not fixed here.
- Gate 2.5 `code-review-orchestrator` → **CLEAN**, having independently re-traced the nesting logic against two exception-list files and re-run the suite.

## Deliberately out of scope — filed, not fixed

- **#1194** — this file's *existing* body carries **eight verified factual errors** (a `/docs/workflows/` DRY source that has never existed; a `tests/unit/` layout that does not exist, in an example held up as ✅ correct; mypy attributed to `lint.sh`, which contains zero references to it; interrogate/pylint attributed to `lint-extended.sh`, whose own header reads *"OPTIONAL — not currently invoked from check-all.sh or CI"*; a `unit` marker that is not registered under `--strict-markers`). Repairing them is a larger job than closing the fence and would have made this diff unreviewable, so §§1.1, 1.2, 1.6, 5.2 and 6.1 are left untouched — wrong.
- **#1193** — three skill/reference docs broken by the same CommonMark nesting trap. These are the exception-list entries; each expires automatically when fixed.
- **#1195** — cross-file link checking (`path.md`, `path.md#fragment`). §7's pointers convert a staleness risk into a link-rot risk, and nothing detects link rot today; #1194's dead `/docs/workflows/` path is the proof.

Closes #1190
