### PR TITLE
fix(ralph): refuse a verdict that cannot name the PR it reviewed

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -61,12 +61,51 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "dependabot[bot]"
           show_full_output: true
+          # THE PR NUMBER IS STATED HERE BECAUSE THE AGENT CANNOT DERIVE IT
+          # (#1181). `actions/checkout` above checks out `refs/pull/<N>/merge` in
+          # DETACHED HEAD, so `gh pr view --json number` — the agent's natural
+          # first move — fails with "could not determine current branch: failed
+          # to run git: not on any branch". On PR #1117 it then guessed via
+          # `gh pr list`, matched the merge ref's base parent to PR #1179's
+          # `mergeCommit.oid`, reviewed that bump's diff, and this workflow
+          # posted the resulting LGTM onto #1117. There is NO diff range anywhere
+          # in this file: the defect was PR-number RESOLUTION, not range
+          # selection, and a "fix" to a range would change nothing.
+          #
+          # INTERPOLATION SAFETY: `github.event.pull_request.number` is an
+          # integer and `github.repository` is `owner/repo` over GitHub's own
+          # name charset. Neither is attacker-controlled free text the way
+          # `title` / `body` / branch names are, so splicing them into the prompt
+          # adds no injection surface.
+          #
+          # AND THE USUAL `env:` + `$VAR` HARDENING DOES NOT APPLY HERE. `prompt`
+          # is an ACTION INPUT, not a shell script: nothing expands `$VAR` on the
+          # way in, so an `env:` indirection would ship the literal characters
+          # `$PR_NUMBER` to the model and silently restore the bug this whole
+          # change exists to fix. Do not "harden" it that way.
           prompt:  |
+            You are reviewing pull request #${{ github.event.pull_request.number }}
+            of the repository ${{ github.repository }}.
+
+            THAT NUMBER IS AUTHORITATIVE. It is the PR this review will be posted
+            to, and it is the only PR you may review. Do not try to work out
+            which PR you are on: the checkout is `refs/pull/${{ github.event.pull_request.number }}/merge`
+            in detached HEAD, so a bare `gh pr view` or `gh pr diff` WILL fail
+            with "could not determine current branch: failed to run git: not on
+            any branch". That failure is expected — it is not a reason to search.
+
+            NEVER infer the pull request from `git log`, from a merge commit's
+            parent OID, or by listing pull requests. Pass the number and the
+            repository explicitly on every `gh` call:
+
+              gh pr diff ${{ github.event.pull_request.number }} -R ${{ github.repository }}
+              gh pr view ${{ github.event.pull_request.number }} -R ${{ github.repository }}
+
             Review this pull request against the repository's CLAUDE.md. Read the
-            change with `gh pr diff` and `gh pr view` (and any files you need).
+            change with those commands (and any files you need).
 
             Do NOT post a comment yourself. Return ONLY the structured result with
-            three fields:
+            four fields:
 
             - "review_markdown": the full review as GitHub markdown, using this
               template (omit the verdict here — it is a separate field below):
@@ -109,16 +148,61 @@ jobs:
               blocking issue(s). For COMMENTS, name the substantive suggestion(s)
               that kept it from LGTM. For LGTM, state why it is ready to merge.
 
+            - "reviewed_pr_number": the integer you actually passed to
+              `gh pr diff` — copy it from your own command, not from the
+              instructions above. It is a report of what you DID, not an echo of
+              what you were told; the workflow compares it with the PR it is
+              about to comment on and discards the whole review if they differ.
+
           # The --json-schema flag makes the action return a validated
           # ``structured_output`` JSON string (verdict + rationale +
-          # review_markdown) instead of relying on the agent to remember to post a
-          # comment — the "Post review" step below then posts it deterministically
-          # (fixes flaky success-with-no-comment runs). gh pr comment is
-          # intentionally NOT in allowed-tools so the agent cannot post on its own.
+          # review_markdown + reviewed_pr_number) instead of relying on the agent
+          # to remember to post a comment — the "Post review" step below then
+          # posts it deterministically (fixes flaky success-with-no-comment
+          # runs). gh pr comment is intentionally NOT in allowed-tools so the
+          # agent cannot post on its own.
+          #
+          # `reviewed_pr_number` is in BOTH `required` and `properties`, with
+          # `additionalProperties:false` kept: `required` without `properties`
+          # validates nothing, and `properties` without `required` makes it
+          # optional — so an agent that cannot work out which PR it read would
+          # simply omit it, which is precisely the #1117 failure. It must be a
+          # hard schema violation instead.
+          #
+          # `Bash(gh pr list:*)` IS GONE, and its absence is worth keeping — but
+          # it is DEFENCE IN DEPTH, NOT A PROOF, and must never be cited as one.
+          # `gh pr list --state all --json number,title,headRefName,mergeCommit,commits`
+          # is literally the command the #1117 run used to guess its way to the
+          # wrong PR, so removing it takes away the specific instrument of that
+          # incident and raises the bar for the next accident. It does NOT remove
+          # the CAPABILITY: `gh search prs --repo owner/repo --json number`
+          # enumerates pull requests just as well. Anyone who reads this list as
+          # "the agent cannot enumerate, therefore it cannot guess" has the
+          # security story backwards.
+          #
+          # `Bash(gh search:*)` STAYS anyway, deliberately. Nothing in the prompt
+          # above asks the reviewer to search — but a reviewer that cannot look up
+          # a related issue or a prior PR writes worse reviews, and taking a
+          # capability away buys nothing here once the real control below is in
+          # place. A review-quality regression traded for a non-guarantee is a bad
+          # trade.
+          #
+          # THE ACTUAL CONTROL IS THE WORKFLOW-SIDE `reviewed_pr_number`
+          # CROSS-CHECK in the "Post review" step: the agent reports the number it
+          # actually passed to `gh pr diff`, this workflow compares it with
+          # `$PR_NUMBER`, and a mismatch discards the review, posts no comment and
+          # fails the check. That check does not care HOW the agent arrived at a
+          # number, so it holds even against one that enumerated by some route
+          # nobody anticipated — which is exactly why it, and not this list, is
+          # the gate. `scripts/ralph/pr-ready.sh` leans on the same asymmetry: its
+          # provenance marker attests only that a pipeline version running THIS
+          # cross-check posted the verdict, so weakening the cross-check silently
+          # empties every marker in the fleet while every test about the marker
+          # stays green.
           claude_args: >-
             --model sonnet
-            --json-schema '{"type":"object","additionalProperties":false,"required":["verdict","verdict_rationale","review_markdown"],"properties":{"verdict":{"type":"string","enum":["CHANGES_REQUESTED","COMMENTS","LGTM"]},"verdict_rationale":{"type":"string"},"review_markdown":{"type":"string"}}}'
-            --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"
+            --json-schema '{"type":"object","additionalProperties":false,"required":["verdict","verdict_rationale","review_markdown","reviewed_pr_number"],"properties":{"verdict":{"type":"string","enum":["CHANGES_REQUESTED","COMMENTS","LGTM"]},"verdict_rationale":{"type":"string"},"review_markdown":{"type":"string"},"reviewed_pr_number":{"type":"integer"}}}'
+            --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
 
       - name: Post review
         # Deterministic: this step always runs after a successful review and posts
@@ -183,9 +267,53 @@ jobs:
             echo "::error::Claude review produced no structured output — failing so it is re-run, never a silent no-review."
             exit 1
           fi
+          # --- THE CROSS-CHECK (#1181) --------------------------------------
+          # Everything from here down runs only on the REAL review path; the
+          # self-skip branch above returns at its own `exit 0` with no verdict
+          # and no marker, and must keep doing so — it is the path taken by any
+          # PR that edits this very file.
+          #
+          # The agent reports the number it actually passed to `gh pr diff`. If
+          # that is not this PR, the review describes somebody else's code: it is
+          # discarded, no comment is posted, and the check goes red.
+          #
+          # STRING comparison on purpose, and the `^[0-9]+$` guard is what makes
+          # the reason narrow: an empty or lettered report is already refused by
+          # the regex, so `0100` is the ONE surviving value where `-eq` and a
+          # string `!=` disagree at all — and the two shells this repo runs under
+          # disagree with EACH OTHER about it. Measured, not assumed:
+          #
+          #   bash 5.3.15                        [[ "0100" -eq 100 ]] → TRUE   -eq 64 → FALSE
+          #   bash 3.2 (stock /bin/bash, macOS)  [[ "0100" -eq 100 ]] → FALSE  -eq 64 → TRUE
+          #
+          # (bash 5 reads the leading zero as decimal in `[[ ]]`'s arithmetic
+          # context; bash 3.2 reads it as octal 64. The runner here is bash 5, so
+          # the octal reading does NOT happen on CI — which is what makes a
+          # numeric compare worse than merely wrong: it is shell-version-
+          # dependent, with nothing in the output to say which reading ran.)
+          # String equality is exact and version-independent, and it is the same
+          # choice `pr-ready.sh` makes on the parser side of this contract, with
+          # the same measurements recorded there and a `pr=0100` case pinning it
+          # in `scripts/ralph/test_pr_ready.sh`.
+          reviewed_pr=$(jq -r '.reviewed_pr_number // ""' <<<"$STRUCTURED")
+          if [[ ! "$reviewed_pr" =~ ^[0-9]+$ ]] || [[ "$reviewed_pr" != "$PR_NUMBER" ]]; then
+            echo "::error::The reviewer reports it read PR '${reviewed_pr}', not #${PR_NUMBER} — it reviewed the wrong pull request (or could not say which). This is NOT a defect in this PR's code and nothing here needs changing; the review itself is void and must be re-run. See #1181."
+            exit 1
+          fi
           verdict=$(jq -r '.verdict' <<<"$STRUCTURED")
           rationale=$(jq -r '.verdict_rationale // ""' <<<"$STRUCTURED")
-          jq -r '.review_markdown' <<<"$STRUCTURED" > review.md
+          # PROVENANCE MARKER, PREPENDED — `> review.md` here and `>>` below.
+          # Prepending (rather than appending) puts it at column 0 on the first
+          # line, exactly like the `<!-- review-self-skip -->` marker above, so
+          # no markdown indentation rule can ever swallow it. `%s`, not `%d`:
+          # `scripts/ralph/test_pr_ready.sh` greps THIS format string out of THIS
+          # file, renders it, and round-trips it through `pr-ready.sh`'s parser,
+          # which compares bytes — so the literal below is a CROSS-FILE CONTRACT
+          # with that parser and `.github/workflows/iteration-trigger.yml`, not a
+          # cosmetic detail. Change it in one place and CI goes red in the other.
+          # `$PR_NUMBER` is GitHub's own event field, never the agent's claim.
+          printf '<!-- creek-review pr=%s -->\n\n' "$PR_NUMBER" > review.md
+          jq -r '.review_markdown' <<<"$STRUCTURED" >> review.md
           # Keep the "## Verdict: <verdict>" line exactly — downstream skills
           # (address-feedback, await-claude-review) parse it. The rationale goes
           # on the following line so the verdict is never ambiguous.

--- a/.github/workflows/iteration-trigger.yml
+++ b/.github/workflows/iteration-trigger.yml
@@ -7,11 +7,17 @@ name: Iteration Trigger
 # per PR to avoid runaway loops.
 #
 # The "cleared to squash merge" line this job emits is a merge instruction, so it
-# must enforce the SAME invariant as scripts/ralph/pr-ready.sh or it becomes a
-# second code path that falsifies it. It therefore also checks that the head is
-# current with its base (compare API `behind_by == 0`) and that no
-# `do-not-auto-merge` hold is set, and names the blocker instead of clearing when
-# either fails. Both fail closed on an unreadable answer.
+# must enforce the SAME invariants as scripts/ralph/pr-ready.sh or it becomes a
+# second code path that falsifies it. It therefore mirrors three of them, and
+# names the blocker instead of clearing when any fails:
+#   * no `do-not-auto-merge` hold on the PR;
+#   * the head is current with its base (compare API `behind_by == 0`);
+#   * the verdict carries the `<!-- creek-review pr=N -->` provenance marker for
+#     THIS PR (#1181) — the marker pr-ready.sh's MARKER_RE parses, read from the
+#     same comment the verdict came from.
+# All three fail closed on an unreadable answer. Note that only the provenance
+# branch also rewrites `VERDICT`; see the comment at that `elif` for why the
+# other two do not, and #1202 for the gap that leaves.
 #
 # Required secrets:
 #   GEOFFE_GA_PAT  - personal access token for the repo owner with `pull-requests: write`.
@@ -83,6 +89,27 @@ jobs:
           ID=$(jq -r '.id'   <<<"$CLAUDE")
           BODY=$(jq -r '.body' <<<"$CLAUDE")
 
+          # PROVENANCE (#1181), read from the SAME comment the verdict came from
+          # — the parity requirement in this file's header, and byte-for-byte the
+          # marker scripts/ralph/pr-ready.sh parses. code-review.yml prepends
+          # `<!-- creek-review pr=N -->` with N taken from
+          # `github.event.pull_request.number`, so a verdict without it came from
+          # the pipeline that reviewed PR #1179 and posted the LGTM onto #1117.
+          # Whole-LINE match: a marker quoted mid-sentence in review prose (a
+          # review of that change quotes one) attests to nothing. The trailing
+          # `[[:space:]]*` absorbs a carriage return, matching MARKER_RE in
+          # pr-ready.sh so the two clearance paths cannot disagree about bytes.
+          # `head -n 1` for the same reason: pr-ready.sh takes the FIRST marker in
+          # the body, so this must too.
+          #
+          # `|| true` on the whole pipeline because `set -euo pipefail` is on at
+          # the top of this step: grep exits 1 when there is no marker, which is
+          # the ordinary legacy case and not an error — and under `pipefail` that
+          # 1 would abort the step even though `tr` (the LAST command, whose
+          # status the pipeline would otherwise report) exits 0.
+          MARKER_PR=$(grep -oE '^<!-- creek-review pr=[0-9]+ -->[[:space:]]*$' <<<"$BODY" \
+                        | head -n 1 | tr -dc '0-9' || true)
+
           # Parse the verdict from that line only — grepping the whole body is
           # unsafe (a COMMENTS rationale may itself mention "LGTM"). When the
           # body carries several verdict lines (the reviewer re-verdicted in
@@ -129,6 +156,41 @@ jobs:
           if [ "$GREEN" = "$TOTAL" ] && [ "$VERDICT" = "LGTM" ]; then
             if [ "$HELD" != "no" ]; then
               ACTION="NOT cleared to merge: the do-not-auto-merge hold is set on this PR (or its labels could not be read). A human owns this one - leave it alone."
+            elif [ "$MARKER_PR" != "$PR" ]; then
+              # Fails CLOSED: an absent or unparseable marker leaves MARKER_PR
+              # empty, which never equals a PR number, so it does not clear.
+              #
+              # REWRITING `VERDICT` IS WHAT ACTUALLY STOPS THE MERGE; `ACTION` IS
+              # NOT LOAD-BEARING. `.claude/skills/await-claude-review/SKILL.md`
+              # Step 4a parses `**VERDICT**:` and `**CI**: x/y Green` and nothing
+              # else — its item 3 returns LGTM to the caller on those two fields
+              # alone, and its item 5 says in as many words "Do not infer a
+              # verdict from the `Action:` prose". VERDICT is computed from the
+              # review comment ABOVE this clearance chain, and the chain only ever
+              # rewrote ACTION, so a marker-mismatched PR still posted
+              # `**VERDICT**: LGTM` + `**CI**: N/N Green` and a woken session
+              # merged on it — while Step 3 makes this summary SHORT-CIRCUIT
+              # per-event classification, so it is exactly the half that wins over
+              # pr-ready.sh's `awaiting-review`. A comment must not assert a
+              # merge-clearing verdict that the same comment then refuses.
+              #
+              # `NOT ATTESTED` is chosen for its BYTES: it contains no `LGTM`
+              # substring, so neither the `*LGTM*` glob above nor a downstream
+              # `test("LGTM")` can match it, and it is none of the three verdicts
+              # SKILL.md's recognition rule accepts — so Step 4a falls to item 5
+              # (marker present, verdict unparseable → surface to the user), which
+              # is the destination we want: a human looks, nobody merges.
+              # Assigning it here is safe because the enclosing
+              # `[ "$GREEN" = "$TOTAL" ] && [ "$VERDICT" = "LGTM" ]` has already
+              # been evaluated, and nothing reads VERDICT again before the BODY
+              # printf below.
+              #
+              # DELIBERATELY NOT DONE ON THE `HELD` AND `BEHIND` BRANCHES. They
+              # carry the identical pre-existing hole — a `do-not-auto-merge` hold
+              # is defeated the same way — and it is filed as #1202 (P1). The
+              # asymmetry is scoped to #1181 on purpose, not an oversight.
+              VERDICT='NOT ATTESTED'
+              ACTION="NOT cleared to merge: the latest verdict does not attest that the reviewer read THIS PR - its provenance marker names '${MARKER_PR}', not ${PR}. Run scripts/ralph/fleet.sh sync (or push any commit) so the marker-emitting review workflow runs on this branch and the re-review is attested; re-running the old review run will not help, it replays the workflow file from the commit that run was launched from. See #1181."
             elif [ "$BEHIND" != "0" ]; then
               ACTION="NOT cleared to merge: this head is not current with ${BASE:-its base} (behind_by='${BEHIND}'). Run scripts/ralph/fleet.sh sync and let CI re-run first."
             else

--- a/.github/workflows/ralph-recap-tests.yml
+++ b/.github/workflows/ralph-recap-tests.yml
@@ -10,15 +10,39 @@ name: Ralph Tooling Tests
 # same `scripts/ralph/**` paths, so the split was two workflows pretending to
 # be two concerns while covering one directory (#1096 fix 3).
 
+# code-review.yml is in BOTH path lists for the same reason every suite below is
+# listed explicitly: a suite that is written but never wired in here is not a
+# gate, it is a file. test_pr_ready.sh's coupling cases (issue #1181) read that
+# workflow — the EMITTER of the `<!-- creek-review pr=N -->` provenance marker —
+# and round-trip its printf format through pr-ready.sh's parser. Filtering on
+# `scripts/ralph/**` alone meant a PR that edits only the emitter ran no coupling
+# check at all: precisely the one change class those cases exist to guard. Both
+# triggers, because a `push`-only filter still lets the drift land through a PR
+# and a `pull_request`-only filter misses a direct push to `main`.
+#
+# iteration-trigger.yml is here for the identical reason: it is the SECOND
+# merge-clearance path. It posts "You are cleared to squash merge" off its own
+# verdict parse, so it must enforce the same invariant as pr-ready.sh or it
+# becomes a code path that falsifies the first — and it cleared PR #1117 on
+# #1179's verdict too. test_pr_ready.sh asserts two literals lifted out of it:
+# the anchored marker ERE its `MARKER_PR` extraction greps with, and the
+# `[ "$MARKER_PR" != "$PR" ]` clearance guard that consults it (extracting a
+# marker and never reading it is the same bug with an extra step). Both
+# assertions are as coupled to that file as the round trip is to the emitter, so
+# a PR that edits only iteration-trigger.yml must run this suite as well.
 on:
   push:
     paths:
       - "scripts/ralph/**"
       - ".github/workflows/ralph-recap-tests.yml"
+      - ".github/workflows/code-review.yml"
+      - ".github/workflows/iteration-trigger.yml"
   pull_request:
     paths:
       - "scripts/ralph/**"
       - ".github/workflows/ralph-recap-tests.yml"
+      - ".github/workflows/code-review.yml"
+      - ".github/workflows/iteration-trigger.yml"
 
 permissions:
   contents: read

--- a/scripts/ralph/pr-ready.sh
+++ b/scripts/ralph/pr-ready.sh
@@ -7,7 +7,8 @@
 #
 #   ready            LGTM (fresh) + CI green + verified current with main → merge now
 #   ready-unreviewed CI green (with real checks that actually passed) + verified
-#                    current with main, but this PR HAS no review gate: Dependabot
+#                    current with main, but this PR HAS no review gate: NO
+#                    verdict-bearing comment was ever posted on it, Dependabot
 #                    authored it AND pushed its HEAD commit, and `claude-review`
 #                    reported SKIPPED → the orchestrator decides (see ralph-tick.md)
 #   behind           LGTM (fresh) + CI green, but `main` has landed something
@@ -85,9 +86,16 @@
 # `ralph-tick.md` and never silently here — and in THIS repo ralph-tick.md's
 # Step 1 routing does not merge on this token, it hands the lane to a human.
 #
-# Two conditions beyond "Dependabot authored it" make that safe, because the
+# Three conditions beyond "Dependabot authored it" make that safe, because the
 # token's whole justification is "green CI against current main replaces the
 # review":
+#   * NO verdict-bearing comment may exist on the PR — the `verdict_comment_seen`
+#     latch, checked first inside `review_gate_absent` and argued at its own
+#     block further down (#1181). A comment carrying a verdict LINE (whatever
+#     `VERDICT_RE` accepts) is proof that SOMETHING reviewed this PR, so the
+#     shortcut's premise — "there is no review gate to wait for" — is already
+#     false, whatever became of that verdict afterwards: refused for provenance,
+#     stale, or unreadable.
 #   * At least one NON-review check must have actually SUCCEEDED. `gh pr checks`
 #     exits 0 when every check merely skipped, and the test workflows here are
 #     `paths:`-filtered to their own sources — so a `github-actions` ecosystem
@@ -102,7 +110,165 @@
 #
 # Stale-verdict guard: a review verdict only counts when it was posted AFTER the
 # PR's HEAD commit. An LGTM from before the latest push is stale (it reviewed
