### PR TITLE
chore(ralph): require a priority label on lane-filed issues, and stop ranking untriaged work silently

### DIFF
--- a/.claude/agents/ralph-worker.md
+++ b/.claude/agents/ralph-worker.md
@@ -70,6 +70,10 @@ So, concretely:
   (`./scripts/fix-all.sh` for autofixable lint/format — never bypass).
 - **Gate 2.5:** dispatch `code-review-orchestrator` over your diff; fix every
   blocker (drop to Gate 1 via the owning specialist) until `CLEAN`.
+- **Filing a follow-up?** Any issue you `gh issue create` for an unrelated bug
+  needs a priority label (`--label P2` etc.) — see PROMPT.md step 8 for the
+  rubric. Unlabelled is not neutral: `pick-next.sh` ranks it P1 by default, so
+  it preempts triaged work on a judgement nobody made (#1011).
 - Commit with a conventional-commit subject and the repo trailer, push your
   branch, and open the PR with `## Summary`, `## Test plan`, `Closes #RALPH_ISSUE`
   (and `Refs #<epic>` if named).

--- a/scripts/ralph/PROMPT.md
+++ b/scripts/ralph/PROMPT.md
@@ -91,6 +91,17 @@ drives Gates 3–4. The taxonomy you dispatch is mapped in
    blocking finding (drop to Gate 1 via the owning specialist) until `CLEAN`.
 8. **Stay scoped.** Implement exactly the issue. Found an unrelated bug?
    `gh issue create` for it and reference in the PR — do not fix it here.
+   **Always apply a priority label** (`--label P1` etc.). An issue filed
+   without one is not "unprioritised": `pick-next.sh` ranks it at
+   `RALPH_DEFAULT_PRIORITY_RANK` (P1), so it jumps ahead of deliberately
+   triaged P2/P3 work on a judgement nobody made. Rubric:
+   - **P1** — correctness or security defect on a reachable production path.
+   - **P2** — a real defect that is latent, cosmetic, or has no production
+     caller.
+   - **P3** — chore, cleanup, or tracked tech debt.
+
+   Pick the tier for the bug you found, not for how much it obstructed you
+   while you worked around it.
 9. **Commit.** Conventional-commit subject (e.g. `feat(link): …`), body
    referencing the issue, ending with the repo trailer:
    `Co-Authored-By: Claude <noreply@anthropic.com>` (kept model-agnostic — a

--- a/scripts/ralph/pick-next.sh
+++ b/scripts/ralph/pick-next.sh
@@ -81,6 +81,24 @@ RESPECT_EPICS="${RALPH_RESPECT_EPICS:-1}"
 #                                collapses to the previous oldest-first behavior
 #                                — this change is backward compatible.
 #
+# #1011 asked whether this default should move off P1, since untriaged issues
+# were reaching the front of the queue unjudged (two groom gates, ten issues,
+# eventual triage spanning P1..P3 — wrong more often than right, in BOTH
+# directions). The default stays at 1, deliberately:
+#
+#   * No fixed default is defensible. The evidence shows the correct tier for an
+#     untriaged issue is genuinely unknown, so any constant is a guess.
+#   * Between the two guesses, P1 fails safer. Ranking untriaged work last would
+#     let a genuinely urgent finding sit unseen indefinitely; ranking it first
+#     costs, at worst, some queue order that a human can re-triage.
+#   * The real defect was the *silence*, not the number — a rank asserted with no
+#     signal that it was assumed. So the fix is at the two ends instead: labels
+#     are mandatory at the point of filing (PROMPT.md step 8), and the walk below
+#     announces on stderr whenever it falls back to this default.
+#
+# Once labelling holds at the source the default should rarely be consulted at
+# all, which is the point: it is a backstop, not a policy.
+#
 # To enforce the pipeline's stricter "agent-ready required" gate (so ONLY fully
 # specified scan/feature issues are picked), set RALPH_REQUIRE_LABELS=agent-ready.
 # It is left empty by default to avoid starving an existing unlabeled backlog.
@@ -193,6 +211,19 @@ epic_labels() {
   printf '%s\n' "${1//,/$'\n'}" | grep -iE '^epic' | tr '[:upper:]' '[:lower:]' | sort -u || true
 }
 
+# Both label vocabularies that count as a deliberate triage decision (#1011).
+_PRIORITY_LABELS="P0 P1 P2 P3 priority-critical priority-high priority-medium priority-low"
+
+# Has this candidate been triaged at all? Delegates to has_label, so matching is
+# per whole comma-separated token — a near-miss like `P1x` is not triage.
+has_priority_label() {
+  local labels="$1" p
+  for p in $_PRIORITY_LABELS; do
+    has_label "$labels" "$p" && return 0
+  done
+  return 1
+}
+
 # Does the candidate (labels CSV) conflict with any active issue?
 conflicts_with_active() {
   local cand_labels="$1"
@@ -242,6 +273,16 @@ while IFS=$'\t' read -r n cand_labels; do
   is_active "$n" && continue
   if conflicts_with_active "$cand_labels"; then
     continue
+  fi
+  # Rank the untriaged, but never silently (#1011). An unlabeled issue sorts at
+  # DEFAULT_RANK, which two groom gates showed was wrong more often than right
+  # (ten issues; eventual triage spanned P1..P3, in both directions). The rank
+  # is left alone — ranking untriaged work last would bury a genuinely urgent
+  # finding, the worse of the two failures — so the fix is to stop the silence.
+  # stderr only: stdout is the orchestrator's parse target and stays bare.
+  if ! has_priority_label "$cand_labels"; then
+    printf 'pick-next: issue #%s has no priority label; ranking it at the default tier P%s. Triage it, or set RALPH_DEFAULT_PRIORITY_RANK.\n' \
+      "$n" "$DEFAULT_RANK" >&2
   fi
   echo "$n"
   exit 0

--- a/scripts/ralph/test_pick_next.sh
+++ b/scripts/ralph/test_pick_next.sh
@@ -87,6 +87,12 @@ set_labels() { printf '%s' "$2" > "$STUBDIR/labels/$1"; }                    # <
 pr_closes()  { printf 'Closes #%s\n' "$1" >> "$STUBDIR/pr_bodies"; }
 worktree()   { mkdir -p "$REPO/.ralph/worktrees/issue-$1"; }
 run_pick()   { (cd "$REPO" && PATH="$BIN:$PATH" "$PICK"); }
+# stderr only — stdout is discarded so a scenario can assert on the diagnostic
+# channel without the issue number bleeding into the comparison (#1011). Braced
+# rather than `2>&1 >/dev/null` so the ordering is explicit (shellcheck SC2069).
+run_pick_err() {
+  (cd "$REPO" && { PATH="$BIN:$PATH" "$PICK" >/dev/null; } 2>&1)
+}
 
 # JSON-mode helpers: build the fixture the stub feeds to pick-next's REAL --jq
 # filter (mirrors `gh issue list --json number,labels`), so require/exclude
@@ -252,6 +258,44 @@ check "mixed P0/priority-critical share tier 0 (oldest wins)" "40" "$(run_pick)"
 new_scenario prio_high_beats_medium
 ij_add 5 "priority-medium"; ij_add 9 "priority-high"; ij_finalize
 check "priority-high (tier 1) beats priority-medium (tier 2)" "9" "$(run_pick)"
+
+# --- untriaged issues are ranked by default, but never silently (#1011) -------
+#
+# An issue with no priority label sorts at RALPH_DEFAULT_PRIORITY_RANK. Two
+# consecutive groom gates found ten such issues, whose eventual triage ranged
+# P1..P3 — so no fixed default is right more often than it is wrong. The rank
+# stays at P1 (burying a genuinely urgent finding is the worse failure), and the
+# picker announces the assumption instead of making it silently.
+
+# 20) Picking an unlabeled issue warns on stderr, naming the issue and the tier.
+new_scenario default_rank_warns
+ij_add 300 ""; ij_finalize
+check "unlabeled pick warns on stderr" "1" \
+  "$(run_pick_err | grep -c 'no priority label' || true)"
+check "the warning names the issue number" "1" \
+  "$(run_pick_err | grep -c '#300' || true)"
+
+# 21) The warning goes to stderr ONLY. The orchestrator parses stdout for a bare
+# issue number; a warning leaking there would break every caller.
+new_scenario default_rank_stdout_clean
+ij_add 301 ""; ij_finalize
+check "stdout stays a bare issue number while warning" "301" "$(run_pick)"
+
+# 22) A triaged issue is silent — the warning must mean something when it fires.
+new_scenario labeled_pick_is_silent
+ij_add 302 "P2"; ij_finalize
+check "labeled pick emits no warning" "" "$(run_pick_err)"
+
+# 23) Both label vocabularies count as triaged, matching the tiering block.
+new_scenario named_priority_is_silent
+ij_add 303 "priority-low"; ij_finalize
+check "priority-* labels also count as triaged" "" "$(run_pick_err)"
+
+# 24) The label must be a whole token: a `P1x`-style near-miss is not triage.
+new_scenario near_miss_label_still_warns
+ij_add 304 "P1x,bug"; ij_finalize
+check "a near-miss label does not count as triaged" "1" \
+  "$(run_pick_err | grep -c 'no priority label' || true)"
 
 echo
 echo "pick-next tests: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## What

`PROMPT.md` step 8 tells a lane that finds an unrelated bug to `gh issue create` for it — and says nothing about a priority label. `pick-next.sh` then ranks any unlabelled issue at `RALPH_DEFAULT_PRIORITY_RANK`, which is **P1**, so untriaged work reaches the front of the queue ahead of deliberately-triaged P2/P3 on a judgement nobody made. Two consecutive groom gates found ten such issues.

Two halves, fixed at both ends.

**Source.** Step 8 now requires a label and carries a rubric so the choice isn't arbitrary:

- **P1** — correctness or security defect on a reachable production path
- **P2** — a real defect that is latent, cosmetic, or has no production caller
- **P3** — chore, cleanup, or tracked tech debt

`.claude/agents/ralph-worker.md` gets the matching bullet, since a lane reads that file directly rather than only through PROMPT.md.

**Backstop.** `pick-next.sh` now announces on stderr whenever it falls back to the default tier, naming the issue and the tier.

## The decision you asked for

The issue asked whether `RALPH_DEFAULT_PRIORITY_RANK` should move off P1, and explicitly said to *decide rather than doing both blindly*, and to state which and why.

**It stays at 1.** The reasoning comes from the issue's own evidence:

1. **No fixed default is defensible.** The ten unlabelled issues triaged out across the full P1–P3 range — the default was, in the issue's words, "wrong more often than it was right, and in both directions." So the correct tier for an untriaged issue is genuinely unknown, and any constant is a guess dressed as a policy.
2. **Between the two guesses, P1 fails safer.** Ranking untriaged work *last* would let a genuinely urgent finding sit unseen indefinitely — a risk the issue names itself. Ranking it first costs, at worst, some queue order a human can re-triage. Silent burial is harder to notice than silent promotion.
3. **The defect was the silence, not the number.** The issue's own title says "**silently** rank as P1". Changing 1 to 3 would have swapped one unannounced assumption for another. Announcing the fallback fixes the thing the title actually names.

The two options interact exactly as the issue predicted: once labelling holds at the source, the default is rarely consulted at all — it's a backstop, not a policy, and the code comment now says so.

## Why stderr specifically

`pick-next.sh`'s stdout is a parse target — the orchestrator reads a bare issue number from it. A warning on stdout would break every caller. Scenario 21 pins this: it asserts stdout is exactly `301` *while* the warning fires, so a future edit that switches the stream fails the suite rather than the fleet.

## Testing

5 new scenarios in `scripts/ralph/test_pick_next.sh` (**30 passed, 0 failed**):

| # | Asserts |
|---|---|
| 20 | Unlabelled pick warns on stderr, naming the issue |
| 21 | stdout stays a bare issue number while warning |
| 22 | A `P2`-labelled pick is silent |
| 23 | `priority-*` spellings also count as triaged |
| 24 | A near-miss like `P1x` is **not** triage (whole-token matching) |

22 and 23 matter as much as 20: a warning that fires on everything means nothing.

`test_exec_bits.sh`, `test_fleet.sh`, `test_pr_ready.sh` still pass. `shellcheck` reports no new findings on either touched script (the two `SC2086` infos in `pick-next.sh` are pre-existing and intentional — the label lists are deliberately word-split). `creek-tools/scripts/check-all.sh`: 12/12, though no Python changed.

## Verification

Per the issue, no new tooling is needed: the groom gate already surfaces this, and a fix is working when a groom finds zero unlabelled non-excluded issues. That's a future-groom observation, not something this PR can assert — flagging it rather than implying it's been confirmed.

Closes #1011
