### PR TITLE
fix(mcp): make compiled thread/eddy sections raise creek.draft's routing tier

### DIFF
--- a/creek-tools/creek_mcp/tools/draft.py
+++ b/creek-tools/creek_mcp/tools/draft.py
@@ -11,17 +11,32 @@ and hands it over.
 Three properties of that routing rule, none of them visible at the call
 site, all of them load-bearing:
 
-- **The tier is derived from the seed's *source fragments* only.** The
-  ``## Threads`` and ``## Eddies`` prompt sections render compiled-page
-  bodies and frontmatter descriptions with **no tier filtering at all**
+- **The tier is derived from every fragment the prompt carries, not just
+  the seed's ``source_fragments``.** The ``## Threads`` and ``## Eddies``
+  sections render compiled-page bodies and frontmatter descriptions with
+  no tier filtering of their own
   (``creek.generate.drafts.DraftGenerator._compose_thread_section`` /
   ``._compose_eddy_section``, fed by
   :func:`creek.generate.drafts._load_threads_by_id` /
-  :func:`creek.generate.drafts._load_eddies_by_id`), so whatever reaches
-  the model through those sections does **not** raise the routing tier.
-  That is a pre-existing residual in the #931 family, deliberately out
-  of scope for #958, and stated here rather than left for the next
-  reader to rediscover.
+  :func:`creek.generate.drafts._load_eddies_by_id`) — and they *cannot*
+  filter, because neither :class:`~creek.models.Thread` nor
+  :class:`~creek.models.Eddy` carries a ``privacy_tier`` to filter on.
+  Until #1013 that let a compiled page summarising ``intimate``
+  fragments reach a cloud provider on a draft routed ``open``: the #931
+  laundering shape, where a derived artifact carries above-ceiling
+  content past a source-tier computation that cannot see it.
+
+  :func:`_compiled_source_ids` closes it by surveying what those pages
+  already record — :attr:`~creek.models.CompiledPage.provenance`, the
+  fragment ids behind each claim — and folding those ids into the same
+  survey the seed's own sources go through. A named thread or eddy whose
+  sources cannot be enumerated (no compiled page, or a page recording no
+  provenance) fails closed to ``intimate``.
+
+  The blast radius is deliberate and worth knowing: a vault whose
+  compiled pages predate provenance recording will route every threaded
+  draft to the local model. That is the safe direction, but it is a
+  behaviour change, not a no-op.
 - **The ceiling alone is not sufficient** — which is the whole reason
   the sources are surveyed at all.
   :func:`creek.generate.drafts._render_fragment_section` emits
@@ -65,6 +80,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Protocol
 
 from creek.classify.privacy_filter import max_source_tier, source_tiers
+from creek.generate.compile_routing import load_compiled_pages
 from creek.generate.drafts import DraftGenerator
 from creek.generate.mining import IdeaMiner
 from creek.models import Phase, PrivacyTier