-# older code) and must not gate a merge.
+# older code) and must not gate a merge. The `createdAt` it compares is the
+# SELECTED comment's, so the selector's exclusion of iteration-trigger.yml's
+# summary (ITER_SUMMARY_RE) belongs to THIS guard as much as to the provenance
+# one: before that exclusion, a stale review followed by a fresh summary handed
+# this comparison the SUMMARY's stamp and read as fresh. That hole predates
+# #1181, which masked it (the summary was refused for want of a marker before
+# freshness was ever consulted) rather than closing it. It is closed and pinned
+# now.
+#
+# ---------------------------------------------------------------------------
+# PROVENANCE GUARD: A VERDICT MUST NAME THE PR IT REVIEWED (#1181)
+# ---------------------------------------------------------------------------
+# A verdict also only counts when the comment carrying it carries the marker
+# `.github/workflows/code-review.yml` prepends to every review it posts —
+# `<!-- creek-review pr=N -->` — and N is THIS PR. The marker is read from the
+# SAME comment `VERDICT_RE` already selected (one `--jq`, one `$v` binding), and
+# a marker that is absent, malformed, or names another PR makes the verdict NO
+# VERDICT AT ALL: it gates neither `ready` nor `changes-requested`, so the lane
+# falls through to `awaiting-review` — and never FORWARD into `ready-unreviewed`,
+# which is what the verdict-EXISTED latch at the parse site enforces.
+#
+# WHICH COMMENT "THE VERDICT" IS, HOWEVER, IS ITS OWN QUESTION, AND GETTING IT
+# WRONG DEFEATS EVERYTHING BELOW. The selector takes the LAST comment matching
+# VERDICT_RE, and in this repo that was routinely NOT a review at all:
+# `.github/workflows/iteration-trigger.yml`'s executive summary matches
+# VERDICT_RE too and posts last on every lane, so between #1181 landing and this
+# fix the guard was refusing a comment that had never been a verdict and holding
+# the entire fleet on it. ITER_SUMMARY_RE excludes that comment inside the same
+# `--jq`; the measurement, the decision to anchor it, and the residual it accepts
+# are argued at that constant, and the correction to this file's own
+# fleet-wide-risk argument is in the third-polarity block below.
+#
+# IT IS A PROVENANCE ATTESTATION, NOT A WRONG-DIFF DETECTOR. The workflow
+# computes `pr=` from `github.event.pull_request.number` — the same value it
+# posts the comment to — so in normal operation `pr=` CANNOT disagree with the
+# PR the comment lives on, and this parser therefore cannot, on its own, catch a
+# reviewer that read the wrong diff. Its whole force is negative: it refuses any
+# verdict that did not come from a pipeline version which runs the
+# WORKFLOW-SIDE `reviewed_pr_number` cross-check, where the agent self-reports
+# the number it actually passed to `gh pr diff`, the workflow compares it with
+# `$PR_NUMBER`, and any mismatch fails the check with no comment posted. THAT
+# cross-check is the detector; this marker is the proof it was in force. It is
+# spelled out because the tempting "simplification" is to delete the cross-check
+# believing the marker covers it — after which every marker in the fleet would
+# attest to nothing at all.
+#
+# THE INCIDENT (2026-08-07, PR #1117). The `prompt:` never stated the PR number,
+# and `actions/checkout` leaves the runner in DETACHED HEAD on
+# `refs/pull/<N>/merge`, so the agent's first command — `gh pr view --json
+# number,…` — died with "could not determine current branch: failed to run git:
+# not on any branch". It then GUESSED: `gh pr list --state all --limit 20 --json
+# number,title,headRefName,mergeCommit,commits`, read `git log`'s `Merge a332aec
+# into 46182a6f`, matched that BASE parent against PR #1179's `mergeCommit.oid`,
+# and reviewed #1179's `cryptography`-floor bump (`gh pr diff 1179`, `gh pr view
+# 1179`, `gh pr checks 1179`). The workflow posted the resulting LGTM onto #1117
+# (`PR_NUMBER: 1117`), and `pr-ready.sh 1117` printed `ready` — a 38-file
+# authenticated HTTP surface one orchestrator tick from merging on a review of a
+# dependency bump. FOR THE NEXT READER: the issue's `HEAD^1..HEAD` diff-range
+# hypothesis is REFUTED, by the owner himself. There is no diff range anywhere
+# in that workflow; the defect was PR-number RESOLUTION, and a range-selection
+# "fix" would have changed nothing.
+#
+# NO GRANDFATHER CLAUSE FOR UNMARKED LEGACY VERDICTS — and a time-based one
+# would be incorrect rather than merely lenient. `pull_request` runs execute the
+# workflow file from the PR's OWN merge ref, not from `main`, so a branch cut
+# before this change keeps emitting unmarked verdicts AFTER it lands. There is
+# no cutoff T that ever expires, which makes a grandfather clause here
+# indistinguishable from leaving the feature switched off.
+# What failing closed actually cost was measured, not assumed: at the time of
+# writing there were 7 open PRs — 5 Dependabot lanes (which take the
+# `ready-unreviewed` path and consult no verdict at all), #1117 (held under
+# `do-not-auto-merge`), and #1070, #943, #863, none of which carried ANY verdict
+# comment. Zero re-reviews. Structurally the bill was already owed too: this
+# change touches `.github/workflows/`, which is on RISK_SURFACE_RE below, so
+# every open lane already faced a sync → HEAD advance → stale-verdict
+# invalidation → re-review. What changes is routing, not quota.
+#
+# THE ROUTING COST, NAMED HONESTLY — IT HAS TWO PARTS.
+#
+# (1) THE WEDGE. The verdict is consulted BEFORE `branch_is_current`, so a
+# refused verdict prints `awaiting-review` and never reaches the `behind` branch
+# that would have dispatched the sync — and `awaiting-review` is in watch-pr.sh's
+# IN_FLIGHT_TOKENS, so the watcher sleeps on it. That is a wedge, and the un-wedge
+# is one push by anybody. It is the accepted price of never merging an unattested
+# verdict.
+# "ONE PUSH BY ANYBODY" IS TRUE ONLY BECAUSE THE SELECTOR NOW EXCLUDES
+# iteration-trigger.yml's SUMMARY. While it did not, a push produced a fresh
+# review comment and then, 15 seconds later, a fresh unmarked summary that the
+# selector preferred — so the wedge survived every push, on every lane, with no
+# self-heal at all. See ITER_SUMMARY_RE: the sentence is a claim about which
+# comment gets selected, not just about pushing.
+#
+# (2) THE LATCH'S OWN, NARROWER ROUTING CHANGE, on a lane the wedge above does
+# not describe: a Dependabot bump whose only verdict is STALE BUT PERFECTLY
+# ATTESTED. Before the `verdict_comment_seen` latch that lane fell past the
+# stale-verdict guard into `review_gate_absent`, cleared it, and printed
+# `ready-unreviewed`. It now prints `awaiting-review`. That is CORRECT — a stale
+# verdict is not a missing review gate, it is an out-of-date one, and the
+# shortcut's precondition is absence — and the un-wedge is the same single push,
+# which (being ours, not the bot's) makes `claude-review` runnable again and
+# lands the lane back on the normal `ready` path. It is written down because an
+# unnamed behaviour change is how the next reader concludes the latch is a bug.
+#
+# WHAT THIS IS NOT: IT IS NOT AN AUTHORSHIP CONTROL, AND A FORGED VERDICT STILL
+# CLEARS THE GATE. The marker is a public, hard-coded literal, and the parser
+# below checks WHAT the comment says and never WHO said it: the verdict `--jq`
+# selects `createdAt`, the verdict test and the marker, and no author field
+# enters the decision at any point. So anybody who can comment on the
+# PR can write `<!-- creek-review pr=<N> -->` above a `## Verdict: LGTM`, the
+# selector will pick that comment (latest verdict-bearing comment wins), the
+# marker will match, and the lane will print `ready` — exactly as a hand-posted
+# verdict did before #1181. Nothing about forgery got harder here, and a reader
+# who takes the guard for an anti-forgery measure will under-protect the next
+# thing they build on it.
+#
+# What DID change is what an HONEST verdict attests to: the marker proves the
+# comment was produced by a PIPELINE VERSION that runs the workflow-side
+# `reviewed_pr_number` cross-check described above — the control that actually
+# catches #1117's class — so drift, replay and legacy accidents are refused
+# where before they merged. That is a provenance claim about the emitter, not an
+# identity claim about the author.
+#
+# Authenticating the verdict's AUTHOR is tracked as #1199 and deliberately NOT
+# done here. It is not the one-liner it looks like: `--json comments` already
+# carries `.author.login` at zero extra API cost, but this repo's emitter posts
+# as `GEOFFE_GA_PAT`'s account when that secret exists and as
+# `github-actions[bot]` when it does not (see the `GH_TOKEN:` fallback in
+# `.github/workflows/code-review.yml`), so the allowlist has two legitimate
+# members whose presence depends on secret availability — and an allowlist that
+# guesses wrong unmarks every verdict in the fleet at once, which is the one
+# failure mode the polarity block below says this guard cannot afford.
+#
+# TWO ALTERNATIVES CONSIDERED AND REJECTED (recorded here, not as issues, for
+# the same reason the #1160 block below records its own):
+#   * an AGENT-REPORTED diff fingerprint (`reviewed_paths_sha256`) instead of a
+#     number, which would attest to the DIFF rather than to the PR. Coherent —
+#     but an agent hashing a sorted path list is fragile (renames, whitespace,
+#     locale, its own truncation), and each false positive turns a good review
+#     red for no gain over the number the workflow already knows for certain.
+#   * a distinct `verdict-unverifiable` token outside IN_FLIGHT_TOKENS, making
+#     the wedge above an actionable state instead of a wait. It adds routing
+#     surface to watch-pr.sh, ralph-tick.md Step 1 and test_watch_pr.sh at once,
+#     and a token the orchestrator has no route for is worse than a wait.
+#     Revisit it if the wedge is ever actually observed FOR THE SHAPE IT DESCRIBES
+#     — a genuine review whose marker this parser cannot admit. It has NOT been.
+#     What WAS observed live, fleet-wide, was the selector preferring
+#     iteration-trigger.yml's summary over the review (see ITER_SUMMARY_RE), which
+#     is a wrong-comment bug and not an unverifiable verdict; a new token would
+#     have dressed it up as a routing state instead of fixing it. Keeping the two
+#     apart is the point of this note.
+#
+# AND IT IS NOT A SIBLING SCRIPT. `main-health.sh` and `review-quota.sh` are
+# separate helpers because each asks a question this file has no other way to
+# answer. This is a pure function of a string already fetched, computed in the
+# same `--jq`, at zero extra API cost. Extracting it would force a second
+# `--json comments` call, or an argv/`MAX_ARG_STRLEN` dance to hand a whole
+# comment thread to a child process, or a duplicated `VERDICT_RE` selector in
+# two files — and that last one destroys the same-comment invariant that is the
+# only thing making the check mean anything.
 #
 # TOKEN PRECEDENCE (deliberate, pinned by test_pr_ready.sh): `optout` is checked
 # before everything else; then CI state (`pending` / `ci-failed`), exactly as it
@@ -114,6 +280,13 @@
 # path the fresh-non-LGTM check sits exactly where `awaiting-review` used to be
 # emitted, and it wins over the `ready-unreviewed` shortcut: a posted verdict
 # proves a review gate exists, so the verdict — not the shortcut — decides.
+# THAT SENTENCE IS ENFORCED IN TWO PLACES, and it needs both to stay true: the
+# `verdict_lgtm == "false"` branch covers a FRESH NON-LGTM verdict, and the
+# verdict-EXISTED latch covers every verdict the provenance guard REFUSES —
+# whose fields that guard has already blanked, so the first branch can no longer
+# see them. Without the latch, "this verdict is inadmissible" would arrive at
+# `review_gate_absent` as "this PR has no review gate", which is the shortcut's
+# precondition and not what an unreadable marker means (#1181).
 # FAIL-CLOSED: an unreadable verdict lookup still dies (exit 2, nothing on
 # stdout — the tooling-error contract above), and a malformed verdict answer
 # degrades to `awaiting-review` (wait), NEVER to `changes-requested` — the one
@@ -253,7 +426,12 @@
 #     `available`, `unknown`, an empty answer, a non-zero exit, a garbage word, a
 #     MISSING helper and a NON-EXECUTABLE helper all fall through to today's
 #     `behind` → sync.
-# Both are fail-closed in the IDENTICAL sense — prefer the recoverable error —
+#   provenance (#1181): anything that is not a well-formed marker naming THIS PR
+#     REFUSES the verdict — main-health.sh's polarity, not review-quota.sh's.
+# THE THREE POLARITIES ARE DELIBERATELY NOT UNIFORM; the first two are argued
+# here and the third in the block that follows. Read both before making any of
+# them agree.
+# The first two are fail-closed in the IDENTICAL sense — prefer the recoverable error —
 # and therefore take OPPOSITE actions, because the recoverable error differs.
 # There, merging a stale green onto a broken tree buries the culprit and waiting
 # one wake costs nothing. Here, holding a lane on an unproven claim wedges a
@@ -266,6 +444,65 @@
 # consistent" either re-introduces #1160 or wedges the fleet; test_pr_ready.sh's
 # inverted sweep and test_review_quota.sh's `never_exhausted()` pin both
 # directions.
+#
+# ---------------------------------------------------------------------------
+# THE THIRD POLARITY, AND WHY IT SIDES WITH `main-health.sh` (#1181)
+# ---------------------------------------------------------------------------
+# The provenance guard holds on doubt: an absent, malformed or mismatched marker
+# refuses the verdict. That is main-health.sh's polarity, and the reason is not
+# "two out of three win".
+#   * It is a different KIND of object. Both siblings above are preconditions on
+#     a REMEDY — they decide whether the sync a lane is about to be told to run
+#     is safe. This is a property of the MERGE GATE itself, and a merge gate's
+#     doubt-polarity is settled by the oldest rule in this file: never weaken a
+#     gate. An unattributable review is not a review.
+#   * Against `main-health.sh` the shape is identical. The unrecoverable error
+#     is merging an unreviewed 38-file authenticated surface on somebody else's
+#     LGTM; the recoverable one is one wait plus one push.
+#   * Against `review-quota.sh` the inversion rests on two legs. Leg (1) — a
+#     false hold wedges a lane for DAYS with no self-heal — is normally false
+#     here: the remedy is a self-service push and lands in one tick. Leg (2) —
+#     the false-positive trigger is CORRELATED FLEET-WIDE — DOES apply, and it is
+#     the strongest argument against this polarity: a broken emitter unmarks
+#     every verdict at once, so every lane holds at once.
+#     WHAT NEUTRALISES LEG (2) IS THE CROSS-FILE COUPLING TEST. test_pr_ready.sh
+#     greps the emitter's own `printf` format out of
+#     `.github/workflows/code-review.yml`, renders it, and round-trips it
+#     through THIS parser — and `ralph-recap-tests.yml` runs that suite on
+#     changes to that workflow. Emitter and parser therefore cannot drift
+#     without CI going red ON THE VERY PR THAT CAUSES THE DRIFT, before any lane
+#     can hold. Those two facts are load-bearing TOGETHER: delete the round-trip
+#     case, or the `paths:` entry that makes it run, and this polarity loses its
+#     justification. Do not remove either believing the other covers it.
+#
+#     AND THAT ARGUMENT WAS INCOMPLETE WHEN IT WAS FIRST WRITTEN — SAY IT PLAINLY,
+#     BECAUSE IT IS THE NEAR-MISS THE NEXT READER NEEDS. "A broken emitter" said
+#     THE emitter, and there are TWO emitters of a VERDICT_RE-matching comment in
+#     this repo. The second is `.github/workflows/iteration-trigger.yml`'s
+#     executive summary, whose `**VERDICT**: <X>` line satisfies VERDICT_RE and
+#     VERDICT_LGTM_RE, which cannot carry a `creek-review` marker, and which posts
+#     LAST on every lane — so the selector picked it, the guard refused it, and
+#     the correlated fleet-wide hold this block claims to have neutralised was
+#     happening on EVERY lane, from the moment #1181 landed. Leg (1) fell with it:
+#     the self-service push does NOT un-wedge that shape, because a push produces
+#     a fresh review comment and then, 15 seconds later, a fresh unmarked summary.
+#     Before the fix, the string `iteration-trigger.yml` appeared in this file
+#     ZERO times, and no fixture ANYWHERE in test_pr_ready.sh carried an
+#     iteration-trigger summary — so nothing anywhere went red. (The suite did
+#     have multi-comment fixtures; what it did not have was the second emitter's
+#     comment. A test bench that models one producer cannot fail on a second one
+#     it has never heard of.) It was found by reading four
+#     merged PRs' live comment threads (#906, #905, #904, #902 — 4 of 4) at
+#     Gate 2.5 round 3.
+#     The same coupling discipline now covers the second emitter: ITER_SUMMARY_RE
+#     below excludes it, its bytes are read out of that workflow's own `MARKER:`
+#     and asserted against this constant, and the behavioural cases are built from
+#     those bytes rather than from the suite's own. What that costs, and the
+#     residual it accepts, is argued at the constant. THE GENERAL LESSON IS NOT
+#     "add one more coupling test": it is that a polarity argument of the form
+#     "only a broken EMITTER can do this, and the coupling test catches the
+#     emitter" is only as good as the enumeration of emitters behind it. Before
+#     adding a third consumer of VERDICT_RE, enumerate again.
 #
 # Usage:  pr-ready.sh <PR_NUMBER> [--repo <owner/repo>]
 set -euo pipefail
@@ -410,6 +647,163 @@ done
 readonly VERDICT_RE='(?im)^\\s*(?:#{1,6}\\s+|\\*\\*)?verdict[:*\\s]'
 readonly VERDICT_LGTM_RE="${VERDICT_RE}+lgtm"
 
