### PR TITLE
fix(lint): resolve wiki-links through aliases, not filename stems alone

### DIFF
--- a/creek-tools/creek/clean/hygiene.py
+++ b/creek-tools/creek/clean/hygiene.py
@@ -23,10 +23,14 @@ from typing import TYPE_CHECKING
 import frontmatter
 from pydantic import BaseModel, Field
 
+from creek.vault.links import build_link_index
+
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from creek.vault.links import LinkIndex
 
 
 # ---------------------------------------------------------------------------
@@ -496,8 +500,12 @@ class StaleReviewScanner:
 class BrokenLinkScanner:
     """Scan fragments for wiki-links and relative links to nonexistent files.
 
-    Builds a set of all known file stems in the vault and checks each
-    link target against it.
+    Wiki-links resolve through :func:`creek.vault.links.build_link_index`,
+    which knows every name a page can be linked by — filename stem,
+    frontmatter ``title``, and each ``aliases`` entry. Matching stems alone
+    (the behaviour before #887) called 99.2% of the demo vault's links
+    broken, because the linkers write date-prefixed filenames and put the
+    human-readable name in ``aliases``.
     """
 
     def scan(self, vault_path: Path) -> BrokenLinkResult:
@@ -513,13 +521,13 @@ class BrokenLinkScanner:
             A :class:`BrokenLinkResult` with broken link details.
         """
         fragment_files = _list_fragment_files(vault_path)
-        all_stems = {f.stem for f in _list_all_md_files(vault_path)}
+        link_index = build_link_index(vault_path)
 
         broken_links: dict[str, list[str]] = {}
         total_broken = 0
 
         for frag_file in fragment_files:
-            file_broken = self._check_file(frag_file, all_stems, vault_path)
+            file_broken = self._check_file(frag_file, link_index, vault_path)
             if file_broken:
                 broken_links[str(frag_file)] = file_broken
                 total_broken += len(file_broken)
@@ -533,14 +541,16 @@ class BrokenLinkScanner:
     def _check_file(
         self,
         frag_file: Path,
-        all_stems: set[str],
+        link_index: LinkIndex,
         vault_path: Path,
     ) -> list[str]:
         """Check a single file for broken links.
 
         Args:
             frag_file: Path to the fragment file.
-            all_stems: Set of all known file stems in the vault.
+            link_index: Vault-wide name → page index. A wiki-link is broken
+                only when nothing in the vault answers to its target under
+                any of its names.
             vault_path: Root of the vault for resolving relative paths.
 
         Returns:
@@ -550,7 +560,7 @@ class BrokenLinkScanner:
         broken: list[str] = [
             f"[[{target}]]"
             for target in _extract_wikilinks(content)
-            if target not in all_stems
+            if target not in link_index
         ]
 
         broken.extend(

--- a/creek-tools/creek/lint/checks/orphan_compiled.py
+++ b/creek-tools/creek/lint/checks/orphan_compiled.py
@@ -4,6 +4,13 @@ Orphan *fragments* are normal — only orphan *compiled* pages
 (Threads, Eddies, Praxis, Frequency-indexes) are surfaced, per
 ADOPT-002 and FEAT-008. The check emits suggestions only; it never
 deletes anything.
+
+Inbound links are counted through :func:`creek.vault.links.build_link_index`,
+so a page is credited for links naming it by any of its names. Comparing
+filename stems alone (the behaviour before #887) reported
+``02-Threads/Dormant/2020-09-26-Messages.md`` as orphaned despite roughly
+30,000 inbound ``[[Messages]]`` links, because the human-readable name lives
+in ``aliases`` while the filename carries a date prefix.
 """
 
 from __future__ import annotations
@@ -13,6 +20,7 @@ from datetime import datetime  # noqa: TC003  # used at runtime as a parameter t
 from pathlib import Path  # noqa: TC003  # plain stdlib import; no lazy benefit
 
 from creek.lint._result import CheckResult
+from creek.vault.links import build_link_index
 
 _COMPILED_DIRS: tuple[str, ...] = (
     "02-Threads",
@@ -58,15 +66,27 @@ def run(vault_path: Path, *, since: datetime | None = None) -> CheckResult:
 
     The ``since`` parameter is accepted for interface symmetry but
     ignored — the orphan check is cheap.
+
+    Every inbound wiki-link target is resolved to the page it actually names
+    before the comparison, so a page counts as linked when a fragment
+    references it by alias or title. Resolution is per-page: a link that
+    resolves *somewhere* credits only that page, never the whole compiled
+    layer — otherwise the check would fall silent, which is the same end
+    state as the bug it fixes.
     """
     del since
     compiled_files = _stems_in(vault_path, _COMPILED_DIRS)
     fragment_files = _stems_in(vault_path, _FRAGMENT_DIRS)
-    inbound = _inbound_targets(fragment_files)
+    link_index = build_link_index(vault_path)
+    linked_pages = {
+        resolved
+        for target in _inbound_targets(fragment_files)
+        if (resolved := link_index.resolve(target)) is not None
+    }
 
     findings: list[str] = []
     for compiled in sorted(compiled_files):
-        if compiled.stem not in inbound:
+        if compiled not in linked_pages:
             rel = compiled.relative_to(vault_path)
             findings.append(f"- `{rel}` (suggestion: review; never auto-deleted)")
     summary = f"{len(findings)} orphan compiled page(s)"

--- a/creek-tools/creek/vault/links.py
+++ b/creek-tools/creek/vault/links.py
@@ -1,0 +1,175 @@
+"""Wiki-link resolution for the vault — one definition, shared by every check.
+
+A vault page is linkable by more than its filename. Since #730 the eddy and
+thread linkers write date-prefixed files (``2020-09-26-Messages.md``) and put
+the human-readable name in ``aliases:``; fragments then link the alias form,
+``[[Messages]]``. Two lint checks nevertheless resolved links against filename
+stems alone — ``BrokenLinkScanner`` in :mod:`creek.clean.hygiene` and the
+orphan-compiled check — each with its own copy of that answer.
+
+The result (issue #887, demo vault, 2026-07-22) was a lint report that was
+almost entirely wrong: ``broken-links`` flagged 66,380 links of which 65,879
+(99.2%) resolved through some page's ``aliases`` or ``title``, and
+``orphan-compiled`` flagged a thread page carrying roughly 30,000 inbound
+``[[Messages]]`` links. A check wrong 99.2% of the time is worse than one
+that does not exist, because its output still has to be read.
+
+This module is the single answer to "does this wiki-link resolve, and to
+what". Callers build one :class:`LinkIndex` per run and query it.
+
+Resolution follows Obsidian: an exact-case match wins, and a case-insensitive
+match is the fallback. The frontmatter is read **header-only** — a 35k-file
+vault must never pay to load every body into memory just to learn a page's
+aliases.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import yaml
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_FENCE: str = "---"
+"""Delimiter opening and closing a YAML frontmatter block."""
+
+_MAX_HEADER_LINES: int = 200
+"""Give up on a header longer than this rather than scan a whole file.
+
+A frontmatter block this long is malformed — almost certainly an unclosed
+fence — and following it would read the entire body, which is the cost this
+module exists to avoid.
+"""
+
+_MAX_HEADER_BYTES: int = 64 * 1024
+"""Byte ceiling on a single header, for the same reason as the line cap."""
+
+
+@dataclass(frozen=True)
+class LinkIndex:
+    """Every name a vault page can be linked by, mapped to that page.
+
+    Attributes:
+        by_name: Exact-case name → page path.
+        by_folded: Case-folded name → page path, the Obsidian-style fallback
+            consulted only when no exact-case entry matches.
+    """
+
+    by_name: dict[str, Path]
+    by_folded: dict[str, Path]
+
+    def resolve(self, target: str) -> Path | None:
+        """Return the page *target* names, or ``None`` if nothing matches.
+
+        Args:
+            target: A wiki-link target, with any ``#heading`` or ``|display``
+                suffix already stripped by the caller's link regex.
+
+        Returns:
+            The resolved page path, or ``None`` when the link is genuinely
+            dangling.
+        """
+        name = target.strip()
+        exact = self.by_name.get(name)
+        if exact is not None:
+            return exact
+        return self.by_folded.get(name.casefold())
+
+    def __contains__(self, target: object) -> bool:
+        """Return whether *target* is a string naming some page in the vault."""
+        return isinstance(target, str) and self.resolve(target) is not None
+
+
+def _read_header_block(path: Path) -> str | None:
+    """Return the raw YAML frontmatter text of *path*, or ``None``.
+
+    Reads line by line and stops at the closing fence, so the body is never
+    pulled into memory. Returns ``None`` for a file with no frontmatter, an
+    unterminated header, or one exceeding the size caps.
+    """
+    try:
+        with path.open(encoding="utf-8", errors="replace") as handle:
+            if handle.readline().strip() != _FENCE:
+                return None
+            lines: list[str] = []
+            size = 0
+            for _ in range(_MAX_HEADER_LINES):
+                line = handle.readline()
+                if not line:
+                    return None
+                if line.strip() == _FENCE:
+                    return "".join(lines)
+                size += len(line)
+                if size > _MAX_HEADER_BYTES:
+                    return None
+                lines.append(line)
+    except OSError:
+        return None
+    return None
+
+
+def _declared_names(meta: dict[str, object]) -> list[str]:
+    """Extract the linkable names a frontmatter mapping declares.
+
+    ``title`` contributes one name; ``aliases`` contributes each entry, and
+    is accepted as either a scalar or a list because Obsidian permits both.
+    Non-string and blank entries are ignored rather than stringified — an
+    accidental ``aliases: [null]`` should not create a page named ``None``.
+    """
+    names: list[str] = []
+    title = meta.get("title")
+    if isinstance(title, str) and title.strip():
+        names.append(title.strip())
+    raw = meta.get("aliases")
+    entries = [raw] if isinstance(raw, str) else raw
+    if isinstance(entries, list):
+        names.extend(
+            entry.strip()
+            for entry in entries
+            if isinstance(entry, str) and entry.strip()
+        )
+    return names
+
+
+def _header_names(path: Path) -> list[str]:
+    """Return the ``title`` and ``aliases`` names declared by *path*.
+
+    Any failure — unreadable file, malformed YAML, a header that is not a
+    mapping — yields no names rather than raising. Lint walks every file in
+    the vault, so one bad header must not cost the whole run its index.
+    """
+    block = _read_header_block(path)
+    if block is None:
+        return []
+    try:
+        meta = yaml.safe_load(block)
+    except yaml.YAMLError:
+        return []
+    if not isinstance(meta, dict):
+        return []
+    return _declared_names(meta)
+
+
+def build_link_index(vault_path: Path) -> LinkIndex:
+    """Build the name → page index for every markdown file under *vault_path*.
+
+    Each page is registered under its filename stem plus every name its
+    frontmatter declares. Ties go to the first page in sorted path order, so
+    the index is deterministic across runs regardless of filesystem ordering.
+
+    Args:
+        vault_path: Root of the Obsidian vault.
+
+    Returns:
+        A :class:`LinkIndex` covering the whole vault.
+    """
+    by_name: dict[str, Path] = {}
+    by_folded: dict[str, Path] = {}
+    for md_file in sorted(vault_path.rglob("*.md")):
+        for name in (md_file.stem, *_header_names(md_file)):
+            by_name.setdefault(name, md_file)
+            by_folded.setdefault(name.casefold(), md_file)
+    return LinkIndex(by_name=by_name, by_folded=by_folded)

--- a/creek-tools/tests/test_lint_alias_resolution.py
+++ b/creek-tools/tests/test_lint_alias_resolution.py
@@ -1,0 +1,175 @@
+"""Alias-aware resolution in the ``broken-links`` and ``orphan-compiled`` checks.
+
+Regression tests for #887. Both checks resolved wiki-links against filename
+stems alone, which stopped being correct at #730 when the eddy/thread linkers
+began writing date-prefixed pages (``2020-09-26-Messages.md``) and putting the
+human-readable name in ``aliases:``. Fragments link the alias form
+(``[[Messages]]``), so on the demo vault:
+
+* ``broken-links`` flagged 66,380 links, 65,879 of which (99.2%) resolved
+  through some page's ``aliases`` or ``title``; only 243 were truly dangling;
+* ``orphan-compiled`` flagged ``02-Threads/Dormant/2020-09-26-Messages.md``,
+  a page with roughly 30,000 inbound ``[[Messages]]`` links.
+
+A check that is wrong 99.2% of the time is worse than absent, because its
+output still has to be read. These tests pin both directions: aliased links
+resolve, and genuinely dangling ones are still reported.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from creek.lint.checks import broken_links, orphan_compiled
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write(vault: Path, relpath: str, text: str) -> Path:
+    """Write *text* to *relpath* under *vault*, creating parents."""
+    path = vault / relpath
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _fragment(vault: Path, name: str, body: str) -> Path:
+    """Write a fragment note carrying *body* in its content."""
+    return _write(
+        vault,
+        f"01-Fragments/{name}.md",
+        f"---\ntype: fragment\nid: {name}\ntitle: {name}\n---\n\n{body}\n",
+    )
+
+
+def _aliased_thread(vault: Path, filename: str, alias: str) -> Path:
+    """Write a date-prefixed thread page whose human name lives in ``aliases``."""
+    return _write(
+        vault,
+        f"02-Threads/{filename}.md",
+        f"---\ntype: thread\naliases:\n  - {alias}\n---\n\nThread body.\n",
+    )
+
+
+@pytest.fixture()
+def vault(tmp_path: Path) -> Path:
+    """A vault with the fragment and compiled folders the checks walk."""
+    for rel in ("01-Fragments", "02-Threads", "03-Eddies", "10-Liminal"):
+        (tmp_path / rel).mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+# ---- broken-links ----
+
+
+def test_alias_link_is_not_reported_broken(vault: Path) -> None:
+    """``[[Messages]]`` resolving via ``aliases`` is not a broken link."""
+    _aliased_thread(vault, "2020-09-26-Messages", "Messages")
+    _fragment(vault, "frag-1", "See [[Messages]] for the thread.")
+
+    result = broken_links.run(vault)
+
+    assert result.findings == []
+    assert "0 broken link(s)" in result.summary
+
+
+def test_title_link_is_not_reported_broken(vault: Path) -> None:
+    """A link matching a page's frontmatter ``title`` also resolves."""
+    _write(
+        vault,
+        "02-Threads/2023-03-30-x.md",
+        "---\ntype: thread\ntitle: Long Walks\n---\n\nBody.\n",
+    )
+    _fragment(vault, "frag-2", "See [[Long Walks]].")
+
+    result = broken_links.run(vault)
+
+    assert result.findings == []
+
+
+def test_genuinely_dangling_link_is_still_reported(vault: Path) -> None:
+    """The true dangling set must survive the fix.
+
+    The issue is explicit that 243 real stale targets — date-coded names
+    like ``2025-09-20-w3`` — should keep being reported. A fix that made
+    the check quiet by resolving everything would be the opposite failure.
+    """
+    _aliased_thread(vault, "2020-09-26-Messages", "Messages")
+    _fragment(vault, "frag-3", "Live [[Messages]] and stale [[2025-09-20-w3]].")
+
+    result = broken_links.run(vault)
+
+    assert len(result.findings) == 1
+    assert "2025-09-20-w3" in result.findings[0]
+    assert "Messages" not in result.findings[0]
+
+
+def test_stem_links_keep_resolving(vault: Path) -> None:
+    """The pre-existing stem behaviour is not regressed by adding aliases."""
+    _write(vault, "02-Threads/Sourdough.md", "---\ntype: thread\n---\n\nBody.\n")
+    _fragment(vault, "frag-4", "See [[Sourdough]].")
+
+    result = broken_links.run(vault)
+
+    assert result.findings == []
+
+
+# ---- orphan-compiled ----
+
+
+def test_page_with_inbound_alias_links_is_not_orphaned(vault: Path) -> None:
+    """The ``2020-09-26-Messages.md`` case: ~30k inbound links, called orphan."""
+    _aliased_thread(vault, "2020-09-26-Messages", "Messages")
+    _fragment(vault, "frag-5", "See [[Messages]].")
+
+    result = orphan_compiled.run(vault)
+
+    assert result.findings == []
+    assert "0 orphan compiled page(s)" in result.summary
+
+
+def test_page_with_inbound_title_links_is_not_orphaned(vault: Path) -> None:
+    """Inbound links matching a page's ``title`` count as inbound too."""
+    _write(
+        vault,
+        "02-Threads/2023-03-30-y.md",
+        "---\ntype: thread\ntitle: Deep Work\n---\n\nBody.\n",
+    )
+    _fragment(vault, "frag-6", "See [[Deep Work]].")
+
+    result = orphan_compiled.run(vault)
+
+    assert result.findings == []
+
+
+def test_page_with_no_inbound_links_is_still_orphaned(vault: Path) -> None:
+    """A genuinely unreferenced compiled page is still surfaced."""
+    _aliased_thread(vault, "2020-09-26-Lonely", "Lonely")
+    _fragment(vault, "frag-7", "Links nowhere in particular.")
+
+    result = orphan_compiled.run(vault)
+
+    assert len(result.findings) == 1
+    assert "2020-09-26-Lonely" in result.findings[0]
+
+
+def test_orphan_check_does_not_credit_a_link_to_a_different_page(
+    vault: Path,
+) -> None:
+    """Resolution must be per-page, not "some alias somewhere matched".
+
+    Counting any resolvable inbound target as covering every compiled page
+    would silence the check entirely — the same end state as the bug, just
+    reached from the other side.
+    """
+    _aliased_thread(vault, "2020-09-26-Messages", "Messages")
+    _aliased_thread(vault, "2021-01-01-Orphan", "Orphan Thread")
+    _fragment(vault, "frag-8", "Only [[Messages]] is linked.")
+
+    result = orphan_compiled.run(vault)
+
+    assert len(result.findings) == 1
+    assert "2021-01-01-Orphan" in result.findings[0]

--- a/creek-tools/tests/test_vault_links.py
+++ b/creek-tools/tests/test_vault_links.py
@@ -1,0 +1,202 @@
+"""Tests for creek.vault.links — the shared wiki-link resolution index (#887).
+
+Two lint checks each carried their own answer to "does this wiki-link
+resolve", and both answered it with filename stems alone:
+``BrokenLinkScanner`` (``creek/clean/hygiene.py``) and the orphan-compiled
+check. Since #730 the eddy/thread linkers write date-prefixed pages
+(``2023-03-30-Messages.md``) and put the human-readable name in ``aliases:``,
+so stem-only matching declares almost every real link broken — 65,879 of
+66,380 on the demo vault, 99.2%.
+
+This module pins the single definition both checks now share.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from creek.vault.links import build_link_index
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _page(
+    vault: Path,
+    relpath: str,
+    *,
+    title: str | None = None,
+    aliases: list[str] | str | None = None,
+    body: str = "Body text.",
+) -> Path:
+    """Write a markdown page with an optional frontmatter header."""
+    path = vault / relpath
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines: list[str] = []
+    if title is not None or aliases is not None:
+        lines.append("---")
+        if title is not None:
+            lines.append(f"title: {title}")
+        if isinstance(aliases, str):
+            lines.append(f"aliases: {aliases}")
+        elif aliases is not None:
+            lines.append("aliases:")
+            lines.extend(f"  - {alias}" for alias in aliases)
+        lines.append("---")
+    lines.extend(("", body, ""))
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path
+
+
+@pytest.fixture()
+def vault(tmp_path: Path) -> Path:
+    """An empty vault root."""
+    (tmp_path / "02-Threads").mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+def test_resolves_a_page_by_its_filename_stem(vault: Path) -> None:
+    """The pre-existing stem behaviour is preserved."""
+    page = _page(vault, "02-Threads/Sourdough.md")
+    index = build_link_index(vault)
+
+    assert index.resolve("Sourdough") == page
+    assert "Sourdough" in index
+
+
+def test_resolves_a_page_by_a_frontmatter_alias(vault: Path) -> None:
+    """The #730 convention: date-prefixed filename, human name in ``aliases``.
+
+    This is the exact shape behind the 60,993 ``[[Messages]]`` links the
+    stem-only checker called broken.
+    """
+    page = _page(vault, "02-Threads/2020-09-26-Messages.md", aliases=["Messages"])
+    index = build_link_index(vault)
+
+    assert index.resolve("Messages") == page
+
+
+def test_resolves_a_page_by_its_frontmatter_title(vault: Path) -> None:
+    """``title`` is a linkable name too, per the issue's acceptance criteria."""
+    page = _page(vault, "02-Threads/2023-03-30-x.md", title="Long Walks")
+    index = build_link_index(vault)
+
+    assert index.resolve("Long Walks") == page
+
+
+def test_resolves_every_entry_in_a_multi_alias_list(vault: Path) -> None:
+    """A page with several aliases is reachable by each of them."""
+    page = _page(
+        vault,
+        "02-Threads/2021-01-01-many.md",
+        aliases=["First Name", "Second Name"],
+    )
+    index = build_link_index(vault)
+
+    assert index.resolve("First Name") == page
+    assert index.resolve("Second Name") == page
+
+
+def test_accepts_a_scalar_alias(vault: Path) -> None:
+    """Obsidian permits ``aliases: Name`` as well as a list."""
+    page = _page(vault, "02-Threads/2021-02-02-solo.md", aliases="Solo Name")
+    index = build_link_index(vault)
+
+    assert index.resolve("Solo Name") == page
+
+
+def test_unknown_target_resolves_to_none(vault: Path) -> None:
+    """A genuinely dangling link must still be reported as unresolvable.
+
+    The issue is explicit that the true dangling set (243 links, date-coded
+    names like ``2025-09-20-w3``) has to survive the fix.
+    """
+    _page(vault, "02-Threads/Sourdough.md")
+    index = build_link_index(vault)
+
+    assert index.resolve("2025-09-20-w3") is None
+    assert "2025-09-20-w3" not in index
+
+
+def test_case_insensitive_fallback_matches_obsidian(vault: Path) -> None:
+    """Obsidian resolves links case-insensitively; the index follows."""
+    page = _page(vault, "02-Threads/2020-09-26-Messages.md", aliases=["Messages"])
+    index = build_link_index(vault)
+
+    assert index.resolve("messages") == page
+    assert index.resolve("MESSAGES") == page
+
+
+def test_exact_case_wins_over_a_differently_cased_page(vault: Path) -> None:
+    """A case-sensitive hit is preferred over the folded fallback."""
+    lower = _page(vault, "02-Threads/messages.md")
+    _page(vault, "02-Threads/2020-09-26-Messages.md", aliases=["Messages"])
+    index = build_link_index(vault)
+
+    assert index.resolve("messages") == lower
+
+
+def test_a_page_without_frontmatter_is_still_indexed_by_stem(vault: Path) -> None:
+    """Plain markdown notes coexist with fragments and must stay resolvable."""
+    path = vault / "02-Threads" / "Plain.md"
+    path.write_text("Just a body, no header.\n", encoding="utf-8")
+    index = build_link_index(vault)
+
+    assert index.resolve("Plain") == path
+
+
+def test_malformed_frontmatter_does_not_break_the_index(vault: Path) -> None:
+    """One unparseable header must not cost the whole vault its index.
+
+    Lint runs across every file in a 35k-file vault; aborting on the first
+    bad YAML block would make the check useless exactly when it matters.
+    """
+    bad = vault / "02-Threads" / "Broken.md"
+    bad.write_text("---\ntitle: [unclosed\n---\n\nBody.\n", encoding="utf-8")
+    good = _page(vault, "02-Threads/Good.md", aliases=["Fine"])
+
+    index = build_link_index(vault)
+
+    assert index.resolve("Fine") == good
+    assert index.resolve("Broken") == bad
+
+
+def test_alias_like_text_in_the_body_is_not_indexed(vault: Path) -> None:
+    """Only the YAML header counts — the body is never parsed as frontmatter.
+
+    This is the observable consequence of the memory bound the issue
+    requires ("stream frontmatter, don't load bodies"): a body that happens
+    to contain ``aliases:`` must not contribute a name. A reader that
+    slurped whole files and searched them would fail here.
+    """
+    _page(
+        vault,
+        "02-Threads/Real.md",
+        aliases=["Genuine"],
+        body="aliases:\n  - Ghost\ntitle: Phantom\n",
+    )
+    index = build_link_index(vault)
+
+    assert index.resolve("Genuine") is not None
+    assert index.resolve("Ghost") is None
+    assert index.resolve("Phantom") is None
+
+
+def test_index_spans_the_whole_vault_not_one_folder(vault: Path) -> None:
+    """Links cross folders, so the index must too."""
+    thread = _page(vault, "02-Threads/2020-01-01-t.md", aliases=["Thread Name"])
+    eddy = _page(vault, "03-Eddies/2020-01-01-e.md", aliases=["Eddy Name"])
+    index = build_link_index(vault)
+
+    assert index.resolve("Thread Name") == thread
+    assert index.resolve("Eddy Name") == eddy
+
+
+def test_empty_vault_yields_an_empty_index(vault: Path) -> None:
+    """A vault with no pages resolves nothing and does not raise."""
+    index = build_link_index(vault)
+
+    assert index.resolve("anything") is None
+    assert "anything" not in index


### PR DESCRIPTION
## What

`creek lint`'s `broken-links` and `orphan-compiled` checks resolved wiki-links against filename stems alone. Since #730 the eddy and thread linkers write date-prefixed pages (`2020-09-26-Messages.md`) and put the human-readable name in `aliases:`, and fragments link the alias form — so stem-only matching declared almost every real link broken.

On the demo vault (`creek-demo-2026-06-07`, lint run 2026-07-22):

| Check | Reported | Actually wrong |
|---|---|---|
| `broken-links` | 66,380 | 65,879 (**99.2%**) resolved via `aliases`/`title`; `[[Messages]]` alone was 60,993 |
| `orphan-compiled` | 225 pages | includes `02-Threads/Dormant/2020-09-26-Messages.md`, which has ~30k inbound `[[Messages]]` links |

Only 243 broken links were genuine. A check that is wrong 99.2% of the time is worse than one that doesn't exist, because its output still has to be read.

## Approach

Adds `creek/vault/links.py` — one definition of "does this wiki-link resolve, and to what". `build_link_index(vault_path)` maps every name a page answers to (filename stem, frontmatter `title`, each `aliases` entry) to its path, using Obsidian's resolution order: exact case wins, case-folded is the fallback.

Both checks now query it instead of carrying private copies. The issue asks for exactly this so `compile_routing` can adopt it when #881 (same defect class, different code path) lands.

## Two things this deliberately does not do

**It does not silence the genuinely dangling links.** The 243 real stale targets — date-coded names like `2025-09-20-w3` — must survive, or the fix has just traded a noisy check for a useless one. `test_genuinely_dangling_link_is_still_reported` puts a stale link and a live alias link in the same fragment and asserts exactly one finding.

**`orphan-compiled` resolves per-page, not "did this resolve anywhere".** Crediting every compiled page whenever some inbound target resolved would silence the check completely — the bug's end state, reached from the other side. `test_orphan_check_does_not_credit_a_link_to_a_different_page` pins it: two aliased threads, one linked, and the unlinked one is still reported.

## Memory bound

The issue requires the index stay bounded at 35k files ("stream frontmatter, don't load bodies"). `_read_header_block` reads line by line and stops at the closing fence, with 200-line / 64 KB caps so an unclosed fence can't degrade into a full-file read.

`test_alias_like_text_in_the_body_is_not_indexed` is the behavioural proof rather than a comment: a page whose *body* contains a decoy `aliases:\n  - Ghost` block must not make `Ghost` resolvable. A reader that slurped whole files and searched them would fail that test.

Malformed YAML in one header yields no names instead of raising — lint walks every file in the vault, so one bad header must not cost the whole run its index.

## Acceptance criteria

- [x] A fragment linking `[[X]]` where a page has `aliases: [X]` (or `title: X`) is NOT reported broken
- [x] A compiled page with inbound alias links is NOT reported orphaned
- [x] Genuinely dangling links are still reported
- [x] Extracted as a shared helper (`creek/vault/links.py`) ready for `compile_routing` / #881
- [x] `./scripts/check-all.sh` passes
- [ ] Re-run on the demo-scale vault — not done here; needs the 35k-fixture vault, which isn't in the repo (FEAT-019). The fixtures reproduce the exact shapes, but the 66k→243 number itself is unverified by this PR.

## Testing

21 new tests: 13 in `tests/test_vault_links.py` (stem/title/alias resolution, scalar vs list aliases, case fallback and exact-case precedence, malformed frontmatter, body-decoy rejection, empty vault), 8 in `tests/test_lint_alias_resolution.py` (both checks, both directions).

`./scripts/check-all.sh`: **12/12 gates, 0 failed** — 8133 passed, 94.07% coverage. No existing test needed changing, which is the useful signal here: the old stem-only behaviour had no test asserting it, which is how the regression survived #730.

Closes #887