@@ -158,9 +174,9 @@ def _source_routing_tier(
     Args:
         vault_path: Vault root; source fragments are read from
             ``01-Fragments`` by the shared survey.
-        idea: The mined seed about to be drafted. Only its
-            ``source_fragments`` are consulted — see the module docstring
-            for why its ``threads`` / ``eddies`` do not raise the tier.
+        idea: The mined seed about to be drafted. Its ``source_fragments``
+            *and* the provenance behind any ``threads`` / ``eddies`` it
+            names are surveyed — see :func:`_compiled_source_ids`.
         ceiling: The caller's declared ceiling.
 
     Returns:
@@ -168,10 +184,61 @@ def _source_routing_tier(
         with. It is a routing signal only and **must never** be echoed
         back to the caller in any form.
     """
-    if not idea.source_fragments:
+    compiled_ids, opaque = _compiled_source_ids(vault_path, idea)
+    if opaque:
+        return routing_tier(ceiling, PrivacyTier.INTIMATE)
+    if not idea.source_fragments and not compiled_ids:
         return routing_tier(ceiling, None)
-    tiers = source_tiers(vault_path, idea.source_fragments)
+    tiers = source_tiers(vault_path, [*idea.source_fragments, *compiled_ids])
     return routing_tier(ceiling, max_source_tier(tiers))
+
+
+def _compiled_source_ids(
+    vault_path: Path,
+    idea: IdeaSeed,
+) -> tuple[list[str], bool]:
+    """Return the fragment ids behind this prompt's compiled sections (#1013).
+
+    The ``## Threads`` and ``## Eddies`` sections render compiled-page bodies,
+    and neither :class:`~creek.models.Thread` nor :class:`~creek.models.Eddy`
+    carries a ``privacy_tier`` — so those sections cannot be tier-*filtered*,
+    only tier-*accounted*. What they do carry is
+    :attr:`~creek.models.CompiledPage.provenance`, the fragment ids each claim
+    was synthesised from, which is exactly the evidence the source survey
+    needs to see them.
+
+    Returns:
+        ``(fragment_ids, opaque)``. ``opaque`` is ``True`` when some named
+        thread or eddy contributes prompt text whose sources cannot be
+        enumerated — the page is missing, or records no provenance. Both cases
+        are treated identically by the caller, which fails closed: a page with
+        no provenance is *unknown*, not *empty*, and reading it as empty would
+        reopen this hole for every page compiled before provenance existed.
+
+        Callers must not skip an unresolvable id and survey the rest, which
+        would silently clear a prompt on the strength of its safe half.
+    """
+    if not idea.threads and not idea.eddies:
+        return [], False
+    index = load_compiled_pages(vault_path)
+    ids: list[str] = []
+    opaque = False
+    for lookup, target_ids in (
+        (index.thread, idea.threads),
+        (index.eddy, idea.eddies),
+    ):
+        for target_id in target_ids:
+            page = lookup(target_id)
+            page_ids = (
+                [fid for entry in page.provenance for fid in entry.fragment_ids]
+                if page is not None
+                else []
+            )
+            if not page_ids:
+                opaque = True
+                continue
+            ids.extend(page_ids)
+    return ids, opaque
 
 
 def draft_tool(

--- a/creek-tools/tests/test_mcp_draft_compiled_tier.py
+++ b/creek-tools/tests/test_mcp_draft_compiled_tier.py
@@ -1,0 +1,344 @@
+"""Compiled thread/eddy sections must raise ``creek.draft``'s routing tier (#1013).
+
+``_source_routing_tier`` derived the LLM routing tier from the seed's
+``source_fragments`` alone. But the draft prompt also carries ``## Threads``
+and ``## Eddies`` sections rendered from compiled-layer pages, and nothing
+tier-filtered those: ``Thread`` and ``Eddy`` carry no ``privacy_tier`` field
+at all, and their loaders take no ``PrivacyTierOverride``.
+
+So a compiled thread page that summarises ``intimate`` fragments could reach a
+cloud provider on a draft whose routing tier was computed as ``open``. Same
+family as #931 — a derived artifact laundering above-ceiling content past a
+source-tier computation that cannot see it.
+
+The tier survey now folds in the provenance the compiled pages already record
+(``CompiledPage.provenance[].fragment_ids``), and fails closed to ``intimate``
+whenever a named thread or eddy contributes text whose sources cannot be
+enumerated. These tests pin both halves: the laundering is closed, and the
+existing ``UNEXPLORED_ONTOLOGY`` exemption still routes by ceiling alone.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import frontmatter
+import pytest
+
+from creek.compile.provenance import ProvenanceEntry
+from creek.models import (
+    CompiledPage,
+    Fragment,
+    FragmentSource,
+    Frequency,
+    FrequencyClassification,
+    PrivacyTier,
+    SourcePlatform,
+    VoiceClassification,
+)
+from creek_mcp.tier_ceiling import TierCeiling
+from creek_mcp.tools.draft import _source_routing_tier
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_THREAD_DIR = "02-Threads"
+_EDDY_DIR = "03-Eddies"
+
+
+def _write_fragment(vault: Path, frag_id: str, tier: PrivacyTier) -> None:
+    """Write a fragment note carrying *tier*."""
+    fragment = Fragment(
+        id=frag_id,
+        title=f"Fragment {frag_id}",
+        source=FragmentSource(platform=SourcePlatform.JOURNAL),
+        created=datetime(2026, 3, 1, 9, 0, 0),
+        ingested=datetime(2026, 3, 1, 9, 0, 0),
+        frequency=FrequencyClassification(primary=Frequency.F5),
+        voice=VoiceClassification(),
+        privacy_tier=tier,
+    )
+    post = frontmatter.Post(content="Fragment body.")
+    post.metadata.update(fragment.model_dump(mode="json"))
+    path = vault / "01-Fragments" / f"{frag_id}.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(frontmatter.dumps(post), encoding="utf-8")
+
+
+def _write_compiled_page(
+    vault: Path,
+    *,
+    reldir: str,
+    target_kind: str,
+    target_id: str,
+    fragment_ids: list[str] | None,
+) -> None:
+    """Write a compiled page whose provenance names *fragment_ids*.
+
+    ``fragment_ids=None`` writes a page with **no** provenance entries — the
+    shape that makes a page's sources unenumerable.
+    """
+    provenance = (
+        []
+        if fragment_ids is None
+        else [
+            ProvenanceEntry(
+                claim_id="c1",
+                claim_excerpt="A synthesised claim.",
+                fragment_ids=fragment_ids,
+                compiled_at=datetime(2026, 3, 2, 10, 0, 0, tzinfo=UTC),
+                compile_method="llm",
+            ),
+        ]
+    )
+    page = CompiledPage(
+        target_kind=target_kind,  # type: ignore[arg-type]  # Literal narrowed by caller
+        target_id=target_id,
+        title=f"Page {target_id}",
+        body="Synthesised body text.",
+        provenance=provenance,
+    )
+    post = frontmatter.Post(content="Synthesised body text.")
+    post.metadata.update(page.model_dump(mode="json"))
+    path = vault / reldir / f"{target_id}.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(frontmatter.dumps(post), encoding="utf-8")
+
+
+def _seed(
+    *,
+    source_fragments: tuple[str, ...] = (),
+    threads: tuple[str, ...] = (),
+    eddies: tuple[str, ...] = (),
+) -> object:
+    """Build an ``IdeaSeed`` with the given vault references."""
+    from creek.generate.mining import IdeaSeed, MiningStrategy
+
+    return IdeaSeed(
+        strategy=MiningStrategy.THREAD_TERMINUS,
+        title="Routing seed",
+        source_fragments=source_fragments,
+        threads=threads,
+        eddies=eddies,
+        frequency_affinity=(),
+        brief_description="brief",
+        score=0.5,
+    )
+
+
+@pytest.fixture()
+def vault(tmp_path: Path) -> Path:
+    """A vault with the folders the tier survey walks."""
+    for rel in ("01-Fragments", _THREAD_DIR, _EDDY_DIR):
+        (tmp_path / rel).mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+# ---- The laundering channel this issue is about ----
+
+
+def test_thread_page_summarising_intimate_raises_the_tier(vault: Path) -> None:
+    """An open seed whose thread page came from intimate fragments routes local.
+
+    The exact bug: ``source_fragments`` are all ``open`` and the declared
+    ceiling is ``OPEN``, yet the prompt carries a compiled thread body
+    synthesised from ``intimate`` content.
+
+    The ceiling has to be ``OPEN`` for this test to mean anything. Under
+    ``TierCeiling.ALL`` the ceiling itself derives ``intimate``, so
+    ``routing_tier`` returns ``intimate`` whatever the content says — the
+    assertion would pass against the unfixed code and prove nothing.
+    """
+    _write_fragment(vault, "frag-open", PrivacyTier.OPEN)
+    _write_fragment(vault, "frag-intimate", PrivacyTier.INTIMATE)
+    _write_compiled_page(
+        vault,
+        reldir=_THREAD_DIR,
+        target_kind="thread",
+        target_id="thread-1",
+        fragment_ids=["frag-intimate"],
+    )
+
+    tier = _source_routing_tier(
+        vault,
+        _seed(source_fragments=("frag-open",), threads=("thread-1",)),
+        TierCeiling.OPEN,
+    )
+
+    assert tier == PrivacyTier.INTIMATE
+
+
+def test_eddy_page_summarising_intimate_raises_the_tier(vault: Path) -> None:
+    """The eddy section is the same channel as the thread section."""
+    _write_fragment(vault, "frag-open", PrivacyTier.OPEN)
+    _write_fragment(vault, "frag-intimate", PrivacyTier.INTIMATE)
+    _write_compiled_page(
+        vault,
+        reldir=_EDDY_DIR,
+        target_kind="eddy",
+        target_id="eddy-1",
+        fragment_ids=["frag-intimate"],
+    )
+
+    tier = _source_routing_tier(
+        vault,
+        _seed(source_fragments=("frag-open",), eddies=("eddy-1",)),
+        TierCeiling.OPEN,
+    )
+
+    assert tier == PrivacyTier.INTIMATE
+
+
+def test_open_thread_page_does_not_raise_the_tier(vault: Path) -> None:
+    """The fix must not force every threaded draft local.
+
+    A compiled page whose provenance names only ``open`` fragments carries no
+    above-ceiling content, so it leaves the routing tier where it was. Without
+    this, the fix would be indistinguishable from disabling cloud drafting.
+    """
+    _write_fragment(vault, "frag-open", PrivacyTier.OPEN)
+    _write_fragment(vault, "frag-open-2", PrivacyTier.OPEN)
+    _write_compiled_page(
+        vault,
+        reldir=_THREAD_DIR,
+        target_kind="thread",
+        target_id="thread-open",
+        fragment_ids=["frag-open-2"],
+    )
+
+    tier = _source_routing_tier(
+        vault,
+        _seed(source_fragments=("frag-open",), threads=("thread-open",)),
+        TierCeiling.OPEN,
+    )
+
+    assert tier == PrivacyTier.OPEN
+
+
+# ---- Fail closed when the sources cannot be enumerated ----
+
+
+def test_thread_with_no_compiled_page_fails_closed(vault: Path) -> None:
+    """A named thread with no compiled page still puts text in the prompt.
+
+    ``_compose_thread_section`` falls back to the thread's frontmatter
+    ``description`` when no compiled page exists — derived text whose sources
+    the survey cannot enumerate. With no evidence about what it carries, the
+    safe assumption is the worst one.
+    """
+    _write_fragment(vault, "frag-open", PrivacyTier.OPEN)
+
+    tier = _source_routing_tier(
+        vault,
+        _seed(source_fragments=("frag-open",), threads=("thread-missing",)),
+        TierCeiling.OPEN,
+    )
+
+    assert tier == PrivacyTier.INTIMATE
+
+
+def test_compiled_page_without_provenance_fails_closed(vault: Path) -> None:
+    """A page recording no provenance is opaque, not empty.
+
+    Reading "no provenance entries" as "no sensitive sources" would reopen the
+    exact hole this issue reports, for every page compiled before provenance
+    was recorded.
+    """
+    _write_fragment(vault, "frag-open", PrivacyTier.OPEN)
+    _write_compiled_page(
+        vault,
+        reldir=_THREAD_DIR,
+        target_kind="thread",
+        target_id="thread-bare",
+        fragment_ids=None,
+    )
+
+    tier = _source_routing_tier(
+        vault,
+        _seed(source_fragments=("frag-open",), threads=("thread-bare",)),
+        TierCeiling.OPEN,
+    )
+
+    assert tier == PrivacyTier.INTIMATE
+
+
+def test_provenance_naming_an_unresolvable_fragment_fails_closed(
+    vault: Path,
+) -> None:
+    """A page citing a fragment that no longer exists cannot be cleared.
+
+    ``max_source_tier`` already fails closed on an empty survey; this pins that
+    the compiled path inherits that behaviour rather than skipping the id.
+    """
+    _write_fragment(vault, "frag-open", PrivacyTier.OPEN)
+    _write_compiled_page(
+        vault,
+        reldir=_THREAD_DIR,
+        target_kind="thread",
+        target_id="thread-stale",
+        fragment_ids=["frag-deleted"],
+    )
+
+    tier = _source_routing_tier(
+        vault,
+        _seed(threads=("thread-stale",)),
+        TierCeiling.OPEN,
+    )
+
+    assert tier == PrivacyTier.INTIMATE
+
+
+# ---- Behaviour that must not change ----
+
+
+def test_unexplored_ontology_seed_still_routes_by_ceiling(vault: Path) -> None:
+    """The documented exemption survives: no vault content, no forced local.
+
+    ``UNEXPLORED_ONTOLOGY`` builds its title and description from ontology enum
+    labels and leaves sources, threads and eddies all empty. Failing closed
+    there would push every such draft onto the local model for no privacy gain
+    — the existing docstring says so explicitly, and this fix must not quietly
+    reverse it.
+    """
+    tier = _source_routing_tier(vault, _seed(), TierCeiling.OPEN)
+
+    assert tier == PrivacyTier.OPEN
+
+
+def test_sources_only_seed_is_unaffected(vault: Path) -> None:
+    """A seed with no threads or eddies routes exactly as it did before."""
+    _write_fragment(vault, "frag-open", PrivacyTier.OPEN)
+
+    tier = _source_routing_tier(
+        vault,
+        _seed(source_fragments=("frag-open",)),
+        TierCeiling.OPEN,
+    )
+
+    assert tier == PrivacyTier.OPEN
+
+
+def test_ceiling_still_wins_when_more_sensitive(vault: Path) -> None:
+    """Reconciliation with the declared ceiling is unchanged.
+
+    A caller cannot pick low-tier sources *and* a clean thread page to win
+    cloud routing under a broad ceiling — ``routing_tier`` still takes the more
+    sensitive of the two signals.
+    """
+    _write_fragment(vault, "frag-open", PrivacyTier.OPEN)
+    _write_compiled_page(
+        vault,
+        reldir=_THREAD_DIR,
+        target_kind="thread",
+        target_id="thread-open",
+        fragment_ids=["frag-open"],
+    )
+
+    tier = _source_routing_tier(
+        vault,
+        _seed(source_fragments=("frag-open",), threads=("thread-open",)),
+        TierCeiling.INTIMATE,
+    )
+
+    assert tier == PrivacyTier.INTIMATE


### PR DESCRIPTION
## What

`_source_routing_tier` derived `creek.draft`'s LLM routing tier from the seed's `source_fragments` only. The prompt also carries `## Threads` and `## Eddies` sections rendered from compiled-layer pages, and nothing tier-filtered those — so a compiled thread summarising `intimate` fragments could reach a **cloud provider** on a draft whose routing tier was computed as `open`.

Same shape as #931: a derived artifact carrying above-ceiling content past a source-tier computation that cannot see it. #1012 made it reachable by fixing the router bypass that had kept `creek.draft` dead in production.

## The design decision you asked for

The issue offered two options and said the fix "needs design".

**Option 1 — tier-filter the thread/eddy loaders behind `PrivacyTierOverride` — is not implementable as stated.** Neither `Thread` nor `Eddy` carries a `privacy_tier` field, and neither records fragment ids (`Eddy` has `fragment_count: int` and `threads: list[str]` of *titles*; `Thread` likewise). `PrivacyTierOverride` filtering works on fragments precisely because fragments carry a tier. There is nothing on a compiled page to filter by. Those sections can be tier-**accounted** but not tier-**filtered**.

**So this takes option 2, scoped to draft.** `CompiledPage` already records `provenance[].fragment_ids` — the fragments each synthesised claim came from. That is exactly the evidence the survey was missing. Those ids are folded into the same `source_tiers` walk the seed's own sources go through, so a single `max_source_tier` reduction covers the whole prompt rather than two reductions that can drift.

The issue notes option 2 "should probably be designed with #931". `_compiled_source_ids` is deliberately shaped as a reusable survey over a set of compiled-page ids, so #931's structural-path case can adopt it rather than growing a second answer — but I've kept this PR to the draft path rather than speculatively generalising for a case I haven't read.

## Failing closed

A named thread or eddy whose sources cannot be enumerated routes `intimate`. Two cases, treated identically:

- **No compiled page.** `_compose_thread_section` falls back to the thread's frontmatter `description` — still derived text, still unenumerable.
- **A page recording no provenance.** A page with no provenance is *unknown*, not *empty*. Reading it as empty would reopen this exact hole for every page compiled before provenance recording existed.

The survey also refuses to clear a prompt on the strength of its safe half: one unresolvable id makes the whole call opaque, rather than surveying the rest and returning a tier that ignores what it couldn't see.

**The `UNEXPLORED_ONTOLOGY` exemption is preserved deliberately.** It's the only strategy with empty sources *and* empty threads *and* eddies, so it still routes by ceiling alone — sweeping it into the fail-closed path would force every such draft local for no privacy gain, which the existing docstring explicitly argues against.

## Behaviour change worth naming

A vault whose compiled pages predate provenance recording will route **every threaded draft to the local model**. That's the safe direction, and it's the correct default for a privacy gate — but it is not a no-op, and on a large existing vault it may be a noticeable shift in where drafts execute. Recorded in the module docstring rather than left to be discovered. Flagging it explicitly in case you'd rather gate it behind a config knob; I didn't add one, because a privacy control that defaults to off isn't one.

## Testing

9 new tests in `tests/test_mcp_draft_compiled_tier.py`: the thread channel, the eddy channel, an all-`open` page that must *not* raise the tier (otherwise the fix is indistinguishable from disabling cloud drafting), three fail-closed paths, and three regression guards.

One methodology note that changed the outcome: **the ceiling in these tests is `OPEN`, not `ALL`.** Under `TierCeiling.ALL` the ceiling itself derives `intimate`, so `routing_tier` returns `intimate` regardless of content — an `ALL`-ceiling assertion passes against the *unfixed* code and proves nothing. My first draft of these tests made exactly that mistake and showed 4 green security tests; switching to `OPEN` turned them red, which is what a real reproduction looks like.

`./scripts/check-all.sh`: **12/12 gates, 0 failed** — 8142 passed, 94.08% coverage.

Closes #1013
Refs #931, #958