+# The provenance marker `.github/workflows/code-review.yml` PREPENDS to every
+# review comment it posts, with N interpolated by the WORKFLOW from
+# `github.event.pull_request.number` — never from anything the review agent
+# says. Read from the SAME comment `VERDICT_RE` selects; see the provenance
+# block in the header for why a second scan of the thread would prove nothing.
+#
+# Written with literal spaces, `[0-9]` and a POSIX class only: not one backslash
+# appears here, so the doubled-escape hazard documented three lines up (this text
+# is spliced into a jq string literal, where `\s` is invalid and must arrive as
+# `\\s`) cannot arise by construction.
+#
+# `(?m)` IS LOAD-BEARING AND IS WRITTEN INLINE ON PURPOSE, exactly as it is in
+# VERDICT_RE. Under the PRODUCTION engine (Go's `regexp`; see the note below) the
+# `m` flag is documented as off unless asked for, so without it `^`/`$` would
+# mean `\A`/`\Z` and this pattern would only match a marker that IS the entire
+# comment. Spelling the flag out is also what makes the pattern independent of
+# the OTHER engine's default, which is a question this file deliberately does not
+# answer — see the two-engine note below for how their agreement is established
+# instead. With `(?m)` in force, `^` is what stops review prose that merely
+# quotes a marker — a review of this very change quotes one — from attesting, and
+# the tail anchor is what refuses `pr=100 7` on PR 100, where a lax
+# `pr=([0-9]+)` would capture `100` and merge.
+#
+# AND TWO DIFFERENT REGEX ENGINES HAVE TO AGREE ABOUT ALL OF THAT. This pattern
+# is never run by the `jq` binary in production: it is spliced into a `--jq`
+# expression that `gh` evaluates in its OWN process with gojq
+# (`github.com/itchyny/gojq`), whose `test`/`scan` are Go's `regexp` — RE2.
+# `scripts/ralph/test_pr_ready.sh` pipes its fixtures through the SYSTEM `jq`
+# instead, which is Oniguruma. That the two agree about THIS pattern is asserted
+# from OBSERVED BEHAVIOUR, not from any claim about what either engine's flags
+# default to. That claim was in this comment once, stated confidently for both
+# engines; a reviewer read Oniguruma's default the other way, and nobody had
+# measured either reading. Behaviour settles it and a documentation reading does
+# not, so behaviour is what is recorded:
+#   * Under the system `jq` (Oniguruma), this exact pattern was MEASURED to do
+#     the three things the guard needs: a marker quoted mid-line does NOT match,
+#     a marker on its own line DOES, and a CRLF-terminated marker line DOES.
+#     Those are not anecdotes — they are three named cases in
+#     `scripts/ralph/test_pr_ready.sh` ("marker embedded mid-line", "marker
+#     present and MATCHING", "CRLF comment body still attests"), so the
+#     observation re-runs on every CI pass rather than aging into a claim.
+#   * Under gojq (RE2), the same property has been carrying production for
+#     months: VERDICT_RE sets the same inline `m` flag (as `(?im)`) and depends
+#     on the same line-anchored `^` to find `## Verdict:` at the END of a
+#     multi-line `## Summary …` body, and it has been selecting verdict comments
+#     correctly the whole time.
+# Both engines also accept `[[:space:]]` and `[0-9]+`. They agree on every byte
+# written here because this pattern is DELIBERATELY RESTRICTED to the constructs
+# common to both, not because the suite and production share an engine. They do
+# not.
+#
+# SO THE COUPLING TEST VALIDATES THIS PARSER AGAINST AN ENGINE PRODUCTION DOES
+# NOT USE, which is as far as an offline suite can go — and the failure it cannot
+# see is one-directional: an Oniguruma-only construct (a lookahead, a
+# backreference, `\K`) passes the local suite GREEN and then fails LIVE, where
+# RE2 refuses to compile it, the whole `--jq` errors out, `gh` exits non-zero and
+# this script dies mid-classification on every lane at once. Keeping to the
+# common subset is what makes the local green transferable. VERDICT_RE rests on
+# the identical property, and this is the one place it is written down.
+#
+# The trailing `[[:space:]]*` tolerates a carriage return (and stray trailing
+# blanks) on the marker's own line. It loosens nothing that matters — the line
+# must still be the marker and then whitespace to its end — and it is the one
+# cheap hedge against the correlated failure this whole guard's polarity depends
+# on not happening: a comment body that came back CRLF-delimited would otherwise
+# unmark every verdict in the fleet at once.
+readonly MARKER_RE='(?m)^<!-- creek-review pr=([0-9]+) -->[[:space:]]*$'
+
+# The loose probe that tells "no marker at all" (every verdict posted before
+# #1181 landed) apart from "a marker this emitter cannot have produced" (the
+# emitter and this parser have drifted). It picks WHICH diagnostic is printed
+# and nothing else — both shapes refuse the verdict — so its one false-positive
+# shape, a review whose prose mentions the word, costs a slightly wrong message.
+readonly MARKER_ANY_RE='creek-review'
+
+# What the `--jq` puts in the marker field when MARKER_ANY_RE matched and
+# MARKER_RE did not. Safe as a sentinel because `$pr` is `^[0-9]+$`-validated
+# above, so no real PR number can ever collide with it.
+readonly MARKER_MALFORMED='malformed'
+
+# ---------------------------------------------------------------------------
+# THE SECOND EMITTER OF A VERDICT_RE MATCH, AND WHY IT IS EXCLUDED (#1181)
+# ---------------------------------------------------------------------------
+# Everything above assumes the only thing on a PR that matches VERDICT_RE is a
+# review comment. IN THIS REPO THAT IS FALSE, and the comment that falsifies it
+# posts LAST on every lane. `.github/workflows/iteration-trigger.yml` posts a
+# four-line executive summary whenever CI completes and a review verdict exists:
+#
+#     <!-- iteration-trigger -->
+#     **CI**: 10/10 Green
+#     **VERDICT**: LGTM
+#     **Action**: You are cleared to squash merge, ...
+#
+# Line 3 SATISFIES VERDICT_RE, through the `(?:#{1,6}\s+|\*\*)?` alternative that
+# pattern deliberately tolerates: the leading `**` matches it, `VERDICT` matches
+# `verdict` case-insensitively, the second `*` matches `[:*\s]`, and `**: LGTM`
+# then satisfies VERDICT_LGTM_RE as well. Measured through these very patterns
+# with jq: VERDICT_RE true, VERDICT_LGTM_RE true, `creek-review` marker NONE.
+#
+# IT IS NOT A VERDICT, IT IS A REPORT OF ONE. That workflow SELECTS the review
+# comment (`[.[] | select(.body | test("(^|\\n)## Verdict:"))] | last`) and
+# copies the verdict line out of it. It cannot carry `<!-- creek-review pr=N -->`
+# and must not: that marker attests the CODE-REVIEW pipeline produced the
+# comment, and this one is posted by a workflow that never read a diff.
+#
+# WITHOUT THIS EXCLUSION IT WEDGES THE WHOLE FLEET, because the selector takes
+# the LAST match and the summary is always it. Merged PR #906's comment tail:
+#   06:53:17Z  `## Summary\nPR #906 fixes false-positive "broke...` <- the review
+#   06:53:32Z  `<!-- iteration-trigger -->\n**CI**: 4/7 Green...`   <- 15 s later
+#   07:03:05Z  `<!-- iteration-trigger -->\n**CI**: 10/10 Green...` <- LAST
+# Same shape on #905, #904 and #902 — 4 of 4 merged PRs. The provenance guard
+# then refuses that summary on EVERY lane at once; `awaiting-review` is in
+# watch-pr.sh's IN_FLIGHT_TOKENS so the watcher sleeps on it; and the un-wedge
+# the routing-cost block promises ("one push by anybody") does NOT clear it — a
+# push yields a fresh review comment and, 15 seconds later, a fresh unmarked
+# summary. That is precisely the correlated fleet-wide hold the third-polarity
+# block says this guard cannot afford.
+#
+# THE EXCLUSION IS LINE-ANCHORED, AND THAT IS A DECISION. Both directions fail
+# closed — skipping a comment can only ever LOSE a verdict, never invent one — so
+# what is being chosen is how much verdict is lost, not whether it is safe:
+#   * a BARE SUBSTRING `test("<!-- iteration-trigger -->")` also skips any review
+#     whose PROSE quotes the marker. Not hypothetical: a review of THIS VERY
+#     CHANGE quotes it, and the identical shape is already written down for the
+#     OTHER marker — at MARKER_RE above ("a review of this very change quotes
+#     one"), in iteration-trigger.yml's own extraction, and in two named cases of
+#     test_pr_ready.sh. The cost is not one lost verdict either — it is a lane
+#     wedged at `awaiting-review`, i.e. the failure this exclusion exists to
+#     remove, re-entering through a narrower door.
+#   * anchoring costs nothing against every REAL summary: that workflow builds
+#     the body with `printf '%s\n%s\n%s\n%s\n'` and `$MARKER` FIRST, so the marker
+#     sits on line 1 at column 0 — exactly where code-review.yml puts
+#     `creek-review`. The two markers' parse rules are then symmetric, and this is
+#     the very pattern iteration-trigger.yml itself uses to read the creek-review
+#     marker (`grep -oE '^<!-- creek-review pr=[0-9]+ -->[[:space:]]*$'`).
+# THE RESIDUAL IS ACCEPTED AND NAMED: a review that quotes the marker on a line
+# of its OWN (inside a fenced block) is still skipped. That is one verdict lost
+# on one PR, recoverable by one re-review — never a fleet-wide hold.
+#
+# `(?m)` IS SPELLED OUT rather than relied upon, and the pattern is restricted to
+# the constructs gojq/RE2 (production) and Oniguruma (the suite) share. Not one
+# backslash appears in it, so the jq-string-literal hazard documented at
+# VERDICT_RE (`\s` is invalid there and must arrive as `\\s`) cannot arise by
+# construction. Those are MARKER_RE's rules for MARKER_RE's reasons — read its
+# engine note above before changing a byte here. The tighter `^` alone, anchoring
+# to the START OF THE BODY where the emitter always puts it, is rejected for the
+# reason recorded there: it would rest on a flag DEFAULT, and a confident claim
+# about those defaults was written down once, read the other way by a reviewer,
+# and never measured by anybody.
+#
+# AND THE BYTES ARE COUPLED TO THE EMITTER, exactly as the marker round trip
+# couples this file to code-review.yml: test_pr_ready.sh reads `MARKER:` out of
+# iteration-trigger.yml and asserts THIS constant carries it, so renaming the
+# marker there without teaching this parser turns CI red on the renaming PR
+# instead of silently re-opening the wedge.
+readonly ITER_SUMMARY_RE='(?m)^<!-- iteration-trigger -->[[:space:]]*$'
+
 # `${arr[@]+"${arr[@]}"}` expands to nothing when the array is empty instead of
 # tripping `set -u` on bash 3.2 (stock /bin/bash on macOS).
 gh_args=("$pr" ${repo_args[@]+"${repo_args[@]}"})
@@ -485,8 +879,12 @@ fi
 
 # --- CI is green: check mergeability + a FRESH LGTM verdict -----------------
 # One call yields "<mergeStateStatus>|<HEAD committedDate>|<HEAD author login>",
-# another the latest top-level verdict as "<createdAt>|<isLGTM>". gh applies --jq
-# server-side. The HEAD author rides along here rather than in its own call: it is
+# another the latest top-level verdict as "<createdAt>|<isLGTM>|<marker pr= value>"
+# — one call for both halves of the verdict question, see below. `gh` applies the
+# `--jq` itself, with gojq rather than the `jq` binary (see MARKER_RE's engine
+# note), so the whole answer arrives already reduced to one scalar per call and
+# no comment thread is ever piped through this shell. The HEAD author rides along
+# here rather than in its own call: it is
 # only needed by `review_gate_absent`, and `gh` already hands us the commit.
 # (`gh` caps `commits` at 100. That is already how `head_date` is derived, and it
 # fails CLOSED for the author too: on an adopted lane the bot's bump is commit 1
@@ -501,12 +899,184 @@ merge_line="$(gh pr view "${gh_args[@]}" \
 IFS='|' read -r merge_state head_date head_author merge_rest <<<"$merge_line"
 [[ -z "$merge_rest" ]] || { merge_state=""; head_date=""; head_author=""; }
 
+# THREE fields now: "<createdAt>|<isLGTM>|<marker pr= value>". The marker is
+# captured from `$v` — the SAME comment the VERDICT_RE selector above already
+# picked — because a whole-thread question ("does this PR have a matching marker
+# anywhere?") answers yes for every PR that was ever reviewed once, and would
+# vouch for a verdict comment that carries no marker of its own (#1181).
+# `[scan(...)] | flatten | first` rather than `capture`: `capture` THROWS on no
+# match, which would turn "this verdict is unattested" — the single most common
+# case while legacy verdicts are still on the fleet — into a failed `gh` call
+# and a lane the orchestrator refuses to classify at all.
+#
+# THE ITER_SUMMARY_RE EXCLUSION IS PART OF THE SELECTOR, INSIDE THIS ONE `--jq`,
+# and it has to be. Every field below — `createdAt`, the LGTM test, the marker —
+# is read off the single `$v` binding, and that SAME-COMMENT INVARIANT is the
+# only thing that makes any of them mean anything: a second selector for the
+# freshness stamp, or a marker lookup rebound to the comment that was skipped,
+# resurrects #1181's own failure with one extra step. test_pr_ready.sh's W3, W3b
+# and W5 cases are what kill those three mutants; the "AND IT IS NOT A SIBLING
+# SCRIPT" block in the header is the same argument against splitting the answer
+# across files.
+#
+# IT ALSO CLOSES A PRE-EXISTING FRESHNESS HOLE, as a side effect worth naming:
+# before this, a STALE review followed by a FRESH summary handed the stale-verdict
+# guard the SUMMARY's `createdAt`, so the guard compared the wrong comment's time
+# against HEAD and a review of code that is no longer there passed as fresh. The
+# provenance guard has been masking that since #1181 landed (it refused the
+# summary before freshness was ever consulted) rather than closing it. It is
+# closed now, and pinned.
 verdict_line="$(gh pr view "${gh_args[@]}" \
   --json comments \
-  --jq "([.comments[] | select(.body != null and (.body | test(\"$VERDICT_RE\")))] | last) as \$v
-        | ((\$v.createdAt // \"\") + \"|\" + ((\$v.body // \"\" | test(\"$VERDICT_LGTM_RE\")) | tostring))")"
-verdict_date="${verdict_line%%|*}"
-verdict_lgtm="${verdict_line#*|}"
+  --jq "([.comments[] | select(.body != null
+                               and ((.body | test(\"$ITER_SUMMARY_RE\")) | not)
+                               and (.body | test(\"$VERDICT_RE\")))] | last) as \$v
+        | (\$v.body // \"\") as \$b
+        | ((\$b | [scan(\"$MARKER_RE\")] | flatten | first)
+           // (if (\$b | test(\"$MARKER_ANY_RE\")) then \"$MARKER_MALFORMED\" else \"\" end)) as \$mk
+        | ((\$v.createdAt // \"\") + \"|\" + ((\$b | test(\"$VERDICT_LGTM_RE\")) | tostring) + \"|\" + \$mk)")"
+# Split by FIELD COUNT, exactly like the mergeState answer above and the rollup
+# answer below: an RFC3339 stamp, a jq boolean and a PR number can none of them
+# contain `|`, so a fourth field means the answer is not the shape we asked for
+# and every branch below must fail closed on it. The two-expansion split this
+# replaces (`%%|*` / `#*|`) read `true|100` into the LGTM flag the moment the
+# answer grew its third field — the `|`-seeking class this file has already
+# proven exploitable once.
+IFS='|' read -r verdict_date verdict_lgtm verdict_pr verdict_rest <<<"$verdict_line"
+[[ -z "$verdict_rest" ]] || { verdict_date=""; verdict_lgtm=""; verdict_pr=""; }
+
+# --- the verdict-EXISTED latch, recorded BEFORE the guard blanks (#1181) ----
+# The provenance guard immediately below is about to erase `verdict_date` and
+# `verdict_lgtm`, and those two fields are the only trace a verdict comment
+# leaves in this process. What must survive that erasure is NOT the verdict —
+# refusing it is the whole point — but the bare FACT that one was posted, because
+# `review_gate_absent` further down asks a different question and would otherwise
+# answer it from evidence that no longer exists.
+#
+# THE TWO QUESTIONS ARE NOT THE SAME, AND CONFLATING THEM MOVES A LANE TOWARDS
+# MERGING. `ready-unreviewed`'s precondition is "this PR HAS NO REVIEW GATE to
+# wait for" — nobody has reviewed it and nobody ever will. An inadmissible marker
+# says the verdict is UNUSABLE; it does not say the gate is ABSENT. A comment
+# carrying a `## Verdict:` line means SOMETHING reviewed this PR and spoke: the
+# `claude-review` job posted it, or (as the authorship note in the header
+# concedes) a human did. Either way the shortcut's premise is already false, and
+# an unreadable marker is a reason to distrust WHAT was said, never evidence that
+# nothing was.
+#
+# Without this latch, the one lane where the difference is visible went the wrong
+# way: a Dependabot bump whose every `claude-review` rollup entry really is
+# SKIPPED, carrying an UNMARKED verdict. The guard blanks the fields, so
+# `verdict_lgtm` is `""` and not `"false"` and the `changes-requested` branch can
+# no longer fire; `review_gate_absent` consults only the author and the rollup,
+# knows nothing of the verdict it never saw, and clears — and the lane prints
+# `ready-unreviewed`, which is merge-adjacent. Refusing a verdict would then have
+# pushed the lane FORWARD, leaving a PR that HAS a posted verdict further along
+# than one that has none. That is the regression this latch closes, and it is
+# what keeps the header's precedence sentence ("a posted verdict proves a review
+# gate exists, so the verdict — not the shortcut — decides") true on the one path
+# where the provenance guard, not the verdict, is doing the deciding.
+#
+# THE DISCRIMINATOR IS `$verdict_date`, DELIBERATELY — the same field the guard
+# below uses to mean "a verdict actually exists", so the two can never disagree
+# about whether there was one. NOT the marker field, which is EMPTY for precisely
+# the case this latch exists to catch (a legacy verdict with no marker at all)
+# and would therefore latch nothing exactly when it is needed.
+#
+# AND THE DISCRIMINATOR IS NOT "the rollup looks dirty". With no verdict-bearing
+# comment at all, `$v` is null and every field of this answer comes back empty —
+# that lane latches nothing and MUST still reach the shortcut. It is the control
+# against the lazy fix: "stop `ready-unreviewed` firing after a refused verdict"
+# must not degenerate into "delete `ready-unreviewed`", which re-wedges every
+# Dependabot bump at `awaiting-review` forever, waiting on a review the workflow
+# provably never runs (see the WHY `ready-unreviewed` EXISTS block in the header).
+#
+# THE SUMMARY EXCLUSION NARROWS WHAT FEEDS THIS LATCH, AND THAT WAS CHECKED
+# RATHER THAN ASSUMED. `$verdict_date` now comes from a selector that skips
+# iteration-trigger.yml's executive summary, so a summary is no longer evidence
+# that a review gate exists. Exactly one lane could care: Dependabot author, every
+# `claude-review` rollup entry SKIPPED, a summary on the thread, and NO review
+# comment at all — `awaiting-review` before the exclusion, `ready-unreviewed`
+# (merge-adjacent) after it.
+#
+# THAT LANE CANNOT OCCUR, and the proof is in the emitter, not in this file:
+# iteration-trigger.yml EXITS EARLY ("No Claude review yet - skipping") unless
+# `[.[] | select(.body | test("(^|\\n)## Verdict:"))] | last` finds a comment. So
+# a summary exists only where a `## Verdict:` comment already does — and every
+# such comment matches VERDICT_RE (`##` takes the `#{1,6}\s+` alternative, then
+# `verdict`, then `:`), carries no `<!-- iteration-trigger -->` line of its own,
+# and therefore still latches. The latch is left feeding off the SAME corrected
+# selector as everything else; it is deliberately NOT given a looser selector of
+# its own, which would break the same-comment invariant for the sake of a lane
+# that does not exist.
+#
+# IF THAT EARLY EXIT EVER LEAVES iteration-trigger.yml, this reasoning leaves with
+# it, and the safe move is to fail CLOSED — latch on the summary as well — never
+# to leave the latch reading a selector that can no longer see one.
+#
+# AND IT SITS AFTER THE FIELD-COUNT BLANK, one line up, not before it: a
+# surplus-field answer is not evidence that a verdict exists, it is evidence that
+# the answer is unreadable, and reading a latch out of fields we just refused to
+# trust would be the same mistake in the other direction. The residual — a
+# malformed answer letting a Dependabot lane keep the shortcut — is unreachable
+# by construction, because an RFC3339 stamp, a jq boolean and a `[0-9]+` marker
+# (or the `malformed` sentinel) can none of them contain a `|`.
+verdict_comment_seen=""
+[[ -z "$verdict_date" ]] || verdict_comment_seen="yes"
+
+# --- provenance: does this verdict attest to THIS PR? (#1181) ---------------
+# STRING equality on purpose, and NOT for the reason it is tempting to give. A
+# numeric `[[ "$verdict_pr" -eq "$pr" ]]` would not admit an absent marker:
+# `[[ "" -eq 100 ]]`, `[[ "abc" -eq 100 ]]` and `[[ "malformed" -eq 100 ]]` are
+# all FALSE on both shells this repo runs on, so the empty and lettered fields
+# are precisely the ones `-eq` gets right.
+#
+# The hazard is a single value, and it is worse than a wrong answer — it is a
+# DISAGREEMENT BETWEEN INTERPRETERS. `pr=0100` is the one point in the whole
+# space where `-eq` and a string `!=` differ at all, and the two shells this file
+# actually runs under differ from EACH OTHER about it. Measured, not assumed:
+#
+#   bash 5.3.15 (aarch64-apple-darwin24.6)  [[ "0100" -eq 100 ]] → TRUE,  -eq 64 → FALSE
+#   /bin/bash 3.2 (stock macOS)             [[ "0100" -eq 100 ]] → FALSE, -eq 64 → TRUE
+#
+# (bash 5 reads the leading zero as decimal inside `[[ ]]`'s arithmetic context;
+# bash 3.2 reads it as octal.) A numeric compare would therefore make the MERGE
+# GATE SHELL-VERSION-DEPENDENT: the same marker clears on one interpreter and is
+# refused on the other, with nothing in the output to say which one ran. String
+# equality is exact and version-independent, and it is what the emitter produces:
+# the workflow interpolates `github.event.pull_request.number` verbatim through a
+# `%s`, so anything but the verbatim bytes is a marker it did not emit.
+# test_pr_ready.sh pins this with a `pr=0100` case carrying the same measurements.
+#
+# Guarded on `$verdict_date` so the diagnostic describes a verdict that actually
+# exists: with no verdict-bearing comment at all the marker field is empty too,
+# and that is the ordinary `awaiting-review` lane, not a provenance failure.
+if [[ -n "$verdict_date" && "$verdict_pr" != "$pr" ]]; then
+  case "$verdict_pr" in
+    "")
+      marker_what='carries NO provenance marker'
+      marker_tail='Expected for any verdict posted before #1181 landed: that pipeline never named the PR it reviewed.'
+      ;;
+    "$MARKER_MALFORMED")
+      marker_what='carries a provenance marker this workflow cannot emit'
+      marker_tail="The emitter and this parser have drifted; test_pr_ready.sh's coupling case should have caught it — fix the emitter, do not loosen the parser."
+      ;;
+    *)
+      marker_what="names PR #$verdict_pr, not #$pr"
+      marker_tail='A verdict produced for another PR, a forged comment, or an emitter bug. Do NOT merge. Unreachable in normal operation; file an issue against .github/workflows/code-review.yml.'
+      ;;
+  esac
+  # One printf per LINE, and each fact whole within its own line: the operator
+  # reads this in a log, and test_pr_ready.sh greps it line by line.
+  {
+    printf 'pr-ready: the latest verdict on PR #%s %s.\n' "$pr" "$marker_what"
+    printf 'pr-ready:   %s\n' "$marker_tail"
+    printf 'pr-ready:   It is treated as no verdict at all — it gates neither `ready` nor `changes-requested`, so this lane falls through to `awaiting-review` (#1181).\n'
+    printf 'pr-ready:   Remedy: scripts/ralph/fleet.sh sync (or push any commit). That advances HEAD — which invalidated the old verdict anyway — and brings the marker-emitting workflow onto the branch, so the re-review is attested.\n'
+    printf 'pr-ready:   Re-running the old review workflow run will NOT help: a re-run replays the workflow file from the commit that run was launched from, which is the one without the fix.\n'
+  } >&2
+  verdict_date=""
+  verdict_lgtm=""
+fi
 
 # Without a HEAD commit time we cannot prove the verdict is fresh — fail closed.
 if [[ -z "$head_date" ]]; then
@@ -527,9 +1097,10 @@ all_conclusions_skipped() {
   done
 }
 
-# True only when this PR has no review gate to wait for: Dependabot authored it,
-# Dependabot also pushed its HEAD commit (so nothing of ours rides the branch —
-# see the force-push note in the header), at least one non-review check actually
+# True only when this PR has no review gate to wait for: no verdict-bearing
+# comment was ever posted (the latch above), Dependabot authored it, Dependabot
+# also pushed its HEAD commit (so nothing of ours rides the branch — see the
+# force-push note in the header), at least one non-review check actually
 # SUCCEEDED (so "green" is not "nothing ran"), and every `claude-review` entry in
 # its rollup reported SKIPPED (the rollup carries one entry per triggering event,
 # so a single non-SKIPPED entry means the job did run and a verdict is genuinely
@@ -538,6 +1109,26 @@ all_conclusions_skipped() {
 # as "the gate exists", so an unreadable answer can only ever hold the lane.
 review_gate_absent() {
   local line author conclusions passes rest
+  # THE LATCH, CHECKED FIRST (#1181). A verdict comment exists on this PR, so the
+  # review gate EXISTS and this function's question is already answered NO — no
+  # amount of author or rollup evidence can unsay a comment that is sitting on
+  # the thread. The caller reaches here only because that verdict was REFUSED by
+  # the provenance guard, is STALE, or came back MALFORMED — unusable, out of
+  # date, unreadable. Not one of those is "there is no gate", and all three are
+  # waits.
+  #
+  # THE ROLLUP IS NOT A SUBSTITUTE FOR THIS. `statusCheckRollup` is per-HEAD-
+  # commit, so all-SKIPPED means the job did not run FOR THIS HEAD — the verdict
+  # may have been posted against an earlier one, by a re-run, or by a pipeline
+  # version this parser refuses. Every one of those makes the verdict unusable
+  # and none of them makes the gate absent.
+  #
+  # Checked ahead of the `gh` call rather than after it because the answer cannot
+  # change, and it spares the lane one API request per wake — the same laziness
+  # argument every other probe in this file makes. (The `probed` sentinels in
+  # test_pr_ready.sh pin the one path that MUST still pay for it: the lane with
+  # no verdict comment at all.)
+  [[ -z "$verdict_comment_seen" ]] || return 1
   line="$(gh pr view "${gh_args[@]}" --json author,statusCheckRollup \
     --jq "(.author.login // \"\") + \"|\" + ([.statusCheckRollup[]? | select((.name // \"\") == \"$REVIEW_CHECK_NAME\") | (.conclusion // \"\")] | join(\",\")) + \"|\" + ([.statusCheckRollup[]? | select((.name // \"\") != \"$REVIEW_CHECK_NAME\" and (.conclusion // \"\") == \"$SUCCESS_CONCLUSION\")] | length | tostring)" \
     2>/dev/null)" || return 1
@@ -703,12 +1294,22 @@ branch_is_current() {
 # Fresh LGTM ⇔ latest verdict is LGTM AND its createdAt is strictly newer than
 # the HEAD commit. RFC3339 UTC timestamps are fixed-width, so a lexical string
 # compare is a correct chronological compare (portable — no date arithmetic).
+# The guards COMPOSE rather than substitute: an inadmissible marker has already
+# blanked both fields above (#1181), so a verdict must be attested AND fresh AND
+# LGTM to reach `ready` — and an attested LGTM that predates HEAD is still stale.
 # Absent that: a FRESH non-LGTM verdict is Gate 4 failed → `changes-requested`
 # (checked FIRST — the verdict is the review gate speaking, so it outranks the
 # no-gate shortcut); otherwise the lane waits for review, unless there is
 # provably no review to wait for — and the review-gate probe is LAZY for the
 # same rate-limit reason as the compare probe: only a lane already lacking a
 # fresh verdict ever pays for it.
+#
+# The `changes-requested` test below is only HALF of "the verdict outranks the
+# shortcut": it reads `verdict_lgtm`, which the provenance guard blanks, so it
+# cannot speak for a REFUSED verdict. The other half is the latch inside
+# `review_gate_absent`, which refuses the shortcut on the mere existence of a
+# verdict comment. Both are needed, and a change that drops either one lets a
+# refused verdict end at a token the loop merges on (#1181).
 ready_token="ready"
 if [[ "$verdict_lgtm" != "true" || -z "$verdict_date" ]] || ! [[ "$verdict_date" > "$head_date" ]]; then
   # Exactly `false` (jq's tostring), never `!= true`: anything else in that

--- a/scripts/ralph/test_pr_ready.sh
+++ b/scripts/ralph/test_pr_ready.sh
@@ -6,15 +6,38 @@
 # lane. CI state is keyed off the `gh pr checks` EXIT CODE (0=green, 8=pending,
 # else=failed), never a text grep of its TAB-delimited output, and an LGTM
 # verdict only counts when it is fresher than the PR's HEAD commit (stale-verdict
-# guard). We put a fake, arg-aware `gh` on PATH and assert every classification.
+# guard) AND carries the review workflow's provenance marker naming THIS PR
+# (issue #1181). We put a fake, arg-aware `gh` on PATH and assert every
+# classification.
 #
-# Beyond that baseline, these tests pin seven more dimensions:
+# Beyond that baseline, these tests pin nine more dimensions:
 #
 #   verdict split  the four verdict states are distinct outcomes (issue #1097):
 #                  missing → awaiting-review, stale (LGTM or not) →
 #                  awaiting-review, fresh LGTM → ready, fresh non-LGTM →
 #                  changes-requested — with a malformed verdict answer failing
 #                  closed to awaiting-review, never to the dispatch token.
+#   verdict provenance
+#                  a verdict counts only when the comment carrying it also
+#                  carries the marker `.github/workflows/code-review.yml` emits
+#                  from `github.event.pull_request.number` —
+#                  `<!-- creek-review pr=N -->` — and N is THIS PR. That prompt
+#                  never states the PR number, and `actions/checkout` leaves the
+#                  runner in DETACHED HEAD on `refs/pull/<N>/merge`, so the
+#                  agent's `gh pr view --json number` fails and it GUESSES: on
+#                  PR #1117 it guessed #1179, reviewed that bump's diff, and the
+#                  workflow posted the resulting LGTM here — `pr-ready.sh 1117`
+#                  said `ready` (issue #1181). A marker that is absent,
+#                  malformed, or names a different PR is therefore NOT A
+#                  VERDICT: it gates neither `ready` NOR `changes-requested`, so
+#                  the lane reads `awaiting-review`. Legacy unmarked verdicts
+#                  are not grandfathered — every one of them was posted by the
+#                  pipeline that had the bug. Refusing a verdict must not push a
+#                  lane FORWARD either: a Dependabot lane whose every
+#                  `claude-review` entry is SKIPPED must not fall out of a
+#                  refused verdict into `ready-unreviewed`, because a posted
+#                  verdict proves the review gate exists even when the marker
+#                  makes it inadmissible.
 #   opt-out        a `do-not-auto-merge` label on the PR — or on the LAST issue
 #                  its body links — parks the lane (`optout`), checked BEFORE CI
 #                  so a human hold is honoured even mid-run. An UNDETERMINABLE
@@ -25,10 +48,15 @@
 #                  freshness signal — GitHub happily reports UNSTABLE/MERGEABLE
 #                  for a branch 22 commits behind main. Fails CLOSED (`behind`)
 #                  on an API error, an empty answer, or a non-integer.
-#   ready-unreviewed  a PR with PROVABLY no review gate (dependabot-authored PR
-#                  AND a dependabot-authored HEAD commit AND a real non-review
-#                  SUCCESS AND every `claude-review` entry exactly SKIPPED) may
-#                  merge without a verdict. Anything less ⇒ `awaiting-review`.
+#   ready-unreviewed  a PR with PROVABLY no review gate may merge without a
+#                  verdict. FIVE preconditions now, and #1181 added the first of
+#                  them: NO verdict-bearing comment was ever posted (the
+#                  `verdict_comment_seen` latch — a verdict the provenance guard
+#                  REFUSED still proves a review gate exists, so refusing it must
+#                  not push the lane FORWARD into this token), AND a
+#                  dependabot-authored PR, AND a dependabot-authored HEAD commit,
+#                  AND a real non-review SUCCESS, AND every `claude-review` entry
+#                  exactly SKIPPED. Anything less ⇒ `awaiting-review`.
 #   laziness       both new probes cost an extra API call per wake per lane, so
 #                  each must run ONLY on the path that would otherwise print
 #                  `ready`/`ready-unreviewed`. Sentinel files prove it.
@@ -54,9 +82,39 @@
 #                  non-executable helper all fall through to today's `behind`,
 #                  because merging (or holding) stale is the worse error.
 #
-# Plus one cross-file coupling check: pr-ready.sh matches the review check by the
-# literal name `claude-review`, so `.github/workflows/code-review.yml` must keep
-# that job key and must NOT add a `name:` override.
+# Plus the cross-file coupling checks at the end of this file. They are
+# LOAD-BEARING, not decoration: `.github/workflows/code-review.yml` is the
+# EMITTER and pr-ready.sh is the PARSER, and drift between them does not wedge
+# one lane, it wedges every lane at once.
+#   * pr-ready.sh matches the review check by the literal name `claude-review`,
+#     so code-review.yml must keep that job key and must NOT add a `name:`
+#     override.
+#   * the provenance marker ROUND-TRIPS: the WHOLE `printf` format argument is
+#     extracted from code-review.yml, rendered for this PR, and must be the
+#     exact bytes pr-ready.sh accepts — and rendered for another PR, the exact
+#     bytes it refuses (issue #1181). Rendered, not grepped: a `grep -oF` for a
+#     literal this file already holds can only ever print that literal back.
+#     The emitter's REDIRECTION (`>` for the marker, `>>` for the review body)
+#     is pinned alongside it, because "the marker is first" is a property of the
+#     redirection and no format string can see its own.
+#   * the workflow keeps the piece the marker ATTESTS TO: a `reviewed_pr_number`
+#     in the structured-output schema, which is what makes the workflow-side
+#     cross-check possible. Alongside it, and NOT of equal weight, the absence of
+#     `Bash(gh pr list:*)` from `--allowed-tools` — that is the instrument the
+#     #1117 run guessed with, so removing it is defence in depth. It is not a
+#     proof: `Bash(gh search:*)` is deliberately kept and `gh search prs` also
+#     enumerates PRs. See the block at that assertion.
+#   * the suite actually RUNS on emitter-only changes (ralph-recap-tests.yml's
+#     `paths:`), and the second merge-clearance path (iteration-trigger.yml)
+#     both EXTRACTS the marker with the same anchored pattern and REFUSES to
+#     clear a merge when it does not name this PR.
+#   * THAT SAME FILE IS ALSO A SECOND EMITTER OF A VERDICT_RE MATCH, and the one
+#     the provenance guard would otherwise select on every lane in this repo: its
+#     executive summary's `**VERDICT**: <X>` line satisfies VERDICT_RE, it can
+#     never carry a `creek-review` marker, and it posts LAST. So the marker it
+#     excludes itself by (`<!-- iteration-trigger -->`) is read out of that
+#     workflow and round-tripped through this parser, in the verdict block and
+#     again at the end of this file (#1181).
 #
 # Run:  bash scripts/ralph/test_pr_ready.sh
 set -euo pipefail
@@ -76,6 +134,45 @@ probed() { # probed <desc> <yes|no> <sentinel path> — did the probe run?
 no_merge_token() { # no_merge_token <desc> <token> — any token the loop won't merge on
   if [[ "$2" != "ready" && "$2" != "ready-unreviewed" ]]; then ok "$1"; else bad "$1 (got '$2')"; fi
 }
+says() { # says <desc> <ERE> <text> — the text must carry this phrasing
+  # Herestring, never `printf … | grep -q`: that pipeline is the pipefail/SIGPIPE
+  # inversion pr-ready.sh:634-637 documents at `has_optout_label` (grep -q exits
+  # at the first match, the writer dies 141, and the pipeline reports non-zero ON
+  # A MATCH). Cited by name as well as by line because pr-ready.sh moves.
+  if grep -Eqi -- "$2" <<<"$3"; then ok "$1"; else bad "$1 (no /$2/ in: $3)"; fi
+}
+
+# --- jq IS A HARD REQUIREMENT, DECIDED ONCE, HERE ---------------------------
+# This used to be FIVE separate `if command -v jq` guards, each of which printed
+# a `skip` line and carried on. Between them they covered the ENTIRE verdict-
+# provenance block (#1181), the emitter round trip, main-health.sh's production
+# run-list expression, the review-gate rollup expression and the
+# `reviewed_pr_number` schema coupling — so on a jq-less host this file printed
+# a GREEN summary while asserting nothing whatsoever about the gate it exists to
+# pin. A suite that reports success for a run in which it tested nothing is a
+# silent no-gate hole, and it is the same hole the #1181 polarity argument in
+# pr-ready.sh's header says it cannot afford: that argument's whole neutralising
+# leg is "the coupling test round-trips the emitter through this parser and CI
+# runs it", which is false the moment the round trip can silently not run.
+#
+# Failing LOUDLY costs nothing: `ubuntu-latest` ships jq, the ralph CI job that
+# runs this file uses it, and a developer host without jq is a broken
+# environment rather than a supported configuration — one `brew install jq` /
+# `apt-get install jq` away, and the message says so. Everything below therefore
+# assumes jq unconditionally: the stub's REAL-jq arms (COMMENTS_JSON,
+# ROLLUP_JSON, MAIN_RUNS_JSON), the marker round trip, and the schema check.
+#
+# EXIT 2, NOT 1, and on stderr rather than as a `bad`: the closing
+# `[[ "$FAIL" -eq 0 ]]` already owns exit 1 for "assertions failed", and "this
+# suite could not run" is a different fact from "this suite ran and found a
+# bug". Same split pr-ready.sh's own `die` makes, for the same reason — a caller
+# must never read one as the other.
+if ! command -v jq >/dev/null 2>&1; then
+  printf 'pr-ready tests: FATAL — jq is not installed.\n' >&2
+  printf 'pr-ready tests:   Without it this suite cannot run the production `--jq` expressions (the verdict regex, the provenance-marker extraction, the emitter round trip, the rollup counts) and would report a green summary having tested none of them.\n' >&2
+  printf 'pr-ready tests:   Install jq (brew install jq / apt-get install jq) and re-run.\n' >&2
+  exit 2
+fi
 
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
@@ -137,10 +234,35 @@ mkdir -p "$BIN"
 #                   rollup expression that miscounts SKIPPED/null conclusions is
 #                   caught here (a scalar stub would mask it).
 #   VERDICT       — the "<createdAt>|<isLGTM>" scalar the verdict jq resolves to
+#   VERDICT_PR    — the THIRD field of that scalar (issue #1181): the PR number
+#                   the selected comment's `<!-- creek-review pr=N -->` marker
+#                   names, so the whole answer is
+#                   "<createdAt>|<isLGTM>|<markerPr>". Defaulted with `-` (not
+#                   `:-`) so `VERDICT_PR=''` reproduces a verdict comment with NO
+#                   marker at all, which must fail closed. The default is `100`
+#                   — the PR number every scalar case in this file passes to
+#                   `run` — so all ~109 pre-existing `VERDICT=` cases keep
+#                   asserting exactly what they asserted before #1181. Same
+#                   convention as MAIN_HEALTH (`green`) and REVIEW_QUOTA
+#                   (`available`), and for the same reason: a new gate must not
+#                   silently re-target the tests that were already here.
 #   COMMENTS_JSON — raw `--json comments` payload; when set, the stub runs the
 #                   REAL jq with pr-ready.sh's own `--jq` expression against it,
-#                   so the production verdict regex is genuinely exercised
-#                   (otherwise a scalar stub would mask a broken regex).
+#                   so the production verdict regex AND the production marker
+#                   extraction are genuinely exercised (otherwise a scalar stub
+#                   would mask a broken regex). WITH ONE CAVEAT, and pr-ready.sh
+#                   now concedes it in MARKER_RE's own block: the PATTERNS are
+#                   production's, the ENGINE is not. This stub runs the system
+#                   `jq` (Oniguruma); in production the `--jq` is evaluated by
+#                   `gh` in its own process with gojq, i.e. Go's `regexp` (RE2).
+#                   VERDICT_RE and MARKER_RE are deliberately restricted to the
+#                   constructs both engines share, so the two agree on every byte
+#                   written there — but "exercised" here means the pattern, not
+#                   the interpreter, and the failure this cannot see is
+#                   one-directional: an Oniguruma-only construct (a lookahead, a
+#                   backreference, `\K`) passes GREEN here and then fails LIVE,
+#                   where RE2 refuses to compile it and `gh` exits non-zero on
+#                   every lane at once.
 #   MAIN_HEALTH   — scalar shortcut for the `gh run list` arm that main-health.sh
 #                   (pr-ready.sh's sibling, issue #1159) calls: `green` / `red` /
 #                   `pending` emit one synthetic run line, `unknown` emits
@@ -298,7 +420,7 @@ case "$args" in
       for a in "$@"; do [[ "$prev" == "--jq" ]] && expr="$a"; prev="$a"; done
       printf '%s' "$COMMENTS_JSON" | jq -rc "$expr"
     else
-      printf '%s\n' "${VERDICT:-|false}"
+      printf '%s|%s\n' "${VERDICT:-|false}" "${VERDICT_PR-100}"
     fi ;;
   *)                        echo '' ;;
 esac
@@ -306,6 +428,25 @@ STUB
 chmod +x "$BIN/gh"
 
 run() { PATH="$BIN:$PATH" "$READY" "$@" 2>/dev/null; }
+
+# The sibling for the cases that assert ON the diagnostic rather than on the
+# token. `run()` swallows stderr so a token assertion is never polluted by one,
+# and changing that would re-write ~181 call sites to test one message. The
+# ORDER is load-bearing: stdout is dropped INSIDE the group and stderr is routed
+# into the capture OUTSIDE it, so only stderr is ever captured — capture both and
+# every assertion below would pass on the token instead of on the message. This
+# is shellcheck's own rewrite of the equivalent `2>&1 >/dev/null` (SC2069), which
+# is what pr-ready.sh:679-682 uses for `gh pr checks` (the `ci_err=` capture —
+# named as well as line-cited, because pr-ready.sh moves); the redirections there
+# are on a command rather than a group, where the order alone is unambiguous.
+run_err() { { PATH="$BIN:$PATH" "$READY" "$@" >/dev/null; } 2>&1; }
+
+# Wrap comment object(s) as a `--json comments` payload for COMMENTS_JSON. Kept
+# up here with the other harness helpers rather than inside the real-jq block
+# below, because the very first case in this file (the argv-validation collision)
+# already needs it — and because there is no longer a `command -v jq` block for
+# it to live inside.
+cj() { printf '{"comments":[%s]}' "$1"; }
 
 # The default `gh run view --log` payload for the review run (issue #1160): the
 # verbatim rate-limit rejection from PR #1158's re-review (run 30685776913,
@@ -344,6 +485,37 @@ STALE="2026-07-01T09:00:00Z"      # a verdict posted BEFORE HEAD (stale)
 rc=0
 PATH="$BIN:$PATH" "$READY" >/dev/null 2>&1 || rc=$?
 check "missing PR number exits 2" "2" "$rc"
+
+# …and a NON-NUMERIC argument is the same class with a sharper reason, which is
+# why the sentinel word is the one that gets passed here. pr-ready.sh's
+# `^[0-9]+$` argument check is the ONLY thing keeping `$pr` out of collision with
+# `MARKER_MALFORMED` — the literal string the verdict `--jq` writes into the
+# marker field when a comment matched `creek-review` but not the whole-line
+# marker pattern.
+#
+# THE FIXTURE BUILDS THAT COLLISION FOR REAL, and it has to. An argv-only
+# invocation never reaches it: with no HEAD_DATE and no comment payload the stub
+# serves the `VERDICT_PR` default `100`, so the run exits at the `head_date`
+# guard with `awaiting-review` and the mutant dies on the EXIT CODE — a passing
+# assertion attached to a false explanation, which is worse than no explanation.
+# So HEAD_DATE is set and the selected comment carries
+# `<!-- creek-review pr=abc -->`, which the PRODUCTION `--jq` (real jq, via
+# COMMENTS_JSON) reduces to the literal `malformed` sentinel. Delete pr-ready.sh's
+# argv check and this exact invocation compares `verdict_pr` ("malformed")
+# against `$pr` ("malformed"), finds them EQUAL, skips the provenance guard
+# entirely, and prints `ready` — ATTESTING a verdict whose marker the parser
+# could not read (#1181). With the check in place the run never makes an API
+# call at all: exit 2 on argv.
+#
+# The empty stdout matters as much as the exit code: the orchestrator's contract
+# is that a non-zero exit carries no token, ever — silence is not a verdict —
+# and under that mutant this same invocation prints one the loop merges on.
+rc=0
+out="$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H \
+       COMMENTS_JSON="$(cj '{"createdAt":"'"$FRESH"'","body":"<!-- creek-review pr=abc -->\n\n## Verdict: LGTM\n"}')" \
+       PATH="$BIN:$PATH" "$READY" malformed 2>/dev/null)" || rc=$?
+check "non-numeric PR argument (the 'malformed' sentinel) exits 2" "2" "$rc"
+check "non-numeric PR argument prints nothing" "" "$out"
 
 # --- pending: gh pr checks exit 8 is NEVER ready (the core bug) -------------
 check "exit 8 → pending" "pending" \
@@ -400,13 +572,37 @@ check "malformed verdict flag → awaiting-review, never changes-requested" "awa
 # long `## Summary …` body. These cases feed raw comment JSON through pr-ready.sh's
 # own `--jq`, so a regex that fails to match `## Verdict:` — or that reads "LGTM"
 # from prose instead of the verdict line — is caught here (a scalar stub can't).
-if command -v jq >/dev/null 2>&1; then
-  cj() { printf '{"comments":[%s]}' "$1"; }   # wrap comment object(s) as a payload
-
+#
+# WHAT "REAL jq" DOES AND DOES NOT MEAN, precisely — pr-ready.sh now concedes
+# the same thing in MARKER_RE's own block, and the two files must not drift on
+# it. The PATTERNS below are production's, byte for byte. The ENGINE is not: this
+# harness runs the system `jq` (Oniguruma), while in production the `--jq` string
+# is evaluated by `gh` in its own process with gojq, whose `test`/`scan` are Go's
+# `regexp` — RE2. VERDICT_RE and MARKER_RE are deliberately confined to the
+# constructs both engines accept (`(?i)`/`(?m)`, `[0-9]`, `[[:space:]]`, plain
+# anchors), which is what makes a green run here transferable — not any shared
+# implementation. The gap is one-directional and therefore worth naming: an
+# Oniguruma-only construct passes HERE and fails LIVE, where RE2 refuses to
+# compile it, `gh` exits non-zero, and pr-ready.sh dies mid-classification on
+# every lane at once.
+#
+# This is an unconditional GROUP, not a `command -v jq` guard: jq is asserted
+# once at the top of this file (see the hard-requirement block there for why
+# skipping was a silent no-gate hole). The braces are kept so the block's shape
+# and indentation stay exactly what they were.
+{
   # Canonical `## Verdict: LGTM`, fresh + CLEAN → ready.
+  #
+  # Every body in THIS block whose verdict is meant to COUNT also carries the
+  # `<!-- creek-review pr=100 -->` provenance marker, because that is what
+  # code-review.yml prepends to a real review comment (#1181). These cases are
+  # about the verdict REGEX; leaving them unmarked would make them assert the
+  # provenance gate instead, and the marker cases below would then be the only
+  # thing testing the regex. The provenance gate has its own block after this
+  # one.
   check "real ## Verdict: LGTM (fresh) → ready" "ready" \
     "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H \
-       COMMENTS_JSON="$(cj '{"createdAt":"'"$FRESH"'","body":"## Summary\ngood\n\n## Verdict: LGTM\n"}')" \
+       COMMENTS_JSON="$(cj '{"createdAt":"'"$FRESH"'","body":"<!-- creek-review pr=100 -->\n\n## Summary\ngood\n\n## Verdict: LGTM\n"}')" \
        run 100)"
 
   # `**Verdict:** CHANGES_REQUESTED` whose prose mentions "LGTM" must NOT count as
@@ -414,7 +610,7 @@ if command -v jq >/dev/null 2>&1; then
   # fresh, non-LGTM verdict, so it classifies as actionable `changes-requested`.
   check "real CHANGES_REQUESTED w/ 'LGTM' in prose → changes-requested" "changes-requested" \
     "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H \
-       COMMENTS_JSON="$(cj '{"createdAt":"'"$FRESH"'","body":"Not ready for LGTM yet.\n\n**Verdict:** CHANGES_REQUESTED\n"}')" \
+       COMMENTS_JSON="$(cj '{"createdAt":"'"$FRESH"'","body":"<!-- creek-review pr=100 -->\n\nNot ready for LGTM yet.\n\n**Verdict:** CHANGES_REQUESTED\n"}')" \
        run 100)"
 
   # The other non-LGTM verdict the reviewer posts. Observed live on PR #1095:
@@ -422,7 +618,7 @@ if command -v jq >/dev/null 2>&1; then
   # watcher's whole timeout because it classified as in-flight `awaiting-review`.
   check "real ## Verdict: COMMENTS (fresh) → changes-requested" "changes-requested" \
     "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H \
-       COMMENTS_JSON="$(cj '{"createdAt":"'"$FRESH"'","body":"## Summary\nnits\n\n## Verdict: COMMENTS\n"}')" \
+       COMMENTS_JSON="$(cj '{"createdAt":"'"$FRESH"'","body":"<!-- creek-review pr=100 -->\n\n## Summary\nnits\n\n## Verdict: COMMENTS\n"}')" \
        run 100)"
 
   # No verdict-bearing comment at all → awaiting-review.
@@ -434,17 +630,704 @@ if command -v jq >/dev/null 2>&1; then
   # Latest verdict wins: an LGTM posted after an earlier CHANGES_REQUESTED → ready.
   check "real latest-verdict-wins (LGTM after CR) → ready" "ready" \
     "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H \
-       COMMENTS_JSON="$(cj '{"createdAt":"'"$STALE"'","body":"## Verdict: CHANGES_REQUESTED\n"},{"createdAt":"'"$FRESH"'","body":"## Verdict: LGTM\n"}')" \
+       COMMENTS_JSON="$(cj '{"createdAt":"'"$STALE"'","body":"<!-- creek-review pr=100 -->\n\n## Verdict: CHANGES_REQUESTED\n"},{"createdAt":"'"$FRESH"'","body":"<!-- creek-review pr=100 -->\n\n## Verdict: LGTM\n"}')" \
        run 100)"
 
-  # A real, fresh `## Verdict: LGTM` that predates HEAD is still stale → awaiting.
-  check "real ## Verdict: LGTM but stale → awaiting-review" "awaiting-review" \
+  # A real verdict that predates HEAD is still stale → awaiting. MARKED,
+  # deliberately: an unmarked body here would be refused for TWO reasons at once
+  # (stale AND unattested, after #1181), so deleting the freshness comparison
+  # outright would leave the case green — a confound, not a test. With the
+  # marker present the ONLY thing between this lane and `ready` is the
+  # stale-verdict guard. `**Verdict:**` rather than `## Verdict:` so it is not a
+  # restatement of the provenance block's own stale case either: this is the one
+  # place the alternate spelling is exercised on the LGTM-detecting side.
+  check "real **Verdict:** LGTM but stale → awaiting-review" "awaiting-review" \
     "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H \
-       COMMENTS_JSON="$(cj '{"createdAt":"'"$STALE"'","body":"## Verdict: LGTM\n"}')" \
+       COMMENTS_JSON="$(cj '{"createdAt":"'"$STALE"'","body":"<!-- creek-review pr=100 -->\n\n**Verdict:** LGTM\n"}')" \
        run 100)"
-else
-  echo "  skip - real-jq verdict-regex cases (jq not installed)"
-fi
+
+  # ==========================================================================
+  # VERDICT PROVENANCE: which PR did that verdict actually review? (issue #1181)
+  # ==========================================================================
+  # `.github/workflows/code-review.yml`'s `prompt:` never states the PR number,
+  # and `actions/checkout` puts the runner in DETACHED HEAD on
+  # `refs/pull/<N>/merge`. So the review agent's first command — `gh pr view
+  # --json number,…` — fails with "could not determine current branch: failed to
+  # run git: not on any branch", and it GUESSES.
+  #
+  # On PR #1117 (verdict posted 2026-08-07T05:27:24Z) it ran `gh pr list --state
+  # all --json number,title,headRefName,mergeCommit,commits`, matched the merge
+  # ref's base parent 46182a6f against PR #1179's `mergeCommit.oid`, and reviewed
+  # #1179's `cryptography`-bump diff — `gh pr diff 1179`, `gh pr view 1179`, `gh
+  # pr checks 1179`. The workflow then posted that LGTM onto #1117, and
+  # `pr-ready.sh 1117` printed `ready`. Gate 4 was bypassed on a 38-file
+  # authenticated HTTP surface by a verdict about a dependency bump.
+  #
+  # THE FIX, and what these cases pin. code-review.yml PREPENDS a machine-
+  # readable marker computed by the WORKFLOW from
+  # `${{ github.event.pull_request.number }}` — never from anything the agent
+  # says — in the shape of the `<!-- review-self-skip -->` marker that file
+  # already uses:  `<!-- creek-review pr=1117 -->`.  pr-ready.sh reads that
+  # marker FROM THE SAME COMMENT its VERDICT_RE selector already picked, and
+  # treats a verdict whose marker is absent, malformed, or names a DIFFERENT PR
+  # as no verdict at all: it gates neither `ready` NOR `changes-requested`, so
+  # the lane reads `awaiting-review`.
+  #
+  # It is a PROVENANCE ATTESTATION, not a wrong-diff detector. It cannot tell
+  # you the agent read the right diff; it proves the verdict was posted by a
+  # pipeline version that runs the workflow-side `reviewed_pr_number`
+  # cross-check. That is why exactly ONE key is defined (`pr=`) and why legacy
+  # unmarked verdicts are NOT grandfathered: the entire population of them was
+  # posted by the pipeline that had the bug, so "old but honest" is not a
+  # distinction the data supports.
+  #
+  # A second `createdAt` strictly newer than $FRESH, so a case can have TWO
+  # verdicts that are both fresh — the shape that makes "fall back to the newest
+  # CORRECTLY MARKED verdict" look attractive and be wrong.
+  LATER="2026-07-01T12:00:00Z"
+
+  # THE INCIDENT, replayed. PR #1117's own thread carrying the verdict that was
+  # actually posted to it: fresh, LGTM, and marked for #1179. Nothing else about
+  # this lane is wrong — CI green, CLEAN, current, verdict newer than HEAD — so
+  # the marker is the only thing between it and a merge, which is exactly the
+  # situation on 2026-08-07.
+  check "the #1117 incident: fresh LGTM marked for a DIFFERENT PR → awaiting-review" \
+    "awaiting-review" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H \
+       COMMENTS_JSON="$(cj '{"createdAt":"'"$FRESH"'","body":"<!-- creek-review pr=1179 -->\n\n## Summary\nPR #1179 raises the cryptography floor to clear PYSEC-2026-3552.\n\n## Verdict: LGTM\n"}')" \
+       run 1117)"
+
+  # A LEGACY verdict: posted by the pipeline that had the bug, so nothing about
+  # it says which PR the agent read. Not grandfathered — an absent marker is the
+  # single most common shape of the failure, and exempting it would exempt the
+  # bug.
+  check "unmarked fresh LGTM (legacy verdict) → awaiting-review" "awaiting-review" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H \
+       COMMENTS_JSON="$(cj '{"createdAt":"'"$FRESH"'","body":"## Summary\ngood\n\n## Verdict: LGTM\n"}')" \
+       run 100)"
+
+  # It gates NEITHER direction. An unattested CHANGES_REQUESTED is not evidence
+  # that THIS PR needs changes — it may be a verdict about somebody else's diff
+  # — so it must not dispatch address-feedback either. `changes-requested` here
+  # would send a fix worker at a review nobody performed, and the worker would
+  # "address" feedback about another PR's code.
+  check "unmarked fresh CHANGES_REQUESTED → awaiting-review, not changes-requested" \
+    "awaiting-review" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H \
+       COMMENTS_JSON="$(cj '{"createdAt":"'"$FRESH"'","body":"## Summary\nnope\n\n## Verdict: CHANGES_REQUESTED\n"}')" \
+       run 100)"
+
+  # MALFORMED markers. `pr=` with no value and `pr=abc` are what a broken
+  # interpolation emits (an empty `github.event.pull_request.number`, a literal
+  # `${{ … }}` that never expanded). `pr=11 17` is the whitespace-mangled
+  # number. The last one is the mutation-resistant case: `pr=100 7` on PR 100
+  # SATISFIES a lax `pr=([0-9]+)` extractor, which would read 100 and merge —
+  # only a whole-marker match (`<!-- creek-review pr=<digits> -->` and nothing
+  # else) refuses it. None of these is a marker this workflow can emit, so none
+  # of them attests to anything.
+  for mm in '<!-- creek-review pr= -->' \
+            '<!-- creek-review pr=abc -->' \
+            '<!-- creek-review pr=11 17 -->' \
+            '<!-- creek-review pr=100 7 -->'; do
+    check "malformed marker '$mm' → awaiting-review" "awaiting-review" \
+      "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H \
+         COMMENTS_JSON="$(cj '{"createdAt":"'"$FRESH"'","body":"'"$mm"'\n\n## Verdict: LGTM\n"}')" \
+         run 100)"
+  done
+
+  # THE CONTROL. Without it, an implementation that simply always printed
+  # `awaiting-review` from the verdict branch would pass every case above and
+  # wedge the entire fleet. Marker present, well-formed, naming THIS PR: merge.
+  check "marker present and MATCHING, fresh LGTM → ready" "ready" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H \
+       COMMENTS_JSON="$(cj '{"createdAt":"'"$FRESH"'","body":"<!-- creek-review pr=100 -->\n\n## Summary\ngood\n\n## Verdict: LGTM\n"}')" \
+       run 100)"
+
+  # STRING equality, not numeric — and `0100` is THE value to pin, because it is
+  # the one point in the whole space where `-eq` and `!=` disagree AND the two
+  # shells this repo actually runs on disagree with EACH OTHER. Measured, not
+  # assumed:
+  #
+  #   bash 5.3.15                        [[ "0100" -eq 100 ]] → TRUE   -eq 64 → FALSE
+  #   bash 3.2 (stock /bin/bash, macOS)  [[ "0100" -eq 100 ]] → FALSE  -eq 64 → TRUE
+  #
+  # (bash 5 reads the leading zero as decimal in `[[ ]]`'s arithmetic context;
+  # bash 3.2 reads it as octal 64. Both agree that `[[ "" -eq 100 ]]` and
+  # `[[ "abc" -eq 100 ]]` are FALSE, so an absent or lettered marker is not what
+  # a numeric compare would get wrong.) A numeric compare would therefore make
+  # the MERGE GATE shell-version-dependent: the same marker clears on CI's bash
+  # and refuses on the operator's, or the reverse, with nothing in the output to
+  # say which happened. String equality is exact and version-independent, and it
+  # is what the emitter produces: the workflow interpolates
+  # `github.event.pull_request.number` verbatim through `%s`, so anything but
+  # the verbatim bytes is a marker this pipeline did not emit.
+  check "leading-zero marker pr=0100 on PR 100 → awaiting-review" "awaiting-review" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H \
+       COMMENTS_JSON="$(cj '{"createdAt":"'"$FRESH"'","body":"<!-- creek-review pr=0100 -->\n\n## Verdict: LGTM\n"}')" \
+       run 100)"
+
+  # THE SAME-COMMENT INVARIANT. The marker must be read from the comment
+  # VERDICT_RE already selected — the same `$v` binding in the same jq
+  # expression, never a second scan of the thread. Here an OLDER comment carries
+  # a perfectly valid marker for this very PR and no verdict at all, while the
+  # NEWER (selected) comment carries the verdict and no marker. Any whole-thread
+  # question ("does this PR have a matching marker anywhere?") answers yes and
+  # merges an unattested verdict — and every PR reviewed even once would have
+  # such a comment.
+  check "marker on an OLDER comment does not vouch for the selected verdict" \
+    "awaiting-review" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H \
+       COMMENTS_JSON="$(cj '{"createdAt":"'"$STALE"'","body":"<!-- creek-review pr=100 -->\n\nStarting the review now."},{"createdAt":"'"$FRESH"'","body":"## Summary\ngood\n\n## Verdict: LGTM\n"}')" \
+       run 100)"
+
+  # LATEST-VERDICT-WINS still decides WHICH comment is the verdict; provenance
+  # only decides whether that one counts. Both verdicts here are fresh, so an
+  # implementation that fell back to "the newest CORRECTLY MARKED verdict" would
+  # resurrect the older one and merge — reviving a verdict the reviewer itself
+  # superseded, which is the stale-verdict guard's failure mode one field over.
+  check "older MARKED LGTM + newer UNMARKED LGTM → awaiting-review" "awaiting-review" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H \
+       COMMENTS_JSON="$(cj '{"createdAt":"'"$FRESH"'","body":"<!-- creek-review pr=100 -->\n\n## Verdict: LGTM\n"},{"createdAt":"'"$LATER"'","body":"## Verdict: LGTM\n"}')" \
+       run 100)"
+
+  # LINE-ANCHORED, exactly like the verdict line itself. The marker occupies its
+  # own line because the workflow's printf puts it there; a body-substring
+  # search would let review PROSE that merely quotes a marker attest to the
+  # verdict — and a review of THIS change would quote one.
+  check "marker embedded mid-line → awaiting-review" "awaiting-review" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H \
+       COMMENTS_JSON="$(cj '{"createdAt":"'"$FRESH"'","body":"## Summary\nsome prose <!-- creek-review pr=100 --> more prose\n\n## Verdict: LGTM\n"}')" \
+       run 100)"
+
+  # THE TAIL ANCHOR, ISOLATED. Nothing above actually exercises it: the mid-line
+  # case is refused by the LEADING `^`, and `pr=100 7` is refused by the literal
+  # ` -->`. So `(?m)^<!-- creek-review pr=([0-9]+) -->` — MARKER_RE with its
+  # `[[:space:]]*$` tail deleted — survives every other provenance case in this
+  # file while admitting the body below, and the body below is the REALISTIC
+  # forgery: review prose that quotes a marker at the start of its own line.
+  # A review of THIS change quotes one. The marker must be the whole line, or a
+  # reviewer who writes it down attests on the author's behalf.
+  check "marker followed by prose on the SAME line → awaiting-review" "awaiting-review" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H \
+       COMMENTS_JSON="$(cj '{"createdAt":"'"$FRESH"'","body":"<!-- creek-review pr=100 --> as quoted above\n\n## Verdict: LGTM\n"}')" \
+       run 100)"
+
+  # FIRST MARKER, NOT LAST. No other fixture in this file puts TWO markers in one
+  # body, so swapping `first` for `last` (or `.[-1]`) in the `[scan(…)] | flatten
+  # | first` extraction survives everything above. Under `last` this body
+  # ATTESTS: a genuine `pr=999` marker at the top — the #1117 shape, a verdict
+  # produced for another PR — plus a column-0 marker quoted in the review's own
+  # prose, which is all a chatty reviewer (or a forger) has to write to move the
+  # attestation onto this PR. The emitter PREPENDS exactly one marker, so only
+  # the first one can be the one it produced; everything after it is content.
+  check "quoted pr=100 marker BELOW a genuine pr=999 marker → awaiting-review" \
+    "awaiting-review" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H \
+       COMMENTS_JSON="$(cj '{"createdAt":"'"$FRESH"'","body":"<!-- creek-review pr=999 -->\n\n## Summary\nThe marker this change adds looks like:\n\n<!-- creek-review pr=100 -->\n\n## Verdict: LGTM\n"}')" \
+       run 100)"
+
+  # CRLF, the one LOOSENING that is load-bearing. MARKER_RE's trailing
+  # `[[:space:]]*` is described in pr-ready.sh as "the one cheap hedge against
+  # the correlated failure this whole guard's polarity depends on not
+  # happening": a comment body that came back CRLF-delimited would unmark every
+  # verdict in the fleet AT ONCE, and the #1181 polarity argument ("a false hold
+  # is one push away from repair") does not survive a fleet-wide false hold.
+  # Delete that `[[:space:]]*` and only this case goes red.
+  check "CRLF comment body still attests → ready" "ready" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H \
+       COMMENTS_JSON="$(cj '{"createdAt":"'"$FRESH"'","body":"<!-- creek-review pr=100 -->\r\n\r\n## Summary\ngood\r\n\r\n## Verdict: LGTM\r\n"}')" \
+       run 100)"
+
+  # THE GUARDS COMPOSE: provenance is ADDED to the freshness rule, not
+  # substituted for it. A correctly attested LGTM that predates HEAD reviewed
+  # code that is no longer there. (The unmarked twin above is held for two
+  # reasons after #1181; this one isolates the freshness half.)
+  check "marker MATCHING but verdict STALE → awaiting-review" "awaiting-review" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H \
+       COMMENTS_JSON="$(cj '{"createdAt":"'"$STALE"'","body":"<!-- creek-review pr=100 -->\n\n## Verdict: LGTM\n"}')" \
+       run 100)"
+
+  # PROSE IS NOT PROVENANCE. Real reviews name other PRs constantly ("supersedes
+  # #1179", "same shape as PR 1179"), and the incident's own summary opened with
+  # `PR #1179`. Only the marker line attests. A naive `#[0-9]+` body grep — the
+  # obvious cheap "did it review the right PR?" heuristic — reads this
+  # correctly-attested verdict as a mismatch and wedges the lane at
+  # `awaiting-review` forever, with no verdict the reviewer could post to fix it.
+  check "prose naming other PRs does not override the marker → ready" "ready" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H \
+       COMMENTS_JSON="$(cj '{"createdAt":"'"$FRESH"'","body":"<!-- creek-review pr=100 -->\n\n## Summary\nSupersedes #1179; same shape as PR 1179.\n\n## Verdict: LGTM\n"}')" \
+       run 100)"
+
+  # THE DEPENDABOT LANE. A mismatched verdict must not fall through into the one
+  # shortcut that merges WITHOUT a review. The rollup here carries a real
+  # non-SKIPPED entry because that is the only universe in which this comment
+  # exists — a posted verdict proves the `claude-review` job ran — so
+  # `review_gate_absent` is false and the hold holds for free. That free-ness is
+  # a property of the FIXTURE being realistic, which is exactly why it is
+  # pinned: a future change that stops consulting the rollup on this path turns
+  # a verdict about another PR into `ready-unreviewed`.
+  check "dependabot lane + mismatched marker → awaiting-review, never ready-unreviewed" \
+    "awaiting-review" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H BEHIND_BY=0 \
+       PR_AUTHOR="app/dependabot" HEAD_AUTHOR="dependabot[bot]" \
+       REVIEW_CONCLUSIONS="SKIPPED,SUCCESS" \
+       COMMENTS_JSON="$(cj '{"createdAt":"'"$FRESH"'","body":"<!-- creek-review pr=999 -->\n\n## Verdict: LGTM\n"}')" \
+       run 100)"
+
+  # THE ALL-SKIPPED SIBLING — the one place this guard can push a lane the WRONG
+  # WAY, and the case the fixture above hides. That lane's rollup carries a real
+  # non-SKIPPED entry, so `review_gate_absent` is false whatever the verdict
+  # does and the hold holds for free. Take that away — a Dependabot lane whose
+  # every `claude-review` entry really IS SKIPPED, plus a real non-review
+  # SUCCESS — and blanking the verdict does not merely withhold `ready`: it
+  # hands the lane to the shortcut that merges with NO review at all.
+  # `ready-unreviewed` is merge-adjacent (watch-pr.sh does not treat it as
+  # in-flight, and ralph-tick.md Step 1 routes on it), so a lane that HAS a
+  # posted verdict now comes out FURTHER ALONG than one that does not. Before
+  # #1181 this same fixture printed `changes-requested` (actionable) or
+  # `awaiting-review` (a wait); after it, `ready-unreviewed`.
+  #
+  # That contradicts pr-ready.sh's own precedence rule, stated in its header and
+  # again at the `review_gate_absent` call site: "a posted verdict proves a
+  # review gate exists, so the verdict — not the shortcut — decides." A comment
+  # carrying a `## Verdict:` line is proof the review job RAN. An unreadable
+  # marker makes that verdict INADMISSIBLE; it does not make the review gate
+  # NON-EXISTENT, and non-existence is the shortcut's whole precondition.
+  #
+  # Both verdict flavours, because they reach the shortcut by different routes:
+  # the LGTM falls through the freshness/LGTM test, the CHANGES_REQUESTED
+  # through the `verdict_lgtm == false` test — and neither may end at a token
+  # the loop will merge on. `awaiting-review` and not merely "not mergeable",
+  # because pr-ready.sh's own header fixes the destination: a refused verdict
+  # "gates neither `ready` nor `changes-requested`, so the lane falls through to
+  # `awaiting-review`". `changes-requested` here would dispatch a fix worker at
+  # a review nobody can attribute; `ready-unreviewed` would merge on it.
+  for vflav in LGTM CHANGES_REQUESTED; do
+    check "dependabot lane, all-SKIPPED review + UNMARKED $vflav → awaiting-review" \
+      "awaiting-review" \
+      "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H BEHIND_BY=0 \
+         PR_AUTHOR="app/dependabot" HEAD_AUTHOR="dependabot[bot]" \
+         REVIEW_CONCLUSIONS="SKIPPED" \
+         COMMENTS_JSON="$(cj '{"createdAt":"'"$FRESH"'","body":"## Summary\nfine\n\n## Verdict: '"$vflav"'\n"}')" \
+         run 100)"
+  done
+
+  # THE CONTROL for the two above, and the guard against the lazy fix. The same
+  # lane with NO verdict-bearing comment at all — one chat comment — must STILL
+  # take the shortcut. Otherwise "stop `ready-unreviewed` firing after a
+  # verdict" degenerates into "delete `ready-unreviewed`", which re-wedges every
+  # Dependabot bump at `awaiting-review` forever waiting for a review the
+  # workflow provably never runs: the exact deadlock that token exists to break.
+  # The discriminator is "did a verdict comment EXIST", not "is the rollup
+  # clean".
+  check "dependabot lane, all-SKIPPED review + NO verdict comment → ready-unreviewed" \
+    "ready-unreviewed" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H BEHIND_BY=0 \
+       PR_AUTHOR="app/dependabot" HEAD_AUTHOR="dependabot[bot]" \
+       REVIEW_CONCLUSIONS="SKIPPED" \
+       COMMENTS_JSON="$(cj '{"createdAt":"'"$FRESH"'","body":"just a chat comment"}')" \
+       run 100)"
+
+  # THE OTHER TWO REFUSAL SHAPES, on the same all-SKIPPED lane. The `$vflav`
+  # pair above is the ABSENT-marker flavour only, and absent is the arm whose
+  # marker field comes back EMPTY — so an implementation that latched on the
+  # MARKER field rather than on `$verdict_date` would fail there and pass here,
+  # while one that latched on the guard having FIRED would pass all three of
+  # these and fail only the stale case below. Malformed and mismatched reach
+  # `review_gate_absent` through the guard's blanking exactly as absent does,
+  # and neither may end at the merge-adjacent token either.
+  for mk in 'pr=abc:malformed' 'pr=999:mismatched'; do
+    check "dependabot lane, all-SKIPPED review + ${mk#*:} marker → awaiting-review" \
+      "awaiting-review" \
+      "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H BEHIND_BY=0 \
+         PR_AUTHOR="app/dependabot" HEAD_AUTHOR="dependabot[bot]" \
+         REVIEW_CONCLUSIONS="SKIPPED" \
+         COMMENTS_JSON="$(cj '{"createdAt":"'"$FRESH"'","body":"<!-- creek-review '"${mk%%:*}"' -->\n\n## Verdict: LGTM\n"}')" \
+         run 100)"
+  done
+
+  # THE LATCH WITH THE PROVENANCE GUARD ENTIRELY UNINVOLVED — the one route
+  # through `verdict_comment_seen` that nothing else in this file travels, and
+  # the one pr-ready.sh's own latch comment names when it lists "is STALE"
+  # alongside "was REFUSED" and "came back MALFORMED".
+  #
+  # Every other STALE fixture here omits PR_AUTHOR/HEAD_AUTHOR/REVIEW_CONCLUSIONS,
+  # so `review_gate_absent` fails on the author long before the latch could
+  # matter and the two are indistinguishable. This lane is a Dependabot bump that
+  # would genuinely earn `ready-unreviewed` on its own evidence — bot PR, bot
+  # HEAD commit, a real non-review SUCCESS, every `claude-review` entry SKIPPED,
+  # behind_by 0, CLEAN — carrying a verdict whose marker is PERFECT (`pr=100`, so
+  # the guard never fires and blanks nothing) and whose only defect is that it
+  # predates HEAD.
+  #
+  # Delete the latch and this prints `ready-unreviewed`: the stale-verdict guard
+  # withholds `ready`, the `verdict_lgtm == "false"` branch cannot fire (the
+  # verdict says true), and `review_gate_absent` — which sees only the author and
+  # the rollup — clears. A lane whose reviewer looked at it and said LGTM would
+  # then merge under the token reserved for lanes NO reviewer will ever look at,
+  # on the strength of a review of code that is no longer there. `awaiting-review`
+  # is the whole point: the re-review is owed and the workflow will run it,
+  # because a verdict comment on the thread is proof the job posts here.
+  check "dependabot lane, all-SKIPPED review + STALE but MARKED LGTM → awaiting-review" \
+    "awaiting-review" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H BEHIND_BY=0 \
+       PR_AUTHOR="app/dependabot" HEAD_AUTHOR="dependabot[bot]" \
+       REVIEW_CONCLUSIONS="SKIPPED" \
+       COMMENTS_JSON="$(cj '{"createdAt":"'"$STALE"'","body":"<!-- creek-review pr=100 -->\n\n## Summary\ngood\n\n## Verdict: LGTM\n"}')" \
+       run 100)"
+
+  # THE DIAGNOSTIC. `awaiting-review` is an IN-FLIGHT token (it is in
+  # watch-pr.sh's IN_FLIGHT_TOKENS), so a lane held by this gate is
+  # indistinguishable from one whose review simply has not landed — and the
+  # operator's reflex, re-running the old review workflow run, replays the same
+  # agent from the same detached HEAD and posts another unattested verdict. The
+  # remedy is a sync onto a `main` that carries the fixed workflow, so the
+  # holder has to SAY so, on stderr, where `run()` deliberately does not look.
+  # Several assertions rather than one string match: the wording may improve, the
+  # facts may not go missing.
+  err="$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H \
+         COMMENTS_JSON="$(cj '{"createdAt":"'"$FRESH"'","body":"## Summary\ngood\n\n## Verdict: LGTM\n"}')" \
+         run_err 100)" || err="exit-$?"
+  says "unattested-verdict diagnostic names the remedy (fleet.sh sync)" \
+    'fleet\.sh sync' "$err"
+  says "unattested-verdict diagnostic names re-running the old run" 're-?run' "$err"
+  says "unattested-verdict diagnostic says that will NOT help" 'not help' "$err"
+  says "unattested-verdict diagnostic cites the issue (#1181)" '#1181' "$err"
+
+  # …AND TWO OF THEM MUST BE THE ABSENT ARM'S OWN WORDS. Every pattern above
+  # matches a line pr-ready.sh prints for ALL THREE `case` arms, and `$err` here
+  # comes from the ABSENT-marker fixture — so before these two, deleting the
+  # absent arm outright left the suite green while a legacy lane was told "A
+  # verdict produced for another PR … Do NOT merge", which is precisely the
+  # confusion the block below calls dangerous. Each arm must pin at least one
+  # string that only IT can produce; `marker_what` and `marker_tail` are the two
+  # strings the `case` actually chooses between.
+  says "absent-marker diagnostic says the marker is MISSING, not wrong" \
+    'carries NO provenance marker' "$err"
+  says "absent-marker diagnostic explains it as a pre-#1181 verdict" \
+    'before #1181 landed' "$err"
+
+  # …AND THE THREE VARIANTS MUST STAY THREE. Four of the six assertions above
+  # sit on lines pr-ready.sh prints for EVERY arm; the last two are the absent
+  # arm's own `marker_what` / `marker_tail`. This block supplies the same for the
+  # other two arms, so the rule holds across all three: each arm pins at least
+  # one string only IT can produce, and collapsing the whole `case` into one
+  # generic message now goes red three times over rather than passing silently.
+  # The generic message is precisely the one that leaves an operator unable to
+  # tell apart:
+  # "this predates #1181, push anything" / "the emitter is broken, do NOT touch
+  # the parser" / "somebody's verdict landed on the wrong PR, do not merge this
+  # at all". Those are three different remedies, and two of them are dangerous
+  # if confused with the first.
+  #
+  # MISMATCHED: the #1117 shape. It must name BOTH numbers (the operator's next
+  # move is to go look at the OTHER PR) and it must say do not merge, because
+  # unlike the other two arms this one can mean the review pipeline attested
+  # something false rather than merely nothing.
+  err_mismatch="$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H \
+         COMMENTS_JSON="$(cj '{"createdAt":"'"$FRESH"'","body":"<!-- creek-review pr=1179 -->\n\n## Verdict: LGTM\n"}')" \
+         run_err 100)" || err_mismatch="exit-$?"
+  says "mismatched-marker diagnostic names BOTH PR numbers" \
+    'names PR #1179, not #100' "$err_mismatch"
+  says "mismatched-marker diagnostic says do NOT merge" 'do not merge' "$err_mismatch"
+
+  # MALFORMED: the emitter and this parser have drifted, which is the ONE arm
+  # whose remedy is a code change rather than a push — and the tempting code
+  # change is the wrong one. The message has to point at the emitter and
+  # explicitly forbid loosening the parser, or the fleet-wide hold this shape
+  # causes gets "fixed" by deleting the guard.
+  err_malformed="$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H \
+         COMMENTS_JSON="$(cj '{"createdAt":"'"$FRESH"'","body":"<!-- creek-review pr=abc -->\n\n## Verdict: LGTM\n"}')" \
+         run_err 100)" || err_malformed="exit-$?"
+  says "malformed-marker diagnostic names the emitter/parser drift" \
+    'drift' "$err_malformed"
+  says "malformed-marker diagnostic forbids loosening the parser" \
+    'do not loosen the parser' "$err_malformed"
+
+  # ==========================================================================
+  # THE SECOND EMITTER: iteration-trigger.yml's executive summary (issue #1181)
+  # ==========================================================================
+  # Everything above assumes the only thing on a PR that matches VERDICT_RE is a
+  # review comment. In THIS repo that is false, and the comment that falsifies it
+  # posts LAST on every lane.
+  #
+  # `.github/workflows/iteration-trigger.yml` posts a four-line executive summary
+  # whenever CI completes green and a review verdict exists. Its emitted body is
+  # `printf '%s\n%s\n%s\n%s\n'` over `<!-- iteration-trigger -->`,
+  # `**CI**: G/T Green`, `**VERDICT**: V`, `**Action**: A` (that file's final
+  # step). The second line SATISFIES VERDICT_RE: the `(?:#{1,6}\s+|\*\*)?`
+  # alternative pr-ready.sh deliberately tolerates matches the leading `**`,
+  # `verdict` matches `VERDICT` case-insensitively, and `[:*\s]` matches the
+  # second `*` — after which `[:*\s]+lgtm` matches `**: LGTM` and
+  # VERDICT_LGTM_RE is satisfied too. Measured through these very patterns with
+  # jq: VERDICT_RE true, VERDICT_LGTM_RE true, `creek-review` marker NONE.
+  #
+  # IT IS NOT A VERDICT. It is a REPORT OF one: that workflow selects the review
+  # comment with `jq '[.[] | select(.body | test("(^|\\n)## Verdict:"))] | last'`
+  # and copies the verdict out of it. It cannot carry `<!-- creek-review pr=N -->`
+  # and must not — the marker attests that the CODE-REVIEW pipeline produced the
+  # comment, and this one is posted by a workflow that never read the diff. So
+  # after #1181 the summary is refused on every lane, and because it posts LAST
+  # the `| last` selector picks it on every lane.
+  #
+  # MEASURED, NOT HYPOTHESISED. Merged PR #906's comment tail:
+  #   06:53:17Z  `## Summary\nPR #906 fixes false-positive "broke…`  ← the review
+  #   06:53:32Z  `<!-- iteration-trigger -->\n**CI**: 4/7 Green…`    ← 15 s later
+  #   07:03:05Z  `<!-- iteration-trigger -->\n**CI**: 10/10 Green…`  ← LAST
+  # Same shape on #905, #904 and #902 — 4 of 4. The result is the correlated
+  # FLEET-WIDE hold pr-ready.sh's own #1181 polarity block says this guard cannot
+  # afford: every lane reads `awaiting-review`, `awaiting-review` is in
+  # watch-pr.sh's IN_FLIGHT_TOKENS so the watcher sleeps on it, and the documented
+  # un-wedge ("one push by anybody") does NOT clear it — a push produces a fresh
+  # review comment and then, 15 s later, a fresh unmarked summary. The polarity
+  # block's neutralising leg is the emitter coupling test, and that test only ever
+  # knew about ONE emitter.
+  #
+  # THE FIX these cases pin: exclude the iteration-trigger summary from the
+  # verdict SELECTOR, inside the same single `--jq`. iteration-trigger.yml already
+  # does the mirror image for itself (it selects only comments matching
+  # `(^|\n)## Verdict:`, which no summary of its own carries), so the asymmetry is
+  # one-sided.
+  #
+  # WHY THE SUITE COULD NOT SEE THIS: no fixture anywhere in this file carried an
+  # iteration-trigger summary. Multi-comment fixtures existed (the
+  # latest-verdict-wins pair above is one), so "the suite only modelled single
+  # comments" is NOT the reason and stating it that way would send the next
+  # reader looking for the wrong gap. The reason is narrower and worse: the bench
+  # modelled ONE producer of verdict-shaped comments, and the repo has two.
+
+  # The summary's marker, READ OUT OF THE EMITTER rather than restated here, so
+  # the fixtures below carry the workflow's bytes and not the test's — the same
+  # round-trip discipline the code-review.yml coupling block at the end of this
+  # file applies to the FIRST emitter, applied now to the second. Rename `MARKER:`
+  # in iteration-trigger.yml without teaching pr-ready.sh the new name and W1/W2
+  # below go red on the rename itself.
+  ITER_TRIGGER_WORKFLOW="$(cd "$(dirname "$0")/../.." && pwd)/.github/workflows/iteration-trigger.yml"
+  ITER_MARKER_EXPECTED='<!-- iteration-trigger -->'
+  ITER_MARKER="$(sed -n "s/^[[:space:]]*MARKER: '\([^']*\)'[[:space:]]*\$/\1/p" \
+                 "$ITER_TRIGGER_WORKFLOW" | head -n 1 || true)"
+  # Kills the mutant that renames the emitter's marker and leaves the parser
+  # behind: this is the one coupling that cannot be inferred from either file
+  # alone, and drift in it re-opens the fleet wedge silently.
+  check "iteration-trigger.yml's MARKER: is the literal pr-ready.sh must exclude" \
+    "$ITER_MARKER_EXPECTED" "$ITER_MARKER"
+  # Fall back ONLY so the behavioural cases still assert something: with an empty
+  # marker every fixture body below would start with a blank line, and an empty
+  # exclusion pattern matches every comment — the cases would pass while testing
+  # nothing. The `check` above has already reported the drift.
+  [[ -n "$ITER_MARKER" ]] || ITER_MARKER="$ITER_MARKER_EXPECTED"
+
+  # A comment object whose body is escaped by `jq -Rs` rather than by hand, for
+  # the reason `marker_body` at the end of this file gives: a hand-written `\\n`
+  # can disagree with the bytes the fixture claims to carry, and these bodies are
+  # multi-line by nature.
+  rev_comment() { # rev_comment <createdAt> <body>
+    printf '{"createdAt":"%s","body":%s}' "$1" "$(printf '%s' "$2" | jq -Rs .)"
+  }
+
+  # The executive summary in its EMITTED shape. `**VERDICT**` and `**Action**` are
+  # reproduced verbatim rather than abbreviated because they are the two fields
+  # `.claude/skills/await-claude-review/SKILL.md` Step 4a actually reads.
+  iter_summary() { # iter_summary <createdAt> <CI field> <VERDICT field> <Action field>
+    rev_comment "$1" "${ITER_MARKER}
+**CI**: $2
+**VERDICT**: $3
+**Action**: $4
+"
+  }
+
+  # The two `**Action**:` strings iteration-trigger.yml can emit on a lane whose
+  # verdict is admissible: the cleared-to-merge instruction from its final `else`,
+  # and the iterate line from the outer `else` (a summary posted while CI was not
+  # yet fully green). Both are verbatim from that file.
+  ITER_ACTION_CLEARED='You are cleared to squash merge, delete the branch, clean any worktrees, and unsubscribe from webhooks. Please proceed.'
+  ITER_ACTION_ITERATE='pull comment 4242 to see in-depth feedback and continue iterating'
+
+  # A third stamp, strictly newer than $LATER: the live shape needs THREE comments
+  # in chronological order, all of them fresher than HEAD.
+  LATEST="2026-07-01T13:00:00Z"
+
+  # The review bodies, in code-review.yml's emitted shape: the marker printf
+  # (`<!-- creek-review pr=%s -->\n\n` > review.md), the review markdown, then
+  # `\n\n## Verdict: %s\n` appended.
+  MARKED_LGTM_BODY='<!-- creek-review pr=100 -->
+
+## Summary
+good
+
+## Verdict: LGTM
+'
+  MARKED_CR_BODY='<!-- creek-review pr=100 -->
+
+## Summary
+one blocking issue
+
+## Verdict: CHANGES_REQUESTED
+'
+  UNMARKED_LGTM_BODY='## Summary
+good
+
+## Verdict: LGTM
+'
+
+  # W1 — THE LIVE SHAPE, AND THE FLEET WEDGE. PR #906's tail exactly: a
+  # correctly-marked review LGTM, then the summary the trigger posted 15 s later,
+  # then the one it posted after the next CI round. The marked LGTM is the only
+  # verdict on this thread; the summaries quote it.
+  #
+  # FAILS TODAY with `awaiting-review` — the selector takes the LAST comment
+  # matching VERDICT_RE, which is a summary, and a summary can never carry a
+  # `creek-review` marker, so the provenance guard refuses it and the lane holds
+  # forever.
+  #
+  # TWO summaries rather than one, on purpose: that also kills "if the LAST
+  # comment is a summary, take the one before it", which is wrong on every lane
+  # whose CI ran more than once — i.e. on every lane that was ever synced.
+  w1_json="$(cj "$(rev_comment "$FRESH" "$MARKED_LGTM_BODY"),$(iter_summary "$LATER" '4/7 Green' 'LGTM' "$ITER_ACTION_ITERATE"),$(iter_summary "$LATEST" '10/10 Green' 'LGTM' "$ITER_ACTION_CLEARED")")"
+  check "W1 marked LGTM + TWO iteration-trigger summaries → ready" "ready" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H COMMENTS_JSON="$w1_json" run 100)"
+
+  # W2 — THE SAME WEDGE ON THE ACTIONABLE SIDE. A marked, fresh
+  # `## Verdict: CHANGES_REQUESTED` followed by its summary. The reviewer's
+  # verdict must still decide, and the summary must not be what is read.
+  #
+  # FAILS TODAY with `awaiting-review`: the summary is selected, carries no
+  # marker, and the provenance guard blanks the verdict fields before the
+  # `verdict_lgtm == "false"` branch can fire — so the lane that most needs a fix
+  # worker dispatched instead reads as in-flight and nobody is woken.
+  #
+  # `CHANGES REQUESTED` with a SPACE in the summary and an UNDERSCORE in the
+  # review comment is not a typo: iteration-trigger.yml's `case` sets
+  # `VERDICT='CHANGES REQUESTED'` (its own bytes), while code-review.yml appends
+  # `## Verdict: CHANGES_REQUESTED`. Both are reproduced as their emitters write
+  # them.
+  w2_json="$(cj "$(rev_comment "$FRESH" "$MARKED_CR_BODY"),$(iter_summary "$LATER" '10/10 Green' 'CHANGES REQUESTED' "$ITER_ACTION_ITERATE")")"
+  check "W2 marked CHANGES_REQUESTED + its summary → changes-requested" "changes-requested" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H COMMENTS_JSON="$w2_json" run 100)"
+
+  # W3 — THE SUMMARY MUST NOT RESCUE AN UNATTESTED VERDICT EITHER. An unmarked
+  # (legacy) review verdict followed by a summary: skipping the summary must land
+  # on the real review comment and REFUSE it, not reach past it for something
+  # admissible.
+  #
+  # GREEN TODAY, and honestly so: today the summary is selected and refused for
+  # want of a marker, so this lands on the expected token by a different route.
+  # It is here for the FIX, and the mutant it kills is the same-comment invariant
+  # one — an exclusion implemented by re-binding `createdAt`/`isLGTM` to the
+  # comment BEFORE the summary while leaving the marker extraction bound to the
+  # comment it skipped (or dropping the marker check on that path because "we
+  # skipped a summary, so what is left must be a review comment"). Under that
+  # implementation this unmarked legacy LGTM comes out `ready`, which is #1181's
+  # own failure with one extra step.
+  w3_json="$(cj "$(rev_comment "$FRESH" "$UNMARKED_LGTM_BODY"),$(iter_summary "$LATER" '10/10 Green' 'LGTM' "$ITER_ACTION_CLEARED")")"
+  check "W3 UNMARKED verdict + summary → awaiting-review" "awaiting-review" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H COMMENTS_JSON="$w3_json" run 100)"
+
+  # W3b — THE REACH-BACK MUTANT, which W3 alone does not kill. Same shape plus an
+  # OLDER, correctly-marked, still-FRESH LGTM underneath. The rule pinned at
+  # "older MARKED LGTM + newer UNMARKED LGTM → awaiting-review" above is CORRECT
+  # and stays: latest verdict wins, and provenance only decides whether that one
+  # counts. Excluding the summary must not turn the selector into "the newest
+  # correctly MARKED verdict", which would resurrect a verdict the reviewer itself
+  # superseded and merge on it.
+  #
+  # GREEN TODAY (the summary is selected and refused). Under that mutant it prints
+  # `ready`.
+  w3b_json="$(cj "$(rev_comment "$FRESH" "$MARKED_LGTM_BODY"),$(rev_comment "$LATER" "$UNMARKED_LGTM_BODY"),$(iter_summary "$LATEST" '10/10 Green' 'LGTM' "$ITER_ACTION_CLEARED")")"
+  check "W3b older MARKED + newer UNMARKED + summary → awaiting-review" "awaiting-review" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H COMMENTS_JSON="$w3b_json" run 100)"
+
+  # W4 — THE SUMMARY ALONE. No review comment at all. Excluding it must leave
+  # "no verdict was posted", never "some verdict was posted".
+  #
+  # GREEN TODAY (selected, unmarked, refused) — AND IT IS THE ONLY CASE HERE THAT
+  # KILLS THE TEMPTING WRONG FIX. That fix is "the summary is posted by our own
+  # workflow, so accept `<!-- iteration-trigger -->` as a second provenance
+  # marker" instead of excluding it, and it passes W1 (summary says
+  # `**VERDICT**: LGTM` → ready) and W2 (summary says CHANGES REQUESTED →
+  # changes-requested) exactly as the real fix does. Here it prints `ready` for a
+  # PR on which no reviewer ever spoke. It is also strictly weaker than the
+  # marker it would join: `<!-- creek-review pr=N -->` names the PR, while these
+  # four lines name nothing at all, so anyone who can comment could write them.
+  # W1 and W2 are the wedge; this is the case that keeps its fix honest.
+  w4_json="$(cj "$(iter_summary "$FRESH" '10/10 Green' 'LGTM' "$ITER_ACTION_CLEARED")")"
+  check "W4 iteration-trigger summary ALONE → awaiting-review" "awaiting-review" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H COMMENTS_JSON="$w4_json" run 100)"
+
+  # W5 — FRESHNESS COMES FROM THE REVIEW COMMENT. A marked LGTM that predates HEAD
+  # (it reviewed code that is no longer there) followed by a FRESH summary. The
+  # stale-verdict guard must read the REVIEW comment's `createdAt`, not the
+  # summary's.
+  #
+  # GREEN TODAY, and the reason matters: today the marker guard refuses the
+  # summary before freshness is ever consulted, so the pre-#1181 hole this shape
+  # opened (a stale review + a fresh summary reading as a FRESH LGTM → `ready`) is
+  # currently masked rather than closed. The mutant it kills is the two-selector
+  # implementation: one binding for the marker (summary excluded) and another for
+  # `createdAt` (summary included) — which prints `ready` here, and which is
+  # exactly the same-comment invariant the provenance block above already had to
+  # defend once.
+  w5_json="$(cj "$(rev_comment "$STALE" "$MARKED_LGTM_BODY"),$(iter_summary "$FRESH" '10/10 Green' 'LGTM' "$ITER_ACTION_CLEARED")")"
+  check "W5 STALE marked LGTM + FRESH summary → awaiting-review" "awaiting-review" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H COMMENTS_JSON="$w5_json" run 100)"
+
+  # W6 — THE EXCLUSION IS LINE-ANCHORED, NOT A BODY SUBSTRING. A genuine review
+  # comment whose PROSE quotes the marker mid-sentence must still be selectable.
+  #
+  # THE DECISION, and it is a decision (both directions fail closed — skipping a
+  # comment can only ever LOSE a verdict, never invent one — so this is a choice
+  # about how much verdict is lost, not about safety):
+  #   * `test("<!-- iteration-trigger -->")` is a SUBSTRING match, so any review
+  #     that quotes the marker is skipped. That is not hypothetical here: a review
+  #     of THIS VERY CHANGE quotes it, and the identical shape is already written
+  #     down twice for the OTHER marker ("a review of THIS change quotes one", at
+  #     the mid-line and same-line marker cases above). The cost is not one lost
+  #     verdict either — it is a lane wedged at `awaiting-review`, which is
+  #     precisely the failure this whole block exists to remove, re-introduced
+  #     through a narrower door.
+  #   * `(?m)^<!-- iteration-trigger -->[[:space:]]*$` costs nothing to match every
+  #     REAL summary: the emitter's `printf '%s\n…'` puts the marker on line 1 at
+  #     column 0, exactly as code-review.yml does for `creek-review`. It makes the
+  #     two markers' parse rules symmetric, and it is the pattern
+  #     iteration-trigger.yml itself already uses to read the creek-review marker
+  #     (`grep -oE '^<!-- creek-review pr=[0-9]+ -->[[:space:]]*$'`).
+  #   * The residual is ACCEPTED and named: a review that quotes the marker on a
+  #     line of its OWN (inside a fenced block) is still skipped. That is one
+  #     verdict lost on one PR, recoverable by one re-review — not a fleet-wide
+  #     hold. The tighter alternative — a BARE `^`, i.e. anchoring to the start of
+  #     the body, which is where the emitter always puts it — is rejected not
+  #     because it is wrong but because it rests on a flag DEFAULT, and this suite
+  #     runs Oniguruma while production runs RE2. MARKER_RE's engine note in
+  #     pr-ready.sh records that a confident claim about those defaults was
+  #     written down once, read the other way by a reviewer, and never measured by
+  #     anybody. Spelling `(?m)` out is what makes the pattern independent of both
+  #     defaults, and it is why MARKER_RE spells it out too.
+  # So: anchored. This case goes red under the substring implementation and stays
+  # green under the anchored one. It is GREEN TODAY (no exclusion exists yet, so
+  # the comment is selected on its own merits).
+  w6_json="$(cj "$(rev_comment "$FRESH" "<!-- creek-review pr=100 -->
+
+## Summary
+The wedge is that a ${ITER_MARKER} summary matches VERDICT_RE, so the selector picks it.
+
+## Verdict: LGTM
+")")"
+  check "W6 review PROSE quoting the summary marker mid-line → ready" "ready" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H COMMENTS_JSON="$w6_json" run 100)"
+}
+
+# The verdict answer is now THREE fields — `<createdAt>|<isLGTM>|<markerPr>` —
+# and it is split by FIELD COUNT for the same reason the mergeState answer at
+# pr-ready.sh:720-721 (`merge_rest`) and the rollup answer at :917-918 (`rest`,
+# inside `review_gate_absent`) are — cited by variable name as well as by line,
+# because pr-ready.sh moves: an RFC3339 stamp, a
+# jq boolean and a PR number can none of them contain `|`, so a fourth field
+# means the answer is not the shape we asked for. Blank it and wait, rather than
+# seek one end of the string and merge on whatever lands in the flag — the
+# `|`-injection class this file has already proven exploitable once.
+check "surplus field in the verdict answer → awaiting-review" "awaiting-review" \
+  "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H BEHIND_BY=0 \
+     VERDICT="$FRESH|true|100" VERDICT_PR=extra run 100)"
 
 # --- opt-out: a human hold beats every other signal ------------------------
 # `do-not-auto-merge` is the kill switch a human reaches for when a lane is green
@@ -755,8 +1638,10 @@ probed "lazy compare: opt-out lane does not probe" "no" "$S_OPTOUT"
 # --- main health: the #1157 relaxation's PRECONDITION (issue #1159) ---------
 # #1157 let a lane that is behind `main` merge anyway whenever the two
 # changesets provably cannot interact. Its whole justification is one sentence
-# in pr-ready.sh's header (lines 129-133): "What backstops the residual risk is
-# the full CI run on `push: main` — every squash-merge re-proves the merged
+# in pr-ready.sh's header (lines 274-276, inside the "WHY IT IS `behind_by > 0`
+# PLUS A REASON" block — named as well as line-cited, because pr-ready.sh
+# moves): "What backstops the residual risk is the full CI run on `push: main`
+# — every squash-merge re-proves the merged
 # result." Nothing in the loop had ever read that run's conclusion, so the
 # backstop was an assumption. It is now a check, and it is deliberately a
 # precondition of the RELAXATION, not a new gate on merging: only a lane that is
@@ -870,7 +1755,10 @@ check "behind a risk-surface change with main CI green → behind" "behind" \
 # `conclusion` is JSON null while a run is in flight. Feeding raw payloads
 # through the REAL sibling proves the two scripts agree end to end — including
 # on the token STRING, which a fake sibling would let drift.
-if command -v jq >/dev/null 2>&1; then
+#
+# An unconditional GROUP, not a `command -v jq` guard: see the hard-requirement
+# block at the top of this file. Braces keep the indentation unchanged.
+{
   MH_SUCCESS='{"status":"completed","conclusion":"success","headSha":"abc1234","databaseId":11,"url":"https://x/11"}'
   MH_FAILURE='{"status":"completed","conclusion":"failure","headSha":"dead1234","databaseId":12,"url":"https://x/12"}'
   MH_FLIGHT='{"status":"in_progress","conclusion":null,"headSha":"feed1234","databaseId":13,"url":"https://x/13"}'
@@ -883,6 +1771,13 @@ if command -v jq >/dev/null 2>&1; then
   # A run in flight over an older success is the STEADY STATE of a busy fleet
   # (main CI lags every merge by ~14 minutes). It must read green, or this gate
   # reintroduces the serialization #1138 removed.
+  #
+  # #1138 IS NOT A TYPO FOR #1137 here, and it has now been queried twice. The
+  # convention across `main-health.sh`, `test_main_health.sh` and this file is
+  # consistent: #1137 is the issue that MEASURED the serialization (this file
+  # says "the serialization #1137 measured" in two other places), #1138 is the
+  # change that REMOVED it ("the serialization #1138 removed", the same words in
+  # all three files). Checked against those files rather than assumed.
   check "real run-list payload, in flight over a success → ready" "ready" \
     "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=22 \
        THEIR_FILES="creek/classify/privacy.py" OUR_FILES="creek/vault/writer.py" \
@@ -892,13 +1787,12 @@ if command -v jq >/dev/null 2>&1; then
     "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H VERDICT="$FRESH|true" BEHIND_BY=22 \
        THEIR_FILES="creek/classify/privacy.py" OUR_FILES="creek/vault/writer.py" \
        MAIN_RUNS_JSON='[]' run 100)"
-else
-  echo "  skip - real-jq main-health payload cases (jq not installed)"
-fi
+}
 
 # --- the sibling seam: a helper that is not there holds the lane ------------
 # pr-ready.sh resolves main-health.sh by its own `dirname`, exactly as
-# watch-pr.sh resolves pr-ready.sh (test_watch_pr.sh:53). A copy of the script
+# watch-pr.sh resolves pr-ready.sh (test_watch_pr.sh:59-62, where the stub is
+# planted next to a copy of watch-pr.sh for that reason). A copy of the script
 # in a directory with no sibling IS that seam. A partial checkout, a bad
 # packaging change, or a rename must never read as "main is fine".
 NOSIB="$WORK/nosibling"
@@ -1020,7 +1914,9 @@ probed "malformed merge base does not pay for main-health" "no" "$M_BADBASE"
 # The issue says so outright: "Fails closed: if reviewability cannot be
 # determined, behave as today (sync), since merging stale is the worse error."
 #
-# The new token is printed in the terminal `else` (pr-ready.sh:651) ONLY when ALL
+# The new token is printed in the terminal `else` of pr-ready.sh's final
+# if/elif/else (pr-ready.sh:1118-1151, the branch that would otherwise `echo
+# behind`) ONLY when ALL
 # of these hold: the lane would otherwise print `behind`, `ready_token` is
 # `ready` (not `ready-unreviewed`), `merge_state` is `CLEAN`, and the helper
 # positively answered `exhausted`.
@@ -1108,9 +2004,13 @@ check "a healthy 'allowed' log carrying the word rejected → behind" "behind" \
      run 100)"
 
 # --- the sibling seam, in the INVERTED direction ----------------------------
-# The same seam test_pr_ready.sh already exercises for main-health.sh at
-# :806-836 — a copy of pr-ready.sh in a directory whose siblings we control —
-# but with the opposite expectation. A main-health.sh that cannot be asked HOLDS
+# The same seam this file already exercises for main-health.sh in the `$NOSIB` /
+# `$NOEXEC` block above — a copy of pr-ready.sh in a directory whose siblings we
+# control — but with the opposite expectation. Cited by the fixture's variable
+# names rather than by line number on purpose: the two intra-file line citations
+# that used to be here were made stale by this very diff's own growth, and will
+# be again by the next one, whereas `$NOSIB` and `$NOEXEC` are greppable and
+# move with the code. A main-health.sh that cannot be asked HOLDS
 # the lane; a review-quota.sh that cannot be asked must NOT.
 #
 # Each lane plants a main-health.sh that answers `green`, because otherwise the
@@ -1188,9 +2088,10 @@ check "MISSING review-quota.sh sibling → behind" "behind" "$tok"
 # And a helper that exists but cannot be executed — the dropped exec bit #1092
 # actually shipped and test_exec_bits.sh guards. The planted file WOULD say
 # `exhausted` if it ran, so an implementation that `bash`es the helper instead of
-# checking `-x` fails here. Note this is the mirror of the main-health case at
-# :833-836: there a non-executable helper must never read as `green`; here it
-# must never read as `exhausted`.
+# checking `-x` fails here. Note this is the mirror of the main-health `$NOEXEC`
+# case above (named, not line-cited, for the reason given in the seam block):
+# there a non-executable helper must never read as `green`; here it must never
+# read as `exhausted`.
 P_NOEXEC="$(plant_lane noexec '#!/usr/bin/env bash
 echo exhausted
 ' 644)"
@@ -1410,7 +2311,10 @@ check "one non-review SUCCESS → ready-unreviewed" "ready-unreviewed" \
 # `null`, not a string. These two feed a real payload through pr-ready.sh's own
 # expression, so a `select(.conclusion == "SUCCESS")` that accidentally counts
 # nulls or SKIPPEDs is caught here.
-if command -v jq >/dev/null 2>&1; then
+#
+# An unconditional GROUP, not a `command -v jq` guard: see the hard-requirement
+# block at the top of this file. Braces keep the indentation unchanged.
+{
   REVIEW_ENTRY='{"name":"claude-review","conclusion":"SKIPPED"}'
   rj() { # rj <extra rollup entries> — a real --json author,statusCheckRollup payload
     printf '{"author":{"login":"app/dependabot"},"statusCheckRollup":[%s,%s]}' \
@@ -1430,9 +2334,7 @@ if command -v jq >/dev/null 2>&1; then
        HEAD_AUTHOR="$DEPENDABOT_COMMIT" \
        ROLLUP_JSON="$(rj '{"name":"ci","conclusion":"SUCCESS"},{"name":"lint","conclusion":null}')" \
        run 100)"
-else
-  echo "  skip - real-jq review-gate rollup cases (jq not installed)"
-fi
+}
 
 # The PR author is not enough: anyone can push a commit onto a Dependabot branch
 # (that is how we fix a bump's fallout), and that commit is unreviewed code
@@ -1549,6 +2451,339 @@ if grep -qx "name" <<<"$job_keys"; then
   bad "claude-review declares a name: override — GitHub will report a different check name"
 else
   ok "claude-review declares no name: override (check name stays 'claude-review')"
+fi
+
+# --- cross-file coupling: the provenance marker (issue #1181) ---------------
+# code-review.yml is the EMITTER of the marker and pr-ready.sh is the PARSER.
+# Nothing else connects them: they are different languages in different
+# directories, and the only test that could catch drift is one that reads both.
+# Drift here does not wedge one lane, it wedges every lane at once — an emitter
+# that stops emitting turns the whole fleet to `awaiting-review` with no verdict
+# anyone can post to clear it.
+WF_DIR="$(dirname "$REVIEW_WORKFLOW")"
+RECAP_WORKFLOW="$WF_DIR/ralph-recap-tests.yml"
+ITER_WORKFLOW="$WF_DIR/iteration-trigger.yml"
+
+# The shared bytes, written out once. The prefix is what a READER of the marker
+# matches on; the full format is what the emitter's `printf` carries.
+MARKER_PREFIX='<!-- creek-review pr='
+MARKER_FMT_LITERAL="${MARKER_PREFIX}%s -->"
+
+# THE WHOLE printf FORMAT ARGUMENT — everything between the emitter's quotes,
+# not the substring this file already knows. What used to be here was
+# `grep -oF -- "$MARKER_FMT_LITERAL"`, and `grep -oF` can only ever print back
+# the pattern it was handed: the "extracted" value was either empty or
+# byte-identical to the literal three lines up, so the round trip below fed the
+# parser the TEST's bytes while claiming to feed it the EMITTER's. Three real
+# drifts survived that, each of which unmarks the whole fleet:
+#   * dropping the trailing `\n\n` — the marker then glues onto `## Summary` and
+#     MARKER_RE's tail `$` refuses it, but a fixture supplying its own blank
+#     line never notices;
+#   * any same-line prefix ahead of the marker inside the same format;
+#   * flipping `> review.md` to `>>` so the marker is no longer first (pinned
+#     separately, just below — a format string cannot see its own redirection).
+# `sed` takes the whole single-quoted argument instead, so the trailing escapes
+# are part of what gets rendered and compared.
+#
+# `%s`, not `%d`: the parser compares STRINGS (see the pr=0100 case above), and
+# `%d` would silently renormalise a number on the way out — the one place where
+# emitter and parser could disagree about bytes that both look correct. A `%d`
+# fails this extraction outright (the pattern is anchored on `pr=%s`) and is
+# reported LOUDLY rather than quietly rendered into something plausible.
+# Braces around the variable are required, not stylistic: `$MARKER_FMT_LITERAL[`
+# reads as an array subscript to shellcheck (SC1087, an ERROR), and the ralph CI
+# job shellchecks these scripts at --severity=warning.
+MARKER_FMT="$(sed -n "s/.*printf '\(${MARKER_FMT_LITERAL}[^']*\)'.*/\1/p" \
+              "$REVIEW_WORKFLOW" | head -n 1 || true)"
+if [[ -z "$MARKER_FMT" ]]; then
+  # BRACES ARE LOAD-BEARING HERE TOO, and for a sharper reason than SC1087
+  # above: the `…` that follows is multi-byte UTF-8, and bash swallowed its
+  # first byte into the parameter NAME — so this line died with
+  # `MARKER_FMT_LITERAL<byte>: unbound variable` under `set -u`. That crash sits
+  # on the ONE path this assertion exists to travel: it only runs when the
+  # emitter's format cannot be extracted, i.e. exactly when `code-review.yml`
+  # and this parser have drifted. The suite aborted mid-run instead of reporting
+  # the drift, which is how a coupling check silently stops being one. Caught by
+  # running this file against an unmodified `code-review.yml`.
+  bad "could not extract code-review.yml's \"printf '${MARKER_FMT_LITERAL}…'\" format — nothing attests to any verdict"
+else
+  ok "extracted code-review.yml's whole marker printf format"
+fi
+
+# THE MARKER IS FIRST, and that is a property of the REDIRECTION, not of the
+# format. The round trip below renders the format in isolation, so it cannot see
+# WHERE those bytes land in the file the comment body is built from: `>` on the
+# marker printf (truncate) and `>>` on everything after it is the only thing
+# putting the marker on line 1 at column 0. Flip the marker's `>` to `>>` and
+# the review markdown lands first — pr-ready.sh's `^` then anchors to a
+# `## Summary` line, every verdict in the fleet reads as unmarked, and the
+# format-level round trip stays green throughout.
+marker_printf_line="$(grep -F -- "$MARKER_FMT_LITERAL" "$REVIEW_WORKFLOW" | head -n 1 || true)"
+if [[ -z "$marker_printf_line" ]]; then
+  bad "no line of code-review.yml carries the marker printf format"
+elif grep -Eq -- '[^>]> *review\.md[[:space:]]*$' <<<"$marker_printf_line"; then
+  ok "the marker printf TRUNCATES review.md ('> review.md'), so the marker is first"
+else
+  bad "the marker printf does not redirect with a single '> review.md' — the marker may not be first in the comment body: $marker_printf_line"
+fi
+
+# The other half of the same property: the review markdown must be APPENDED. An
+# emitter that truncated here would overwrite the marker it just wrote.
+if grep -Eq -- '^[[:space:]]*jq .*review_markdown.*>> *review\.md[[:space:]]*$' "$REVIEW_WORKFLOW"; then
+  ok "the review markdown is APPENDED after the marker ('>> review.md')"
+else
+  bad "code-review.yml does not append the review markdown with '>> review.md' — it would overwrite the provenance marker"
+fi
+
+# THE ROUND TRIP, and the reason this check is not a shared-substring grep: the
+# bytes fed to the parser below are the EMITTER's own format argument, rendered
+# the way the workflow renders it and escaped by `jq` rather than by hand. A
+# grep for "both files mention creek-review" passes on two files that agree on a
+# word and disagree on a format; this passes only if the emitter's output is
+# accepted end to end — and only if the SAME bytes rendered for a different PR
+# are refused, which is the half that proves the acceptance was not vacuous.
+#
+# No `command -v jq` arm any more (it used to sit between these two): jq is a
+# hard requirement asserted at the top of this file, and THIS is the case that
+# made the skip intolerable — the #1181 polarity argument in pr-ready.sh's header
+# rests explicitly on "the round trip runs in CI", which a silent skip falsifies.
+if [[ -z "$MARKER_FMT" ]]; then
+  : # already reported above; rendering an empty format would assert nothing
+else
+  marker_body() { # marker_body <pr number> — a verdict comment carrying the RENDERED marker
+    local rendered body
+    # `%b` over the substituted format, rather than `printf "$MARKER_FMT" "$1"`:
+    # identical bytes for a format whose only directive is the `%s` asserted
+    # above, and it keeps this file clean under `shellcheck` without a
+    # `# shellcheck disable` (SC2059, a variable used as a printf format).
+    #
+    # The `X` sentinel is LOAD-BEARING: `$( … )` strips trailing newlines, and
+    # the format's trailing `\n\n` is exactly the byte sequence whose loss this
+    # case exists to catch. Without it the fixture would silently supply its own
+    # blank line and the drift would stay green — the original defect, one layer
+    # down.
+    rendered="$(printf '%b' "${MARKER_FMT//%s/$1}X")"
+    rendered="${rendered%X}"
+    body="${rendered}## Summary
+fine
+
+## Verdict: LGTM
+"
+    # `jq -Rs .` does the JSON escaping, so the fixture cannot disagree with the
+    # rendered bytes the way a hand-written `\\n\\n` did.
+    printf '{"createdAt":"%s","body":%s}' "$FRESH" "$(printf '%s' "$body" | jq -Rs .)"
+  }
+  check "round trip: emitter bytes rendered for THIS PR → ready" "ready" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H \
+       COMMENTS_JSON="$(cj "$(marker_body 100)")" run 100)"
+  check "round trip: the same bytes rendered for ANOTHER PR → awaiting-review" \
+    "awaiting-review" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H \
+       COMMENTS_JSON="$(cj "$(marker_body 999)")" run 100)"
+fi
+
+# WHAT THE MARKER ATTESTS TO. The marker itself proves only "a pipeline version
+# that runs the cross-check posted this". If the cross-check leaves the
+# workflow, every marker in the world still says `pr=N` and means nothing — so
+# the schema field the agent must report BACK is pinned here, in both halves of
+# the schema (`required` without `properties` validates nothing; `properties`
+# without `required` is optional and an agent that cannot determine the number
+# will simply omit it — which is precisely the failure).
+#
+# An unconditional GROUP, not a `command -v jq` guard: see the hard-requirement
+# block at the top of this file. Braces keep the indentation unchanged.
+{
+  review_schema="$(sed -n "s/.*--json-schema '\({.*}\)'.*/\1/p" "$REVIEW_WORKFLOW" | head -n 1)"
+  if [[ -z "$review_schema" ]]; then
+    bad "could not extract code-review.yml's --json-schema"
+  elif jq -e '(.required | index("reviewed_pr_number") != null)
+              and (.properties | has("reviewed_pr_number"))' <<<"$review_schema" >/dev/null 2>&1; then
+    ok "--json-schema lists reviewed_pr_number in BOTH required and properties"
+  else
+    bad "--json-schema must list reviewed_pr_number in BOTH required and properties"
+  fi
+}
+
+# THE INSTRUMENT — DEFENCE IN DEPTH, NOT A PROOF, and this comment used to claim
+# otherwise. `gh pr list --state all --json number,title,headRefName,mergeCommit,commits`
+# is literally the command the #1117 run used to guess its way to the wrong PR,
+# and #1181 REMOVED `Bash(gh pr list:*)` from code-review.yml's
+# `--allowed-tools`. This assertion keeps it removed, which takes away the
+# specific instrument of that incident and raises the bar for the next accident.
+#
+# WHAT IT DOES NOT DO IS REMOVE THE CAPABILITY, and `code-review.yml` says so in
+# its own words right where the tool list is declared: `Bash(gh search:*)` is
+# deliberately KEPT, and `gh search prs --repo owner/repo --json number`
+# enumerates pull requests perfectly well. So "an agent that can neither ask
+# which PR it is on nor enumerate PRs has no way to guess" — the inference this
+# comment used to draw — is FALSE, and the workflow now disowns it in the same
+# diff. Two files in one change must not assert opposite things about the same
+# control; if this claim ever comes back, it has to come back on both sides.
+#
+# THE ACTUAL CONTROL IS THE WORKFLOW-SIDE `reviewed_pr_number` CROSS-CHECK,
+# pinned by the `--json-schema` assertion immediately above: the agent reports
+# the number it
+# actually passed to `gh pr diff`, the workflow compares it with `$PR_NUMBER`,
+# and a mismatch discards the review with no comment posted. That check does not
+# care HOW the agent arrived at a number, so it holds even against a route
+# nobody anticipated — which is exactly why it, and not this list, is the gate,
+# and why the marker pr-ready.sh parses attests to the cross-check being in
+# force rather than to the tool list being short.
+allowed_tools_line="$(grep -n -- '--allowed-tools' "$REVIEW_WORKFLOW" | head -n 1 || true)"
+if [[ -z "$allowed_tools_line" ]]; then
+  bad "code-review.yml declares no --allowed-tools line — nothing constrains what the agent may run"
+elif grep -q 'gh pr list' <<<"$allowed_tools_line"; then
+  bad "code-review.yml still allows Bash(gh pr list:*) — the instrument the #1117 run guessed with"
+else
+  ok "Bash(gh pr list:*) is not in code-review.yml's --allowed-tools"
+fi
+
+# SELF-SKIP INTEGRITY. claude-code-action self-skips (anti-tamper) on any PR
+# that edits code-review.yml — including the PR that ADDS the marker — so that
+# path posts a static comment and exits without a review. It must therefore
+# carry no marker and no verdict line: a marker there would attest to a review
+# that never happened, on exactly the PRs that rewrite the review pipeline. The
+# block is read out of the file rather than restated, so a future edit to those
+# literals is what this checks, not a copy of them.
+self_skip_lines="$(awk '/self_skip_body=\$\(printf/ {b = 1}
+                        b {print; if ($0 !~ /\\$/) exit}' "$REVIEW_WORKFLOW")"
+if [[ -z "$self_skip_lines" ]]; then
+  bad "could not find code-review.yml's static self-skip body literals"
+else
+  if grep -qF -- "creek-review" <<<"$self_skip_lines"; then
+    bad "the self-skip body carries the provenance marker — it would attest to a review that did not happen"
+  else
+    ok "the self-skip body carries no provenance marker"
+  fi
+  # VERDICT_RE's own shape, plus an optional leading `'` because these are shell
+  # literals in the workflow rather than the comment body a parser sees.
+  if grep -Eq "^[[:space:]]*'?(#{1,6}[[:space:]]+|\*\*)?[Vv]erdict[:*[:space:]]" <<<"$self_skip_lines"; then
+    bad "the self-skip body carries a verdict LINE — the merge-critical parsers would read it as a verdict"
+  else
+    ok "the self-skip body carries no verdict line"
+  fi
+fi
+
+# …and the marker printf must sit AFTER that path's `exit 0`, or the self-skip
+# comment grows provenance on its way out the door. Line numbers, because
+# "appears in the file" is not the property — ORDER is.
+marker_line="$(grep -nF -- "$MARKER_FMT_LITERAL" "$REVIEW_WORKFLOW" | head -n 1 | cut -d: -f1 || true)"
+self_skip_exit_line="$(awk '/review-self-skip/ {seen = 1}
+                            seen && /^[[:space:]]*exit 0$/ {print NR; exit}' "$REVIEW_WORKFLOW")"
+if [[ -z "$marker_line" || -z "$self_skip_exit_line" ]]; then
+  bad "cannot order the marker printf against the self-skip exit 0 (marker='$marker_line', exit='$self_skip_exit_line')"
+elif [[ "$marker_line" -gt "$self_skip_exit_line" ]]; then
+  ok "the marker printf sits AFTER the self-skip exit 0"
+else
+  bad "the marker printf sits BEFORE the self-skip exit 0 — the self-skip comment would carry provenance"
+fi
+
+# THE COUPLING CHECKS MUST ACTUALLY RUN. ralph-recap-tests.yml filters on
+# `scripts/ralph/**`, so a PR that edits ONLY code-review.yml — the one change
+# class every check above exists to guard — never runs this suite, and the
+# emitter can be rewritten with nothing red anywhere. Both triggers, because a
+# `push`-only filter still lets the drift land through a PR and a
+# `pull_request`-only filter misses a direct push to `main`.
+recap_trigger_block() { # recap_trigger_block <push|pull_request>
+  awk -v want="  $1:" '$0 == want {b = 1; next}
+                       b && /^[^[:space:]#]/ {exit}
+                       b && /^  [^[:space:]#]/ {exit}
+                       b {print}' "$RECAP_WORKFLOW"
+}
+for trig in push pull_request; do
+  trig_block="$(recap_trigger_block "$trig")"
+  if [[ -n "$trig_block" ]] && grep -q 'code-review\.yml' <<<"$trig_block"; then
+    ok "ralph-recap-tests.yml runs this suite on $trig changes to code-review.yml"
+  else
+    bad "ralph-recap-tests.yml's $trig paths: omit .github/workflows/code-review.yml — an emitter-only PR runs no coupling check"
+  fi
+done
+
+# THE SECOND MERGE-CLEARANCE PATH. iteration-trigger.yml posts "You are cleared
+# to squash merge" off its own verdict parse, and its header already commits it
+# to enforcing the SAME invariant as pr-ready.sh — otherwise it is a second code
+# path that falsifies the first. It cleared #1117 on the #1179 verdict too.
+#
+# NOT a bare `grep -F "$MARKER_PREFIX"`, which is what this used to be: that
+# string also appears in that file's COMMENTS, so the entire `MARKER_PR`
+# extraction and the `elif` consuming it could be deleted and the check would
+# stay green — the "shared-substring grep" this whole block exists to be better
+# than. Two literals instead, both lifted from the code that runs.
+ITER_MARKER_ERE='^'"$MARKER_PREFIX"'[0-9]+ -->[[:space:]]*$'
+# Written with `\$` inside double quotes rather than as a single-quoted literal:
+# the bytes are identical (`[ "$MARKER_PR" != "$PR" ]`) and it carries no
+# single-quoted `$…` for a linter to read as a lost expansion.
+ITER_CLEARANCE_GUARD="[ \"\$MARKER_PR\" != \"\$PR\" ]"
+
+if grep -qF -- "$ITER_MARKER_ERE" "$ITER_WORKFLOW"; then
+  ok "iteration-trigger.yml extracts the marker with the same anchored pattern"
+else
+  bad "iteration-trigger.yml no longer greps '$ITER_MARKER_ERE' — its extraction has drifted from pr-ready.sh's MARKER_RE"
+fi
+
+# Extracting the marker and never consulting it is the same bug with an extra
+# step. That `elif` is the ONLY thing between an unattested verdict and a
+# "cleared to squash merge" comment — and .claude/skills/await-claude-review
+# says this summary SHORT-CIRCUITS per-event classification, so when the two
+# paths disagree it is this one that wins over pr-ready.sh's `awaiting-review`.
+if grep -qF -- "$ITER_CLEARANCE_GUARD" "$ITER_WORKFLOW"; then
+  ok "iteration-trigger.yml refuses to clear a merge on a marker that is not this PR"
+else
+  bad "iteration-trigger.yml has lost its '$ITER_CLEARANCE_GUARD' clearance guard — it would clear a merge on a verdict pr-ready.sh refuses"
+fi
+
+# And rewriting `ACTION` is NOT what stops the merge — this is the assertion the
+# other two would otherwise let you delete with CI green. `.claude/skills/
+# await-claude-review/SKILL.md` Step 4a decides from `**VERDICT**:` plus
+# `**CI**:` ONLY; it never reads `**Action**:` (item 5 says in so many words: "Do
+# not infer a verdict from the `Action:` prose"). So a summary that still carries
+# `**VERDICT**: LGTM` merges no matter how emphatically `**Action**` refuses.
+# The `elif` therefore has to neutralise the VERDICT FIELD, and the value has to
+# be chosen for its BYTES: `NOT ATTESTED` contains no `LGTM` substring, so
+# neither a `*LGTM*` glob nor a `test("LGTM")` can match it.
+# (`HELD` and `BEHIND` still post `**VERDICT**: LGTM` and are defeated exactly
+# this way — pre-existing, filed as #1202, deliberately out of #1181's scope.)
+ITER_UNATTESTED_VERDICT="VERDICT='NOT ATTESTED'"
+
+if grep -qF -- "$ITER_UNATTESTED_VERDICT" "$ITER_WORKFLOW"; then
+  ok "iteration-trigger.yml also neutralises the VERDICT field, not just ACTION"
+else
+  bad "iteration-trigger.yml no longer sets $ITER_UNATTESTED_VERDICT — its summary would still say '**VERDICT**: LGTM' and await-claude-review Step 4a would merge on it (#1202)"
+fi
+
+# --- cross-file coupling: the SECOND emitter of a VERDICT_RE match (#1181) ---
+# Every coupling check above treats `.github/workflows/code-review.yml` as THE
+# emitter. It is not the only one. iteration-trigger.yml's executive summary
+# carries `**VERDICT**: <X>`, which satisfies VERDICT_RE and VERDICT_LGTM_RE (see
+# the block in the verdict section above for the measurement and for PR #906's
+# comment tail), and it posts LAST on every lane in this repo — so pr-ready.sh's
+# `| last` selector picks it, it can never carry a `creek-review` marker, and the
+# whole fleet holds at `awaiting-review` with no push able to clear it.
+#
+# pr-ready.sh must therefore EXCLUDE that comment from the verdict selector, and
+# the bytes it excludes must be the bytes that workflow emits. `$ITER_MARKER` is
+# the value read out of iteration-trigger.yml's own `MARKER:` env entry up in the
+# verdict block (and asserted there to be the expected literal), so this is a
+# comparison between two files and not between this file and itself — the same
+# distinction the `grep -oF` post-mortem at the marker round trip draws.
+#
+# The constant is matched by PREFIX (`ITER_SUMMARY_…`) rather than by one exact
+# name: the exclusion may reasonably be held as the bare marker or as the
+# line-anchored pattern built from it (see W6 above for why anchored), and both
+# spellings carry these bytes on the assignment line. What is NOT optional is that
+# the bytes come from the emitter.
+iter_exclude_line="$(grep -E "^readonly ITER_SUMMARY_[A-Z_]+=" "$READY" | head -n 1 || true)"
+if [[ -z "$iter_exclude_line" ]]; then
+  bad "pr-ready.sh defines no 'readonly ITER_SUMMARY_…' constant — nothing excludes iteration-trigger.yml's summary from the verdict selector, so the LAST verdict-bearing comment on every PR in this repo is one that can never carry a provenance marker (#1181)"
+elif grep -qF -- "$ITER_MARKER" <<<"$iter_exclude_line"; then
+  ok "pr-ready.sh's exclusion constant carries iteration-trigger.yml's own MARKER: bytes"
+else
+  # Braces on both expansions, not stylistic: each is followed by a `'`, and this
+  # file has already been bitten twice by an unbraced name running into what came
+  # after it (SC1087 at the marker round trip, and a multi-byte `…` swallowed into
+  # a parameter name under `set -u`) — on diagnostic paths that only execute when
+  # the coupling has ALREADY drifted, i.e. exactly when the message is needed.
+  bad "pr-ready.sh's '${iter_exclude_line}' does not carry iteration-trigger.yml's MARKER: value ('${ITER_MARKER}') — emitter and parser have drifted and every lane reads awaiting-review"
 fi
 
 # --- summary ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Makes every verdict self-identifying and refuses the ones that are not.** `.github/workflows/code-review.yml` now prepends `<!-- creek-review pr=N -->` (N from `github.event.pull_request.number`) to every review it posts, and `scripts/ralph/pr-ready.sh` reads that marker **from the same comment its verdict selector already picked**. A marker that is absent, malformed, or names another PR makes the verdict **no verdict at all** — it gates neither `ready` nor `changes-requested`, so the lane reads `awaiting-review`. `.github/workflows/iteration-trigger.yml`, the second merge-clearance path, enforces the same rule.
- **Removes the root cause: the reviewer no longer has to guess which PR it is on.** The prompt now states the authoritative PR number and repo, says the checkout is a detached-HEAD merge ref so a bare `gh pr view`/`gh pr diff` *will* fail, and forbids inferring the PR from `git log`, a merge parent, or a PR listing. `Bash(gh pr list:*)` — the instrument the #1117 run actually guessed with — is removed from `--allowed-tools`, and a required `reviewed_pr_number` is added to the `--json-schema`: the agent reports the integer it passed to `gh pr diff`, the workflow compares it with `$PR_NUMBER`, and **a mismatch fails the check with no comment posted**.
- **Wires the coupling test to the file it guards.** `.github/workflows/ralph-recap-tests.yml` now runs the ralph shell suites on changes to `code-review.yml` and `iteration-trigger.yml`, so the emitter and the parser cannot drift without CI going red on the PR that causes the drift.

## Root cause — confirmed from the run logs, not inferred

The issue proposed `HEAD^1..HEAD` as the mechanism, and @Geoffe-Ga refuted it himself in a follow-up comment. Both are wrong for the same reason: **there is no diff range anywhere in `code-review.yml`.**

`gh run view 31150507883 --log` (the offending run on PR #1117) and `gh run view 31154718802 --log` (a correct run on #1183) show the same first command and the same failure:

```
$ gh pr view --json number,title,url,headRefName,baseRefName
could not determine current branch: failed to run git: not on any branch
```

`actions/checkout` checks out `refs/pull/<N>/merge` in detached HEAD, and the prompt never named the PR — so each agent **guessed**, and the guess is non-deterministic:

| run | how it resolved the PR | result |
|---|---|---|
| #1183 | `git log` + `gh pr list --state open` | guessed **1183** — correct |
| #1117 | `git log` showed `Merge a332aec… into 46182a6f…`; `gh pr list --state all --json …,mergeCommit` matched that **base parent** to PR **#1179**'s `mergeCommit.oid` | reviewed **#1179** — wrong |

The #1117 run then ran `gh pr diff 1179`, `gh pr view 1179`, `gh pr checks 1179` while `Post review` posted to `PR_NUMBER: 1117`. That is the whole bug, and it explains all three of the data points in the issue thread — merge-HEAD is irrelevant; what varies is the guess.

## Design notes

**The marker is a provenance attestation, not a wrong-diff detector.** It is computed by the workflow from the same value the comment is posted to, so it can never disagree with its own PR in normal operation. Its force is negative: `pr-ready.sh` refuses any verdict that did not come from a pipeline version which **runs the `reviewed_pr_number` cross-check**. That cross-check is the detector; the marker is the proof it was in force. Both are spelled out in `pr-ready.sh`'s header so the cross-check is not "simplified away" later.

**No grandfather clause for unmarked legacy verdicts.** A time-based cutoff would be *incorrect*, not merely lenient: `pull_request` runs execute the workflow file from the PR's own merge ref, not from `main`, so a branch cut before this change keeps emitting unmarked verdicts *after* it lands — there is no T that ever expires. The measured cost of failing closed was **zero re-reviews**: of 7 open PRs, 5 are Dependabot lanes (which consult no verdict), #1117 is opted out, and #1070/#943/#863 carry no verdict comment at all. Structurally the bill was already owed anyway — this PR touches `.github/workflows/`, which is on `RISK_SURFACE_RE`, so every open lane already faced a sync → HEAD advance → stale-verdict invalidation → re-review.

**Polarity.** This is the third fail-closed polarity in `pr-ready.sh` and it sides with `main-health.sh` (doubt ⇒ hold), not `review-quota.sh` (doubt ⇒ proceed). The one leg of `review-quota.sh`'s inversion that reaches here — a false positive is correlated fleet-wide — is neutralised by the cross-file coupling test, which is why that test is load-bearing and is now actually wired into CI. The three polarities are deliberately not uniform, and the header says so.

**Not done here, deliberately:** verdict-author authentication. The marker is a public literal and no author is checked, so a forged `## Verdict: LGTM` still clears the gate exactly as it did before this PR — that is pre-existing and is filed as #1199, not silently claimed as fixed.

## The near-miss this PR nearly shipped

Gate 2.5 caught, on the third review round, that **there are two emitters of a comment matching `pr-ready.sh`'s `VERDICT_RE`**, not one. `.github/workflows/iteration-trigger.yml`'s executive summary carries `**VERDICT**: LGTM`, which satisfies `VERDICT_RE`'s `(?:#{1,6}\s+|\*\*)?` alternative — and it posts **last** on every PR, ~15 s after the review. It can never carry a `creek-review` marker.

So the provenance guard as first written would have refused it on **every lane**, self-sustainingly: `awaiting-review` is in `watch-pr.sh`'s `IN_FLIGHT_TOKENS`, and a push produces a fresh review comment followed 15 s later by a fresh unmarked summary. That is the correlated fleet-wide false positive the polarity argument claims is neutralised by the coupling test — and it was not, because the coupling test only knew about one emitter.

Measured against the real comment payload of merged PR #906, running the production selector by hand:

```
before the fix: selected 2026-07-23T07:03:05Z  <!-- iteration-trigger -->\n**CI**: ...   <- the summary
after  the fix: selected 2026-07-23T06:53:17Z  ## Summary\nPR #906 fixes false-pos...    <- the actual review
```

Same shape on #905, #904, #902 — 4 of 4. The fix excludes that summary from the selector (it is a *report of* a verdict, not a verdict), inside the same single `--jq` and the same `$v` binding, with an anchored pattern and a coupling assertion tying the constant to the workflow's own `MARKER:` value. **It also closes a pre-existing bug:** the stale-verdict guard was reading the *summary's* `createdAt`, not the review's, so a stale review followed by a fresh summary passed the freshness check. That is now pinned by a test.

The generalised lesson is written into `pr-ready.sh`'s header, because it is the reusable part: a fail-closed polarity argument of the form *"only a broken emitter can trigger this, and the coupling test catches the emitter"* is only ever as good as the **enumeration of emitters**.

## Test plan

- `bash scripts/ralph/test_pr_ready.sh` → **242 passed, 0 failed** (was 181 before this PR; 61 new provenance, wedge and coupling assertions).
- **RED demonstrated against unfixed production code** — final test file, production files stashed: 106 passed / **119 failed**, headed by the reproduction of this exact incident:
  ```
  FAIL - the #1117 incident: fresh LGTM marked for a DIFFERENT PR → awaiting-review (expected 'awaiting-review', got 'ready')
  FAIL - unmarked fresh LGTM (legacy verdict) → awaiting-review (expected 'awaiting-review', got 'ready')
  FAIL - unmarked fresh CHANGES_REQUESTED → awaiting-review, not changes-requested (got 'changes-requested')
  ```
- **Emitter/parser agreement, mutation-tested** (a check for a field nothing emits would hold every lane forever). Mutating `code-review.yml` and re-running the suite: renaming the marker → 3 failures; making the marker not its own line → 1 failure; flipping the marker's `>` to `>>` so it is no longer first → 1 failure; dropping one of the two trailing newlines (still its own line, still parseable) → correctly 0 failures. The coupling case extracts the emitter's whole `printf` format with `sed`, renders it, and feeds the rendered bytes through `pr-ready.sh`'s own parser.
- `shellcheck --severity=warning scripts/ralph/*.sh` → exit 0.
- The other six ralph suites (`test_fleet`, `test_pick_next`, `test_watch_pr`, `test_main_health`, `test_review_quota`, `test_exec_bits`) all pass; `python3 -m pytest scripts/ralph -q` → 65 passed.
- `cd creek-tools && ./scripts/check-all.sh` → **exit 0**, 12/12.
- All three edited workflows parse as valid YAML.

## Reviewer note

**This PR edits `.github/workflows/code-review.yml`, so `claude-code-action` self-skips (anti-tamper) and will post no automated verdict** — it posts the `<!-- review-self-skip -->` warning comment instead and the check stays green. That path is unchanged and is pinned by two new assertions: the self-skip body contains neither `creek-review` nor a verdict line, and the marker `printf` sits strictly after the self-skip `exit 0`. **This one needs a human LGTM.**

Gate 2.5 ran four rounds (`code-review-orchestrator`), ending `CLEAN`. Follow-ups filed: **#1199** (verdict comments are not author-authenticated — the marker attests to pipeline version, not authorship, and this PR's header says so rather than claiming otherwise), **#1200** (`pr-ready.sh` cannot tell a failed `claude-review` from a real CI failure), **#1201** (`code-review.yml` has no `workflow_dispatch`, so a re-review costs a commit), **#1202** (P1 — `iteration-trigger.yml`'s pre-existing `HELD`/`BEHIND` branches still post `**VERDICT**: LGTM`, and `await-claude-review` Step 4a merges on that field, defeating `do-not-auto-merge`).

Closes #1181
