### PR TITLE
fix(link): bound cluster degeneration in message streams

### DIFF
--- a/creek-tools/README.md
+++ b/creek-tools/README.md
@@ -161,7 +161,7 @@ read the threat model below before doing anything else.
 | `llm`            | `LLMRoutingConfig`     | Per-stage provider+model routing (`default` / `classification` / `generation` / `frontend` + a `writing_desk` role map), or a legacy flat `LLMConfig` block. See [LLM providers](#llm-providers). |
 | `embeddings`     | `EmbeddingsConfig`     | Sentence-transformer model, similarity thresholds. |
 | `ocr`            | `OCRConfig`            | Tesseract path, languages, PSM mode. |
-| `linking`        | `LinkingConfig`        | Embedding/temporal/eddy thresholds. |
+| `linking`        | `LinkingConfig`        | Embedding/temporal/thread/eddy thresholds, message-stream segmentation, and the cluster-size guardrail. See [ADR-0008](docs/architecture/ADR/0008-bounding-cluster-degeneration-in-message-streams.md). |
 | `classification` | `ClassificationConfig` | Auto-classify sources, confidence threshold, review-required sources. |
 | `context`        | `ContextConfig`        | How non-user content (others' messages, collaborative docs) is handled. |
 | `redaction`      | `RedactionConfig`      | Pattern enable list, exclusion globs, allow-list. |

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -1914,7 +1914,8 @@ def _format_link_summary(summary: LinkSummary) -> str:
             f"{summary.eddies_detected} eddy(ies) detected, "
             f"{summary.eddies_written} eddy file(s) written to 03-Eddies/, "
             f"{summary.member_fragments_updated} fragment(s) updated with "
-            f"`eddies:` wiki-links."
+            f"`eddies:` wiki-links"
+            f"{_format_cluster_stats(summary)}."
         )
     elif summary.method == "temporal":
         body = (
@@ -1927,12 +1928,42 @@ def _format_link_summary(summary: LinkSummary) -> str:
             f"{summary.threads_written} page(s) written to "
             "02-Threads/{Active,Dormant,Resolved}/, "
             f"{summary.member_fragments_updated} fragment(s) updated with "
-            "`threads:` wiki-links."
+            "`threads:` wiki-links"
+            f"{_format_cluster_stats(summary)}."
         )
     else:
         msg = f"Unknown link method: {summary.method!r}"
         raise ValueError(msg)
     return f"[bold green]{body}[/bold green]"
+
+
+def _format_cluster_stats(summary: LinkSummary) -> str:
+    """Render the clustering-health clause for a link summary.
+
+    Issue #880: the largest cluster is the one number that tells an
+    operator whether detection degenerated — a single eddy holding 87% of
+    the vault used to be invisible from the CLI. Splits and discards are
+    reported only when they happened, so an ordinary run stays terse; a
+    discard is data loss (those fragments carry no wiki-link at all) and
+    therefore always named when non-zero.
+
+    Args:
+        summary: The link summary being rendered.
+
+    Returns:
+        A clause to append to the method's sentence, starting with ``", "``,
+        or an empty string when nothing was detected.
+    """
+    if summary.largest_cluster_fragments == summary.oversized_discarded == 0:
+        return ""
+    parts = [f"largest cluster: {summary.largest_cluster_fragments} fragment(s)"]
+    if summary.clusters_split:
+        parts.append(f"{summary.clusters_split} oversized cluster(s) re-clustered")
+    if summary.oversized_discarded:
+        parts.append(
+            f"{summary.oversized_discarded} fragment(s) discarded as unsplittable",
+        )
+    return ", " + ", ".join(parts)
 
 
 @app.command()

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -473,6 +473,141 @@ class LinkingConfig(BaseModel):
     introduced by FEAT-022.
     """
 
+    # ---- Detector thresholds (issue #880) ----
+    #
+    # Every default below is the exact value of the module-private constant
+    # it replaces, so a vault whose creek_config.yaml predates these keys
+    # clusters identically after the upgrade.
+
+    eddy_eps: float = Field(default=0.3, gt=0.0, lt=1.0)
+    """Maximum cosine *distance* for a DBSCAN neighbour in eddy detection.
+
+    ``0.3`` means an edge exists between two fragments at cosine similarity
+    ``>= 0.70``. Lowering it tightens every cluster; it cannot, on its own,
+    separate a continuous message stream (see ``stream_platforms``).
+    """
+
+    eddy_min_samples: int = Field(default=5, ge=1)
+    """Minimum neighbourhood size for a DBSCAN core point in eddy detection."""
+
+    eddy_correlation_threshold: float = Field(default=0.3, ge=0.0, le=1.0)
+    """Absolute Spearman ceiling above which a cluster is thread-like.
+
+    A candidate eddy whose content drift correlates with chronological rank
+    at or above this value is a directional progression, and is filtered out
+    of the eddy set rather than emitted as a topic cluster.
+    """
+
+    thread_window_days: int = Field(default=30, ge=1)
+    """Sliding-window width, in days, for thread detection.
+
+    Distinct from ``temporal_window_hours``, which feeds only the temporal
+    *proximity* linker and has never influenced threads.
+    """
+
+    thread_similarity_threshold: float = Field(default=0.6, ge=0.0, le=1.0)
+    """Cosine similarity a pair must strictly exceed to join one thread."""
+
+    thread_union_without_embeddings: bool = False
+    """Whether a pair missing an embedding may union on frequency alone.
+
+    When the detector has *no* embeddings at all, thread detection falls
+    back to frequency agreement by design. On a *partially* embedded vault
+    the same fallback fires per pair, silently chaining fragments the
+    similarity gate would have rejected — so it is closed by default and
+    must be opted into.
+    """
+
+    # ---- Cluster-size guardrail (issue #880) ----
+
+    cluster_size_ceiling: int = Field(default=500, ge=1)
+    """Absolute member count below which a cluster is never split.
+
+    The effective ceiling is ``max(cluster_size_ceiling, floor(corpus_size *
+    cluster_max_fraction))``: the absolute floor dominates ordinary vaults,
+    so the guardrail stays inert until a corpus is large enough for
+    degeneration to matter.
+    """
+
+    cluster_max_fraction: float = Field(default=0.10, gt=0.0, le=1.0)
+    """Largest share of the corpus a single eddy or thread may hold.
+
+    ``1.0`` is the documented opt-out: one cluster may then span everything.
+    """
+
+    cluster_split_max_depth: int = Field(default=3, ge=0)
+    """Re-clustering rounds allowed per oversized cluster.
+
+    ``0`` disables splitting entirely, sending any oversized cluster
+    straight to noise.
+    """
+
+    eddy_split_eps_step: float = Field(default=0.05, gt=0.0, lt=1.0)
+    """Amount ``eddy_eps`` is tightened by on each re-clustering round."""
+
+    thread_split_similarity_step: float = Field(default=0.1, gt=0.0, lt=1.0)
+    """Amount ``thread_similarity_threshold`` is raised on each round."""
+
+    # ---- Message-stream segmentation (issue #880) ----
+
+    stream_platforms: list[str] = Field(
+        default_factory=lambda: ["discord", "email"],
+    )
+    """Source platforms whose fragments are cut into conversation episodes.
+
+    A continuous chat stream violates the precondition both detectors rely
+    on — clusters separated by low-density regions — so it is partitioned
+    into independent clustering domains *before* any similarity graph is
+    built. The default names the two platforms Creek already routes to the
+    ``01-Fragments/Messages/`` subfolder. An empty list disables
+    segmentation. Values must be :class:`~creek.models.SourcePlatform`
+    members.
+    """
+
+    stream_episode_max_gap_hours: int = Field(default=24, ge=1)
+    """Inactivity gap, in hours, that ends a conversation episode.
+
+    The conversational rule: people stop talking, and that silence is the
+    real topic boundary. Inclusive — a gap exactly this long does not cut.
+    """
+
+    stream_episode_max_span_days: int = Field(default=30, ge=1)
+    """Maximum span, in days, of a single conversation episode.
+
+    The backstop for a channel that never falls idle, so a permanently-busy
+    channel yields channel-month units rather than one multi-year blob.
+    Inclusive — a span exactly this long does not cut.
+    """
+
+    @field_validator("stream_platforms")
+    @classmethod
+    def _validate_stream_platforms(cls, value: list[str]) -> list[str]:
+        """Reject platform names that no ingestor can ever produce.
+
+        Args:
+            value: The configured platform values.
+
+        Returns:
+            The value unchanged when every entry names a
+            :class:`~creek.models.SourcePlatform` member.
+
+        Raises:
+            ValueError: If any entry is not a known source platform — a
+                typo would otherwise disable segmentation silently.
+        """
+        from creek.models import SourcePlatform
+
+        known = {platform.value for platform in SourcePlatform}
+        unknown = [name for name in value if name not in known]
+        if unknown:
+            msg = (
+                f"unknown source platform(s) in stream_platforms: "
+                f"{', '.join(sorted(unknown))}; "
+                f"valid values are {', '.join(sorted(known))}"
+            )
+            raise ValueError(msg)
+        return value
+
 
 class ClassificationConfig(BaseModel):
     """Classification pipeline configuration."""

--- a/creek-tools/creek/ingest/discord.py
+++ b/creek-tools/creek/ingest/discord.py
@@ -711,10 +711,24 @@ class DiscordIngestor(Ingestor):
     def generate_frontmatter(self, fragment: ParsedFragment) -> dict[str, Any]:
         """Generate YAML frontmatter metadata for a Discord fragment.
 
-        Produces frontmatter with source platform, channel, timestamps,
-        and participant information. FEAT-031: the message's source-side
-        ``timestamp`` (preserved with its native offset) lands on
-        ``authored_at``.
+        Produces frontmatter with a title, source platform, channel,
+        timestamps, and participant information. FEAT-031: the message's
+        source-side ``timestamp`` (preserved with its native offset) lands
+        on ``authored_at``.
+
+        Issue #880: the ``title`` key is emitted here rather than left to
+        :func:`creek.ingest.base.assemble_ingested_fragment`'s filename-stem
+        fallback. :meth:`discover` only ever reads
+        ``<channel_dir>/messages.json``, so that fallback gave *every*
+        Discord fragment in every vault the title ``messages`` — and since
+        :class:`~creek.models.Fragment` carries no body, a fragment's title
+        is the only text the linker ever sees. 30,795 identical titles are
+        what named a mega-eddy ``Messages``. Naming the channel and the day
+        gives the linker something that actually distinguishes one
+        conversation from another.
+
+        No fragment id churns: :func:`creek.ingest.base.generate_fragment_id`
+        hashes source path, timestamp and content, never the title.
 
         Args:
             fragment: The parsed fragment.
@@ -722,17 +736,23 @@ class DiscordIngestor(Ingestor):
         Returns:
             A dict of frontmatter key-value pairs.
         """
+        channel = fragment.metadata.get("channel_name", "unknown")
+        authored_at: datetime | None = fragment.metadata.get("authored_at")
+        # The source-side day when the export carried one, so the title
+        # agrees with ``authored_at`` rather than with the LA-anchored
+        # ingest timestamp (FEAT-031).
+        titled_on = (authored_at or fragment.timestamp).date()
         frontmatter_dict: dict[str, Any] = {
+            "title": f"{channel} {titled_on.isoformat()}",
             "source": {
                 "platform": "discord",
-                "channel": fragment.metadata.get("channel_name", "unknown"),
+                "channel": channel,
                 "channel_id": fragment.metadata.get("channel_id", "unknown"),
             },
             "created": fragment.timestamp.isoformat(),
             "authors": fragment.metadata.get("authors", []),
             "message_count": fragment.metadata.get("message_count", 0),
         }
-        authored_at: datetime | None = fragment.metadata.get("authored_at")
         if authored_at is not None:
             frontmatter_dict["authored_at"] = authored_at.isoformat()
         return frontmatter_dict

--- a/creek-tools/creek/link/cluster_limits.py
+++ b/creek-tools/creek/link/cluster_limits.py
@@ -1,0 +1,380 @@
+"""Cluster-size guardrail — a bounded last line of defence, not the cure.
+
+Density-based clustering has no size bound. DBSCAN propagates one label
+across an entire density-connected component, and thread union-find takes
+the transitive closure of every windowed pair. On a continuous message
+stream — semantically homogeneous, temporally unbroken — a single
+mega-cluster is not a badly chosen threshold, it is the algorithm's own
+precondition (clusters separated by low-density regions) being violated.
+No value of ``eps`` or ``similarity_threshold`` fixes that.
+
+**This module is therefore not the fix, and must not be read as one.**
+Recursively tightening a parameter on a 30k-member continuous semantic
+manifold shatters it into arbitrary slices with no interpretable identity
+— trading one meaningless page for sixty. The cure is *naming* (a term
+carried by most of the corpus can never become a title) and *segmentation*
+(never build one epsilon-graph over seven years of chat in the first
+place). What this module supplies is the guarantee that holds when those
+fail, or when a corpus nobody has looked at yet degenerates in a way
+nobody predicted:
+
+    no emitted cluster exceeds ``policy.ceiling_for(corpus_size)``
+
+That is the machine-checkable invariant behind the acceptance criterion
+"no single eddy or thread contains more than the configured ceiling
+fraction of the corpus". It is a floor on badness, not a definition of
+goodness.
+
+Placement is deliberate. Every function here operates on *membership
+lists a detector has already produced*. Nothing in this module calls,
+wraps, patches or perturbs DBSCAN's neighbour discovery or its cluster
+expansion, so the equivalence contract that pins ``_dbscan`` against an
+independent brute-force reference (``test_dbscan_matches_brute_force_reference``)
+is untouched: that oracle compares raw ``_dbscan`` output, which this
+guardrail never sees and never alters. Re-clustering is likewise not
+performed here — the caller injects a ``recluster`` callable that takes
+the tightened parameter as an *argument*, so no detector's own state is
+ever mutated mid-run.
+
+Termination is governed by TWO independent bounds, and both are load
+bearing:
+
+1. :attr:`SplitPolicy.max_depth` — the recursion budget.
+2. :class:`Tightening` running out of valid range — epsilon may not reach
+   ``0.0``, similarity may not reach ``1.0``. A depth-only guard would
+   keep re-clustering at a degenerate parameter where nothing is ever a
+   neighbour and every member silently becomes noise.
+
+A cluster still over the ceiling once both are exhausted is discarded to
+noise: its members lose their eddy/thread frontmatter links entirely. That
+is a real cost, accepted because an unusable mega-page is worse than no
+page, and because with segmentation in place the path should be
+unreachable. It is never silent — each discard logs a WARNING naming the
+domain and the size, and the discarded IDs come back to the caller so an
+operator-visible count can be surfaced.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import deque
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from itertools import chain
+from typing import NamedTuple, Protocol
+
+logger = logging.getLogger(__name__)
+
+_EPS_FLOOR = 0.0
+"""Epsilon may be tightened towards, but never to, zero distance."""
+
+_SIMILARITY_CEILING = 1.0
+"""Similarity may be tightened towards, but never to, exact identity."""
+
+Recluster = Callable[[Sequence[str], float], list[list[str]]]
+"""Re-cluster *members* at a tightened parameter, returning subclusters.
+
+The callable must treat the parameter as a per-call override and must
+return clusters drawn from the members it was handed. Any member it omits
+(DBSCAN noise, a component below the minimum size) is counted as noise by
+:func:`split_oversized` and reported as discarded.
+"""
+
+
+class SplitPolicySource(Protocol):
+    """Structural view of the linking-config fields a policy is built from.
+
+    Declared structurally rather than importing the concrete config class,
+    so the guardrail stays a pure, dependency-free module.
+    """
+
+    @property
+    def cluster_size_ceiling(self) -> int:
+        """Absolute member count below which a cluster is never split."""
+
+    @property
+    def cluster_max_fraction(self) -> float:
+        """Largest share of the corpus one cluster may hold."""
+
+    @property
+    def cluster_split_max_depth(self) -> int:
+        """Maximum number of re-clustering rounds per oversized cluster."""
+
+
+class SplitResult(NamedTuple):
+    """The outcome of splitting one oversized cluster.
+
+    ``accepted`` and ``discarded`` partition the input membership: every
+    ID handed to :func:`split_oversized` appears in exactly one of them.
+    """
+
+    accepted: list[list[str]]
+    """Subclusters that fit under the ceiling, in breadth-first order."""
+
+    discarded: list[str]
+    """Member IDs that ended up as noise, in input order."""
+
+
+@dataclass(frozen=True, slots=True)
+class SplitPolicy:
+    """How large a cluster may be, and how hard to try to shrink it.
+
+    The ceiling is the larger of an absolute floor and a fraction of the
+    corpus. The absolute floor dominates small corpora — so ordinary
+    vaults and unit-test fixtures never trip the guardrail at all — while
+    the fraction dominates at scale, which is where degeneration shows up.
+
+    Attributes:
+        size_ceiling: Absolute member count below which no cluster is ever
+            split, regardless of corpus size. Must be at least 1.
+        max_fraction: Largest share of the corpus a single cluster may
+            hold. Must be greater than 0 and at most 1; ``1.0`` is the
+            documented opt-out, permitting a cluster to span everything.
+        max_depth: Re-clustering rounds allowed per oversized cluster.
+            ``0`` disables splitting, sending any oversized cluster
+            straight to noise.
+    """
+
+    size_ceiling: int = 500
+    max_fraction: float = 0.10
+    max_depth: int = 3
+
+    def __post_init__(self) -> None:
+        """Validate the policy fields.
+
+        Raises:
+            ValueError: If any field falls outside its documented range.
+        """
+        if self.size_ceiling < 1:
+            msg = f"size_ceiling must be >= 1, got {self.size_ceiling}"
+            raise ValueError(msg)
+        if not 0.0 < self.max_fraction <= 1.0:
+            msg = f"max_fraction must be in (0, 1], got {self.max_fraction}"
+            raise ValueError(msg)
+        if self.max_depth < 0:
+            msg = f"max_depth must be >= 0, got {self.max_depth}"
+            raise ValueError(msg)
+
+    def ceiling_for(self, corpus_size: int) -> int:
+        """Return the largest permitted cluster size for a corpus.
+
+        Args:
+            corpus_size: Number of clusterable fragments in the corpus.
+
+        Returns:
+            ``max(size_ceiling, floor(corpus_size * max_fraction))``.
+        """
+        return max(self.size_ceiling, int(corpus_size * self.max_fraction))
+
+    @classmethod
+    def from_linking_config(cls, config: SplitPolicySource) -> SplitPolicy:
+        """Build a policy from the linking configuration.
+
+        Args:
+            config: Any object exposing the cluster-limit knobs — in
+                practice ``CreekConfig.linking``.
+
+        Returns:
+            The policy those settings describe.
+        """
+        return cls(
+            size_ceiling=config.cluster_size_ceiling,
+            max_fraction=config.cluster_max_fraction,
+            max_depth=config.cluster_split_max_depth,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class Tightening:
+    """A monotone schedule of progressively stricter clustering parameters.
+
+    Each round moves *start* one *step* closer to *limit*. The limit is
+    exclusive: it is the value at which the parameter stops meaning
+    anything (zero epsilon admits no neighbours; unit similarity admits no
+    pair), so a schedule stops strictly before reaching it. This bound is
+    independent of the depth budget, and both must hold.
+
+    Attributes:
+        start: The detector's configured parameter — never used for
+            re-clustering itself, only as the point the schedule steps
+            away from.
+        step: Signed increment applied each round. Negative tightens
+            downwards (epsilon), positive upwards (similarity).
+        limit: Exclusive bound the parameter may approach but not reach.
+    """
+
+    start: float
+    step: float
+    limit: float
+
+    def __post_init__(self) -> None:
+        """Validate that the schedule actually tightens towards its limit.
+
+        Raises:
+            ValueError: If the step is zero, points away from the limit,
+                or the start already sits at or beyond the limit.
+        """
+        if self.step == 0.0:
+            msg = "step must be non-zero"
+            raise ValueError(msg)
+        if self.start == self.limit:
+            msg = f"start {self.start} sits at the limit, leaving no room to tighten"
+            raise ValueError(msg)
+        if (self.step > 0.0) != (self.start < self.limit):
+            msg = (
+                f"step {self.step} does not tighten {self.start} "
+                f"towards limit {self.limit}"
+            )
+            raise ValueError(msg)
+
+    def _within_range(self, value: float) -> bool:
+        """Return whether *value* is still a usable clustering parameter.
+
+        Args:
+            value: A candidate tightened parameter.
+
+        Returns:
+            ``True`` while *value* remains strictly on the starting side
+            of :attr:`limit`.
+        """
+        if self.step > 0.0:
+            return value < self.limit
+        return value > self.limit
+
+    def schedule(self, max_rounds: int) -> list[float]:
+        """Return the tightened parameters for up to *max_rounds* rounds.
+
+        Values are computed as ``start + step * round`` rather than by
+        repeated addition, so float drift cannot accumulate into an extra
+        (or missing) round.
+
+        Args:
+            max_rounds: Depth budget from :attr:`SplitPolicy.max_depth`.
+
+        Returns:
+            Successively tighter parameters, truncated by whichever bound
+            bites first — the budget or the valid range. May be empty.
+        """
+        values: list[float] = []
+        for round_index in range(1, max_rounds + 1):
+            value = self.start + self.step * round_index
+            if not self._within_range(value):
+                break
+            values.append(value)
+        return values
+
+    @classmethod
+    def for_eddy_eps(cls, eps: float, step: float) -> Tightening:
+        """Build the schedule that tightens eddy DBSCAN epsilon downwards.
+
+        Args:
+            eps: The detector's configured epsilon (cosine distance).
+            step: Positive magnitude to subtract each round.
+
+        Returns:
+            A schedule stepping *eps* down towards, but never reaching,
+            zero distance.
+        """
+        return cls(start=eps, step=-step, limit=_EPS_FLOOR)
+
+    @classmethod
+    def for_thread_similarity(cls, threshold: float, step: float) -> Tightening:
+        """Build the schedule that tightens thread similarity upwards.
+
+        Args:
+            threshold: The detector's configured cosine-similarity floor.
+            step: Positive magnitude to add each round.
+
+        Returns:
+            A schedule stepping *threshold* up towards, but never
+            reaching, exact identity.
+        """
+        return cls(start=threshold, step=step, limit=_SIMILARITY_CEILING)
+
+
+def _discard(domain: str, size: int, ceiling: int, rounds: int) -> None:
+    """Log the discard of a cluster that could not be brought under the bar.
+
+    Args:
+        domain: Clustering domain the cluster came from, for the operator.
+        size: Member count of the discarded cluster.
+        ceiling: Ceiling it failed to meet.
+        rounds: Re-clustering rounds already spent on it.
+    """
+    logger.warning(
+        "Discarding oversized cluster to noise: domain=%s size=%d "
+        "still exceeds the %d-fragment ceiling after %d re-clustering round(s); "
+        "its members will carry no eddy or thread link",
+        domain,
+        size,
+        ceiling,
+        rounds,
+    )
+
+
+def _noise(members: Sequence[str], accepted: list[list[str]]) -> list[str]:
+    """Return the input members that no accepted subcluster kept.
+
+    Args:
+        members: The original membership, in input order.
+        accepted: Subclusters that survived the split.
+
+    Returns:
+        Every member ID absent from *accepted*, in input order.
+    """
+    kept = set(chain.from_iterable(accepted))
+    return [fid for fid in members if fid not in kept]
+
+
+def split_oversized(
+    members: Sequence[str],
+    *,
+    ceiling: int,
+    policy: SplitPolicy,
+    recluster: Recluster,
+    tightening: Tightening,
+    domain: str,
+) -> SplitResult:
+    """Split a cluster until every part fits under *ceiling*.
+
+    Applies bounded recursive re-clustering entirely outside the
+    detectors' own clustering routines: it only ever re-partitions a
+    membership list that has already been produced. Recursion is driven by
+    an explicit work queue rather than nested calls, and stops on
+    whichever bound bites first — the depth budget or the tightening
+    schedule leaving its valid range.
+
+    Args:
+        members: Member IDs of one already-detected cluster.
+        ceiling: Largest permitted cluster size, from
+            :meth:`SplitPolicy.ceiling_for`.
+        policy: Supplies the depth budget.
+        recluster: Callable re-partitioning a membership at a tightened
+            parameter. See :data:`Recluster` for its contract.
+        tightening: Parameter schedule for successive rounds.
+        domain: Clustering domain the cluster belongs to, named in the
+            WARNING if it has to be discarded.
+
+    Returns:
+        A :class:`SplitResult` whose ``accepted`` and ``discarded`` fields
+        partition *members*.
+    """
+    if not members:
+        return SplitResult([], [])
+    schedule = tightening.schedule(policy.max_depth)
+    accepted: list[list[str]] = []
+    pending = deque([(list(members), 0)])
+    while pending:
+        cluster, depth = pending.popleft()
+        if len(cluster) <= ceiling:
+            accepted.append(cluster)
+            continue
+        if depth >= len(schedule):
+            _discard(domain, len(cluster), ceiling, depth)
+            continue
+        subclusters = recluster(cluster, schedule[depth])
+        if not subclusters:
+            _discard(domain, len(cluster), ceiling, depth + 1)
+            continue
+        pending.extend((sub, depth + 1) for sub in subclusters)
+    return SplitResult(accepted, _noise(members, accepted))

--- a/creek-tools/creek/link/eddies.py
+++ b/creek-tools/creek/link/eddies.py
@@ -9,9 +9,20 @@ periods.
 The algorithm mirrors the Creek pipeline's existing pure-numpy style
 (no ``scikit-learn`` dependency):
 
+0. Partition the corpus into independent clustering domains
+   (:mod:`creek.link.segments`). DBSCAN assumes clusters separated by
+   low-density regions; a continuous message stream has no such
+   separator, so one epsilon-graph over seven years of chat is a single
+   connected component whatever ``eps`` is chosen (issue #880). Message
+   streams are therefore cut into conversation episodes *before* any
+   similarity graph is built, and every other fragment shares one
+   domain, leaving cross-source clustering exactly as it was.
 1. Run DBSCAN over the fragment embedding vectors using cosine
-   distance. Each dense cluster of at least ``min_samples`` fragments is
-   a candidate eddy.
+   distance, per domain. Each dense cluster of at least ``min_samples``
+   fragments is a candidate eddy. A cluster still larger than the
+   configured ceiling is re-clustered at a tighter epsilon by
+   :mod:`creek.link.cluster_limits`, and discarded to noise if even that
+   fails — a guardrail, not the cure.
 2. For each candidate, compute the Spearman rank correlation between
    chronological order and *content drift* (cosine distance from the
    oldest fragment). Low |correlation| (below
@@ -19,10 +30,11 @@ The algorithm mirrors the Creek pipeline's existing pure-numpy style
    topic — an eddy. High |correlation| indicates a thread-like monotonic
    drift and is filtered out.
 3. Build an :class:`~creek.models.Eddy` per qualifying cluster with a
-   title derived from the most distinctive content words, ``formed``
-   set to the median fragment creation date, and ``threads`` populated
-   from any thread wiki-links already present on member fragments
-   (i.e. threads that flow through the eddy).
+   title and description derived by :mod:`creek.link.naming`, a
+   content-stable id derived from its membership, ``formed`` set to the
+   median fragment creation date, and ``threads`` populated from any
+   thread wiki-links already present on member fragments (i.e. threads
+   that flow through the eddy).
 
 The module also offers fragment-to-eddy assignment (adding wiki-links
 to fragment ``eddies`` frontmatter).
@@ -30,18 +42,24 @@ to fragment ``eddies`` frontmatter).
 
 from __future__ import annotations
 
+import hashlib
 import logging
-import re
-from collections import Counter
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from creek.config import LinkingConfig
+from creek.link import naming
+from creek.link.cluster_limits import SplitPolicy, Tightening, split_oversized
 from creek.link.neighbours import cosine_neighbours
+from creek.link.segments import partition
 from creek.models import Eddy
 from creek.time import effective_authored_at, effective_authored_date
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from datetime import date
 
+    from creek.link.segments import SegmentationConfig
     from creek.models import Fragment
 
 logger = logging.getLogger(__name__)
@@ -50,193 +68,75 @@ _DEFAULT_EPS = 0.3
 _DEFAULT_MIN_SAMPLES = 5
 _DEFAULT_MIN_FRAGMENTS = 5
 _DEFAULT_CORRELATION_THRESHOLD = 0.3
-_TITLE_TOP_WORDS = 3
-_MIN_TITLE_WORD_LEN = 3
+_DEFAULT_SPLIT_EPS_STEP = 0.05
+_MAX_FALLBACK_TITLE_LEN = 50
 
 _UNVISITED = -1
 _NOISE = -2
 
-_STOPWORDS: frozenset[str] = frozenset(
-    {
-        "a",
-        "about",
-        "above",
-        "after",
-        "again",
-        "against",
-        "all",
-        "am",
-        "an",
-        "and",
-        "any",
-        "are",
-        "as",
-        "at",
-        "be",
-        "because",
-        "been",
-        "before",
-        "being",
-        "below",
-        "between",
-        "both",
-        "but",
-        "by",
-        "can",
-        "did",
-        "do",
-        "does",
-        "doing",
-        "don",
-        "down",
-        "during",
-        "each",
-        "few",
-        "for",
-        "from",
-        "further",
-        "had",
-        "has",
-        "have",
-        "having",
-        "he",
-        "her",
-        "here",
-        "hers",
-        "herself",
-        "him",
-        "himself",
-        "his",
-        "how",
-        "i",
-        "if",
-        "in",
-        "into",
-        "is",
-        "it",
-        "its",
-        "itself",
-        "just",
-        "me",
-        "more",
-        "most",
-        "my",
-        "myself",
-        "no",
-        "nor",
-        "not",
-        "now",
-        "of",
-        "off",
-        "on",
-        "once",
-        "only",
-        "or",
-        "other",
-        "our",
-        "ours",
-        "ourselves",
-        "out",
-        "over",
-        "own",
-        "s",
-        "same",
-        "she",
-        "should",
-        "so",
-        "some",
-        "such",
-        "t",
-        "than",
-        "that",
-        "the",
-        "their",
-        "theirs",
-        "them",
-        "themselves",
-        "then",
-        "there",
-        "these",
-        "they",
-        "this",
-        "those",
-        "through",
-        "to",
-        "too",
-        "under",
-        "until",
-        "up",
-        "very",
-        "was",
-        "we",
-        "were",
-        "what",
-        "when",
-        "where",
-        "which",
-        "while",
-        "who",
-        "whom",
-        "why",
-        "will",
-        "with",
-        "you",
-        "your",
-        "yours",
-        "yourself",
-        "yourselves",
-    },
-)
+
+@dataclass(frozen=True, slots=True)
+class _NamingContext:
+    """Corpus-wide facts every cluster in one run is measured against.
+
+    Bundled into one object so the naming and guardrail parameters travel
+    together through the detection call chain instead of as four parallel
+    arguments.
+
+    Attributes:
+        document_frequency: How many corpus fragments carry each title
+            content word, from :func:`creek.link.naming.document_frequency`.
+        corpus_size: Number of embedded fragments the run considered.
+        ceiling: Largest permitted cluster size for this corpus.
+    """
+
+    document_frequency: dict[str, int]
+    corpus_size: int
+    ceiling: int
 
 
-def _tokenize(text: str) -> list[str]:
-    """Tokenise *text* into lowercase alphabetic words.
+def _stable_eddy_id(frags: list[Fragment]) -> str:
+    """Return a deterministic ``eddy-<8hex>`` id for a cluster of *frags*.
+
+    Mirrors :func:`creek.link.threads._stable_thread_id` (#718): eddy
+    identity is derived from the sorted member fragment ids, so re-detecting
+    the same cluster on the same corpus yields the same id — and therefore
+    the same page filename, which lets :meth:`VaultWriter.write_eddy`
+    recognise the existing page instead of minting a fresh one on every run.
+    The model's random default (:func:`creek.models._generate_eddy_id`)
+    remains for eddies constructed by hand, which have no membership to hash.
+
+    Membership *changes* deliberately yield a new id: the cluster is a
+    different eddy. That matters more now than before, because segmentation
+    and splitting produce many smaller clusters (issue #880).
 
     Args:
-        text: Input string to tokenise.
+        frags: The fragments composing the eddy (non-empty).
 
     Returns:
-        A list of lowercase word tokens (no punctuation, no digits).
+        A stable ``eddy-`` prefixed id, 8 hex chars of a SHA-256 digest.
     """
-    return re.findall(r"[a-z]+", text.lower())
+    member_key = ",".join(sorted(f.id for f in frags))
+    digest = hashlib.sha256(member_key.encode("utf-8")).hexdigest()[:8]
+    return f"eddy-{digest}"
 
 
-def _content_words(text: str) -> list[str]:
-    """Extract content words from *text* (no stopwords, length-filtered).
+def _apply_unique_titles(eddies: list[Eddy]) -> None:
+    """Make every title in one detection run unique, in place.
+
+    :meth:`EddyDetector.assign_fragments_to_eddies` writes ``[[<title>]]``
+    onto each member fragment, so two eddies sharing a title would send both
+    memberships to whichever page Obsidian resolved first.
 
     Args:
-        text: Input string.
-
-    Returns:
-        A list of lowercase content words suitable for title heuristics.
+        eddies: The run's eddies, in emission order.
     """
-    return [
-        w
-        for w in _tokenize(text)
-        if w not in _STOPWORDS and len(w) >= _MIN_TITLE_WORD_LEN
-    ]
-
-
-def _cosine_similarity(a: list[float], b: list[float]) -> float:
-    """Cosine similarity between two equal-length vectors.
-
-    Args:
-        a: First vector.
-        b: Second vector.
-
-    Returns:
-        Cosine similarity in ``[-1.0, 1.0]``; ``0.0`` if either vector
-        has zero norm.
-    """
-    import numpy as np  # lazy: numpy lives in the [embeddings] extra
-
-    va = np.asarray(a, dtype=np.float32)
-    vb = np.asarray(b, dtype=np.float32)
-    na = float(np.linalg.norm(va))
-    nb = float(np.linalg.norm(vb))
-    if 0.0 in (na, nb):
-        return 0.0
-    return float(np.dot(va, vb) / (na * nb))
+    for eddy, title in zip(
+        eddies,
+        naming.disambiguate([e.title for e in eddies]),
+        strict=True,
+    ):
+        eddy.title = title
 
 
 def _cosine_distance(a: list[float], b: list[float]) -> float:
@@ -249,7 +149,7 @@ def _cosine_distance(a: list[float], b: list[float]) -> float:
     Returns:
         Cosine distance; ``1.0`` when either vector has zero norm.
     """
-    return 1.0 - _cosine_similarity(a, b)
+    return 1.0 - naming.cosine(a, b)
 
 
 def _average_ranks(values: list[float]) -> list[float]:
@@ -345,6 +245,11 @@ class EddyDetector:
         correlation_threshold: Absolute Spearman-correlation ceiling. A
             cluster qualifies as an eddy only when its chronological vs
             content-drift correlation has absolute value below this.
+        split_policy: Cluster-size guardrail applied to every detected
+            cluster (issue #880).
+        split_eps_step: How much ``eps`` tightens per re-clustering round.
+        segmentation: Supplies the message-stream segmentation settings
+            consumed by :func:`creek.link.segments.partition`.
     """
 
     def __init__(
@@ -354,6 +259,9 @@ class EddyDetector:
         eps: float = _DEFAULT_EPS,
         min_samples: int = _DEFAULT_MIN_SAMPLES,
         correlation_threshold: float = _DEFAULT_CORRELATION_THRESHOLD,
+        split_policy: SplitPolicy | None = None,
+        split_eps_step: float = _DEFAULT_SPLIT_EPS_STEP,
+        segmentation: SegmentationConfig | None = None,
     ) -> None:
         """Initialise the detector.
 
@@ -370,12 +278,56 @@ class EddyDetector:
             correlation_threshold: Absolute Spearman correlation cutoff
                 for treating a cluster as an eddy (vs a thread-like
                 progression). Defaults to ``0.3``.
+            split_policy: Size ceiling and re-clustering budget. Defaults
+                to :class:`~creek.link.cluster_limits.SplitPolicy`'s own
+                defaults, whose absolute floor of 500 members keeps the
+                guardrail inert on ordinary corpora.
+            split_eps_step: Amount ``eps`` is tightened by on each
+                re-clustering round. Defaults to ``0.05``.
+            segmentation: Message-stream segmentation settings. Defaults
+                to :class:`creek.config.LinkingConfig`'s own defaults, so
+                a bare detector segments Discord and email exactly as the
+                configured pipeline does.
         """
         self.embeddings: dict[str, list[float]] = embeddings or {}
         self.eps = eps
         self.min_samples = min_samples
         self.correlation_threshold = correlation_threshold
+        self.split_policy = split_policy or SplitPolicy()
+        self.split_eps_step = split_eps_step
+        self.segmentation: SegmentationConfig = segmentation or LinkingConfig()
         self._eddy_members: dict[str, list[str]] = {}
+        self._clusters_split = 0
+        self._oversized_discarded = 0
+
+    @classmethod
+    def from_linking_config(
+        cls,
+        embeddings: dict[str, list[float]] | None,
+        config: LinkingConfig,
+    ) -> EddyDetector:
+        """Build a detector wired to the vault's linking configuration.
+
+        The single construction path for both orchestrators
+        (:mod:`creek.link.link_engine` and :mod:`creek.link.linker`), so the
+        same vault cannot cluster differently depending on which one ran.
+
+        Args:
+            embeddings: Mapping of fragment ID to embedding vector.
+            config: The vault's ``linking`` configuration section.
+
+        Returns:
+            A detector using every configured threshold.
+        """
+        return cls(
+            embeddings=embeddings,
+            eps=config.eddy_eps,
+            min_samples=config.eddy_min_samples,
+            correlation_threshold=config.eddy_correlation_threshold,
+            split_policy=SplitPolicy.from_linking_config(config),
+            split_eps_step=config.eddy_split_eps_step,
+            segmentation=config,
+        )
 
     @property
     def eddy_members(self) -> dict[str, list[str]]:
@@ -388,6 +340,28 @@ class EddyDetector:
         """
         return self._eddy_members.copy()
 
+    @property
+    def clusters_split(self) -> int:
+        """Clusters that exceeded the ceiling and were re-clustered.
+
+        Returns:
+            The count from the most recent :meth:`detect_eddies` call.
+        """
+        return self._clusters_split
+
+    @property
+    def oversized_discarded(self) -> int:
+        """Fragments dropped to noise because their cluster would not split.
+
+        Non-zero means those fragments carry no ``eddies:`` link at all —
+        the deliberate cost of refusing to emit an unusable mega-page, and
+        a number an operator should see.
+
+        Returns:
+            The count from the most recent :meth:`detect_eddies` call.
+        """
+        return self._oversized_discarded
+
     def detect_eddies(
         self,
         fragments: list[Fragment],
@@ -395,7 +369,8 @@ class EddyDetector:
     ) -> list[Eddy]:
         """Detect eddies across *fragments*.
 
-        Runs DBSCAN on fragment embeddings, then filters clusters that
+        Partitions the corpus into clustering domains, runs DBSCAN within
+        each, bounds any oversized cluster, then filters clusters that
         exhibit thread-like temporal progression. Each qualifying
         cluster of at least ``min_fragments`` fragments becomes an
         :class:`~creek.models.Eddy`.
@@ -408,7 +383,7 @@ class EddyDetector:
 
         Returns:
             A list of detected :class:`~creek.models.Eddy` objects
-            sorted by ``formed`` date ascending.
+            sorted by ``formed`` date ascending, with unique titles.
         """
         logger.info(
             "Detecting eddies among %d fragment(s) with eps=%.2f, min_samples=%d",
@@ -417,19 +392,115 @@ class EddyDetector:
             self.min_samples,
         )
         self._eddy_members = {}
+        self._clusters_split = 0
+        self._oversized_discarded = 0
         frag_by_id = {f.id: f for f in fragments if f.id in self.embeddings}
         if len(frag_by_id) < min_fragments:
             logger.info("Detected 0 eddies (insufficient embedded fragments)")
             return []
 
-        ids = list(frag_by_id.keys())
-        clusters = self._dbscan(ids)
-        eddies = self._materialise_eddies(clusters, frag_by_id, min_fragments)
+        corpus = list(frag_by_id.values())
+        context = _NamingContext(
+            document_frequency=naming.document_frequency(corpus),
+            corpus_size=len(corpus),
+            ceiling=self.split_policy.ceiling_for(len(corpus)),
+        )
+        eddies: list[Eddy] = []
+        for domain in partition(corpus, config=self.segmentation):
+            eddies.extend(self._detect_in_domain(domain, min_fragments, context))
+        _apply_unique_titles(eddies)
         eddies.sort(key=lambda e: e.formed)
-        logger.info("Detected %d eddies", len(eddies))
+        logger.info(
+            "Detected %d eddies (%d cluster(s) split, %d fragment(s) discarded)",
+            len(eddies),
+            self._clusters_split,
+            self._oversized_discarded,
+        )
         return eddies
 
-    def _dbscan(self, ids: list[str]) -> list[list[str]]:
+    def _detect_in_domain(
+        self,
+        domain: list[Fragment],
+        min_fragments: int,
+        context: _NamingContext,
+    ) -> list[Eddy]:
+        """Detect the eddies of one clustering domain.
+
+        Args:
+            domain: Fragments of a single domain — one conversation
+                episode, or the shared non-stream domain.
+            min_fragments: Minimum cluster size required to emit an eddy.
+            context: Corpus-wide naming and ceiling facts.
+
+        Returns:
+            The eddies found within *domain*.
+        """
+        frag_by_id = {f.id: f for f in domain}
+        clusters = self._bounded_clusters(
+            list(frag_by_id),
+            min_fragments,
+            context,
+            naming.structural_label(domain),
+        )
+        return self._materialise_eddies(clusters, frag_by_id, context)
+
+    def _bounded_clusters(
+        self,
+        ids: list[str],
+        min_fragments: int,
+        context: _NamingContext,
+        domain: str,
+    ) -> list[list[str]]:
+        """Cluster *ids*, splitting anything above the configured ceiling.
+
+        Splitting happens strictly *outside* :meth:`_dbscan`: it only ever
+        re-partitions a membership list DBSCAN has already produced, and it
+        passes the tightened epsilon as an argument rather than mutating
+        :attr:`eps`. The #790 brute-force-equivalence contract, which pins
+        raw ``_dbscan`` output, is therefore untouched.
+
+        Args:
+            ids: Fragment IDs of one domain (all have embeddings).
+            min_fragments: Minimum cluster size worth keeping.
+            context: Corpus-wide naming and ceiling facts.
+            domain: Human-readable domain name, used in discard warnings.
+
+        Returns:
+            Cluster memberships, none larger than ``context.ceiling``.
+        """
+        bounded: list[list[str]] = []
+        for members in self._dbscan(ids):
+            if len(members) < min_fragments:
+                continue
+            if len(members) <= context.ceiling:
+                bounded.append(members)
+                continue
+            self._clusters_split += 1
+            result = split_oversized(
+                members,
+                ceiling=context.ceiling,
+                policy=self.split_policy,
+                recluster=self._recluster,
+                tightening=Tightening.for_eddy_eps(self.eps, self.split_eps_step),
+                domain=domain,
+            )
+            self._oversized_discarded += len(result.discarded)
+            bounded.extend(sub for sub in result.accepted if len(sub) >= min_fragments)
+        return bounded
+
+    def _recluster(self, members: Sequence[str], eps: float) -> list[list[str]]:
+        """Re-run DBSCAN over *members* at a tightened epsilon.
+
+        Args:
+            members: Membership of one oversized cluster.
+            eps: Tightened cosine-distance radius for this round only.
+
+        Returns:
+            The subclusters found; noise points are simply absent.
+        """
+        return self._dbscan(list(members), eps=eps)
+
+    def _dbscan(self, ids: list[str], *, eps: float | None = None) -> list[list[str]]:
         """Run DBSCAN over the provided fragment IDs.
 
         Uses cosine distance against :attr:`embeddings` with parameters
@@ -441,11 +512,16 @@ class EddyDetector:
 
         Args:
             ids: Fragment IDs to cluster (all must have embeddings).
+            eps: Per-call radius override used by the splitter's
+                re-clustering rounds. ``None`` (the default) uses
+                :attr:`eps`. The override never mutates detector state, so
+                concurrent rounds cannot leak parameters into each other.
 
         Returns:
             A list of clusters, each a list of fragment IDs. Noise
             points are excluded.
         """
+        radius = self.eps if eps is None else eps
         n = len(ids)
         labels = [_UNVISITED] * n
         # Vectorised neighbour discovery (issue #790): a fragment's neighbours
@@ -453,7 +529,7 @@ class EddyDetector:
         # <= eps), computed in memory-bounded blocks rather than an O(N²)
         # pure-Python loop. Clusters are identical to the exhaustive path.
         vectors = [self.embeddings[fid] for fid in ids]
-        neighbour_cache = cosine_neighbours(vectors, 1.0 - self.eps)
+        neighbour_cache = cosine_neighbours(vectors, 1.0 - radius)
         cluster_id = 0
         for i in range(n):
             if labels[i] != _UNVISITED:
@@ -515,34 +591,33 @@ class EddyDetector:
         self,
         clusters: list[list[str]],
         frag_by_id: dict[str, Fragment],
-        min_fragments: int,
+        context: _NamingContext,
     ) -> list[Eddy]:
-        """Convert DBSCAN clusters into :class:`Eddy` objects.
+        """Convert bounded clusters into :class:`Eddy` objects.
 
-        Filters out clusters below *min_fragments* and clusters with
-        thread-like temporal progression (|Spearman| at or above
-        :attr:`correlation_threshold`). Side effect: populates
+        Filters out clusters with thread-like temporal progression
+        (|Spearman| at or above :attr:`correlation_threshold`). The
+        minimum-size floor has already been applied by
+        :meth:`_bounded_clusters`. Side effect: adds to
         :attr:`_eddy_members`.
 
         Args:
-            clusters: DBSCAN cluster memberships as lists of IDs.
-            frag_by_id: Fragment lookup table.
-            min_fragments: Minimum cluster size to keep.
+            clusters: Cluster memberships as lists of IDs.
+            frag_by_id: Fragment lookup table for this domain.
+            context: Corpus-wide naming facts.
 
         Returns:
             Constructed eddies for every qualifying cluster.
         """
         eddies: list[Eddy] = []
         for members in clusters:
-            if len(members) < min_fragments:
-                continue
             cluster_frags = sorted(
                 (frag_by_id[fid] for fid in members),
                 key=effective_authored_at,
             )
             if self._has_temporal_direction(cluster_frags):
                 continue
-            eddy = self._build_eddy(cluster_frags)
+            eddy = self._build_eddy(cluster_frags, context)
             eddies.append(eddy)
             self._eddy_members[eddy.id] = [f.id for f in cluster_frags]
         return eddies
@@ -572,44 +647,63 @@ class EddyDetector:
         correlation = _spearman_with_time(drifts)
         return abs(correlation) >= self.correlation_threshold
 
-    def _build_eddy(self, frags: list[Fragment]) -> Eddy:
+    @staticmethod
+    def _build_eddy(frags: list[Fragment], context: _NamingContext) -> Eddy:
         """Construct an :class:`Eddy` from its constituent fragments.
 
         Args:
             frags: Fragments belonging to the cluster, chronologically
                 sorted (non-empty).
+            context: Corpus-wide naming facts.
 
         Returns:
-            A populated :class:`~creek.models.Eddy`.
+            A populated :class:`~creek.models.Eddy`, including a
+            never-empty ``description`` — historically omitted here, which
+            is why generated pages shipped ``description: ''``.
         """
         return Eddy(
-            title=self._generate_title(frags),
+            id=_stable_eddy_id(frags),
+            title=EddyDetector._generate_title(frags, context),
             formed=_median_date(frags),
             fragment_count=len(frags),
-            threads=self._flowing_threads(frags),
+            threads=EddyDetector._flowing_threads(frags),
+            description=naming.cluster_description(
+                frags,
+                context.document_frequency,
+                context.corpus_size,
+            ),
         )
 
-    def _generate_title(self, frags: list[Fragment]) -> str:
-        """Generate a title from the cluster's distinctive content words.
+    @staticmethod
+    def _generate_title(frags: list[Fragment], context: _NamingContext) -> str:
+        """Generate a title for the cluster.
 
-        Uses TF-IDF-lite: content-word frequency inside the cluster
-        scaled by inverse document frequency across :attr:`embeddings`
-        (using fragment titles only when fragment objects are
-        available — falls back to raw counts when the corpus is small).
+        Delegates to :func:`creek.link.naming.cluster_title`, which applies
+        the inverse document frequency this method's docstring used to
+        claim and never implemented: a term carried by most of the corpus
+        — ``messages``, on a Discord-heavy vault — can no longer become a
+        topic label, and a cluster left with no surviving term is named
+        from its structure (dominant channel plus date span) instead.
+
+        A cluster whose member titles contain *no content words at all*
+        (pure punctuation, single letters) is a different case: there is
+        nothing for IDF to suppress, so the historical fallback to the
+        earliest member's own title is kept.
 
         Args:
             frags: Fragments in the cluster (non-empty).
+            context: Corpus-wide naming facts.
 
         Returns:
-            A short title string.
+            A short, non-empty title string.
         """
-        counts: Counter[str] = Counter()
-        for frag in frags:
-            counts.update(_content_words(frag.title))
-        if not counts:
-            return frags[0].title[:50] if frags else "Untitled Eddy"
-        top = [word for word, _ in counts.most_common(_TITLE_TOP_WORDS)]
-        return " ".join(word.capitalize() for word in top)
+        if not any(naming.content_words(f.title) for f in frags):
+            return frags[0].title[:_MAX_FALLBACK_TITLE_LEN]
+        return naming.cluster_title(
+            frags,
+            context.document_frequency,
+            context.corpus_size,
+        )
 
     @staticmethod
     def _flowing_threads(frags: list[Fragment]) -> list[str]:

--- a/creek-tools/creek/link/link_engine.py
+++ b/creek-tools/creek/link/link_engine.py
@@ -96,6 +96,17 @@ class LinkSummary:
             ``02-Threads/{status}/`` by the materialisation step. Equal to
             ``threads_detected`` when every write succeeds; smaller when a
             write fails. Only populated for ``method == "threads"``.
+        largest_cluster_fragments: Member count of the biggest eddy or
+            thread emitted. The operator-visible proof that no cluster
+            swallowed the vault (issue #880); ``0`` when nothing was
+            detected.
+        clusters_split: Clusters that exceeded the configured ceiling and
+            were re-clustered at a tighter parameter.
+        oversized_discarded: Fragments dropped to noise because their
+            cluster stayed above the ceiling even after the split budget
+            was spent. Those fragments carry no ``eddies:``/``threads:``
+            link at all, so a non-zero value is worth an operator's
+            attention.
     """
 
     method: str
@@ -107,6 +118,9 @@ class LinkSummary:
     member_fragments_updated: int = 0
     threads_detected: int = 0
     threads_written: int = 0
+    largest_cluster_fragments: int = 0
+    clusters_split: int = 0
+    oversized_discarded: int = 0
 
 
 def run_link(
@@ -221,7 +235,7 @@ def _run_threads(
         config=config,
         cache_path=cache_path,
     )
-    detector = ThreadDetector(embeddings=embeddings)
+    detector = ThreadDetector.from_linking_config(embeddings, config.linking)
     threads = detector.detect_threads(
         fragments,
         min_fragments=config.linking.thread_min_fragments,
@@ -232,6 +246,8 @@ def _run_threads(
             method="threads",
             fragment_count=len(fragments),
             link_count=0,
+            clusters_split=detector.clusters_split,
+            oversized_discarded=detector.oversized_discarded,
         )
 
     updated_fragments = detector.assign_fragments_to_threads(fragments, threads)
@@ -255,6 +271,9 @@ def _run_threads(
         threads_detected=len(threads),
         threads_written=len(written_paths),
         member_fragments_updated=fragments_updated,
+        largest_cluster_fragments=_largest_cluster(detector.thread_members),
+        clusters_split=detector.clusters_split,
+        oversized_discarded=detector.oversized_discarded,
     )
 
 
@@ -303,7 +322,7 @@ def _run_eddies(
         config=config,
         cache_path=cache_path,
     )
-    detector = EddyDetector(embeddings=embeddings)
+    detector = EddyDetector.from_linking_config(embeddings, config.linking)
     eddies = detector.detect_eddies(
         fragments,
         min_fragments=config.linking.eddy_min_fragments,
@@ -314,6 +333,8 @@ def _run_eddies(
             method="eddies",
             fragment_count=len(fragments),
             link_count=0,
+            clusters_split=detector.clusters_split,
+            oversized_discarded=detector.oversized_discarded,
         )
 
     updated_fragments = detector.assign_fragments_to_eddies(fragments, eddies)
@@ -337,7 +358,24 @@ def _run_eddies(
         eddies_detected=len(eddies),
         eddies_written=len(written_paths),
         member_fragments_updated=fragments_updated,
+        largest_cluster_fragments=_largest_cluster(detector.eddy_members),
+        clusters_split=detector.clusters_split,
+        oversized_discarded=detector.oversized_discarded,
     )
+
+
+def _largest_cluster(members_by_id: dict[str, list[str]]) -> int:
+    """Return the member count of the biggest cluster in a membership map.
+
+    Args:
+        members_by_id: Cluster ID to member fragment IDs, as exposed by
+            :attr:`EddyDetector.eddy_members` /
+            :attr:`ThreadDetector.thread_members`.
+
+    Returns:
+        The largest membership size, or ``0`` when nothing was detected.
+    """
+    return max((len(members) for members in members_by_id.values()), default=0)
 
 
 def _materialise_link_models(

--- a/creek-tools/creek/link/linker.py
+++ b/creek-tools/creek/link/linker.py
@@ -101,16 +101,26 @@ class LinkingPipeline:
             window_hours=self.linking_config.temporal_window_hours,
         )
 
-        # Stage 3: Thread detection (uses embeddings for semantic clustering)
-        thread_detector = ThreadDetector(embeddings=embeddings)
+        # Stage 3: Thread detection (uses embeddings for semantic clustering).
+        # Issue #880: build through ``from_linking_config`` so this pipeline
+        # and ``creek.link.link_engine`` cannot cluster the same vault
+        # differently — every threshold comes from the same config section.
+        thread_detector = ThreadDetector.from_linking_config(
+            embeddings,
+            self.linking_config,
+        )
         threads = thread_detector.detect_threads(
             fragments,
             min_fragments=self.linking_config.thread_min_fragments,
         )
         fragments = thread_detector.assign_fragments_to_threads(fragments, threads)
 
-        # Stage 4: Eddy detection (uses embeddings for density clustering)
-        eddy_detector = EddyDetector(embeddings=embeddings)
+        # Stage 4: Eddy detection (uses embeddings for density clustering).
+        # Issue #880: same single construction path as stage 3.
+        eddy_detector = EddyDetector.from_linking_config(
+            embeddings,
+            self.linking_config,
+        )
         eddies = eddy_detector.detect_eddies(
             fragments,
             min_fragments=self.linking_config.eddy_min_fragments,

--- a/creek-tools/creek/link/naming.py
+++ b/creek-tools/creek/link/naming.py
@@ -1,0 +1,654 @@
+"""Cluster naming for the linker — titles, descriptions, and uniqueness.
+
+Both detectors (:mod:`creek.link.eddies` and :mod:`creek.link.threads`)
+need the same thing once they have a set of member fragments: a short
+human-readable name, a one-line description, and a guarantee that the
+name does not collide with another cluster from the same run. This
+module is the single home for that logic, and for the small text
+helpers the two detectors previously carried in duplicate.
+
+Why it exists as its own module
+-------------------------------
+
+The naive implementation — a :class:`collections.Counter` over member
+fragment titles, take the three most common words — has a failure mode
+that is invisible on a small corpus and catastrophic on a large one.
+A :class:`~creek.models.Fragment` carries no body or content field, so
+its ``title`` is the *only* text the linker ever sees. When an ingestor
+does not supply a title the vault falls back to the source filename, and
+a whole platform's worth of fragments can therefore share one identical,
+meaningless title. Raw frequency then hands that word to every cluster
+in the corpus.
+
+Three properties make that impossible here:
+
+*Inverse document frequency.* :func:`distinctive_terms` scores a term by
+``tf * log(corpus_size / (1 + df))`` and hard-drops any term whose
+document frequency reaches :attr:`NamingPolicy.ubiquity_floor`. A word
+carried by most of the corpus carries no information about which cluster
+it is in, so it can never become a title. IDF is deliberately *not*
+applied below :attr:`NamingPolicy.min_idf_corpus` documents: document
+frequency over a handful of documents is noise rather than evidence, and
+a two-cluster corpus puts every legitimate topic word at ``df/n == 0.5``
+through no fault of its own.
+
+*A structural fallback.* Suppression can leave a cluster with no text at
+all — which is exactly what happens to a stream of identically-titled
+messages. :func:`structural_label` then names the cluster from what is
+still distinctive about it: the dominant source identity (channel,
+conversation, or interlocutor, falling back to the platform) plus the
+date span its members cover.
+
+*Uniqueness.* :func:`disambiguate` separates titles that would otherwise
+collide, because the eddy assigner interpolates a title straight into a
+``[[...]]`` wiki-link; two clusters sharing a name means every member
+fragment links to whichever page resolves first.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from creek.time import effective_authored_date
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping, Sequence
+    from datetime import date
+
+    from creek.models import Fragment
+
+TITLE_TOP_WORDS = 3
+MIN_TITLE_WORD_LEN = 3
+
+#: Document-frequency ratio at (or above) which a term is discarded as
+#: uninformative. Inclusive: a term in exactly this share of the corpus
+#: is suppressed.
+DEFAULT_UBIQUITY_FLOOR = 0.6
+
+#: Smallest corpus for which inverse document frequency is trusted.
+#: Below this, ranking falls back to raw in-cluster counts.
+DEFAULT_MIN_IDF_CORPUS = 20
+
+_UNKNOWN_SOURCE = "Unsourced"
+_UNTITLED = "Untitled"
+
+_WORD_RE = re.compile(r"[a-z]+")
+# Characters that break or make ambiguous an Obsidian ``[[wiki-link]]``.
+_WIKI_HOSTILE_RE = re.compile(r"[\[\]|#^]")
+_WHITESPACE_RE = re.compile(r"\s+")
+
+# Month names are spelled out rather than taken from ``strftime("%b")``
+# so the label is identical under every locale.
+_MONTH_ABBR = (
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+)
+
+STOPWORDS: frozenset[str] = frozenset(
+    {
+        "a",
+        "about",
+        "above",
+        "after",
+        "again",
+        "against",
+        "all",
+        "am",
+        "an",
+        "and",
+        "any",
+        "are",
+        "as",
+        "at",
+        "be",
+        "because",
+        "been",
+        "before",
+        "being",
+        "below",
+        "between",
+        "both",
+        "but",
+        "by",
+        "can",
+        "did",
+        "do",
+        "does",
+        "doing",
+        "don",
+        "down",
+        "during",
+        "each",
+        "few",
+        "for",
+        "from",
+        "further",
+        "had",
+        "has",
+        "have",
+        "having",
+        "he",
+        "her",
+        "here",
+        "hers",
+        "herself",
+        "him",
+        "himself",
+        "his",
+        "how",
+        "i",
+        "if",
+        "in",
+        "into",
+        "is",
+        "it",
+        "its",
+        "itself",
+        "just",
+        "me",
+        "more",
+        "most",
+        "my",
+        "myself",
+        "no",
+        "nor",
+        "not",
+        "now",
+        "of",
+        "off",
+        "on",
+        "once",
+        "only",
+        "or",
+        "other",
+        "our",
+        "ours",
+        "ourselves",
+        "out",
+        "over",
+        "own",
+        "s",
+        "same",
+        "she",
+        "should",
+        "so",
+        "some",
+        "such",
+        "t",
+        "than",
+        "that",
+        "the",
+        "their",
+        "theirs",
+        "them",
+        "themselves",
+        "then",
+        "there",
+        "these",
+        "they",
+        "this",
+        "those",
+        "through",
+        "to",
+        "too",
+        "under",
+        "until",
+        "up",
+        "very",
+        "was",
+        "we",
+        "were",
+        "what",
+        "when",
+        "where",
+        "which",
+        "while",
+        "who",
+        "whom",
+        "why",
+        "will",
+        "with",
+        "you",
+        "your",
+        "yours",
+        "yourself",
+        "yourselves",
+    },
+)
+
+
+@dataclass(frozen=True)
+class NamingPolicy:
+    """Tunable knobs for cluster naming.
+
+    Attributes:
+        ubiquity_floor: Document-frequency ratio at or above which a
+            term is discarded outright. ``0.6`` means "a term carried by
+            60% or more of the corpus tells us nothing about which
+            cluster we are looking at". The comparison is inclusive, so
+            a term sitting exactly on the floor is suppressed.
+        min_idf_corpus: Smallest corpus size for which inverse document
+            frequency is applied at all. Below it, terms are ranked by
+            raw in-cluster frequency and nothing is suppressed — document
+            frequency over a dozen documents is noise, and a two-cluster
+            corpus necessarily puts each cluster's own topic word at
+            ``df / corpus_size == 0.5``.
+        title_terms: Maximum number of distinctive terms to compose a
+            title from.
+    """
+
+    ubiquity_floor: float = DEFAULT_UBIQUITY_FLOOR
+    min_idf_corpus: int = DEFAULT_MIN_IDF_CORPUS
+    title_terms: int = TITLE_TOP_WORDS
+
+
+#: The policy used when a caller does not supply one.
+DEFAULT_NAMING_POLICY = NamingPolicy()
+
+
+# ---- Text helpers ----
+
+
+def tokenize(text: str) -> list[str]:
+    """Tokenise *text* into lowercase alphabetic words.
+
+    Args:
+        text: Input string to tokenise.
+
+    Returns:
+        A list of lowercase word tokens (no punctuation, no digits).
+    """
+    return _WORD_RE.findall(text.lower())
+
+
+def content_words(text: str) -> list[str]:
+    """Extract content words from *text* (no stopwords, length-filtered).
+
+    Args:
+        text: Input string.
+
+    Returns:
+        A list of lowercase content words suitable for title heuristics.
+    """
+    return [
+        w for w in tokenize(text) if w not in STOPWORDS and len(w) >= MIN_TITLE_WORD_LEN
+    ]
+
+
+def cosine(a: Sequence[float], b: Sequence[float]) -> float:
+    """Compute cosine similarity between two equal-length vectors.
+
+    Args:
+        a: First vector.
+        b: Second vector.
+
+    Returns:
+        Cosine similarity in ``[-1.0, 1.0]``; ``0.0`` if either vector
+        has zero norm.
+    """
+    import numpy as np  # lazy: numpy lives in the [embeddings] extra
+
+    va = np.asarray(a, dtype=np.float32)
+    vb = np.asarray(b, dtype=np.float32)
+    na = float(np.linalg.norm(va))
+    nb = float(np.linalg.norm(vb))
+    if 0.0 in (na, nb):
+        return 0.0
+    return float(np.dot(va, vb) / (na * nb))
+
+
+def _collapse(text: str) -> str:
+    """Collapse all whitespace runs in *text* to single spaces and strip.
+
+    Args:
+        text: Input string, possibly carrying newlines or double spaces.
+
+    Returns:
+        A single-line, single-spaced, stripped string.
+    """
+    return _WHITESPACE_RE.sub(" ", text).strip()
+
+
+def _wiki_safe(text: str) -> str:
+    """Make *text* safe to interpolate into an Obsidian ``[[wiki-link]]``.
+
+    Bracket, pipe, hash and caret characters would terminate the link,
+    turn the remainder into an alias, or address a heading/block — so
+    they are replaced with spaces rather than deleted, keeping word
+    boundaries intact.
+
+    Args:
+        text: Candidate link target.
+
+    Returns:
+        A single-line string containing none of ``[``, ``]``, ``|``,
+        ``#`` or ``^``.
+    """
+    return _collapse(_WIKI_HOSTILE_RE.sub(" ", text))
+
+
+# ---- Document frequency and distinctive terms ----
+
+
+def document_frequency(fragments: Iterable[Fragment]) -> dict[str, int]:
+    """Count how many corpus fragments carry each content word.
+
+    Document frequency, not term frequency: a word repeated three times
+    inside one title counts once. This is the corpus-wide statistic
+    :func:`distinctive_terms` needs to tell a topic word apart from a
+    word that merely happens to be everywhere.
+
+    Args:
+        fragments: The whole corpus under consideration — not just one
+            cluster. Passing a single cluster makes every one of its
+            terms look ubiquitous.
+
+    Returns:
+        A mapping of content word to the number of fragments whose title
+        contains it.
+    """
+    counts: Counter[str] = Counter()
+    for frag in fragments:
+        counts.update(set(content_words(frag.title)))
+    return dict(counts)
+
+
+def _is_ubiquitous(term_df: int, corpus_size: int, policy: NamingPolicy) -> bool:
+    """Report whether a term is carried by enough of the corpus to be useless.
+
+    Args:
+        term_df: How many corpus fragments carry the term.
+        corpus_size: Total number of corpus fragments.
+        policy: Naming policy supplying the ubiquity floor.
+
+    Returns:
+        ``True`` when ``term_df / corpus_size`` reaches
+        :attr:`NamingPolicy.ubiquity_floor`.
+    """
+    return corpus_size > 0 and term_df / corpus_size >= policy.ubiquity_floor
+
+
+def _score_terms(
+    tf: Mapping[str, int],
+    df: Mapping[str, int],
+    corpus_size: int,
+    policy: NamingPolicy,
+) -> list[tuple[float, str]]:
+    """Score each in-cluster term, dropping the corpus-ubiquitous ones.
+
+    Args:
+        tf: In-cluster term frequencies.
+        df: Corpus-wide document frequencies.
+        corpus_size: Total number of corpus fragments.
+        policy: Naming policy supplying the floor and the IDF cut-in.
+
+    Returns:
+        ``(score, term)`` pairs for every term that survived suppression.
+    """
+    apply_idf = corpus_size >= max(policy.min_idf_corpus, 1)
+    scored: list[tuple[float, str]] = []
+    for term, count in tf.items():
+        term_df = df.get(term, 0)
+        if not apply_idf:
+            scored.append((float(count), term))
+            continue
+        if _is_ubiquitous(term_df, corpus_size, policy):
+            continue
+        scored.append((count * math.log(corpus_size / (1 + term_df)), term))
+    return scored
+
+
+def distinctive_terms(
+    cluster: Sequence[Fragment],
+    df: Mapping[str, int],
+    corpus_size: int,
+    *,
+    policy: NamingPolicy = DEFAULT_NAMING_POLICY,
+) -> list[str]:
+    """Return the terms that best distinguish *cluster* from the corpus.
+
+    Implements the TF-IDF-lite the linker's docstrings have long claimed:
+    in-cluster term frequency scaled by ``log(corpus_size / (1 + df))``,
+    with a hard ubiquity cut so a term carried by most of the corpus
+    contributes nothing at all. Ties break alphabetically so a run over
+    the same corpus always produces the same title.
+
+    Args:
+        cluster: Member fragments of one cluster (may be empty).
+        df: Corpus-wide document frequencies from
+            :func:`document_frequency`.
+        corpus_size: Total number of fragments the ``df`` mapping was
+            built from.
+        policy: Naming policy. Defaults to
+            :data:`DEFAULT_NAMING_POLICY`.
+
+    Returns:
+        Up to :attr:`NamingPolicy.title_terms` lowercase terms, best
+        first. Empty when the cluster carries no content words, or when
+        every one of them is corpus-ubiquitous — which is the normal
+        outcome for a stream of identically-titled message fragments.
+    """
+    tf: Counter[str] = Counter()
+    for frag in cluster:
+        tf.update(content_words(frag.title))
+    if not tf:
+        return []
+    scored = _score_terms(tf, df, corpus_size, policy)
+    scored.sort(key=lambda pair: (-pair[0], pair[1]))
+    return [term for _, term in scored[: policy.title_terms]]
+
+
+# ---- Structural labels ----
+
+
+def _source_identity(fragment: Fragment) -> str:
+    """Return the most specific source identity available for *fragment*.
+
+    Args:
+        fragment: The fragment to describe.
+
+    Returns:
+        The channel, else the conversation id, else the interlocutor,
+        else the platform name in title case. Never empty.
+    """
+    src = fragment.source
+    for candidate in (src.channel, src.conversation_id, src.interlocutor):
+        if candidate and candidate.strip():
+            return candidate.strip()
+    return str(src.platform).replace("_", " ").title()
+
+
+def _dominant_source(cluster: Sequence[Fragment]) -> str:
+    """Return the source identity shared by most of *cluster*.
+
+    Args:
+        cluster: Member fragments (may be empty).
+
+    Returns:
+        The most common source identity, ties broken alphabetically for
+        determinism; a placeholder when the cluster is empty.
+    """
+    counts = Counter(_source_identity(f) for f in cluster)
+    if not counts:
+        return _UNKNOWN_SOURCE
+    best = max(counts.values())
+    return min(name for name, seen in counts.items() if seen == best)
+
+
+def _month_of(day: date) -> str:
+    """Return the locale-independent three-letter month name for *day*.
+
+    Args:
+        day: The date to name.
+
+    Returns:
+        A month abbreviation such as ``"Mar"``.
+    """
+    return _MONTH_ABBR[day.month - 1]
+
+
+def _date_span(cluster: Sequence[Fragment]) -> str:
+    """Describe the period *cluster* covers, at month granularity.
+
+    Buckets on :func:`creek.time.effective_authored_date` so the span
+    reflects when the content was authored rather than when Creek
+    happened to ingest it.
+
+    Args:
+        cluster: Member fragments (may be empty).
+
+    Returns:
+        ``"Mar 2023"`` for a single month, ``"Mar-Aug 2023"`` within one
+        year, ``"Mar 2023-Aug 2024"`` across years, and ``""`` for an
+        empty cluster.
+    """
+    if not cluster:
+        return ""
+    dates = [effective_authored_date(f) for f in cluster]
+    first, last = min(dates), max(dates)
+    if (first.year, first.month) == (last.year, last.month):
+        return f"{_month_of(first)} {first.year}"
+    if first.year == last.year:
+        return f"{_month_of(first)}-{_month_of(last)} {last.year}"
+    return f"{_month_of(first)} {first.year}-{_month_of(last)} {last.year}"
+
+
+def structural_label(cluster: Sequence[Fragment]) -> str:
+    """Name *cluster* from its structure when it has no usable text.
+
+    This is the only naming path available to a cluster of
+    identically-titled fragments: once IDF has suppressed the shared
+    word there is no text left, because :class:`~creek.models.Fragment`
+    stores no body. What remains distinctive is *where* the fragments
+    came from and *when* — so the label is the dominant source identity
+    plus the date span, e.g. ``"Aspiring Drag Queens, Mar 2023"``.
+
+    Args:
+        cluster: Member fragments (may be empty).
+
+    Returns:
+        A non-empty, wiki-link-safe label.
+    """
+    source = _dominant_source(cluster)
+    span = _date_span(cluster)
+    label = f"{source}, {span}" if span else source
+    return _wiki_safe(label) or _UNTITLED
+
+
+# ---- Composed titles and descriptions ----
+
+
+def cluster_title(
+    cluster: Sequence[Fragment],
+    df: Mapping[str, int],
+    corpus_size: int,
+    *,
+    policy: NamingPolicy = DEFAULT_NAMING_POLICY,
+) -> str:
+    """Return a short, non-empty, wiki-link-safe title for *cluster*.
+
+    Prefers the cluster's distinctive terms; falls back to
+    :func:`structural_label` when IDF leaves no term standing. The result
+    is not yet guaranteed unique across a run — pass the full set of
+    titles through :func:`disambiguate` for that.
+
+    Args:
+        cluster: Member fragments (may be empty).
+        df: Corpus-wide document frequencies.
+        corpus_size: Total number of corpus fragments.
+        policy: Naming policy. Defaults to
+            :data:`DEFAULT_NAMING_POLICY`.
+
+    Returns:
+        A non-empty title containing none of ``[``, ``]``, ``|``, ``#``
+        or ``^``.
+    """
+    terms = distinctive_terms(cluster, df, corpus_size, policy=policy)
+    if not terms:
+        return structural_label(cluster)
+    return _wiki_safe(" ".join(term.capitalize() for term in terms)) or _UNTITLED
+
+
+def cluster_description(
+    cluster: Sequence[Fragment],
+    df: Mapping[str, int],
+    corpus_size: int,
+    *,
+    policy: NamingPolicy = DEFAULT_NAMING_POLICY,
+) -> str:
+    """Return a one-line, never-empty description of *cluster*.
+
+    Generated eddy and thread pages historically shipped
+    ``description: ''`` because neither detector ever supplied one. The
+    line here carries what an operator needs to triage a page without
+    opening it: how many fragments, where they came from, when, and
+    which terms recur.
+
+    Args:
+        cluster: Member fragments (may be empty).
+        df: Corpus-wide document frequencies.
+        corpus_size: Total number of corpus fragments.
+        policy: Naming policy. Defaults to
+            :data:`DEFAULT_NAMING_POLICY`.
+
+    Returns:
+        A single-line, non-empty sentence safe to serialise as a YAML
+        frontmatter scalar.
+    """
+    count = len(cluster)
+    noun = "fragment" if count == 1 else "fragments"
+    head = f"{count} {noun} from {_dominant_source(cluster)}"
+    span = _date_span(cluster)
+    if span:
+        head = f"{head}, {span}"
+    terms = distinctive_terms(cluster, df, corpus_size, policy=policy)
+    tail = f"; recurring terms: {', '.join(terms)}" if terms else ""
+    return _collapse(f"{head}{tail}.")
+
+
+def disambiguate(titles: Sequence[str]) -> list[str]:
+    """Make *titles* unique within one detection run, preserving order.
+
+    The first claimant of a title keeps it bare; every later collision
+    gains a ``" (n)"`` suffix, incrementing until the result is free —
+    so a title that already looks like a suffixed one cannot be
+    duplicated. The suffix survives
+    :func:`creek.vault.writer._sanitize_title`, which strips punctuation
+    but keeps the digit, so the generated page filenames stay distinct
+    too.
+
+    This matters because the eddy assigner writes ``[[<title>]]`` onto
+    every member fragment: two clusters sharing a title would send both
+    memberships to whichever page Obsidian resolved first.
+
+    Args:
+        titles: Candidate titles, in emission order.
+
+    Returns:
+        A list of the same length, in the same order, with no duplicates.
+    """
+    seen: set[str] = set()
+    result: list[str] = []
+    for title in titles:
+        candidate = title
+        suffix = 2
+        while candidate in seen:
+            candidate = f"{title} ({suffix})"
+            suffix += 1
+        seen.add(candidate)
+        result.append(candidate)
+    return result

--- a/creek-tools/creek/link/segments.py
+++ b/creek-tools/creek/link/segments.py
@@ -1,0 +1,237 @@
+"""Clustering-domain partitioning for continuous message streams.
+
+Both detectors in this package assume their input corpus has *shape*:
+:class:`~creek.link.eddies.EddyDetector` builds a single epsilon-graph
+and expands each cluster by unbounded transitive density-reachability,
+and :class:`~creek.link.threads.ThreadDetector` takes the transitive
+closure of overlapping time windows through a union-find. Both are
+correct on a corpus whose clusters are separated by low-density
+regions. A chat stream is not such a corpus. Short messages from one
+channel are semantically homogeneous and temporally continuous, so the
+epsilon-graph over them is one connected component and the sliding
+windows chain end to end — the entire stream collapses into a single
+mega-cluster whatever threshold is chosen. There is no separator to
+find, so no threshold value fixes it.
+
+This module removes the precondition violation instead of tuning around
+it. Before any similarity graph is built, the corpus is partitioned into
+independent **clustering domains**:
+
+* A fragment whose ``source.platform`` is one of the configured
+  ``stream_platforms`` belongs to a *conversation episode*, keyed on
+  ``(platform, series, episode_index)``. ``series`` is the channel, or
+  the conversation id, or the interlocutor — the first one the source
+  records. The series is then cut into episodes by an inactivity gap
+  (the primary, conversational rule: people stop talking, and that
+  silence is the real topic boundary) with a span backstop (so a
+  permanently-busy channel that never falls idle still yields
+  channel-month units rather than one multi-year blob).
+* Every other fragment — essays, journal entries, chat *transcripts*,
+  notes — lands in one shared domain, so cross-source resonance,
+  cross-platform eddies and multi-year threads over long-form material
+  keep working exactly as before. Segmentation is deliberately narrow:
+  it touches only the corpus shape that breaks the algorithms.
+
+Partitioning strictly *reduces* work. Clustering ``d`` domains of
+``n / d`` fragments each costs ``O(n^2 / d)`` in
+:func:`~creek.link.neighbours.cosine_neighbours` and in the thread
+detector's windowed inner loop, against ``O(n^2)`` for the undivided
+corpus — so it relieves the quadratic-cost pressure on large vaults
+rather than adding to it.
+
+Time-bucketing routes through :func:`creek.time.effective_authored_at`
+so episode boundaries follow source time (a Discord message's own
+timestamp) and not the wall-clock moment of a bulk ingest.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING, Final, Protocol
+
+from creek.time import effective_authored_at
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+    from creek.models import Fragment
+
+SHARED_DOMAIN_KEY: Final[str] = "shared"
+"""Domain key carrying every fragment that is not part of a message stream."""
+
+_STREAM_KEY_PREFIX: Final[str] = "stream:"
+"""Prefix distinguishing a stream episode key from :data:`SHARED_DOMAIN_KEY`."""
+
+
+class SegmentationConfig(Protocol):
+    """The linking-config attributes :func:`partition` reads.
+
+    Declared structurally so this module stays independent of the
+    settings tree: :class:`creek.config.LinkingConfig` satisfies it, and
+    so does any small stand-in a caller or test supplies.
+    """
+
+    @property
+    def stream_platforms(self) -> Sequence[str]:
+        """Platform values whose fragments are segmented into episodes."""
+
+    @property
+    def stream_episode_max_gap_hours(self) -> int:
+        """Inactivity gap that ends an episode. Inclusive boundary."""
+
+    @property
+    def stream_episode_max_span_days(self) -> int:
+        """Maximum span of a single episode. Inclusive boundary."""
+
+
+def _is_stream(fragment: Fragment, stream_platforms: Sequence[str]) -> bool:
+    """Return whether *fragment* came from a configured stream platform.
+
+    Args:
+        fragment: The fragment to test.
+        stream_platforms: Platform values treated as message streams.
+
+    Returns:
+        ``True`` when the fragment's source platform is listed.
+    """
+    return str(fragment.source.platform) in stream_platforms
+
+
+def _series_identity(fragment: Fragment) -> tuple[str, str]:
+    """Return the ``(platform, series)`` identity of a stream fragment.
+
+    The series is the first populated one of ``channel``,
+    ``conversation_id`` and ``interlocutor``; a source that records none
+    of them yields an empty series, which groups its fragments together
+    under the platform alone rather than scattering them.
+
+    Args:
+        fragment: The fragment to identify.
+
+    Returns:
+        The platform value and the series identity, both as plain strings.
+    """
+    source = fragment.source
+    series = source.channel or source.conversation_id or source.interlocutor or ""
+    return str(source.platform), series
+
+
+def domain_key(
+    fragment: Fragment,
+    *,
+    stream_platforms: Sequence[str],
+    episode_index: int = 0,
+) -> str:
+    """Return the clustering-domain key for *fragment*.
+
+    Args:
+        fragment: The fragment to key.
+        stream_platforms: Platform values treated as message streams.
+        episode_index: Zero-based position of the episode this fragment
+            belongs to within its series. Ignored for non-stream
+            fragments, which never carry an episode.
+
+    Returns:
+        :data:`SHARED_DOMAIN_KEY` for a non-stream fragment, otherwise a
+        ``stream:<platform>:<series>:<episode_index>`` key. The episode
+        index is the final component, so a series identity containing
+        ``":"`` cannot collide with another series.
+    """
+    if not _is_stream(fragment, stream_platforms):
+        return SHARED_DOMAIN_KEY
+    platform, series = _series_identity(fragment)
+    return f"{_STREAM_KEY_PREFIX}{platform}:{series}:{episode_index}"
+
+
+def _episodes(
+    ordered: Sequence[Fragment],
+    *,
+    max_gap: timedelta,
+    max_span: timedelta,
+) -> list[list[Fragment]]:
+    """Cut one time-ordered series into conversation episodes.
+
+    A new episode starts when the gap since the previous fragment
+    exceeds *max_gap* (the conversational rule), or when adding the
+    fragment would push the current episode's span past *max_span* (the
+    backstop for a channel that never falls idle). Both boundaries are
+    inclusive: a gap or span exactly equal to the limit does not cut.
+
+    Args:
+        ordered: Fragments of a single series, ascending by effective
+            authored time.
+        max_gap: Inactivity gap that ends an episode.
+        max_span: Maximum span from an episode's first fragment.
+
+    Returns:
+        The episodes, in chronological order. Empty for empty input.
+    """
+    if not ordered:
+        return []
+    episodes: list[list[Fragment]] = []
+    current: list[Fragment] = [ordered[0]]
+    started_at = effective_authored_at(ordered[0])
+    previous_at = started_at
+    for fragment in ordered[1:]:
+        authored_at = effective_authored_at(fragment)
+        if authored_at - previous_at > max_gap or authored_at - started_at > max_span:
+            episodes.append(current)
+            current = []
+            started_at = authored_at
+        current.append(fragment)
+        previous_at = authored_at
+    episodes.append(current)
+    return episodes
+
+
+def partition(
+    fragments: Iterable[Fragment],
+    *,
+    config: SegmentationConfig,
+) -> list[list[Fragment]]:
+    """Partition a corpus into independent clustering domains.
+
+    Message-platform fragments are grouped by ``(platform, series)`` and
+    cut into conversation episodes; every other fragment lands in one
+    shared domain. The result is a true partition — each input fragment
+    appears in exactly one domain, and no empty domain is emitted — so a
+    caller may cluster each domain independently and concatenate the
+    results without losing or duplicating anything.
+
+    Args:
+        fragments: The corpus. Any iterable; consumed once.
+        config: Supplies ``stream_platforms``,
+            ``stream_episode_max_gap_hours`` and
+            ``stream_episode_max_span_days``.
+
+    Returns:
+        One list of fragments per domain, ordered by domain key so the
+        result does not depend on input ordering. Stream domains are
+        ordered internally by effective authored time; the shared domain
+        preserves input order.
+    """
+    stream_platforms = tuple(config.stream_platforms)
+    shared: list[Fragment] = []
+    series: dict[tuple[str, str], list[Fragment]] = {}
+    for fragment in fragments:
+        if _is_stream(fragment, stream_platforms):
+            series.setdefault(_series_identity(fragment), []).append(fragment)
+        else:
+            shared.append(fragment)
+
+    max_gap = timedelta(hours=config.stream_episode_max_gap_hours)
+    max_span = timedelta(days=config.stream_episode_max_span_days)
+    domains: dict[str, list[Fragment]] = {}
+    if shared:
+        domains[SHARED_DOMAIN_KEY] = shared
+    for members in series.values():
+        ordered = sorted(members, key=effective_authored_at)
+        episodes = _episodes(ordered, max_gap=max_gap, max_span=max_span)
+        for index, episode in enumerate(episodes):
+            key = domain_key(
+                episode[0],
+                stream_platforms=stream_platforms,
+                episode_index=index,
+            )
+            domains[key] = episode
+    return [domains[key] for key in sorted(domains)]

--- a/creek-tools/creek/link/threads.py
+++ b/creek-tools/creek/link/threads.py
@@ -22,18 +22,25 @@ from __future__ import annotations
 
 import hashlib
 import logging
-import re
 import sys
 from collections import Counter
+from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING
 
 from tqdm import tqdm
 
+from creek.config import LinkingConfig
+from creek.link import naming
+from creek.link.cluster_limits import SplitPolicy, Tightening, split_oversized
+from creek.link.segments import partition
 from creek.models import Frequency, Thread, ThreadStatus
 from creek.time import effective_authored_at, effective_authored_date, now_la
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from creek.link.segments import SegmentationConfig
     from creek.models import Fragment
 
 logger = logging.getLogger(__name__)
@@ -44,140 +51,45 @@ _DEFAULT_MIN_FRAGMENTS = 3
 _DEFAULT_MERGE_JACCARD = 0.3
 _ACTIVE_DAYS = 30
 _DORMANT_DAYS = 180
-_TITLE_TOP_WORDS = 3
-_MIN_TITLE_WORD_LEN = 3
+_DEFAULT_SPLIT_SIMILARITY_STEP = 0.1
+_MAX_FALLBACK_TITLE_LEN = 50
+#: Below this many fragments a domain's pairing loop finishes instantly, so a
+#: progress bar for it is noise. Segmentation makes small domains the norm.
+_PROGRESS_MIN_FRAGMENTS = 500
 
-_STOPWORDS: frozenset[str] = frozenset(
-    {
-        "a",
-        "about",
-        "above",
-        "after",
-        "again",
-        "against",
-        "all",
-        "am",
-        "an",
-        "and",
-        "any",
-        "are",
-        "as",
-        "at",
-        "be",
-        "because",
-        "been",
-        "before",
-        "being",
-        "below",
-        "between",
-        "both",
-        "but",
-        "by",
-        "can",
-        "did",
-        "do",
-        "does",
-        "doing",
-        "don",
-        "down",
-        "during",
-        "each",
-        "few",
-        "for",
-        "from",
-        "further",
-        "had",
-        "has",
-        "have",
-        "having",
-        "he",
-        "her",
-        "here",
-        "hers",
-        "herself",
-        "him",
-        "himself",
-        "his",
-        "how",
-        "i",
-        "if",
-        "in",
-        "into",
-        "is",
-        "it",
-        "its",
-        "itself",
-        "just",
-        "me",
-        "more",
-        "most",
-        "my",
-        "myself",
-        "no",
-        "nor",
-        "not",
-        "now",
-        "of",
-        "off",
-        "on",
-        "once",
-        "only",
-        "or",
-        "other",
-        "our",
-        "ours",
-        "ourselves",
-        "out",
-        "over",
-        "own",
-        "s",
-        "same",
-        "she",
-        "should",
-        "so",
-        "some",
-        "such",
-        "t",
-        "than",
-        "that",
-        "the",
-        "their",
-        "theirs",
-        "them",
-        "themselves",
-        "then",
-        "there",
-        "these",
-        "they",
-        "this",
-        "those",
-        "through",
-        "to",
-        "too",
-        "under",
-        "until",
-        "up",
-        "very",
-        "was",
-        "we",
-        "were",
-        "what",
-        "when",
-        "where",
-        "which",
-        "while",
-        "who",
-        "whom",
-        "why",
-        "will",
-        "with",
-        "you",
-        "your",
-        "yours",
-        "yourself",
-        "yourselves",
-    },
-)
+
+@dataclass(frozen=True, slots=True)
+class _NamingContext:
+    """Corpus-wide facts every cluster in one run is measured against.
+
+    Attributes:
+        document_frequency: How many corpus fragments carry each title
+            content word, from :func:`creek.link.naming.document_frequency`.
+        corpus_size: Number of fragments the run considered.
+        ceiling: Largest permitted cluster size for this corpus.
+    """
+
+    document_frequency: dict[str, int]
+    corpus_size: int
+    ceiling: int
+
+
+def _apply_unique_titles(threads: list[Thread]) -> None:
+    """Make every title in one detection run unique, in place.
+
+    :meth:`ThreadDetector.assign_fragments_to_threads` writes
+    ``[[<title>]]`` onto each member fragment, so two threads sharing a
+    title would send both memberships to whichever page resolved first.
+
+    Args:
+        threads: The run's threads, in emission order.
+    """
+    for thread, title in zip(
+        threads,
+        naming.disambiguate([t.title for t in threads]),
+        strict=True,
+    ):
+        thread.title = title
 
 
 class _UnionFind:
@@ -245,56 +157,6 @@ class _UnionFind:
         return out
 
 
-def _tokenize(text: str) -> list[str]:
-    """Tokenise *text* into lowercase alphabetic words.
-
-    Args:
-        text: Input string to tokenise.
-
-    Returns:
-        A list of lowercase word tokens (no punctuation, no digits).
-    """
-    return re.findall(r"[a-z]+", text.lower())
-
-
-def _content_words(text: str) -> list[str]:
-    """Extract content words from *text* (no stopwords, length-filtered).
-
-    Args:
-        text: Input string.
-
-    Returns:
-        A list of lowercase content words suitable for title heuristics.
-    """
-    return [
-        w
-        for w in _tokenize(text)
-        if w not in _STOPWORDS and len(w) >= _MIN_TITLE_WORD_LEN
-    ]
-
-
-def _cosine(a: list[float], b: list[float]) -> float:
-    """Compute cosine similarity between two equal-length vectors.
-
-    Args:
-        a: First vector.
-        b: Second vector.
-
-    Returns:
-        Cosine similarity in ``[-1.0, 1.0]``; ``0.0`` if either vector
-        has zero norm.
-    """
-    import numpy as np  # lazy: numpy lives in the [embeddings] extra
-
-    va = np.asarray(a, dtype=np.float32)
-    vb = np.asarray(b, dtype=np.float32)
-    na = float(np.linalg.norm(va))
-    nb = float(np.linalg.norm(vb))
-    if 0.0 in (na, nb):
-        return 0.0
-    return float(np.dot(va, vb) / (na * nb))
-
-
 def _stable_thread_id(frags: list[Fragment]) -> str:
     """Return a deterministic ``thread-<8hex>`` id for a cluster of *frags*.
 
@@ -336,6 +198,14 @@ class ThreadDetector:
             semantic match.
         merge_jaccard: Title-token Jaccard similarity above which two
             threads are suggested for merging.
+        union_without_embeddings: Whether a pair missing an embedding may
+            union on frequency overlap alone on an otherwise-embedded
+            corpus (issue #880 — closed by default).
+        split_policy: Cluster-size guardrail applied to every component.
+        split_similarity_step: How much the similarity threshold tightens
+            per re-clustering round.
+        segmentation: Supplies the message-stream segmentation settings
+            consumed by :func:`creek.link.segments.partition`.
     """
 
     def __init__(
@@ -346,6 +216,10 @@ class ThreadDetector:
         similarity_threshold: float = _DEFAULT_SIMILARITY_THRESHOLD,
         merge_jaccard: float = _DEFAULT_MERGE_JACCARD,
         now: datetime | None = None,
+        union_without_embeddings: bool = False,
+        split_policy: SplitPolicy | None = None,
+        split_similarity_step: float = _DEFAULT_SPLIT_SIMILARITY_STEP,
+        segmentation: SegmentationConfig | None = None,
     ) -> None:
         """Initialise the detector.
 
@@ -361,13 +235,66 @@ class ThreadDetector:
             now: Reference "now" for status calculation; defaults to
                 :func:`creek.time.now_la` (America/Los_Angeles tz-aware).
                 Useful for deterministic tests.
+            union_without_embeddings: When ``True``, a pair whose
+                fragments lack embeddings unions on frequency overlap
+                alone even though the corpus is otherwise embedded.
+                Defaults to ``False``. A detector given *no* embeddings at
+                all still runs in frequency-only mode regardless — that is
+                the documented no-embeddings fallback, not the fail-open.
+            split_policy: Size ceiling and re-clustering budget. Defaults
+                to :class:`~creek.link.cluster_limits.SplitPolicy`'s own
+                defaults, whose absolute floor keeps it inert on ordinary
+                corpora.
+            split_similarity_step: Amount the similarity threshold is
+                raised on each re-clustering round. Defaults to ``0.1``.
+            segmentation: Message-stream segmentation settings. Defaults
+                to :class:`creek.config.LinkingConfig`'s own defaults.
         """
         self.embeddings: dict[str, list[float]] = embeddings or {}
         self.window_days = window_days
         self.similarity_threshold = similarity_threshold
         self.merge_jaccard = merge_jaccard
+        self.union_without_embeddings = union_without_embeddings
+        self.split_policy = split_policy or SplitPolicy()
+        self.split_similarity_step = split_similarity_step
+        self.segmentation: SegmentationConfig = segmentation or LinkingConfig()
         self._now = now or now_la()
         self._thread_members: dict[str, list[str]] = {}
+        self._clusters_split = 0
+        self._oversized_discarded = 0
+
+    @classmethod
+    def from_linking_config(
+        cls,
+        embeddings: dict[str, list[float]] | None,
+        config: LinkingConfig,
+        *,
+        now: datetime | None = None,
+    ) -> ThreadDetector:
+        """Build a detector wired to the vault's linking configuration.
+
+        The single construction path for both orchestrators
+        (:mod:`creek.link.link_engine` and :mod:`creek.link.linker`), so the
+        same vault cannot cluster differently depending on which one ran.
+
+        Args:
+            embeddings: Optional mapping of fragment ID to embedding vector.
+            config: The vault's ``linking`` configuration section.
+            now: Reference "now" for status calculation.
+
+        Returns:
+            A detector using every configured threshold.
+        """
+        return cls(
+            embeddings=embeddings,
+            window_days=config.thread_window_days,
+            similarity_threshold=config.thread_similarity_threshold,
+            now=now,
+            union_without_embeddings=config.thread_union_without_embeddings,
+            split_policy=SplitPolicy.from_linking_config(config),
+            split_similarity_step=config.thread_split_similarity_step,
+            segmentation=config,
+        )
 
     @property
     def thread_members(self) -> dict[str, list[str]]:
@@ -380,6 +307,26 @@ class ThreadDetector:
         """
         return self._thread_members.copy()
 
+    @property
+    def clusters_split(self) -> int:
+        """Components that exceeded the ceiling and were re-clustered.
+
+        Returns:
+            The count from the most recent :meth:`detect_threads` call.
+        """
+        return self._clusters_split
+
+    @property
+    def oversized_discarded(self) -> int:
+        """Fragments dropped to noise because their component would not split.
+
+        Non-zero means those fragments carry no ``threads:`` link at all.
+
+        Returns:
+            The count from the most recent :meth:`detect_threads` call.
+        """
+        return self._oversized_discarded
+
     def detect_threads(
         self,
         fragments: list[Fragment],
@@ -387,10 +334,18 @@ class ThreadDetector:
     ) -> list[Thread]:
         """Detect narrative threads in *fragments*.
 
-        Sorts fragments chronologically, then unions any pair within the
+        Partitions the corpus into clustering domains, and within each
+        sorts fragments chronologically and unions any pair inside the
         configured sliding window that is topic consistent. Connected
         components with at least *min_fragments* members become
         :class:`~creek.models.Thread` instances.
+
+        Partitioning is what stops seven years of continuous chat chaining
+        into one component (issue #880): the 30-day window bounds *pairing*
+        only, while :meth:`_UnionFind.union` is unbounded, so overlapping
+        windows previously took the transitive closure across the entire
+        corpus. Union-find is disjoint per domain, so merging the per-domain
+        results is a plain concatenation.
 
         Args:
             fragments: Fragments to scan for thread patterns.
@@ -399,7 +354,7 @@ class ThreadDetector:
 
         Returns:
             A list of detected :class:`~creek.models.Thread` objects,
-            sorted by ``first_seen`` ascending.
+            sorted by ``first_seen`` ascending, with unique titles.
         """
         logger.info(
             "Detecting threads among %d fragment(s) with %d-day window",
@@ -407,20 +362,66 @@ class ThreadDetector:
             self.window_days,
         )
 
+        self._thread_members = {}
+        self._clusters_split = 0
+        self._oversized_discarded = 0
         if len(fragments) < min_fragments:
-            self._thread_members = {}
             return []
 
         sorted_frags = sorted(fragments, key=effective_authored_at)
-        frag_by_id = {f.id: f for f in sorted_frags}
-        uf = self._cluster(sorted_frags)
-        threads = self._materialise_threads(uf, frag_by_id, min_fragments)
+        context = _NamingContext(
+            document_frequency=naming.document_frequency(sorted_frags),
+            corpus_size=len(sorted_frags),
+            ceiling=self.split_policy.ceiling_for(len(sorted_frags)),
+        )
+        threads: list[Thread] = []
+        for domain in partition(sorted_frags, config=self.segmentation):
+            threads.extend(self._detect_in_domain(domain, min_fragments, context))
 
+        _apply_unique_titles(threads)
         threads.sort(key=lambda t: t.first_seen)
-        logger.info("Detected %d thread(s)", len(threads))
+        logger.info(
+            "Detected %d thread(s) (%d component(s) split, %d fragment(s) discarded)",
+            len(threads),
+            self._clusters_split,
+            self._oversized_discarded,
+        )
         return threads
 
-    def _cluster(self, sorted_frags: list[Fragment]) -> _UnionFind:
+    def _detect_in_domain(
+        self,
+        domain: list[Fragment],
+        min_fragments: int,
+        context: _NamingContext,
+    ) -> list[Thread]:
+        """Detect the threads of one clustering domain.
+
+        Args:
+            domain: Fragments of a single domain — one conversation
+                episode, or the shared non-stream domain.
+            min_fragments: Minimum cluster size required to emit a thread.
+            context: Corpus-wide naming and ceiling facts.
+
+        Returns:
+            The threads found within *domain*.
+        """
+        ordered = sorted(domain, key=effective_authored_at)
+        frag_by_id = {f.id: f for f in ordered}
+        components = self._bounded_components(
+            self._cluster(ordered),
+            frag_by_id,
+            min_fragments=min_fragments,
+            ceiling=context.ceiling,
+            domain=naming.structural_label(ordered),
+        )
+        return self._materialise_threads(components, frag_by_id, context)
+
+    def _cluster(
+        self,
+        sorted_frags: list[Fragment],
+        *,
+        similarity_threshold: float | None = None,
+    ) -> _UnionFind:
         """Walk the sliding window, unioning topic-consistent pairs.
 
         Args:
@@ -429,82 +430,174 @@ class ThreadDetector:
                 (FEAT-031). Window comparisons use the same helper so
                 a multi-year corpus ingested in one batch does not
                 collapse into a single window.
+            similarity_threshold: Per-call override used by the splitter's
+                re-clustering rounds. ``None`` (the default) uses
+                :attr:`similarity_threshold`. The override never mutates
+                detector state.
 
         Returns:
             A populated :class:`_UnionFind` covering every fragment ID.
         """
+        threshold = (
+            self.similarity_threshold
+            if similarity_threshold is None
+            else similarity_threshold
+        )
         uf = _UnionFind()
         for frag in sorted_frags:
             uf.add(frag.id)
 
         window = timedelta(days=self.window_days)
         # OPS-004: outer loop drives the wall-time on a 10k-vault link
-        # rebuild. tqdm in TTYs, silent elsewhere.
+        # rebuild. tqdm in TTYs, silent elsewhere — and silent for the small
+        # domains segmentation now produces, which finish instantly.
         outer = tqdm(
             enumerate(sorted_frags),
             total=len(sorted_frags),
             desc="Threads",
             unit="frag",
-            disable=not sys.stderr.isatty(),
+            disable=not sys.stderr.isatty()
+            or len(sorted_frags) < _PROGRESS_MIN_FRAGMENTS,
         )
         for i, frag_a in outer:
             anchor_at = effective_authored_at(frag_a)
             for frag_b in sorted_frags[i + 1 :]:
                 if effective_authored_at(frag_b) - anchor_at > window:
                     break
-                if self._topic_consistent(frag_a, frag_b):
+                if self._topic_consistent(frag_a, frag_b, threshold):
                     uf.union(frag_a.id, frag_b.id)
         return uf
 
-    def _materialise_threads(
+    def _bounded_components(
         self,
         uf: _UnionFind,
         frag_by_id: dict[str, Fragment],
+        *,
         min_fragments: int,
-    ) -> list[Thread]:
-        """Convert union-find groups into :class:`Thread` objects.
+        ceiling: int,
+        domain: str,
+    ) -> list[list[str]]:
+        """Return the domain's components, splitting any above the ceiling.
+
+        Splitting happens strictly outside :meth:`_cluster`: it only ever
+        re-partitions a membership list already produced, and it passes the
+        tightened threshold as an argument rather than mutating
+        :attr:`similarity_threshold`.
 
         Args:
-            uf: Union-find with one node per fragment.
-            frag_by_id: Fragment lookup table.
-            min_fragments: Minimum cluster size to keep.
+            uf: Union-find produced by :meth:`_cluster` for this domain.
+            frag_by_id: Fragment lookup table for this domain.
+            min_fragments: Minimum component size worth keeping.
+            ceiling: Largest permitted component size for this corpus.
+            domain: Human-readable domain name, used in discard warnings.
 
         Returns:
-            The list of threads built from qualifying clusters. Side
-            effect: populates :attr:`_thread_members`.
+            Component memberships, none larger than *ceiling*.
         """
-        self._thread_members = {}
-        threads: list[Thread] = []
+
+        def recluster(members: Sequence[str], threshold: float) -> list[list[str]]:
+            """Re-cluster *members* at a tightened similarity threshold.
+
+            Args:
+                members: Membership of one oversized component.
+                threshold: Tightened cosine floor for this round only.
+
+            Returns:
+                The subcomponents found, including singletons.
+            """
+            subset = sorted(
+                (frag_by_id[fid] for fid in members),
+                key=effective_authored_at,
+            )
+            groups = self._cluster(subset, similarity_threshold=threshold)
+            return list(groups.groups().values())
+
+        bounded: list[list[str]] = []
         for member_ids in uf.groups().values():
             if len(member_ids) < min_fragments:
                 continue
+            if len(member_ids) <= ceiling:
+                bounded.append(member_ids)
+                continue
+            self._clusters_split += 1
+            result = split_oversized(
+                member_ids,
+                ceiling=ceiling,
+                policy=self.split_policy,
+                recluster=recluster,
+                tightening=Tightening.for_thread_similarity(
+                    self.similarity_threshold,
+                    self.split_similarity_step,
+                ),
+                domain=domain,
+            )
+            self._oversized_discarded += len(result.discarded)
+            bounded.extend(sub for sub in result.accepted if len(sub) >= min_fragments)
+        return bounded
+
+    def _materialise_threads(
+        self,
+        components: list[list[str]],
+        frag_by_id: dict[str, Fragment],
+        context: _NamingContext,
+    ) -> list[Thread]:
+        """Convert bounded components into :class:`Thread` objects.
+
+        The minimum-size floor has already been applied by
+        :meth:`_bounded_components`.
+
+        Args:
+            components: Component memberships as lists of IDs.
+            frag_by_id: Fragment lookup table for this domain.
+            context: Corpus-wide naming facts.
+
+        Returns:
+            The list of threads built from qualifying components. Side
+            effect: adds to :attr:`_thread_members`.
+        """
+        threads: list[Thread] = []
+        for member_ids in components:
             cluster = sorted(
                 (frag_by_id[fid] for fid in member_ids),
                 key=effective_authored_at,
             )
-            thread = self._build_thread(cluster)
+            thread = self._build_thread(cluster, context)
             threads.append(thread)
             self._thread_members[thread.id] = [f.id for f in cluster]
         return threads
 
-    def _topic_consistent(self, a: Fragment, b: Fragment) -> bool:
+    def _topic_consistent(
+        self,
+        a: Fragment,
+        b: Fragment,
+        similarity_threshold: float,
+    ) -> bool:
         """Return whether *a* and *b* should be grouped into one thread.
+
+        The missing-embedding case is explicit rather than permissive
+        (issue #880). A detector holding no embeddings at all is in the
+        documented frequency-only mode and still unions. A detector that
+        *does* hold embeddings but is missing one for this pair — a
+        partially-embedded vault — refuses to union unless
+        :attr:`union_without_embeddings` says otherwise, because the old
+        fail-open chained far more aggressively than the similarity gate
+        it was standing in for.
 
         Args:
             a: First fragment.
             b: Second fragment.
+            similarity_threshold: Cosine floor a pair must strictly exceed.
 
         Returns:
-            ``True`` if frequencies overlap and (when embeddings are
-            present) cosine similarity exceeds the configured threshold.
+            ``True`` if the pair belongs in one thread.
         """
         if not self._frequency_overlap(a, b):
             return False
         emb_a = self.embeddings.get(a.id)
         emb_b = self.embeddings.get(b.id)
         if emb_a is None or emb_b is None:
-            return True
-        return _cosine(emb_a, emb_b) > self.similarity_threshold
+            return not self.embeddings or self.union_without_embeddings
+        return naming.cosine(emb_a, emb_b) > similarity_threshold
 
     @staticmethod
     def _frequency_overlap(a: Fragment, b: Fragment) -> bool:
@@ -532,14 +625,17 @@ class ThreadDetector:
         sec_b.discard(unclassified)
         return bool(sec_a & sec_b)
 
-    def _build_thread(self, frags: list[Fragment]) -> Thread:
+    def _build_thread(self, frags: list[Fragment], context: _NamingContext) -> Thread:
         """Construct a :class:`Thread` from its constituent fragments.
 
         Args:
             frags: Fragments belonging to the cluster (non-empty).
+            context: Corpus-wide naming facts.
 
         Returns:
-            A populated :class:`~creek.models.Thread`.
+            A populated :class:`~creek.models.Thread`, including a
+            never-empty ``description`` — historically omitted here, which
+            is why generated pages shipped ``description: ''``.
         """
         # FEAT-031: bucket on the authored-date precedence so a multi-
         # year corpus ingested in one batch surfaces honest first/last
@@ -548,12 +644,17 @@ class ThreadDetector:
         last_seen = max(effective_authored_date(f) for f in frags)
         return Thread(
             id=_stable_thread_id(frags),
-            title=self._generate_title(frags),
+            title=self._generate_title(frags, context),
             status=self._compute_status(last_seen),
             first_seen=first_seen,
             last_seen=last_seen,
             frequency_affinity=self._frequency_affinity(frags),
             fragment_count=len(frags),
+            description=naming.cluster_description(
+                frags,
+                context.document_frequency,
+                context.corpus_size,
+            ),
         )
 
     def _compute_status(self, last_seen: date) -> ThreadStatus:
@@ -574,25 +675,33 @@ class ThreadDetector:
         return ThreadStatus.RESOLVED
 
     @staticmethod
-    def _generate_title(frags: list[Fragment]) -> str:
-        """Generate a human-readable title from common content words.
+    def _generate_title(frags: list[Fragment], context: _NamingContext) -> str:
+        """Generate a human-readable title for the cluster.
 
-        Falls back to the earliest fragment's title (truncated) when no
-        content words are available.
+        Delegates to :func:`creek.link.naming.cluster_title`, so a term
+        carried by most of the corpus cannot become a topic label and a
+        cluster left with no surviving term is named from its structure
+        (dominant channel plus date span) instead.
+
+        A cluster whose member titles contain *no content words at all*
+        (pure punctuation, single letters) is a different case: there is
+        nothing for IDF to suppress, so the historical fallback to the
+        earliest member's own title is kept.
 
         Args:
-            frags: Fragments in the cluster.
+            frags: Fragments in the cluster (non-empty).
+            context: Corpus-wide naming facts.
 
         Returns:
-            A short title string.
+            A short, non-empty title string.
         """
-        counts: Counter[str] = Counter()
-        for frag in frags:
-            counts.update(_content_words(frag.title))
-        if not counts:
-            return frags[0].title[:50] if frags else "Untitled Thread"
-        top = [word for word, _ in counts.most_common(_TITLE_TOP_WORDS)]
-        return " ".join(word.capitalize() for word in top)
+        if not any(naming.content_words(f.title) for f in frags):
+            return frags[0].title[:_MAX_FALLBACK_TITLE_LEN]
+        return naming.cluster_title(
+            frags,
+            context.document_frequency,
+            context.corpus_size,
+        )
 
     @staticmethod
     def _frequency_affinity(frags: list[Fragment]) -> list[Frequency]:
@@ -699,8 +808,8 @@ class ThreadDetector:
             ``True`` if title-token Jaccard similarity passes the
             threshold and frequency affinities intersect.
         """
-        words_a = set(_content_words(a.title))
-        words_b = set(_content_words(b.title))
+        words_a = set(naming.content_words(a.title))
+        words_b = set(naming.content_words(b.title))
         if not words_a or not words_b:
             return False
         union = words_a | words_b

--- a/creek-tools/docs/architecture/ADR/0008-bounding-cluster-degeneration-in-message-streams.md
+++ b/creek-tools/docs/architecture/ADR/0008-bounding-cluster-degeneration-in-message-streams.md
@@ -1,0 +1,295 @@
+# ADR-0008: Bounding cluster degeneration in message streams — segment and rename first, cap only as a guardrail
+
+- **Status**: Accepted
+- **Date**: 2026-08-08
+- **Driving issue**: #880 (eddy/thread mega-cluster on the demo vault). Related: #857 (O(n²) thread pairing), #790 (DBSCAN performance + brute-force equivalence contract), #718 (content-stable thread ids), #730 (wiki-link aliases).
+
+## Context
+
+On the demo vault `creek-demo-2026-06-07` — 35,330 fragments, 30,795 of them
+Discord messages — both detectors collapsed the message corpus into a single
+page:
+
+- `link --method eddies` emitted 17 eddies, one of which
+  (`03-Eddies/2023-03-30-Messages.md`) had `fragment_count: 30795` — **every
+  message in the vault**, ~87% of the corpus — with `description: ''` and
+  `threads: []`.
+- `link --method threads` emitted 195 threads, one of which (`Messages`,
+  `thread-ebdfeb4c`) had `fragment_count: 30108`, spanning `2020-09-26` to
+  `2026-05-20`, also with `description: ''`.
+
+The compiled layer is the retrieval surface: `creek draft`, `creek mine`, and
+the state report all read eddies and threads. A single page holding 87% of the
+vault makes that surface useless for the message corpus, and the `eddies:`
+wiki-link written onto all 30,795 member fragments points at that one page.
+
+Three independent mechanisms produced this, and each had to be understood
+before a fix could be chosen.
+
+### 1. The eddy mega-cluster is DBSCAN behaving correctly
+
+`EddyDetector._dbscan` builds an epsilon-graph (`cosine_neighbours(vectors,
+1.0 - eps)`; at `eps = 0.3` an edge exists at cosine ≥ 0.70) and `_expand_cluster`
+extends the frontier through every point that is itself a core point. That is
+**unbounded transitive density-reachability**: one label propagates across the
+entire density-connected component with no size bound at all. The only size
+guard in the module was a *floor* (`if len(members) < min_fragments: continue`).
+
+Short chat messages are semantically homogeneous, so neighbouring messages sit
+well inside 0.30 cosine distance and effectively every message is a core point.
+The epsilon-graph over 30,795 Discord fragments is therefore *one connected
+component*, even though its diameter is enormous. DBSCAN then returns it as one
+cluster — which is exactly what DBSCAN is defined to do.
+
+The single rejection path, `_has_temporal_direction`, filters clusters whose
+content drift correlates with chronological rank (|Spearman| ≥ 0.3). A
+seven-year scattered blob has near-zero correlation, so it never fired.
+
+**This is the decisive fact for the whole ADR:** DBSCAN's precondition is that
+clusters are *separated by low-density regions*. A continuous chat stream has no
+such separator. There is nothing in the data for any `eps` to find. **No
+threshold value fixes this** — not a lower `eps`, not a higher `min_samples`,
+not a per-source variant of either. Tuning is not on the table because the
+algorithm's contract, not its parameterisation, is what has been violated.
+
+### 2. The thread mega-cluster is an unbounded transitive closure
+
+`ThreadDetector` bounds *pairing* to a 30-day sliding window (`break` once the
+window is exceeded) but the union that follows is unbounded, and `_UnionFind.union`
+merges roots unconditionally. Overlapping windows therefore take the transitive
+closure end to end, chaining 2020-09-26 → 2026-05-20 into a single root of
+30,108 members. The window bounds which pairs are *examined*; it does not bound
+how far a component may *reach*.
+
+The topic gate behind the union — frequency overlap, then cosine >
+`similarity_threshold` (0.6) — did not help: every demo message classifies F2,
+so the frequency gate was a no-op on this corpus. Worse, the gate **failed
+open**: a pair missing an embedding unioned on frequency agreement alone.
+
+### 3. The name was a filename leak, and a docstring/implementation divergence
+
+Why "Messages"? `DiscordIngestor.generate_frontmatter` emitted no `title`, so
+`assemble_ingested_fragment` fell back to `Path(source_path).stem`. `discover`
+only ever reads `<channel_dir>/messages.json`, so **every** Discord fragment in
+every vault got `title: messages`. Since `Fragment` carries no body or content
+field, its title is the *only* text the linker ever sees.
+
+`EddyDetector._generate_title` then took a `Counter` over member titles and its
+three most common words. `most_common(3)` over 30,795 identical titles yields
+`[("messages", 30795)]` → `"Messages"`.
+
+The damning detail, and the reason this is recorded rather than quietly fixed:
+the docstring claimed *"TF-IDF-lite: content-word frequency inside the cluster
+scaled by inverse document frequency"*. Real IDF would have given "messages" a
+document frequency of 30795/35330 and an inverse document frequency of ~0.137,
+suppressing it outright. **The documented algorithm would not have produced this
+bug. The implemented one contained no IDF whatsoever.** A docstring that
+describes an algorithm the code does not implement is a defect class that
+recurs, survives review, and is invisible to tests written from the code — so it
+is named here explicitly.
+
+Separately, neither `_build_eddy` nor `_build_thread` ever passed a
+`description`, so it fell back to the model default `""` on 212 of 214
+linker-written pages in the demo vault.
+
+## Options considered
+
+The issue proposed three, and they are not alternatives at the same level.
+
+**Option 1 — Cluster-size ceiling with recursive split.** Any cluster above N
+members is re-clustered at a tighter parameter until the parts fit; the
+unsplittable remainder becomes noise.
+
+**Option 2 — Segment message streams before clustering.** Pre-partition
+platform-continuous streams into conversation episodes and cluster the episodes,
+not the raw stream.
+
+**Option 3 — Per-source thresholds.** A stricter `eps` / similarity for
+message-platform fragments than for essays and notes.
+
+**Option 3 is rejected outright.** It is the tuning answer, and §1 already
+disposes of tuning: a stricter threshold on a corpus with no low-density
+separator produces a smaller-diameter connected component, not two clusters. It
+would also add a second, source-conditional calibration to maintain against a
+single embedding model, for no structural gain.
+
+**Option 1 alone is symptom treatment, and the failure is worth spelling out.**
+Recursively tightening `eps` on a 30,795-member component does not discover
+latent structure, because there is none to discover — it slices a *continuous
+semantic manifold* at whatever arbitrary distance the schedule happens to reach.
+At the configured ceiling that is roughly sixty subclusters, none of which
+corresponds to any conversation, topic, or period a human would recognise. Every
+one of them is still named from the same 30,795 identical `title: messages`
+strings, so all sixty are still called "Messages", and all sixty still collide
+on the same `[[Messages]]` wiki-link written onto their members. The trade is
+**one meaningless page for sixty meaningless pages** — strictly worse, while
+appearing to satisfy the acceptance criterion. A size cap that passes its own
+test while making the product worse is the exact outcome this ADR exists to
+prevent.
+
+## Decision
+
+Land **three layers, in dependency order**, and adopt options 1 and 2 together
+with an explicit statement of which is the cure and which is the guardrail.
+
+### Layer A — Naming (`creek/link/naming.py`) — root fix
+
+Implement the IDF the docstring already promised. `distinctive_terms` scores a
+term as `tf * log(corpus_size / (1 + df))` and **hard-drops** any term whose
+document frequency reaches `ubiquity_floor` (0.6). A term carried by 60% or more
+of the corpus can never become a title, by construction. IDF is deliberately not
+applied below `min_idf_corpus` (20) documents, because document frequency over a
+handful of documents is noise, and a two-cluster corpus necessarily puts each
+cluster's own topic word at `df / n == 0.5` through no fault of its own.
+
+Suppression can leave a cluster with *no text at all* — which is precisely the
+message case, since `Fragment` has no body and every title is identical. So
+`structural_label` names such a cluster from what remains distinctive: the
+dominant source identity (channel, else conversation id, else interlocutor, else
+platform) plus the date span. `"Aspiring Drag Queens, Mar 2023"` replaces
+`"Messages"`. That data is present and varied on disk today.
+
+The same module derives a never-empty `description` (count, dominant source,
+span, recurring terms) and enforces title uniqueness within a run via
+`disambiguate`, because the eddy assigner interpolates the title straight into
+`[[…]]`.
+
+**Why this layer is independently necessary:** existing vaults keep
+`title: messages` until they are re-ingested. A source-side fix does not repair
+what is already on disk.
+
+### Layer B — Clustering domains (`creek/link/segments.py`) — root fix
+
+Stop building one epsilon-graph over the whole chat stream. Before any
+similarity graph exists, the corpus is partitioned into independent clustering
+domains: a fragment from a configured `stream_platforms` platform belongs to a
+conversation episode keyed on `(platform, series, episode_index)`, where
+`series` is the channel / conversation id / interlocutor. The series is cut by
+an **inactivity gap** (the conversational rule — people stop talking, and that
+silence *is* the topic boundary) with a **span backstop** for a channel that
+never falls idle. Every non-stream fragment lands in one shared domain, so
+cross-source resonance, cross-platform eddies, and multi-year threads over
+long-form material are untouched.
+
+This removes the precondition violation rather than tuning around it, and it
+**strictly reduces work**: clustering `d` domains of `n/d` fragments costs
+`O(n²/d)` against `O(n²)`, in both `cosine_neighbours` and the thread detector's
+windowed inner loop. It therefore relieves #857 rather than regressing it.
+
+Segmentation is deliberately narrow — it touches only the corpus shape that
+breaks the algorithms.
+
+**Why this layer is independently necessary:** naming alone would give a
+30,795-member mega-cluster a *good* name. It would still be one useless page.
+
+### Layer C — Cluster-size ceiling (`creek/link/cluster_limits.py`) — guardrail
+
+A config-keyed ceiling with bounded recursive re-clustering, applied strictly
+**outside** `_dbscan` and outside the thread union-find: it only ever
+re-partitions a membership list a detector has already produced, and the caller
+injects a `recluster` callable that takes the tightened parameter as an
+*argument*, so no detector's state is mutated mid-run. This placement is what
+keeps the #790 brute-force-equivalence contract green — that oracle compares raw
+`_dbscan` output, which the guardrail never sees.
+
+Termination is governed by **two independent bounds, both load-bearing**: the
+depth budget (`cluster_split_max_depth`), and the tightening schedule leaving
+its valid range (epsilon may approach but never reach 0.0; similarity may
+approach but never reach 1.0). A depth-only guard would keep re-clustering at a
+degenerate parameter where nothing is a neighbour and every member silently
+becomes noise.
+
+The ceiling is kept and justified as the **machine-checkable invariant** behind
+acceptance criterion 1 — *no emitted cluster exceeds
+`max(cluster_size_ceiling, floor(corpus_size × cluster_max_fraction))`* — and as
+protection for corpora nobody has looked at yet. It is a floor on badness, not a
+definition of goodness.
+
+**Why this layer is independently necessary:** layers A and B fix the two
+degeneration modes we found. The ceiling is what holds when a corpus degenerates
+in a way we did not predict.
+
+### Product decision: an unsplittable cluster is discarded, loudly
+
+A cluster still over the ceiling once **both** bounds are exhausted is discarded
+to noise. Its members carry no `eddies:` / `threads:` frontmatter link at all.
+
+That is real data loss in the compiled layer and it is accepted deliberately: an
+unusable mega-page is worse than no page, and with segmentation in place the
+path should be unreachable. It is never silent — each discard logs a WARNING
+naming the clustering domain and the size, and the discarded fragment count is
+surfaced to the operator as `LinkSummary.oversized_discarded`, rendered by
+`creek link` alongside the largest emitted cluster.
+
+**No `discard_unsplittable` escape hatch is provided.** A knob that turns the
+discard back into a mega-page would restore the exact defect this ADR closes.
+The supported opt-out is `cluster_max_fraction: 1.0`, which disables the ceiling
+itself and is documented as such.
+
+### Source-side fix
+
+`DiscordIngestor.generate_frontmatter` now emits a real `title`
+(`"<channel> <YYYY-MM-DD>"`), so vaults stop manufacturing 30k identical strings
+at the source. This is safe for existing vaults: `generate_fragment_id` hashes
+source path, timestamp and content — never the title — so no fragment ids churn.
+
+### `Eddy.id` becomes content-stable
+
+Eddy ids are now derived from the sorted member fragment ids
+(`eddy-<8 hex of SHA-256>`), mirroring `_stable_thread_id` (#718). Re-detecting
+the same cluster on the same corpus yields the same id, and therefore the same
+page filename, so `VaultWriter.write_eddy` updates the existing page instead of
+minting a fresh one each run. This matters *more* after this change, not less,
+because segmentation and splitting produce many smaller clusters. Membership
+changes deliberately yield a new id — a different membership is a different
+eddy. The model's random default remains for hand-constructed eddies, which have
+no membership to hash.
+
+### Every previously-hardcoded threshold becomes config
+
+The five module-private constants the detectors used (`eddy_eps`,
+`eddy_min_samples`, `eddy_correlation_threshold`, `thread_window_days`,
+`thread_similarity_threshold`) are exposed on `LinkingConfig` with defaults
+equal to the exact constants they replace, so an upgraded vault clusters
+identically. Both orchestrators (`creek.link.link_engine` and
+`creek.link.linker`) construct detectors through a single
+`from_linking_config` path, so the same vault cannot cluster differently
+depending on which one ran. The fail-open union on missing embeddings is closed
+by default behind `thread_union_without_embeddings: false`.
+
+## Consequences
+
+- **Positive**: a chat corpus yields per-conversation, per-episode eddies and
+  threads with interpretable names and non-empty descriptions; the compiled
+  layer becomes usable for retrieval over messages; the largest cluster is now
+  visible in `creek link` output, so degeneration cannot recur invisibly;
+  segmentation reduces the quadratic pairing cost that #857 tracks; every
+  clustering threshold is now inspectable and tunable from
+  `creek_config.yaml`.
+- **Negative**: a cluster that survives the split budget is discarded, and its
+  fragments lose their eddy/thread links entirely — accepted, logged, and
+  counted, but genuinely lossy. Segmentation prevents multi-episode threads
+  *within* a single chat series, which is the correct trade for a chat stream
+  but does mean a genuinely long-running conversation topic now appears as
+  several episode-scoped threads. `Eddy.id` values change for every existing
+  vault on the next run, so previously written eddy pages are superseded rather
+  than updated once.
+- **Neutral**: `cluster_max_fraction: 1.0` and `stream_platforms: []` restore
+  the pre-#880 unbounded behaviour for anyone who wants it. `stream_platforms`
+  defaults to `["discord", "email"]` only — the two platforms Creek already
+  routes to `01-Fragments/Messages/` — so chat *transcripts* (Claude, ChatGPT)
+  remain long-form material in the shared domain.
+
+## Reopening criteria
+
+Revisit this decision when any of the following holds:
+
+- A corpus is observed where episode segmentation fragments a genuinely
+  coherent long-running conversation badly enough that operators want
+  cross-episode thread stitching.
+- `oversized_discarded` is non-zero on a real vault *after* segmentation, which
+  would mean a degeneration mode neither layer A nor layer B covers.
+- `Fragment` gains a body/content field. The entire naming problem is downstream
+  of the fact that a fragment's title is the only text the linker can see;
+  real content would make `distinctive_terms` far stronger and could retire the
+  structural fallback for many clusters.

--- a/creek-tools/docs/configuration.md
+++ b/creek-tools/docs/configuration.md
@@ -99,16 +99,82 @@ ocr:
 
 ```yaml
 linking:
+  # Temporal proximity linker
   temporal_window_hours: 168
+
+  # Minimum sizes
   thread_min_fragments: 3
   eddy_min_fragments: 5
+
+  # Eddy (DBSCAN) detector thresholds
+  eddy_eps: 0.3
+  eddy_min_samples: 5
+  eddy_correlation_threshold: 0.3
+
+  # Thread detector thresholds
+  thread_window_days: 30
+  thread_similarity_threshold: 0.6
+  thread_union_without_embeddings: false
+
+  # Cluster-size guardrail
+  cluster_size_ceiling: 500
+  cluster_max_fraction: 0.10
+  cluster_split_max_depth: 3
+  eddy_split_eps_step: 0.05
+  thread_split_similarity_step: 0.1
+
+  # Message-stream segmentation
+  stream_platforms: [discord, email]
+  stream_episode_max_gap_hours: 24
+  stream_episode_max_span_days: 30
 ```
+
+### Windows and minimum sizes
 
 | Field                  | Default | Notes |
 |------------------------|---------|-------|
-| `temporal_window_hours`| `168`   | Sliding-window width for thread detection (1 week). |
+| `temporal_window_hours`| `168`   | Sliding-window width (1 week) for the **temporal proximity linker** only (`creek link --method temporal`). It has never influenced thread detection — see `thread_window_days` for that. |
 | `thread_min_fragments` | `3`     | Minimum chain length for a thread. |
 | `eddy_min_fragments`   | `5`     | Minimum cluster size for an eddy. |
+
+### Detector thresholds
+
+Previously hard-coded module constants, exposed by [ADR-0008](architecture/ADR/0008-bounding-cluster-degeneration-in-message-streams.md). Every default equals the constant it replaced, so a vault whose `creek_config.yaml` predates these keys clusters identically after the upgrade.
+
+| Field                             | Default | Notes |
+|-----------------------------------|---------|-------|
+| `eddy_eps`                        | `0.3`   | Maximum cosine **distance** for a DBSCAN neighbour — `0.3` means an edge at cosine similarity ≥ `0.70`. Range `(0.0, 1.0)`. Lowering it tightens every cluster but cannot, on its own, separate a continuous message stream (that is what `stream_platforms` is for). |
+| `eddy_min_samples`                | `5`     | Minimum neighbourhood size for a DBSCAN core point. Minimum `1`. |
+| `eddy_correlation_threshold`      | `0.3`   | Absolute Spearman ceiling above which a candidate cluster is judged *thread-like* (content drift correlates with chronological rank) and filtered out of the eddy set. Range `[0.0, 1.0]`. |
+| `thread_window_days`              | `30`    | Sliding-window width, in days, for **thread detection**. Distinct from `temporal_window_hours`. Minimum `1`. |
+| `thread_similarity_threshold`     | `0.6`   | Cosine similarity a pair must *strictly exceed* to join one thread. Range `[0.0, 1.0]`. |
+| `thread_union_without_embeddings` | `false` | Whether a pair missing an embedding may union on frequency agreement alone. On a *partially* embedded vault this fallback silently chains fragments the similarity gate would have rejected, so it is closed by default. (A vault with **no** embeddings at all still falls back to frequency agreement by design.) |
+
+### Cluster-size guardrail
+
+The last line of defence against a single eddy or thread swallowing the vault. It is a guardrail, not the cure — see ADR-0008.
+
+| Field                          | Default | Notes |
+|--------------------------------|---------|-------|
+| `cluster_size_ceiling`         | `500`   | Absolute member count below which a cluster is never split. The effective ceiling is `max(cluster_size_ceiling, floor(corpus_size × cluster_max_fraction))`, so the absolute floor dominates ordinary vaults and the guardrail stays inert until a corpus is large enough for degeneration to matter. Minimum `1`. |
+| `cluster_max_fraction`         | `0.10`  | Largest share of the corpus a single eddy or thread may hold. Range `(0.0, 1.0]`; **`1.0` is the documented opt-out** — one cluster may then span everything. |
+| `cluster_split_max_depth`      | `3`     | Re-clustering rounds allowed per oversized cluster. `0` disables splitting entirely, sending any oversized cluster straight to noise. Minimum `0`. |
+| `eddy_split_eps_step`          | `0.05`  | Amount `eddy_eps` is tightened by on each re-clustering round. Range `(0.0, 1.0)`. |
+| `thread_split_similarity_step` | `0.1`   | Amount `thread_similarity_threshold` is raised on each re-clustering round. Range `(0.0, 1.0)`. |
+
+A cluster still over the ceiling once **both** bounds are exhausted — the depth budget, and the tightening schedule leaving its valid range (epsilon may never reach `0.0`, similarity may never reach `1.0`) — is **discarded to noise**: its members carry no `eddies:` / `threads:` link at all. Each discard logs a `WARNING` naming the clustering domain and the size, and `creek link` reports the total as `N fragment(s) discarded as unsplittable`.
+
+### Message-stream segmentation
+
+A continuous chat stream violates the precondition both detectors rely on — clusters separated by low-density regions — so no threshold value can separate it. Stream fragments are instead partitioned into independent clustering domains (conversation episodes) *before* any similarity graph is built.
+
+| Field                          | Default              | Notes |
+|--------------------------------|----------------------|-------|
+| `stream_platforms`             | `[discord, email]`   | Source platforms whose fragments are cut into conversation episodes, keyed on `(platform, series, episode_index)` where `series` is the channel, else the conversation id, else the interlocutor. The default names the two platforms Creek already routes to `01-Fragments/Messages/`; chat *transcripts* (`claude`, `chatgpt`) stay long-form material in the shared domain. An **empty list disables segmentation**. Every value must name a `creek.models.SourcePlatform` member — a typo is rejected at load rather than silently disabling segmentation. |
+| `stream_episode_max_gap_hours` | `24`                 | Inactivity gap, in hours, that ends a conversation episode — the primary, conversational rule. Inclusive: a gap exactly this long does not cut. Minimum `1`. |
+| `stream_episode_max_span_days` | `30`                 | Maximum span, in days, of a single episode — the backstop for a channel that never falls idle, so a permanently-busy channel yields channel-month units rather than one multi-year blob. Inclusive. Minimum `1`. |
+
+Every fragment that is not from a `stream_platforms` platform lands in one shared domain, so cross-source resonance, cross-platform eddies and multi-year threads over long-form material behave exactly as before.
 
 ## `classification` — auto-classify thresholds
 

--- a/creek-tools/docs/linking.md
+++ b/creek-tools/docs/linking.md
@@ -1,18 +1,22 @@
 # Linking
 
-`creek link` connects fragments along three orthogonal axes:
+`creek link` connects fragments along four orthogonal axes:
 
 | Linker        | Surfaces       | Backed by                                  |
 |---------------|----------------|--------------------------------------------|
 | `embeddings`  | **Resonances** | `sentence-transformers` cosine similarity. |
-| `temporal`    | **Threads**    | Sliding-window union-find over timestamps + topic stability. |
+| `temporal`    | Temporal links | Proximity edges between fragments within `temporal_window_hours` of each other. |
+| `threads`     | **Threads**    | Sliding-window union-find over timestamps + topic stability. |
 | `eddies`      | **Eddies**     | Density-based clustering on the resonance graph. |
 
-You can run a single linker or all of them. Most users run all three after every classification pass:
+`temporal` and `threads` are distinct methods with distinct windows: `temporal` only draws proximity edges between fragments, while `threads` is what writes the pages under `02-Threads/`.
+
+You can run a single linker or all of them. Most users run all four after every classification pass:
 
 ```bash
 creek link --vault ~/Obsidian/Creek-Vault --method embeddings
 creek link --vault ~/Obsidian/Creek-Vault --method temporal
+creek link --vault ~/Obsidian/Creek-Vault --method threads
 creek link --vault ~/Obsidian/Creek-Vault --method eddies
 ```
 
@@ -39,16 +43,30 @@ Defaults are tuned for the `all-MiniLM-L6-v2` model. If you switch models, recal
 | 0.75 (default)         | Balanced — finds genuine semantic connections.            |
 | 0.65                   | Loose — pulls in distant relatives; expect noise.         |
 
-## Threads (temporal)
+## Temporal proximity
 
-A **thread** is a chain of fragments that span a topic across time. `creek.link.threads.ThreadDetector` slides a window over the timestamped fragments, joins them into a union-find structure when their topics overlap, and writes a thread note under `02-Threads/` for each connected component.
+`creek link --method temporal` draws proximity edges between fragments authored close together. It writes no pages of its own.
+
+```yaml
+linking:
+  temporal_window_hours: 168     # proximity window (default: 1 week)
+```
+
+`temporal_window_hours` feeds **only** this linker. Thread detection has always used its own window — see `thread_window_days` below.
+
+## Threads
+
+A **thread** is a chain of fragments that span a topic across time. `creek.link.threads.ThreadDetector` slides a window over the timestamped fragments, joins them into a union-find structure when their topics overlap, and writes a thread note under `02-Threads/{Active,Dormant,Resolved}/` for each connected component.
 
 Configuration (from `LinkingConfig`):
 
 ```yaml
 linking:
-  temporal_window_hours: 168     # sliding window (default: 1 week)
-  thread_min_fragments: 3        # minimum fragments per thread
+  thread_window_days: 30                    # sliding window for pairing
+  thread_similarity_threshold: 0.6          # cosine a pair must exceed to union
+  thread_union_without_embeddings: false    # don't union on frequency alone
+  thread_min_fragments: 3                   # minimum fragments per thread
+  thread_split_similarity_step: 0.1         # tightening step when over the ceiling
 ```
 
 Threads are **directional** (oldest → newest) and have a **terminus** — the most recent fragment. The `creek mine` strategy `thread-terminus` uses these as essay seeds (a thread that's gone quiet often means there's a synthesis waiting to be written).
@@ -61,8 +79,50 @@ Configuration (from `LinkingConfig`):
 
 ```yaml
 linking:
-  eddy_min_fragments: 5          # minimum cluster size
+  eddy_eps: 0.3                   # max cosine DISTANCE for a DBSCAN neighbour
+  eddy_min_samples: 5             # neighbours needed to be a core point
+  eddy_correlation_threshold: 0.3 # above this |Spearman|, it's a thread, not an eddy
+  eddy_min_fragments: 5           # minimum cluster size
+  eddy_split_eps_step: 0.05       # tightening step when over the ceiling
 ```
+
+### Tuning eddy density
+
+| `eddy_eps` | Effect                                                            |
+|------------|-------------------------------------------------------------------|
+| 0.20       | Tight — an edge only at cosine ≥ 0.80; many small, sharp eddies.   |
+| 0.30 (default) | Balanced — an edge at cosine ≥ 0.70.                          |
+| 0.40       | Loose — an edge at cosine ≥ 0.60; expect large, diffuse eddies.    |
+
+Eddy ids are **content-stable**: derived from the sorted member fragment ids, so re-detecting the same cluster over the same corpus produces the same id and therefore updates the same page instead of minting a new one. A membership change deliberately yields a new id — a different membership is a different eddy.
+
+## Message streams and cluster size
+
+Both detectors assume a corpus whose clusters are separated by low-density regions. A continuous chat stream is not such a corpus: short messages from one channel are semantically homogeneous and temporally unbroken, so the epsilon-graph over them is one connected component and the sliding windows chain end to end. Left alone, an entire message corpus collapses into a single eddy and a single thread — whatever thresholds are chosen. Full reasoning: [ADR-0008](architecture/ADR/0008-bounding-cluster-degeneration-in-message-streams.md).
+
+Three mechanisms bound this.
+
+**Segmentation.** Before any similarity graph is built, fragments from a `stream_platforms` platform are cut into conversation episodes and clustered independently. Every other fragment shares one domain, so cross-source eddies and multi-year threads over long-form material are unchanged.
+
+```yaml
+linking:
+  stream_platforms: [discord, email]   # [] disables segmentation entirely
+  stream_episode_max_gap_hours: 24     # silence that ends an episode
+  stream_episode_max_span_days: 30     # backstop for a never-idle channel
+```
+
+**Naming.** Titles come from TF-IDF-scored distinctive terms, so a term carried by most of the corpus can never become a title. When suppression leaves no term standing — the normal outcome for identically-titled messages — the cluster is named structurally from its dominant source and date span, e.g. `Aspiring Drag Queens, Mar 2023`. Titles are made unique within a run, since a page title is interpolated straight into a `[[wiki-link]]`, and every generated page now carries a non-empty `description`.
+
+**Cluster-size ceiling.** A guardrail, not the cure:
+
+```yaml
+linking:
+  cluster_size_ceiling: 500       # never split below this many members
+  cluster_max_fraction: 0.10      # max share of the corpus; 1.0 opts out
+  cluster_split_max_depth: 3      # re-clustering rounds; 0 disables splitting
+```
+
+The effective ceiling is `max(cluster_size_ceiling, floor(corpus_size × cluster_max_fraction))`, so ordinary vaults never trip it. A cluster over the ceiling is re-clustered at a tighter `eddy_eps` / `thread_similarity_threshold`; one that is still oversized after the budget is spent is **discarded to noise** — its members carry no `eddies:` / `threads:` link at all. Each discard logs a `WARNING` naming the domain and the size, and the count is reported by `creek link`.
 
 ## Synchronicities
 
@@ -82,6 +142,20 @@ Synchronicities:       143 surprising edges
 Mean fragment fan-out: 7.7
 ```
 
+`creek link` itself also reports the largest cluster it emitted, which is the one number that tells you whether detection degenerated:
+
+```
+17 eddy(ies) detected, 17 eddy file(s) written to 03-Eddies/, 4120 fragment(s)
+updated with `eddies:` wiki-links, largest cluster: 312 fragment(s).
+```
+
+Re-clustering and discards are only mentioned when they happened:
+
+```
+… largest cluster: 480 fragment(s), 2 oversized cluster(s) re-clustered,
+61 fragment(s) discarded as unsplittable.
+```
+
 ## Cost / cadence
 
 Embeddings run **locally** by default (CPU-only) and a 10k-fragment vault rebuilds in ~10–20 minutes. Re-running is cheap because embeddings are cached at `<vault>/00-Creek-Meta/embeddings.parquet` and only stale rows are recomputed.
@@ -93,6 +167,7 @@ Embeddings run **locally** by default (CPU-only) and a 10k-fragment vault rebuil
 creek classify --vault ~/Obsidian/Creek-Vault --method rules
 creek link     --vault ~/Obsidian/Creek-Vault --method embeddings
 creek link     --vault ~/Obsidian/Creek-Vault --method temporal
+creek link     --vault ~/Obsidian/Creek-Vault --method threads
 creek link     --vault ~/Obsidian/Creek-Vault --method eddies
 creek report   --type synchronicity --vault ~/Obsidian/Creek-Vault
 

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -1252,6 +1252,56 @@ def test_link_eddies_output_phrases_eddies_written(tmp_path: Path) -> None:
     assert "03-eddies" in output_lower
 
 
+def test_link_summary_reports_cluster_health() -> None:
+    """Issue #880: the largest cluster, splits and discards are operator-visible.
+
+    A single eddy holding 87% of the vault used to be invisible from the
+    CLI — the summary reported how many eddies were detected but never how
+    big any of them was. Discarded fragments carry no wiki-link at all, so
+    that count is named explicitly rather than folded into a total.
+    """
+    from creek.cli import _format_link_summary
+    from creek.link.link_engine import LinkSummary
+
+    rendered = _format_link_summary(
+        LinkSummary(
+            method="eddies",
+            fragment_count=700,
+            link_count=3,
+            eddies_detected=3,
+            eddies_written=3,
+            member_fragments_updated=36,
+            largest_cluster_fragments=12,
+            clusters_split=6,
+            oversized_discarded=521,
+        ),
+    )
+    assert "largest cluster: 12 fragment(s)" in rendered
+    assert "6 oversized cluster(s) re-clustered" in rendered
+    assert "521 fragment(s) discarded as unsplittable" in rendered
+
+
+def test_link_summary_stays_terse_for_a_healthy_run() -> None:
+    """No splits and no discards means no extra clauses beyond the largest."""
+    from creek.cli import _format_link_summary
+    from creek.link.link_engine import LinkSummary
+
+    rendered = _format_link_summary(
+        LinkSummary(
+            method="threads",
+            fragment_count=40,
+            link_count=2,
+            threads_detected=2,
+            threads_written=2,
+            member_fragments_updated=8,
+            largest_cluster_fragments=5,
+        ),
+    )
+    assert "largest cluster: 5 fragment(s)" in rendered
+    assert "re-clustered" not in rendered
+    assert "discarded" not in rendered
+
+
 def test_report_help() -> None:
     """Test that report --help shows subcommand help."""
     result = runner.invoke(app, ["report", "--help"])

--- a/creek-tools/tests/test_cluster_limits.py
+++ b/creek-tools/tests/test_cluster_limits.py
@@ -1,0 +1,456 @@
+"""Tests for the cluster-size guardrail (:mod:`creek.link.cluster_limits`).
+
+These tests pin the *guardrail*, not the cure. The cure for a degenerate
+mega-cluster is naming plus stream segmentation; this module only proves
+that a size ceiling holds even when those fail, that the recursive split
+terminates on BOTH of its bounds, and that anything still oversized when
+the budget runs out is discarded to noise loudly rather than silently
+materialised as a page.
+
+Scale-sensitive cases construct :class:`SplitPolicy` with an explicit
+small ``size_ceiling`` so the *fractional* term governs. Do not
+"simplify" them back to the defaults: ``size_ceiling=500`` exceeds every
+corpus a unit test can afford to build, so the absolute floor would
+dominate and every assertion would pass vacuously.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import pytest
+
+from creek.link.cluster_limits import (
+    Recluster,
+    SplitPolicy,
+    Tightening,
+    split_oversized,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+class _Recorder:
+    """Records every ``(members, parameter)`` pair a splitter re-clusters."""
+
+    def __init__(self) -> None:
+        """Initialise an empty call log."""
+        self.calls: list[tuple[tuple[str, ...], float]] = []
+
+    def record(self, members: Sequence[str], parameter: float) -> None:
+        """Log one re-clustering call.
+
+        Args:
+            members: The cluster handed to the re-clusterer.
+            parameter: The tightened clustering parameter used.
+        """
+        self.calls.append((tuple(members), parameter))
+
+    @property
+    def parameters(self) -> list[float]:
+        """Return the tightened parameter of every recorded call."""
+        return [parameter for _members, parameter in self.calls]
+
+
+def _ids(count: int, prefix: str = "f") -> list[str]:
+    """Return *count* synthetic fragment IDs.
+
+    Args:
+        count: Number of IDs to build.
+        prefix: Prefix for each generated ID.
+
+    Returns:
+        A list of ``count`` distinct fragment IDs.
+    """
+    return [f"{prefix}-{index:04d}" for index in range(count)]
+
+
+def _halving(recorder: _Recorder) -> Recluster:
+    """Return a re-clusterer that halves every cluster it is given.
+
+    Args:
+        recorder: Call log to append to.
+
+    Returns:
+        A callable with the ``recluster`` contract that splits a cluster
+        into two equal halves (a singleton is returned unchanged).
+    """
+
+    def recluster(members: Sequence[str], parameter: float) -> list[list[str]]:
+        recorder.record(members, parameter)
+        midpoint = len(members) // 2
+        if midpoint == 0:
+            return [list(members)]
+        return [list(members[:midpoint]), list(members[midpoint:])]
+
+    return recluster
+
+
+def _never_splits(recorder: _Recorder) -> Recluster:
+    """Return a re-clusterer that hands the same cluster straight back.
+
+    Args:
+        recorder: Call log to append to.
+
+    Returns:
+        A callable with the ``recluster`` contract that never separates
+        anything — the continuous-manifold case the ceiling exists for.
+    """
+
+    def recluster(members: Sequence[str], parameter: float) -> list[list[str]]:
+        recorder.record(members, parameter)
+        return [list(members)]
+
+    return recluster
+
+
+class TestSplitPolicy:
+    """The ceiling arithmetic and its config projection."""
+
+    def test_ceiling_for_uses_the_absolute_floor_on_small_corpora(self) -> None:
+        """The absolute ``size_ceiling`` dominates below the crossover."""
+        policy = SplitPolicy(size_ceiling=500, max_fraction=0.10, max_depth=3)
+        assert policy.ceiling_for(12) == 500
+
+    def test_ceiling_for_uses_the_fraction_at_scale(self) -> None:
+        """The fractional term dominates on a demo-scale corpus."""
+        policy = SplitPolicy(size_ceiling=500, max_fraction=0.10, max_depth=3)
+        assert policy.ceiling_for(35330) == 3533
+
+    def test_ceiling_for_full_fraction_is_the_documented_opt_out(self) -> None:
+        """``max_fraction=1.0`` lets a cluster hold the whole corpus."""
+        policy = SplitPolicy(size_ceiling=500, max_fraction=1.0, max_depth=3)
+        assert policy.ceiling_for(1000) == 1000
+
+    def test_from_linking_config_reads_the_three_cluster_knobs(self) -> None:
+        """The config projection maps each knob to its policy field."""
+
+        class _Config:
+            cluster_size_ceiling = 42
+            cluster_max_fraction = 0.25
+            cluster_split_max_depth = 7
+
+        policy = SplitPolicy.from_linking_config(_Config())
+        assert policy == SplitPolicy(
+            size_ceiling=42,
+            max_fraction=0.25,
+            max_depth=7,
+        )
+
+    @pytest.mark.parametrize(
+        ("ceiling", "fraction", "depth"),
+        [
+            (0, 0.10, 3),
+            (500, 0.0, 3),
+            (500, 1.5, 3),
+            (500, 0.10, -1),
+        ],
+    )
+    def test_rejects_an_out_of_range_field(
+        self,
+        ceiling: int,
+        fraction: float,
+        depth: int,
+    ) -> None:
+        """Out-of-range policy fields fail fast at construction.
+
+        Args:
+            ceiling: Candidate ``size_ceiling``.
+            fraction: Candidate ``max_fraction``.
+            depth: Candidate ``max_depth``.
+        """
+        with pytest.raises(ValueError, match=r"size_ceiling|max_fraction|max_depth"):
+            SplitPolicy(
+                size_ceiling=ceiling,
+                max_fraction=fraction,
+                max_depth=depth,
+            )
+
+
+class TestTightening:
+    """The parameter schedule that bounds re-clustering independently."""
+
+    def test_eddy_schedule_stops_before_eps_reaches_zero(self) -> None:
+        """Stepping eps down from 0.3 by 0.05 yields five valid rounds."""
+        schedule = Tightening.for_eddy_eps(0.3, 0.05).schedule(20)
+        assert len(schedule) == 5
+        assert all(value > 0.0 for value in schedule)
+        assert schedule[0] == pytest.approx(0.25)
+
+    def test_thread_schedule_stops_before_similarity_reaches_one(self) -> None:
+        """Stepping similarity up from 0.6 by 0.1 yields three rounds."""
+        schedule = Tightening.for_thread_similarity(0.6, 0.1).schedule(20)
+        assert len(schedule) == 3
+        assert all(value < 1.0 for value in schedule)
+        assert schedule[0] == pytest.approx(0.7)
+
+    def test_schedule_is_bounded_by_max_rounds(self) -> None:
+        """The depth budget truncates a schedule with range to spare."""
+        assert Tightening.for_eddy_eps(0.3, 0.05).schedule(2) == pytest.approx(
+            [0.25, 0.20]
+        )
+
+    def test_schedule_is_empty_with_no_depth_budget(self) -> None:
+        """A zero depth budget permits no re-clustering rounds at all."""
+        assert Tightening.for_thread_similarity(0.6, 0.1).schedule(0) == []
+
+    @pytest.mark.parametrize("step", [0.0, -0.1])
+    def test_rejects_a_step_that_does_not_tighten(self, step: float) -> None:
+        """A zero or wrong-signed step is rejected at construction.
+
+        Args:
+            step: Candidate step magnitude.
+        """
+        with pytest.raises(ValueError, match="step"):
+            Tightening.for_thread_similarity(0.6, step)
+
+    def test_rejects_a_start_outside_the_valid_range(self) -> None:
+        """A start already at the limit leaves no room to tighten."""
+        with pytest.raises(ValueError, match="start"):
+            Tightening.for_thread_similarity(1.0, 0.1)
+
+
+class TestSplitOversized:
+    """The bounded recursive splitter and its discard path."""
+
+    def test_cluster_within_the_ceiling_is_returned_untouched(self) -> None:
+        """A cluster at or under the ceiling is never re-clustered."""
+        recorder = _Recorder()
+        members = _ids(8)
+        result = split_oversized(
+            members,
+            ceiling=8,
+            policy=SplitPolicy(size_ceiling=1, max_fraction=0.10, max_depth=3),
+            recluster=_halving(recorder),
+            tightening=Tightening.for_eddy_eps(0.3, 0.05),
+            domain="test-domain",
+        )
+        assert result.accepted == [members]
+        assert result.discarded == []
+        assert recorder.calls == []
+
+    def test_empty_membership_yields_nothing(self) -> None:
+        """An empty cluster produces no accepted cluster and no noise."""
+        result = split_oversized(
+            [],
+            ceiling=4,
+            policy=SplitPolicy(size_ceiling=1, max_fraction=0.10, max_depth=3),
+            recluster=_halving(_Recorder()),
+            tightening=Tightening.for_eddy_eps(0.3, 0.05),
+            domain="test-domain",
+        )
+        assert result.accepted == []
+        assert result.discarded == []
+
+    def test_oversized_cluster_is_split_until_every_part_fits(self) -> None:
+        """Recursion continues until no accepted cluster exceeds the bar."""
+        recorder = _Recorder()
+        members = _ids(16)
+        result = split_oversized(
+            members,
+            ceiling=4,
+            policy=SplitPolicy(size_ceiling=1, max_fraction=0.10, max_depth=3),
+            recluster=_halving(recorder),
+            tightening=Tightening.for_eddy_eps(0.3, 0.05),
+            domain="test-domain",
+        )
+        assert result.discarded == []
+        assert all(len(cluster) <= 4 for cluster in result.accepted)
+        assert sorted(fid for cluster in result.accepted for fid in cluster) == members
+        # Each round tightens: 16 -> two 8s -> four 4s.
+        assert recorder.parameters == pytest.approx([0.25, 0.20, 0.20])
+
+    def test_split_terminates_when_the_tightened_parameter_leaves_its_valid_range(
+        self,
+    ) -> None:
+        """Termination is governed by the parameter bound, not depth alone.
+
+        With ``max_depth=20`` the depth cap cannot stop the recursion, so
+        only the tightening schedule can: similarity stepping 0.1 from 0.6
+        runs out of valid range before reaching 1.0. A depth-only guard
+        would keep calling the re-clusterer at similarity >= 1.0, where
+        nothing is ever topic-consistent and every cluster silently
+        becomes noise.
+        """
+        recorder = _Recorder()
+        members = _ids(64)
+        result = split_oversized(
+            members,
+            ceiling=8,
+            policy=SplitPolicy(size_ceiling=1, max_fraction=0.10, max_depth=20),
+            recluster=_never_splits(recorder),
+            tightening=Tightening.for_thread_similarity(0.6, 0.1),
+            domain="test-domain",
+        )
+        assert len(recorder.calls) <= 4
+        assert all(parameter < 1.0 for parameter in recorder.parameters)
+        assert recorder.parameters == pytest.approx([0.7, 0.8, 0.9])
+        assert result.accepted == []
+        assert result.discarded == members
+
+    def test_zero_depth_budget_discards_an_oversized_cluster_immediately(self) -> None:
+        """With no split budget an oversized cluster goes straight to noise."""
+        recorder = _Recorder()
+        members = _ids(20)
+        result = split_oversized(
+            members,
+            ceiling=4,
+            policy=SplitPolicy(size_ceiling=1, max_fraction=0.10, max_depth=0),
+            recluster=_halving(recorder),
+            tightening=Tightening.for_eddy_eps(0.3, 0.05),
+            domain="test-domain",
+        )
+        assert recorder.calls == []
+        assert result.accepted == []
+        assert result.discarded == members
+
+    def test_unsplittable_cluster_warns_with_its_domain_and_size(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """The discard is loud: one WARNING naming the domain and size.
+
+        Args:
+            caplog: Pytest log capture fixture.
+        """
+        members = _ids(30)
+        with caplog.at_level(logging.WARNING, logger="creek.link.cluster_limits"):
+            split_oversized(
+                members,
+                ceiling=5,
+                policy=SplitPolicy(size_ceiling=1, max_fraction=0.10, max_depth=2),
+                recluster=_never_splits(_Recorder()),
+                tightening=Tightening.for_eddy_eps(0.3, 0.05),
+                domain="discord/Aspiring Drag Queens",
+            )
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        message = warnings[0].getMessage()
+        assert "discord/Aspiring Drag Queens" in message
+        assert "30" in message
+
+    def test_recluster_returning_nothing_discards_the_whole_cluster(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A cluster dissolved entirely to noise is discarded and warned.
+
+        Args:
+            caplog: Pytest log capture fixture.
+        """
+        members = _ids(12)
+
+        def _dissolves(_members: Sequence[str], _parameter: float) -> list[list[str]]:
+            return []
+
+        with caplog.at_level(logging.WARNING, logger="creek.link.cluster_limits"):
+            result = split_oversized(
+                members,
+                ceiling=4,
+                policy=SplitPolicy(size_ceiling=1, max_fraction=0.10, max_depth=3),
+                recluster=_dissolves,
+                tightening=Tightening.for_eddy_eps(0.3, 0.05),
+                domain="test-domain",
+            )
+        assert result.accepted == []
+        assert result.discarded == members
+        assert len(caplog.records) == 1
+
+    def test_members_dropped_by_reclustering_are_reported_as_discarded(self) -> None:
+        """Members the re-clusterer drops to noise still show up as noise."""
+        members = _ids(12)
+
+        def _keeps_half(sub: Sequence[str], _parameter: float) -> list[list[str]]:
+            return [list(sub[: len(sub) // 2])]
+
+        result = split_oversized(
+            members,
+            ceiling=4,
+            policy=SplitPolicy(size_ceiling=1, max_fraction=0.10, max_depth=3),
+            recluster=_keeps_half,
+            tightening=Tightening.for_eddy_eps(0.3, 0.05),
+            domain="test-domain",
+        )
+        assert result.accepted == [members[:3]]
+        assert result.discarded == members[3:]
+
+    def test_accepted_and_discarded_partition_the_input(self) -> None:
+        """Every input ID lands in exactly one of accepted or discarded."""
+        members = _ids(37)
+
+        def _drops_the_tail(sub: Sequence[str], _parameter: float) -> list[list[str]]:
+            head = list(sub[:-1])
+            midpoint = len(head) // 2
+            return [head[:midpoint], head[midpoint:]] if midpoint else [head]
+
+        result = split_oversized(
+            members,
+            ceiling=5,
+            policy=SplitPolicy(size_ceiling=1, max_fraction=0.10, max_depth=3),
+            recluster=_drops_the_tail,
+            tightening=Tightening.for_eddy_eps(0.3, 0.05),
+            domain="test-domain",
+        )
+        placed = [fid for cluster in result.accepted for fid in cluster]
+        assert sorted(placed + result.discarded) == members
+        assert not set(placed) & set(result.discarded)
+
+    def test_input_sequence_is_not_mutated(self) -> None:
+        """The splitter never writes through to the caller's membership list."""
+        members = _ids(16)
+        original = list(members)
+        split_oversized(
+            members,
+            ceiling=4,
+            policy=SplitPolicy(size_ceiling=1, max_fraction=0.10, max_depth=3),
+            recluster=_halving(_Recorder()),
+            tightening=Tightening.for_eddy_eps(0.3, 0.05),
+            domain="test-domain",
+        )
+        assert members == original
+
+    def test_tightened_parameter_is_passed_never_assigned_to_the_detector(self) -> None:
+        """Re-clustering overrides the parameter without mutating detector state.
+
+        The splitter drives a detector through a callable that *receives*
+        the tightened value. If it instead reached in and set the
+        detector's own threshold, later unrelated detection on the same
+        instance would silently run at a tightened parameter.
+        """
+
+        class _FakeDetector:
+            """Minimal stand-in exposing a mutable clustering parameter."""
+
+            def __init__(self) -> None:
+                """Start at the module-default eddy epsilon."""
+                self.eps = 0.3
+
+            def recluster(
+                self,
+                sub: Sequence[str],
+                parameter: float,
+            ) -> list[list[str]]:
+                """Cluster *sub* at *parameter* without touching ``self.eps``.
+
+                Args:
+                    sub: Member IDs to re-cluster.
+                    parameter: Tightened epsilon for this round only.
+
+                Returns:
+                    Halves of *sub*, more finely split as eps tightens.
+                """
+                size = max(1, int(len(sub) * parameter / 0.3) // 2)
+                return [list(sub[i : i + size]) for i in range(0, len(sub), size)]
+
+        detector = _FakeDetector()
+        split_oversized(
+            _ids(16),
+            ceiling=4,
+            policy=SplitPolicy(size_ceiling=1, max_fraction=0.10, max_depth=3),
+            recluster=detector.recluster,
+            tightening=Tightening.for_eddy_eps(0.3, 0.05),
+            domain="test-domain",
+        )
+        assert detector.eps == pytest.approx(0.3)

--- a/creek-tools/tests/test_config.py
+++ b/creek-tools/tests/test_config.py
@@ -162,6 +162,87 @@ class TestLinkingConfig:
         cfg = LinkingConfig(cross_source_aggregation=True)
         assert cfg.cross_source_aggregation is True
 
+    def test_detector_threshold_defaults_match_previous_constants(self) -> None:
+        """Issue #880: the five formerly-hardcoded knobs keep their values.
+
+        These thresholds lived as module-private constants in
+        ``creek.link.eddies`` and ``creek.link.threads``. Exposing them must
+        not change what an existing vault — whose ``creek_config.yaml``
+        predates the keys entirely — computes.
+        """
+        cfg = LinkingConfig()
+        assert cfg.eddy_eps == 0.3
+        assert cfg.eddy_min_samples == 5
+        assert cfg.eddy_correlation_threshold == 0.3
+        assert cfg.thread_window_days == 30
+        assert cfg.thread_similarity_threshold == 0.6
+
+    def test_cluster_limit_defaults(self) -> None:
+        """Issue #880: cluster-ceiling defaults never fire on ordinary vaults."""
+        cfg = LinkingConfig()
+        assert cfg.cluster_size_ceiling == 500
+        assert cfg.cluster_max_fraction == 0.10
+        assert cfg.cluster_split_max_depth == 3
+        assert cfg.eddy_split_eps_step == 0.05
+        assert cfg.thread_split_similarity_step == 0.1
+
+    def test_segmentation_defaults(self) -> None:
+        """Issue #880: only Discord and email are segmented into episodes."""
+        cfg = LinkingConfig()
+        assert cfg.stream_platforms == ["discord", "email"]
+        assert cfg.stream_episode_max_gap_hours == 24
+        assert cfg.stream_episode_max_span_days == 30
+
+    def test_thread_union_without_embeddings_defaults_to_closed(self) -> None:
+        """Issue #880: a partially-embedded vault must not union on frequency."""
+        cfg = LinkingConfig()
+        assert cfg.thread_union_without_embeddings is False
+
+    def test_cluster_max_fraction_accepts_the_documented_opt_out(self) -> None:
+        """``1.0`` disables the ceiling — a cluster may span the whole corpus."""
+        cfg = LinkingConfig(cluster_max_fraction=1.0)
+        assert cfg.cluster_max_fraction == 1.0
+
+    def test_cluster_max_fraction_rejects_zero(self) -> None:
+        """A zero fraction would make every cluster oversized."""
+        with pytest.raises(ValueError, match="greater than 0"):
+            LinkingConfig(cluster_max_fraction=0.0)
+
+    def test_cluster_split_max_depth_accepts_zero(self) -> None:
+        """Depth 0 disables splitting (oversized clusters go straight to noise)."""
+        cfg = LinkingConfig(cluster_split_max_depth=0)
+        assert cfg.cluster_split_max_depth == 0
+
+    def test_cluster_size_ceiling_rejects_zero(self) -> None:
+        """A ceiling below one fragment is nonsensical."""
+        with pytest.raises(ValueError, match="greater than or equal to 1"):
+            LinkingConfig(cluster_size_ceiling=0)
+
+    def test_eddy_split_eps_step_rejects_one(self) -> None:
+        """A full-width step would drive epsilon past its valid range at once."""
+        with pytest.raises(ValueError, match="less than 1"):
+            LinkingConfig(eddy_split_eps_step=1.0)
+
+    def test_stream_episode_max_gap_hours_rejects_zero(self) -> None:
+        """A zero-hour gap would cut an episode at every message."""
+        with pytest.raises(ValueError, match="greater than or equal to 1"):
+            LinkingConfig(stream_episode_max_gap_hours=0)
+
+    def test_stream_platforms_accepts_a_known_platform(self) -> None:
+        """Operators may opt extra conversational platforms into segmentation."""
+        cfg = LinkingConfig(stream_platforms=["discord", "chatgpt"])
+        assert cfg.stream_platforms == ["discord", "chatgpt"]
+
+    def test_stream_platforms_rejects_an_unknown_platform(self) -> None:
+        """A typo must fail loudly rather than silently segmenting nothing."""
+        with pytest.raises(ValueError, match="unknown source platform"):
+            LinkingConfig(stream_platforms=["discrod"])
+
+    def test_stream_platforms_accepts_an_empty_list(self) -> None:
+        """An empty list is the documented way to disable segmentation."""
+        cfg = LinkingConfig(stream_platforms=[])
+        assert cfg.stream_platforms == []
+
 
 class TestClassificationConfig:
     """Tests for ClassificationConfig model."""
@@ -609,6 +690,33 @@ class TestLoadConfig:
         assert cfg.ocr.engine == "pytesseract"  # default preserved
         assert cfg.linking.temporal_window_hours == 48
         assert cfg.linking.thread_min_fragments == 3  # default preserved
+
+    def test_loads_cluster_ceiling_override_keeping_sibling_defaults(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Issue #880: one override applies; unset siblings keep their defaults.
+
+        This is the behaviour-preservation guard for vaults whose
+        ``creek_config.yaml`` predates the #880 keys: an operator who tunes a
+        single knob must not silently re-tune the other twelve.
+        """
+        config_file = tmp_path / "creek_config.yaml"
+        config_data = {
+            "linking": {
+                "cluster_max_fraction": 0.05,
+                "stream_platforms": ["discord"],
+            },
+        }
+        config_file.write_text(yaml.dump(config_data))
+
+        cfg = load_config(config_file)
+        assert cfg.linking.cluster_max_fraction == 0.05
+        assert cfg.linking.stream_platforms == ["discord"]
+        assert cfg.linking.cluster_size_ceiling == 500
+        assert cfg.linking.eddy_eps == 0.3
+        assert cfg.linking.thread_window_days == 30
+        assert cfg.linking.stream_episode_max_gap_hours == 24
 
     def test_loads_cross_source_aggregation_flag(self, tmp_path: Path) -> None:
         """YAML ``linking.cross_source_aggregation: true`` is honoured."""

--- a/creek-tools/tests/test_discord_ingest.py
+++ b/creek-tools/tests/test_discord_ingest.py
@@ -9,12 +9,16 @@ custom emoji), and full pipeline integration.
 from __future__ import annotations
 
 import json
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo
 
-from creek.ingest.base import ParsedFragment, RawDocument
+from creek.ingest.base import (
+    ParsedFragment,
+    RawDocument,
+    assemble_ingested_fragment,
+)
 from creek.ingest.discord import (
     DiscordIngestor,
     _build_message_index,
@@ -879,6 +883,87 @@ class TestDiscordIngestorGenerateFrontmatter:
         ingestor = DiscordIngestor()
         fm = ingestor.generate_frontmatter(self._fragment())
         assert fm["message_count"] == 3
+
+    def test_title_names_the_channel_and_date(self) -> None:
+        """Issue #880: the title names the conversation, not the export file.
+
+        ``generate_frontmatter`` emitted no ``title`` at all, so
+        ``assemble_ingested_fragment`` fell back to the source filename
+        stem — and ``discover`` only ever reads ``<channel>/messages.json``,
+        so every Discord fragment in every vault was titled ``messages``.
+        With 30,795 of them, that one word became the linker's only text
+        signal and named the mega-eddy ``Messages``.
+        """
+        ingestor = DiscordIngestor()
+        fm = ingestor.generate_frontmatter(self._fragment())
+        assert fm["title"] == "knowledge-sharing 2024-11-10"
+
+    def test_title_falls_back_to_the_channel_default(self) -> None:
+        """A channel-less export still gets a dated, non-filename title."""
+        frag = ParsedFragment(
+            content="test",
+            metadata={},
+            source_path="/fake/messages.json",
+            timestamp=datetime(2024, 11, 10, 14, 0, 0, tzinfo=LA_TZ),
+        )
+        ingestor = DiscordIngestor()
+        fm = ingestor.generate_frontmatter(frag)
+        assert fm["title"] == "unknown 2024-11-10"
+
+    def test_title_uses_the_source_side_authored_date(self) -> None:
+        """FEAT-031: the date in the title is the message's own, not LA's."""
+        frag = ParsedFragment(
+            content="test",
+            metadata={
+                "channel_name": "knowledge-sharing",
+                "authored_at": datetime(2024, 11, 11, 1, 0, 0, tzinfo=UTC),
+            },
+            source_path="/fake/messages.json",
+            timestamp=datetime(2024, 11, 10, 17, 0, 0, tzinfo=LA_TZ),
+        )
+        ingestor = DiscordIngestor()
+        fm = ingestor.generate_frontmatter(frag)
+        assert fm["title"] == "knowledge-sharing 2024-11-11"
+
+    def test_title_does_not_change_the_fragment_id(self) -> None:
+        """Issue #880: adding a title must not re-key any existing vault.
+
+        ``generate_fragment_id`` hashes source path, timestamp and content
+        and never the title, so an already-ingested Discord corpus keeps
+        every one of its fragment ids — and therefore its filenames, its
+        resonance edges and its frontmatter links — across this change.
+        """
+        parsed = self._fragment()
+        ingestor = DiscordIngestor()
+        frontmatter = ingestor.generate_frontmatter(parsed)
+
+        titled = ParsedFragment(
+            content=parsed.content,
+            metadata={
+                **parsed.metadata,
+                "markdown": "body",
+                "frontmatter": dict(frontmatter),
+            },
+            source_path=parsed.source_path,
+            timestamp=parsed.timestamp,
+        )
+        legacy_frontmatter = {k: v for k, v in frontmatter.items() if k != "title"}
+        untitled = ParsedFragment(
+            content=parsed.content,
+            metadata={
+                **parsed.metadata,
+                "markdown": "body",
+                "frontmatter": legacy_frontmatter,
+            },
+            source_path=parsed.source_path,
+            timestamp=parsed.timestamp,
+        )
+
+        new = assemble_ingested_fragment(titled).fragment
+        old = assemble_ingested_fragment(untitled).fragment
+        assert old.title == "messages"  # the pre-fix filename-stem fallback
+        assert new.title != old.title
+        assert new.id == old.id
 
     def test_missing_metadata_uses_defaults(self) -> None:
         """Should use default values when metadata keys are missing."""

--- a/creek-tools/tests/test_link.py
+++ b/creek-tools/tests/test_link.py
@@ -2126,3 +2126,154 @@ class TestLinkingPipeline:
         )
         assert fragment.threads == []
         assert "[[Link]]" in updated.threads
+
+
+# ---- Issue #880: bounded, honestly-named clusters ----
+
+
+class TestIssue880Detectors:
+    """Regression tests for message-stream cluster degeneration (#880)."""
+
+    @staticmethod
+    def _embedded_pair_corpus() -> tuple[list[Fragment], dict[str, list[float]]]:
+        """Return three F1 fragments where only two carry an embedding.
+
+        Returns:
+            The fragments and a partial embedding map — the shape of a
+            vault whose embedding cache is mid-rebuild.
+        """
+        now = datetime(2026, 4, 1)
+        fragments = [
+            _make_fragment(
+                f"Kiln notes {i}",
+                created=now - timedelta(days=10 - i),
+                primary_freq=Frequency.F1,
+                fid=f"frag-880t-{i}",
+            )
+            for i in range(3)
+        ]
+        return fragments, {
+            "frag-880t-0": [1.0, 0.0, 0.0],
+            "frag-880t-1": [1.0, 0.0, 0.0],
+        }
+
+    def test_eddy_id_is_stable_across_runs(self) -> None:
+        """Re-detecting the same cluster yields the same eddy id.
+
+        A random uuid meant every ``creek link`` run rewrote every eddy page
+        under a fresh filename. Segmentation and splitting produce many more,
+        smaller eddies, which multiplies that churn — so eddy identity now
+        mirrors the content-stable thread identity from #718.
+        """
+        now = datetime(2026, 4, 1)
+        ids = [f"frag-880e-{i}" for i in range(6)]
+        offsets = [600, 45, 400, 120, 500, 15]
+        fragments = [
+            _eddy_fragment(fid, "Kiln firing log", created=now - timedelta(days=off))
+            for fid, off in zip(ids, offsets, strict=True)
+        ]
+        embeddings = _dense_embeddings(ids)
+
+        first = EddyDetector(embeddings=embeddings).detect_eddies(fragments)
+        second = EddyDetector(embeddings=embeddings).detect_eddies(fragments)
+
+        assert len(first) == 1
+        assert [e.id for e in first] == [e.id for e in second]
+        assert first[0].id.startswith("eddy-")
+
+    def test_eddy_and_thread_pages_carry_a_description(self) -> None:
+        """Generated clusters never ship the empty description they used to.
+
+        Neither detector ever passed ``description``, so 212 of 214
+        linker-written pages in the demo vault shipped ``description: ''``.
+        """
+        now = datetime(2026, 4, 1)
+        ids = [f"frag-880d-{i}" for i in range(6)]
+        offsets = [600, 45, 400, 120, 500, 15]
+        fragments = [
+            _eddy_fragment(fid, "Kiln firing log", created=now - timedelta(days=off))
+            for fid, off in zip(ids, offsets, strict=True)
+        ]
+        eddies = EddyDetector(embeddings=_dense_embeddings(ids)).detect_eddies(
+            fragments,
+        )
+        assert eddies
+        assert all(eddy.description.strip() for eddy in eddies)
+
+        thread_frags, _ = self._embedded_pair_corpus()
+        threads = ThreadDetector(now=now).detect_threads(thread_frags)
+        assert threads
+        assert all(thread.description.strip() for thread in threads)
+
+    def test_missing_embedding_does_not_union_on_an_embedded_corpus(self) -> None:
+        """The fail-open is closed: an unembedded fragment does not chain.
+
+        ``_topic_consistent`` returned ``True`` on frequency overlap alone
+        whenever either embedding was absent, so a partially-embedded vault
+        unioned far more aggressively than its similarity gate implied. Two
+        of these three fragments are embedded; the third must not join them.
+        """
+        now = datetime(2026, 4, 1)
+        fragments, embeddings = self._embedded_pair_corpus()
+
+        threads = ThreadDetector(
+            embeddings=embeddings,
+            now=now,
+        ).detect_threads(fragments, min_fragments=3)
+
+        assert threads == []
+
+    def test_missing_embedding_may_union_when_explicitly_opted_in(self) -> None:
+        """The old permissive behaviour survives as a documented opt-in."""
+        now = datetime(2026, 4, 1)
+        fragments, embeddings = self._embedded_pair_corpus()
+
+        threads = ThreadDetector(
+            embeddings=embeddings,
+            now=now,
+            union_without_embeddings=True,
+        ).detect_threads(fragments, min_fragments=3)
+
+        assert len(threads) == 1
+        assert threads[0].fragment_count == 3
+
+    def test_no_embeddings_at_all_still_uses_frequency_only(self) -> None:
+        """A detector with no embeddings keeps its documented fallback.
+
+        Closing the fail-open must not break the frequency-only mode the
+        class docstring has always promised for an unembedded corpus.
+        """
+        now = datetime(2026, 4, 1)
+        fragments, _ = self._embedded_pair_corpus()
+
+        threads = ThreadDetector(now=now).detect_threads(fragments, min_fragments=3)
+
+        assert len(threads) == 1
+        assert threads[0].fragment_count == 3
+
+    def test_colliding_titles_are_disambiguated_within_a_run(self) -> None:
+        """Two clusters that would share a title get distinct wiki-link names.
+
+        ``assign_fragments_to_eddies`` interpolates the title straight into
+        ``[[...]]``, so a collision sends both memberships to whichever page
+        resolves first.
+        """
+        now = datetime(2026, 4, 1)
+        cluster_a = [f"frag-880u-a{i}" for i in range(6)]
+        cluster_b = [f"frag-880u-b{i}" for i in range(6)]
+        embeddings = {fid: [1.0, 0.0, 0.0] for fid in cluster_a}
+        embeddings.update({fid: [0.0, 1.0, 0.0] for fid in cluster_b})
+        offsets = [600, 45, 400, 120, 500, 15]
+        fragments = [
+            _eddy_fragment(fid, "Kiln firing log", created=now - timedelta(days=off))
+            for fid, off in zip(cluster_a, offsets, strict=True)
+        ]
+        fragments.extend(
+            _eddy_fragment(fid, "Kiln firing log", created=now - timedelta(days=off))
+            for fid, off in zip(cluster_b, offsets, strict=True)
+        )
+
+        eddies = EddyDetector(embeddings=embeddings).detect_eddies(fragments)
+
+        assert len(eddies) == 2
+        assert len({eddy.title for eddy in eddies}) == 2

--- a/creek-tools/tests/test_link_engine.py
+++ b/creek-tools/tests/test_link_engine.py
@@ -727,3 +727,135 @@ def test_run_link_eddies_preserves_extra_frontmatter_and_body(
         assert any(
             isinstance(entry, str) and entry.startswith("[[") for entry in eddies_field
         ), f"Fragment {frag.id} lost its eddy wiki-link"
+
+
+# ----- Issue #880: cluster-limit and segmentation plumbing -------------------
+
+
+def test_run_link_eddies_reports_largest_cluster(tmp_path: Path) -> None:
+    """``LinkSummary`` carries the largest detected cluster size.
+
+    Issue #880: ``docs/linking.md`` has advertised a ``largest: N fragments``
+    line since the linker shipped, and no code ever produced the number —
+    which is exactly the statistic that would have made the 30,795-fragment
+    mega-eddy visible without opening the vault.
+    """
+    vault = tmp_path / "vault"
+    fragments = _embedded_eddy_fragments(vault, count=8)
+
+    summary = run_link(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="eddies",
+        rebuild=False,
+    )
+
+    assert summary.eddies_detected == 1
+    assert summary.largest_cluster_fragments == len(fragments)
+    assert summary.clusters_split == 0
+    assert summary.oversized_discarded == 0
+
+
+def test_run_link_honours_configured_cluster_ceiling(tmp_path: Path) -> None:
+    """A configured ceiling reaches the detector and bounds what is emitted.
+
+    Issue #880: ``run_link`` used to construct ``EddyDetector(embeddings=...)``
+    with embeddings only, so every threshold fell back to a module constant
+    and no configured value could change the outcome. Here the ceiling is set
+    below the single dense cluster, which is eight identical vectors and
+    therefore cannot be split by any epsilon — so the guardrail's
+    discard-to-noise path fires and is reported.
+    """
+    vault = tmp_path / "vault"
+    fragments = _embedded_eddy_fragments(vault, count=8)
+    config = CreekConfig()
+    config.linking.cluster_size_ceiling = 1
+    config.linking.cluster_max_fraction = 0.5
+
+    summary = run_link(
+        vault_path=vault,
+        config=config,
+        method="eddies",
+        rebuild=False,
+    )
+
+    assert summary.eddies_detected == 0
+    assert summary.clusters_split == 1
+    assert summary.oversized_discarded == len(fragments)
+    assert summary.largest_cluster_fragments == 0
+
+
+def _embedded_message_stream(vault: Path) -> list[Fragment]:
+    """Seed *vault* with two Discord channels ten days apart, one dense blob.
+
+    Every fragment carries the same title and an identical embedding, so
+    without segmentation DBSCAN sees exactly one cluster spanning both
+    channels — the shape of the #880 mega-eddy in miniature.
+
+    Args:
+        vault: Vault root.
+
+    Returns:
+        The created fragments in creation order.
+    """
+    from datetime import datetime, timedelta
+
+    base = datetime(2026, 4, 1, 9, 0)
+    fragments: list[Fragment] = []
+    for channel_index, channel in enumerate(("stagecraft", "starlight")):
+        for message in range(5):
+            authored = base + timedelta(days=10 * channel_index, hours=message)
+            frag = Fragment(
+                id=f"frag-880-{channel_index}-{message:02d}",
+                title="messages",
+                source=FragmentSource(
+                    platform=SourcePlatform.DISCORD,
+                    channel=channel,
+                ),
+                created=authored,
+                authored_at=authored,
+            )
+            _write_fragment(vault=vault, fragment=frag, body="body")
+            fragments.append(frag)
+
+    config = CreekConfig()
+    linker = EmbeddingLinker(config=config.embeddings)
+    vectors = {frag.id: [1.0, 0.0, 0.0] for frag in fragments}
+    cache_path = embeddings_cache_path(vault)
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    linker.save_cache(linker.build_cache_entries(fragments, vectors), cache_path)
+    return fragments
+
+
+def test_run_link_honours_configured_stream_platforms(tmp_path: Path) -> None:
+    """The configured stream-platform list reaches the detector, both ways.
+
+    Issue #880: with the default list, two Discord channels ten days apart
+    are two conversation episodes and therefore two eddies. Emptying the
+    list — the documented way to disable segmentation — collapses them back
+    into the single ten-fragment blob the bug produced. Neither outcome is
+    reachable unless ``run_link`` actually passes the configuration to
+    ``EddyDetector``, which it previously did not.
+    """
+    vault = tmp_path / "vault"
+    fragments = _embedded_message_stream(vault)
+
+    segmented = run_link(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="eddies",
+        rebuild=False,
+    )
+    assert segmented.eddies_detected == 2
+    assert segmented.largest_cluster_fragments == len(fragments) // 2
+
+    unsegmented_config = CreekConfig()
+    unsegmented_config.linking.stream_platforms = []
+    unsegmented = run_link(
+        vault_path=vault,
+        config=unsegmented_config,
+        method="eddies",
+        rebuild=False,
+    )
+    assert unsegmented.eddies_detected == 1
+    assert unsegmented.largest_cluster_fragments == len(fragments)

--- a/creek-tools/tests/test_link_message_stream_880.py
+++ b/creek-tools/tests/test_link_message_stream_880.py
@@ -1,0 +1,806 @@
+"""Reproduction corpus for issue #880 — message-stream cluster degeneration.
+
+The existing scale fixture (``_clustered_corpus`` in
+``tests/test_link_scale_790.py``) cannot reproduce this defect: it builds
+one-hot vectors, so cross-cluster cosine is exactly ``0.0`` and transitive
+density-bridging is arithmetically impossible; every cluster is exactly
+``per_cluster`` members, so the largest-cluster share is fixed by
+construction; every title is distinct, so the naming defect cannot fire; and
+every fragment is ``Frequency.UNCLASSIFIED``, which ``_frequency_overlap``
+discards, so thread detection yields nothing. A ceiling test written on top of
+it would pass vacuously whether or not the bug exists.
+
+This module builds the corpus the demo vault actually contains:
+
+* A **random walk on the unit sphere** confined to the first ``_WALK_DIMS``
+  dimensions. Consecutive messages sit at cosine ``~0.95``, well inside the
+  ``0.70`` edge threshold implied by ``eps=0.3``, so every point is a DBSCAN
+  core point and the epsilon-graph is a *single connected component with a
+  large diameter* — a continuous semantic manifold with no low-density
+  separator for DBSCAN to find. This is the real mechanism behind the 87%
+  mega-eddy, not injected noise.
+* The walk is **out-and-back**: it drifts away for the first half and returns
+  along its own path for the second. Cosine drift from the earliest member
+  therefore rises and then falls, so ``_spearman_with_time`` lands near zero
+  and ``EddyDetector._has_temporal_direction`` does *not* reject the
+  mega-cluster. A monotone walk would be filtered out and every downstream
+  assertion would pass against zero eddies.
+* Stream fragments all carry ``title="messages"`` verbatim (matching the
+  30,795 Discord fragments on disk), ``platform=discord``, and a shared ``F2``
+  frequency (matching the demo vault's ``frequency_affinity: [F2]``), so both
+  the naming defect and the thread-union defect reproduce.
+* Three **planted topics** sit on dimensions orthogonal to the entire walk
+  subspace, interleaved into the same time range with real, distinct titles
+  and their own frequencies. They must survive as separate eddies and threads,
+  which is what stops "split everything harder" from looking like a fix.
+
+Determinism comes from ``numpy.random.default_rng(_SEED)``.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+from datetime import datetime, timedelta
+from typing import NamedTuple
+from unittest.mock import patch
+
+import numpy as np
+
+from creek.config import LinkingConfig
+from creek.link.cluster_limits import SplitPolicy
+from creek.link.eddies import EddyDetector, _cosine_distance, _spearman_with_time
+from creek.link.segments import partition
+from creek.link.threads import ThreadDetector
+from creek.models import (
+    Fragment,
+    FragmentSource,
+    Frequency,
+    FrequencyClassification,
+    Phase,
+    SourcePlatform,
+    WavelengthClassification,
+)
+from creek.time import effective_authored_at
+
+# --- Detector settings under test (production defaults) ---------------------
+_EPS = 0.3
+_MIN_SAMPLES = 5
+_CORRELATION_THRESHOLD = 0.3
+_WINDOW_DAYS = 30
+_SIMILARITY_THRESHOLD = 0.6
+
+# --- Corpus geometry --------------------------------------------------------
+_SEED = 880
+_DIMS = 16
+_TOPIC_DIMS = 3
+_WALK_DIMS = _DIMS - _TOPIC_DIMS
+_STREAM_FRAGMENTS = 600
+#: Step length for the walk. ``cos(v_k, v_{k+1}) ~= 1/sqrt(1 + step**2)``,
+#: i.e. ~0.95 — comfortably above the 0.70 edge threshold at ``eps=0.3``.
+_WALK_STEP = 0.33
+#: Tiny perturbation on the return leg so the inbound half is a near-retrace
+#: rather than a literal mirror image of the outbound half.
+_RETURN_JITTER = 0.02
+_MESSAGE_SPACING_HOURS = 6
+_CHANNEL_GAP_DAYS = 4
+_CORPUS_START = datetime(2023, 1, 1, 9, 0)
+_STREAM_TITLE = "messages"
+_STREAM_FREQUENCY = Frequency.F2
+_STREAM_CHANNELS = ("Aspiring Drag Queens", "Backyard Astronomy", "Sourdough Hours")
+_TOPIC_MEMBERS = 12
+_PLANTED_TOPICS = (
+    ("harmonic analysis in cathedrals", Frequency.F5),
+    ("tidepool taxonomy fieldnotes", Frequency.F7),
+    ("estate planning for musicians", Frequency.F9),
+)
+
+# --- Fixture-validity bar ---------------------------------------------------
+#: The single connected component must swallow at least 95% of the stream.
+_DEGENERATE_COMPONENT_SHARE = 0.95
+
+# --- Split policy under test ------------------------------------------------
+#: Deliberately far below the 500 production default so the *fractional* term
+#: governs on a 636-fragment corpus; the default ceiling of 500 exceeds the
+#: whole stream, so the test could never fail with it.
+_SPLIT_SIZE_CEILING = 50
+_SPLIT_MAX_FRACTION = 0.10
+_SPLIT_MAX_DEPTH = 3
+
+# --- Single-episode variant -------------------------------------------------
+#: One channel, no inter-channel gap, and hourly spacing so all 600 messages
+#: span 25 days — inside both the 24-hour inactivity gap and the 30-day span
+#: backstop. Segmentation therefore cannot cut it, leaving the size ceiling as
+#: the only thing standing between the corpus and a 600-fragment mega-page.
+_SINGLE_EPISODE_SPACING_HOURS = 1
+
+#: How many of a planted topic's own words its generated title must carry
+#: before the title counts as naming that topic rather than merely being
+#: distinct from the others.
+_MIN_SHARED_TITLE_TOKENS = 2
+
+
+def _unit_vector(rng: np.random.Generator) -> np.ndarray:
+    """Draw a uniformly random unit vector in the walk subspace.
+
+    Args:
+        rng: Seeded generator supplying the draw.
+
+    Returns:
+        A unit-norm array of length ``_WALK_DIMS``.
+    """
+    raw = rng.normal(size=_WALK_DIMS)
+    return raw / np.linalg.norm(raw)
+
+
+def _walk_step(rng: np.random.Generator, current: np.ndarray) -> np.ndarray:
+    """Take one small random step away from *current* on the unit sphere.
+
+    Args:
+        rng: Seeded generator supplying the step direction.
+        current: The unit vector to step away from.
+
+    Returns:
+        A new unit vector at cosine ``~0.95`` from *current*.
+    """
+    stepped = current + _WALK_STEP * _unit_vector(rng)
+    return stepped / np.linalg.norm(stepped)
+
+
+def _jittered(rng: np.random.Generator, vector: np.ndarray) -> np.ndarray:
+    """Return *vector* nudged by a small random perturbation.
+
+    Args:
+        rng: Seeded generator supplying the perturbation.
+        vector: The unit vector to nudge.
+
+    Returns:
+        A unit vector very close to *vector*.
+    """
+    nudged = vector + _RETURN_JITTER * rng.normal(size=_WALK_DIMS)
+    return nudged / np.linalg.norm(nudged)
+
+
+def _embed(walk_vector: np.ndarray) -> list[float]:
+    """Pad a walk vector into full corpus dimensionality.
+
+    The trailing ``_TOPIC_DIMS`` coordinates stay zero, so every walk vector is
+    exactly orthogonal to every planted-topic vector.
+
+    Args:
+        walk_vector: A unit vector of length ``_WALK_DIMS``.
+
+    Returns:
+        A ``_DIMS``-long embedding as plain floats.
+    """
+    return [float(x) for x in walk_vector] + [0.0] * _TOPIC_DIMS
+
+
+def _out_and_back_walk(rng: np.random.Generator, count: int) -> list[list[float]]:
+    """Generate *count* embeddings tracing an out-and-back random walk.
+
+    The outbound half drifts away from the start; the inbound half retraces it
+    with a small jitter. Cosine drift from the first point therefore rises and
+    falls, keeping the Spearman time-vs-drift correlation near zero so
+    ``EddyDetector._has_temporal_direction`` does not reject the cluster.
+
+    Args:
+        rng: Seeded generator driving the walk.
+        count: Number of embeddings to produce.
+
+    Returns:
+        A list of *count* embeddings, each ``_DIMS`` long.
+    """
+    half = (count + 1) // 2
+    outbound = [_unit_vector(rng)]
+    for _ in range(half - 1):
+        outbound.append(_walk_step(rng, outbound[-1]))
+    inbound = [_jittered(rng, vector) for vector in reversed(outbound)]
+    return [_embed(vector) for vector in (outbound + inbound)[:count]]
+
+
+def _fragment(
+    fid: str,
+    *,
+    title: str,
+    platform: SourcePlatform,
+    channel: str | None,
+    frequency: Frequency,
+    at: datetime,
+) -> Fragment:
+    """Build one corpus fragment.
+
+    Args:
+        fid: Fragment ID.
+        title: Fragment title (verbatim; the linker's only text signal).
+        platform: Source platform.
+        channel: Source channel, or ``None`` for non-stream fragments.
+        frequency: Primary APTITUDE frequency.
+        at: Authored/created timestamp.
+
+    Returns:
+        A populated :class:`~creek.models.Fragment`.
+    """
+    return Fragment(
+        id=fid,
+        title=title,
+        source=FragmentSource(platform=platform, channel=channel),
+        created=at,
+        ingested=at,
+        authored_at=at,
+        frequency=FrequencyClassification(primary=frequency),
+        wavelength=WavelengthClassification(phase=Phase.UNCLASSIFIED),
+    )
+
+
+def _stream_fragments(
+    rng: np.random.Generator,
+    *,
+    channels: tuple[str, ...],
+    spacing_hours: float,
+    gap_days: float,
+) -> tuple[list[Fragment], dict[str, list[float]], timedelta]:
+    """Build the Discord-style message stream.
+
+    Args:
+        rng: Seeded generator driving the walk.
+        channels: Channel names, taken in contiguous equal blocks.
+        spacing_hours: Hours between consecutive messages.
+        gap_days: Inactivity gap inserted between channel blocks.
+
+    Returns:
+        The fragments, their embeddings, and the stream's total time span.
+    """
+    vectors = _out_and_back_walk(rng, _STREAM_FRAGMENTS)
+    per_channel = _STREAM_FRAGMENTS // len(channels)
+    fragments: list[Fragment] = []
+    embeddings: dict[str, list[float]] = {}
+    at = _CORPUS_START
+    for index, vector in enumerate(vectors):
+        if index and index % per_channel == 0:
+            at += timedelta(days=gap_days)
+        fid = f"msg-{index:04d}"
+        fragments.append(
+            _fragment(
+                fid,
+                title=_STREAM_TITLE,
+                platform=SourcePlatform.DISCORD,
+                channel=channels[min(index // per_channel, len(channels) - 1)],
+                frequency=_STREAM_FREQUENCY,
+                at=at,
+            )
+        )
+        embeddings[fid] = vector
+        at += timedelta(hours=spacing_hours)
+    return fragments, embeddings, at - _CORPUS_START
+
+
+def _planted_topic_fragments(
+    span: timedelta,
+) -> tuple[list[Fragment], dict[str, list[float]]]:
+    """Build the three planted topics interleaved across the stream's span.
+
+    Each topic owns one trailing dimension, so its cosine against every stream
+    vector is exactly ``0.0``. Members are spaced closely enough to chain
+    inside the 30-day thread window.
+
+    Args:
+        span: Total time span of the message stream.
+
+    Returns:
+        The topic fragments and their embeddings.
+    """
+    fragments: list[Fragment] = []
+    embeddings: dict[str, list[float]] = {}
+    for topic_index, (label, frequency) in enumerate(_PLANTED_TOPICS):
+        vector = [0.0] * _DIMS
+        vector[_WALK_DIMS + topic_index] = 1.0
+        for member in range(_TOPIC_MEMBERS):
+            fid = f"topic-{topic_index}-{member:02d}"
+            at = _CORPUS_START + span * (member / _TOPIC_MEMBERS)
+            fragments.append(
+                _fragment(
+                    fid,
+                    title=f"{label} {member}",
+                    platform=SourcePlatform.CLAUDE,
+                    channel=None,
+                    frequency=frequency,
+                    at=at,
+                )
+            )
+            embeddings[fid] = list(vector)
+    return fragments, embeddings
+
+
+def _message_stream_corpus(
+    *,
+    seed: int = _SEED,
+    channels: tuple[str, ...] = _STREAM_CHANNELS,
+    spacing_hours: float = _MESSAGE_SPACING_HOURS,
+    gap_days: float = _CHANNEL_GAP_DAYS,
+    with_topics: bool = True,
+) -> tuple[list[Fragment], dict[str, list[float]]]:
+    """Build the #880 reproduction corpus.
+
+    Args:
+        seed: Seed for ``numpy.random.default_rng`` — determinism, not chance.
+        channels: Channel names for the stream, in contiguous blocks. Pass a
+            single channel with ``gap_days=0`` for a one-episode variant that
+            segmentation cannot break up.
+        spacing_hours: Hours between consecutive messages.
+        gap_days: Inactivity gap between channel blocks.
+        with_topics: Whether to include the three planted topics.
+
+    Returns:
+        The fragments and the fragment-ID to embedding mapping.
+    """
+    rng = np.random.default_rng(seed)
+    fragments, embeddings, span = _stream_fragments(
+        rng,
+        channels=channels,
+        spacing_hours=spacing_hours,
+        gap_days=gap_days,
+    )
+    if with_topics:
+        topic_fragments, topic_embeddings = _planted_topic_fragments(span)
+        fragments.extend(topic_fragments)
+        embeddings.update(topic_embeddings)
+    return fragments, embeddings
+
+
+def _stream_ids(fragments: list[Fragment]) -> list[str]:
+    """Return the IDs of the message-stream fragments only.
+
+    Args:
+        fragments: The full corpus.
+
+    Returns:
+        Stream fragment IDs in corpus order.
+    """
+    return [f.id for f in fragments if f.source.channel is not None]
+
+
+def _title_tokens(title: str) -> list[str]:
+    """Lowercase alphabetic tokens of *title*.
+
+    Args:
+        title: A generated eddy or thread title.
+
+    Returns:
+        The title's lowercase word tokens.
+    """
+    return re.findall(r"[a-z]+", title.lower())
+
+
+def _dominant_channel(members: list[Fragment]) -> str | None:
+    """Return the most common non-``None`` channel across *members*.
+
+    Args:
+        members: Fragments belonging to one cluster.
+
+    Returns:
+        The dominant channel name, or ``None`` if no member has one.
+    """
+    counts = Counter(f.source.channel for f in members if f.source.channel)
+    if not counts:
+        return None
+    return counts.most_common(1)[0][0]
+
+
+class _Run(NamedTuple):
+    """One detection run, reduced to the facts the acceptance criteria name.
+
+    Both detectors expose the same shape — a membership map plus a page
+    per cluster — so reducing them to this lets one assertion body cover
+    eddies and threads without pretending the two algorithms are the same
+    underneath.
+
+    Attributes:
+        members: Cluster ID to member fragment IDs, for emitted clusters.
+        titles: Cluster ID to generated page title.
+        descriptions: Cluster ID to generated page description.
+        clusters_split: Clusters that exceeded the ceiling and were
+            re-clustered.
+        discarded: Fragments dropped to noise by the size guardrail.
+    """
+
+    members: dict[str, list[str]]
+    titles: dict[str, str]
+    descriptions: dict[str, str]
+    clusters_split: int
+    discarded: int
+
+
+def _eddy_run(
+    fragments: list[Fragment],
+    embeddings: dict[str, list[float]],
+    *,
+    policy: SplitPolicy | None = None,
+) -> _Run:
+    """Detect eddies over the corpus and reduce the result to a :class:`_Run`.
+
+    Args:
+        fragments: The corpus.
+        embeddings: Fragment-ID to embedding mapping.
+        policy: Split policy, or ``None`` for the production default.
+
+    Returns:
+        The run's memberships, pages and guardrail counters.
+    """
+    detector = EddyDetector(
+        embeddings=embeddings,
+        eps=_EPS,
+        min_samples=_MIN_SAMPLES,
+        split_policy=policy,
+    )
+    eddies = detector.detect_eddies(fragments)
+    return _Run(
+        members=detector.eddy_members,
+        titles={e.id: e.title for e in eddies},
+        descriptions={e.id: e.description for e in eddies},
+        clusters_split=detector.clusters_split,
+        discarded=detector.oversized_discarded,
+    )
+
+
+def _thread_run(
+    fragments: list[Fragment],
+    embeddings: dict[str, list[float]],
+    *,
+    policy: SplitPolicy | None = None,
+) -> _Run:
+    """Detect threads over the corpus and reduce the result to a :class:`_Run`.
+
+    Args:
+        fragments: The corpus.
+        embeddings: Fragment-ID to embedding mapping.
+        policy: Split policy, or ``None`` for the production default.
+
+    Returns:
+        The run's memberships, pages and guardrail counters.
+    """
+    detector = ThreadDetector(
+        embeddings=embeddings,
+        window_days=_WINDOW_DAYS,
+        similarity_threshold=_SIMILARITY_THRESHOLD,
+        split_policy=policy,
+    )
+    threads = detector.detect_threads(fragments)
+    return _Run(
+        members=detector.thread_members,
+        titles={t.id: t.title for t in threads},
+        descriptions={t.id: t.description for t in threads},
+        clusters_split=detector.clusters_split,
+        discarded=detector.oversized_discarded,
+    )
+
+
+def _topic_members(topic_index: int) -> set[str]:
+    """Return the fragment IDs the generator planted for one topic.
+
+    Args:
+        topic_index: Position of the topic in :data:`_PLANTED_TOPICS`.
+
+    Returns:
+        The topic's complete member set.
+    """
+    return {f"topic-{topic_index}-{member:02d}" for member in range(_TOPIC_MEMBERS)}
+
+
+def _claimants(members: dict[str, list[str]], wanted: set[str]) -> dict[str, set[str]]:
+    """Return every emitted cluster whose membership touches *wanted*.
+
+    Args:
+        members: Cluster ID to member fragment IDs.
+        wanted: The fragment IDs of one planted topic.
+
+    Returns:
+        Cluster ID to full membership, for each cluster that holds at
+        least one of *wanted*.
+    """
+    return {
+        cid: set(member_ids)
+        for cid, member_ids in members.items()
+        if wanted & set(member_ids)
+    }
+
+
+def test_message_stream_fixture_reproduces_a_single_density_connected_component() -> (
+    None
+):
+    """The stream must degenerate into one huge, temporally-undirected cluster.
+
+    This is the anti-vacuity guard for the whole module, and it is *green on
+    unmodified main by design*: it asserts that the bug exists. It fails the
+    moment the generator stops producing a single connected epsilon-graph, or
+    the moment the out-and-back walk becomes monotone and
+    ``_has_temporal_direction`` starts silently filtering the mega-cluster away
+    — either of which would make every other assertion here pass for free.
+    """
+    fragments, embeddings = _message_stream_corpus()
+    stream_ids = _stream_ids(fragments)
+    assert len(stream_ids) == _STREAM_FRAGMENTS
+
+    detector = EddyDetector(
+        embeddings=embeddings,
+        eps=_EPS,
+        min_samples=_MIN_SAMPLES,
+    )
+    # Issue #880: drive the raw, unpartitioned, unlimited clustering path
+    # directly so the fixture's own geometry is what is under assertion.
+    clusters = detector._dbscan(stream_ids)
+    assert len(clusters) == 1
+    assert len(clusters[0]) >= _STREAM_FRAGMENTS * _DEGENERATE_COMPONENT_SHARE
+
+    by_id = {f.id: f for f in fragments}
+    ordered = sorted((by_id[fid] for fid in clusters[0]), key=effective_authored_at)
+    anchor = embeddings[ordered[0].id]
+    drifts = [_cosine_distance(anchor, embeddings[f.id]) for f in ordered]
+    assert abs(_spearman_with_time(drifts)) < _CORRELATION_THRESHOLD
+
+
+def test_no_eddy_exceeds_the_configured_corpus_fraction() -> None:
+    """No eddy may hold more than the configured fraction of the corpus.
+
+    Acceptance criterion 1 for eddies. On unmodified main the epsilon-graph is
+    one connected component, ``_expand_cluster`` propagates a single label
+    across every stream fragment, ``_has_temporal_direction`` passes it, and
+    the only size guard in the module is a *minimum* — so the largest eddy is
+    ~94% of the corpus against a 10% bar.
+    """
+    fragments, embeddings = _message_stream_corpus()
+    policy = SplitPolicy(
+        size_ceiling=_SPLIT_SIZE_CEILING,
+        max_fraction=_SPLIT_MAX_FRACTION,
+        max_depth=_SPLIT_MAX_DEPTH,
+    )
+    detector = EddyDetector(
+        embeddings=embeddings,
+        eps=_EPS,
+        min_samples=_MIN_SAMPLES,
+        split_policy=policy,
+    )
+    detector.detect_eddies(fragments)
+
+    ceiling = policy.ceiling_for(len(fragments))
+    assert ceiling == math.floor(len(fragments) * _SPLIT_MAX_FRACTION)
+    assert detector.eddy_members
+    largest = max(len(members) for members in detector.eddy_members.values())
+    assert largest <= ceiling
+
+
+def test_eddy_titles_never_reduce_to_the_platform_word() -> None:
+    """A word carried by 87% of the corpus must never become a topic label.
+
+    All 600 stream fragments carry ``title="messages"`` verbatim, exactly as
+    the demo vault does. On unmodified main ``_generate_title`` is a raw
+    ``Counter`` over title content words with no inverse-document-frequency
+    term at all — despite its docstring claiming "TF-IDF-lite" — and
+    ``"messages"`` is absent from ``_STOPWORDS``, so ``most_common(3)`` over
+    600 identical titles yields ``[("messages", 600)]`` and the eddy is named
+    ``Messages``. Every stream-derived eddy must instead be named from
+    structure that actually distinguishes it: its dominant channel.
+    """
+    fragments, embeddings = _message_stream_corpus()
+    detector = EddyDetector(
+        embeddings=embeddings,
+        eps=_EPS,
+        min_samples=_MIN_SAMPLES,
+    )
+    eddies = detector.detect_eddies(fragments)
+    assert eddies
+
+    for eddy in eddies:
+        assert _STREAM_TITLE not in _title_tokens(eddy.title)
+
+    by_id = {f.id: f for f in fragments}
+    for eddy in eddies:
+        members = [by_id[fid] for fid in detector.eddy_members[eddy.id]]
+        channel = _dominant_channel(members)
+        if channel is None:
+            continue
+        assert channel in eddy.title
+
+
+def test_no_thread_exceeds_the_configured_corpus_fraction() -> None:
+    """No thread may hold more than the configured fraction of the corpus.
+
+    Acceptance criterion 1 for threads, which the eddy half of this
+    criterion cannot stand in for: threads degenerate through a *different*
+    mechanism. The 30-day window bounds only which pairs are ever
+    *compared*; ``_UnionFind.union`` is unbounded, so overlapping windows
+    take the transitive closure of the whole stream and put message 0 and
+    message 599 in one component without the two ever being compared.
+    Measured on unmodified main this corpus yields thread sizes
+    ``[600, 12, 12, 12]`` — a largest share of 0.943 against a 10% bar.
+
+    ``clusters_split`` is asserted too, so the test cannot pass by the
+    detector quietly finding nothing at all.
+    """
+    fragments, embeddings = _message_stream_corpus()
+    policy = SplitPolicy(
+        size_ceiling=_SPLIT_SIZE_CEILING,
+        max_fraction=_SPLIT_MAX_FRACTION,
+        max_depth=_SPLIT_MAX_DEPTH,
+    )
+    run = _thread_run(fragments, embeddings, policy=policy)
+
+    ceiling = policy.ceiling_for(len(fragments))
+    assert ceiling == math.floor(len(fragments) * _SPLIT_MAX_FRACTION)
+    assert run.clusters_split >= 1
+    assert run.members
+    largest = max(len(members) for members in run.members.values())
+    assert largest <= ceiling
+
+
+def test_planted_topics_survive_as_distinct_eddies_and_threads() -> None:
+    """Bounding the mega-cluster must not shred the corpus's real topics.
+
+    This is the anti-overcorrection criterion, and it is what separates a
+    fix from "shatter everything" or "cluster nothing": both of those pass
+    every ceiling assertion in this module. The three planted topics sit on
+    dimensions orthogonal to the entire walk subspace, are interleaved
+    across the stream's whole time range, and carry real distinct titles,
+    so each must come back as *exactly one* cluster holding *exactly* its
+    own twelve members — no stream fragment absorbed, no member shed — and
+    the three must carry three different, topic-bearing titles.
+
+    Run at the production default :class:`SplitPolicy`, so the stream is
+    clustered alongside the topics rather than being discarded out from
+    under them.
+
+    Without the fix the stream collapses into one 600-member component
+    named ``Messages``; the topics survive that run, but any subsequent
+    attempt to bound the mega-cluster by tightening a global parameter
+    (eps, or the similarity floor) shatters the twelve-member topics first,
+    because they are the smallest, tightest clusters in the corpus. This
+    test is the reason segmentation was chosen over global tightening.
+    """
+    fragments, embeddings = _message_stream_corpus(with_topics=True)
+    runs = (
+        _eddy_run(fragments, embeddings),
+        _thread_run(fragments, embeddings),
+    )
+
+    for run in runs:
+        claimed: dict[str, int] = {}
+        for topic_index, (label, _) in enumerate(_PLANTED_TOPICS):
+            wanted = _topic_members(topic_index)
+            claimants = _claimants(run.members, wanted)
+            assert len(claimants) == 1
+            cluster_id, membership = next(iter(claimants.items()))
+            assert membership == wanted
+            shared = set(_title_tokens(run.titles[cluster_id])) & set(
+                _title_tokens(label)
+            )
+            assert len(shared) >= _MIN_SHARED_TITLE_TOKENS
+            claimed[cluster_id] = topic_index
+        assert len(claimed) == len(_PLANTED_TOPICS)
+        assert len({run.titles[cid] for cid in claimed}) == len(_PLANTED_TOPICS)
+
+
+def test_every_emitted_eddy_and_thread_has_a_non_empty_description() -> None:
+    """Every generated page must ship a usable one-line ``description``.
+
+    Acceptance criterion 3. ``grep -rn description creek/link/*.py``
+    returned zero hits before the fix: neither detector ever passed the
+    field, so :class:`~creek.models.Eddy` and :class:`~creek.models.Thread`
+    fell back to their empty-string default and 212 of the demo vault's 214
+    linker-written pages shipped ``description: ''``. Against unmodified
+    main every emitted page here fails the non-empty assertion.
+
+    Non-emptiness alone would be satisfiable by a constant, so the
+    description is also required to be a single line (it is serialised as a
+    YAML frontmatter scalar) and to open with this cluster's own member
+    count — which a constant cannot do.
+    """
+    fragments, embeddings = _message_stream_corpus()
+    runs = (
+        _eddy_run(fragments, embeddings),
+        _thread_run(fragments, embeddings),
+    )
+
+    for run in runs:
+        assert run.descriptions
+        for cluster_id, description in run.descriptions.items():
+            assert description.strip()
+            assert "\n" not in description
+            count = len(run.members[cluster_id])
+            assert description.startswith(f"{count} fragment")
+
+
+def test_single_episode_stream_is_bounded_by_the_ceiling_guardrail() -> None:
+    """The ceiling must hold even where segmentation is powerless.
+
+    Every other ceiling assertion in this module runs on a corpus
+    segmentation can cut, so a guardrail that never fired would still let
+    them pass. This variant defeats segmentation on purpose: one channel,
+    no inactivity gap, and 600 messages spanning 25 days, which is inside
+    both the 24-hour episode gap and the 30-day span backstop. The
+    partition is therefore a single domain, and the size ceiling is the
+    only bound left.
+
+    Pins the documented "unsplittable remainder becomes noise, not a page"
+    contract end to end: the emitted clusters and the discarded count must
+    together account for every fragment, so the guardrail can neither
+    silently emit an oversized page nor silently lose fragments off the
+    books. ``tests/test_cluster_limits.py`` pins the same contract against
+    a stub ``recluster``; this pins it against the real degenerate geometry,
+    where tightening epsilon genuinely fails to separate anything.
+
+    Without the fix there is no guardrail to exercise — ``EddyDetector``
+    and ``ThreadDetector`` accept no ``split_policy`` at all, so the test
+    fails at construction, and the corpus produces one 600-member page.
+    """
+    fragments, embeddings = _message_stream_corpus(
+        channels=(_STREAM_CHANNELS[0],),
+        spacing_hours=_SINGLE_EPISODE_SPACING_HOURS,
+        gap_days=0,
+        with_topics=False,
+    )
+    assert len(partition(fragments, config=LinkingConfig())) == 1
+
+    policy = SplitPolicy(
+        size_ceiling=_SPLIT_SIZE_CEILING,
+        max_fraction=_SPLIT_MAX_FRACTION,
+        max_depth=_SPLIT_MAX_DEPTH,
+    )
+    ceiling = policy.ceiling_for(len(fragments))
+    runs = (
+        _eddy_run(fragments, embeddings, policy=policy),
+        _thread_run(fragments, embeddings, policy=policy),
+    )
+
+    for run in runs:
+        assert run.clusters_split == 1
+        assert all(len(members) <= ceiling for members in run.members.values())
+        kept = sum(len(members) for members in run.members.values())
+        assert kept + run.discarded == _STREAM_FRAGMENTS
+
+
+def test_recluster_work_is_bounded_by_split_depth() -> None:
+    """Re-clustering must cost at most one pass over the cluster per round.
+
+    The perf acceptance criterion rests on segmentation *reducing* work,
+    and the splitter is the one place the fix can add any. Its recursion is
+    breadth-first over a work queue that is extended with each round's
+    subclusters, so the danger is fan-out: if a round ever returned
+    overlapping or enlarged subclusters, total work would grow
+    multiplicatively in the depth budget instead of linearly.
+
+    The invariant is that each round re-clusters a partition of its parent,
+    so no depth level costs more than the original cluster and the whole
+    split costs at most ``max_depth`` passes over it. Measured on the
+    single-episode corpus the bound is tight — three rounds, 1800
+    re-clustered members against 3 x 600 — because the continuous manifold
+    never separates.
+
+    ``tests/test_cluster_limits.py`` bounds the *schedule* (how many
+    tightened parameters exist); nothing else bounds the aggregate work
+    those rounds actually perform. Without the fix there is no splitter,
+    so the detector rejects the ``split_policy`` argument outright.
+    """
+    fragments, embeddings = _message_stream_corpus(
+        channels=(_STREAM_CHANNELS[0],),
+        spacing_hours=_SINGLE_EPISODE_SPACING_HOURS,
+        gap_days=0,
+        with_topics=False,
+    )
+    detector = EddyDetector(
+        embeddings=embeddings,
+        eps=_EPS,
+        min_samples=_MIN_SAMPLES,
+        split_policy=SplitPolicy(
+            size_ceiling=_SPLIT_SIZE_CEILING,
+            max_fraction=_SPLIT_MAX_FRACTION,
+            max_depth=_SPLIT_MAX_DEPTH,
+        ),
+    )
+    with patch.object(detector, "_recluster", wraps=detector._recluster) as spy:
+        detector.detect_eddies(fragments)
+
+    assert detector.clusters_split == 1
+    sizes: list[int] = [len(call.args[0]) for call in spy.call_args_list]
+    assert len(sizes) <= _SPLIT_MAX_DEPTH
+    assert sum(sizes) <= _SPLIT_MAX_DEPTH * _STREAM_FRAGMENTS

--- a/creek-tools/tests/test_link_naming.py
+++ b/creek-tools/tests/test_link_naming.py
@@ -1,0 +1,545 @@
+"""Tests for :mod:`creek.link.naming` — cluster titles and descriptions.
+
+The module under test is the root fix for the platform-name-as-topic-label
+defect: a corpus whose fragments all carry the same filename-derived title
+(``title: messages`` on every Discord fragment) used to hand that word
+straight to ``most_common(3)`` and name the cluster ``Messages``. These
+tests pin the four properties that make that impossible:
+
+1. Real inverse document frequency, so a term carried by most of the
+   corpus can never contribute a title token.
+2. A *structural* fallback — dominant source plus date span — for the
+   case IDF creates: a cluster with no surviving text at all. Nothing
+   else is available, because :class:`~creek.models.Fragment` has no
+   body field; the title string is the only text the linker ever sees.
+3. A never-empty description.
+4. Title uniqueness within one detection run, because the eddy assigner
+   writes ``[[<title>]]`` wiki-links and colliding titles collapse them.
+
+The IDF suppression is deliberately disabled for a corpus smaller than
+:attr:`NamingPolicy.min_idf_corpus`: document frequency over a handful of
+documents is noise, not evidence, and the historical docstring already
+promised "falls back to raw counts when the corpus is small".
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from creek.link.naming import (
+    DEFAULT_NAMING_POLICY,
+    STOPWORDS,
+    NamingPolicy,
+    cluster_description,
+    cluster_title,
+    content_words,
+    cosine,
+    disambiguate,
+    distinctive_terms,
+    document_frequency,
+    structural_label,
+    tokenize,
+)
+from creek.models import Fragment, FragmentSource, SourcePlatform
+
+
+def _frag(
+    fid: str,
+    title: str,
+    *,
+    platform: SourcePlatform = SourcePlatform.DISCORD,
+    channel: str | None = None,
+    conversation_id: str | None = None,
+    interlocutor: str | None = None,
+    authored_at: datetime | None = None,
+) -> Fragment:
+    """Build a Fragment with the source metadata the namer reads.
+
+    ``authored_at`` is set explicitly (rather than mirrored through
+    ``ingested``) because :func:`creek.time.effective_authored_date`
+    prefers it, and every date-span assertion here cares about the
+    source-side date rather than construction-time wall-clock.
+    """
+    return Fragment(
+        id=fid,
+        title=title,
+        source=FragmentSource(
+            platform=platform,
+            channel=channel,
+            conversation_id=conversation_id,
+            interlocutor=interlocutor,
+        ),
+        authored_at=authored_at or datetime(2023, 3, 15, 12, 0, 0),
+    )
+
+
+def _corpus(
+    *,
+    ubiquitous: int,
+    total: int,
+    ubiquitous_word: str = "messages",
+) -> list[Fragment]:
+    """Return *total* fragments, *ubiquitous* of which carry a shared word."""
+    corpus = [
+        _frag(f"ubiq-{i}", f"{ubiquitous_word} entry {i}") for i in range(ubiquitous)
+    ]
+    corpus.extend(
+        _frag(f"rest-{i}", f"essay {i} recital") for i in range(total - ubiquitous)
+    )
+    return corpus
+
+
+# ---- Shared text helpers (canonical home for the linker's duplicates) ----
+
+
+class TestTextHelpers:
+    """The tokenising helpers hoisted out of the two detector modules."""
+
+    def test_tokenize_lowercases_and_drops_punctuation_and_digits(self) -> None:
+        """Tokenising keeps alphabetic runs only, lowercased."""
+        assert tokenize("Garden, Journal! 2023 -- Monday") == [
+            "garden",
+            "journal",
+            "monday",
+        ]
+
+    def test_content_words_drops_stopwords_and_short_words(self) -> None:
+        """Stopwords and words under three characters are not content."""
+        assert content_words("The art of a Garden in Spring") == [
+            "art",
+            "garden",
+            "spring",
+        ]
+
+    def test_stopwords_does_not_contain_messages(self) -> None:
+        """'messages' is a real word — the stoplist is not the fix here.
+
+        Pinning this keeps a future reader from "fixing" the mega-cluster
+        title by bolting platform nouns onto the stoplist, which would
+        paper over the missing IDF and break the moment a vault used a
+        different filename.
+        """
+        assert "messages" not in STOPWORDS
+
+    def test_cosine_of_orthogonal_and_identical_vectors(self) -> None:
+        """Cosine returns 1.0 for identical and 0.0 for orthogonal vectors."""
+        assert cosine([1.0, 0.0], [1.0, 0.0]) == pytest.approx(1.0)
+        assert cosine([1.0, 0.0], [0.0, 1.0]) == pytest.approx(0.0)
+
+    def test_cosine_of_zero_norm_vector_is_zero(self) -> None:
+        """A zero vector has no direction — similarity is 0.0, not NaN."""
+        assert cosine([0.0, 0.0], [1.0, 0.0]) == 0.0
+
+
+# ---- Document frequency ----
+
+
+class TestDocumentFrequency:
+    """Corpus-wide document frequency over fragment titles."""
+
+    def test_counts_documents_not_occurrences(self) -> None:
+        """A word repeated inside one title counts that title once."""
+        corpus = [
+            _frag("a", "garden garden garden"),
+            _frag("b", "garden harvest"),
+            _frag("c", "recital"),
+        ]
+        assert document_frequency(corpus)["garden"] == 2
+
+    def test_empty_corpus_yields_empty_mapping(self) -> None:
+        """No documents means no document frequencies."""
+        assert document_frequency([]) == {}
+
+
+# ---- IDF: the missing half of the documented TF-IDF-lite ----
+
+
+class TestDistinctiveTerms:
+    """Ranking by tf * idf, with a ubiquity floor that hard-drops terms."""
+
+    def test_idf_suppresses_terms_carried_by_most_of_the_corpus(self) -> None:
+        """A term in 87% of the corpus contributes no title token.
+
+        This is the exact demo-vault shape: 'messages' is the single most
+        frequent word *inside* the cluster, and it is also carried by
+        almost the whole corpus. Raw ``Counter.most_common`` picks it;
+        IDF must not.
+        """
+        corpus = _corpus(ubiquitous=87, total=100)
+        cluster = [_frag(f"c-{i}", "messages garden") for i in range(30)]
+        corpus.extend(cluster)
+        df = document_frequency(corpus)
+
+        terms = distinctive_terms(cluster, df, len(corpus))
+
+        assert "messages" not in terms
+        assert "garden" in terms
+
+    def test_term_at_exactly_the_ubiquity_floor_is_dropped(self) -> None:
+        """The floor is inclusive: df / corpus == floor means suppressed."""
+        policy = NamingPolicy(ubiquity_floor=0.5, min_idf_corpus=4)
+        corpus = [_frag(f"in-{i}", "shared topic") for i in range(2)]
+        corpus.extend(_frag(f"out-{i}", "elsewhere") for i in range(2))
+        df = document_frequency(corpus)
+        assert df["shared"] / len(corpus) == 0.5
+
+        terms = distinctive_terms(corpus[:2], df, len(corpus), policy=policy)
+
+        assert "shared" not in terms
+
+    def test_term_just_below_the_ubiquity_floor_survives(self) -> None:
+        """One document less than the floor and the term is still usable."""
+        policy = NamingPolicy(ubiquity_floor=0.5, min_idf_corpus=4)
+        corpus = [_frag(f"in-{i}", "shared topic") for i in range(2)]
+        corpus.extend(_frag(f"out-{i}", "elsewhere") for i in range(3))
+        df = document_frequency(corpus)
+        assert df["shared"] / len(corpus) < 0.5
+
+        terms = distinctive_terms(corpus[:2], df, len(corpus), policy=policy)
+
+        assert "shared" in terms
+
+    def test_small_corpus_falls_back_to_raw_counts(self) -> None:
+        """Below ``min_idf_corpus`` the ubiquity floor does not apply.
+
+        Document frequency over a dozen documents is noise: in the
+        existing two-cluster detector fixtures a perfectly good topic word
+        sits at df/corpus == 0.5 purely because there are two clusters.
+        Suppressing it there would destroy real titles to fix a
+        35,000-fragment problem.
+        """
+        corpus = [_frag(f"g-{i}", "garden journal") for i in range(6)]
+        df = document_frequency(corpus)
+        assert df["garden"] == len(corpus)
+
+        terms = distinctive_terms(corpus, df, len(corpus))
+
+        assert terms[0] == "garden"
+
+    def test_ranking_prefers_higher_frequency_within_the_cluster(self) -> None:
+        """Among equally-rare terms, the more frequent one ranks first."""
+        cluster = [_frag(f"r-{i}", "garden") for i in range(5)]
+        cluster.append(_frag("r-solo", "harvest"))
+        df = document_frequency(cluster)
+
+        terms = distinctive_terms(cluster, df, len(cluster))
+
+        assert terms[0] == "garden"
+
+    def test_limit_is_honoured(self) -> None:
+        """No more than ``title_terms`` terms are returned."""
+        cluster = [_frag("m", "alpha bravo charlie delta echo foxtrot")]
+        df = document_frequency(cluster)
+
+        terms = distinctive_terms(cluster, df, len(cluster))
+
+        assert len(terms) == DEFAULT_NAMING_POLICY.title_terms
+
+    def test_cluster_with_no_content_words_yields_no_terms(self) -> None:
+        """Titles made entirely of stopwords produce nothing."""
+        cluster = [_frag("s", "the and of it")]
+        assert distinctive_terms(cluster, {}, 1) == []
+
+    def test_ranking_is_deterministic_for_tied_terms(self) -> None:
+        """Equal scores break alphabetically, so runs are reproducible."""
+        cluster = [_frag("t", "zulu alpha mike bravo")]
+        df = document_frequency(cluster)
+
+        assert distinctive_terms(cluster, df, len(cluster)) == [
+            "alpha",
+            "bravo",
+            "mike",
+        ]
+
+
+# ---- Structural labels: the only path left for a message cluster ----
+
+
+class TestStructuralLabel:
+    """Labels built from source metadata plus date span."""
+
+    def test_uses_dominant_channel_and_date_span(self) -> None:
+        """A Discord cluster names itself after its channel and month."""
+        cluster = [
+            _frag(
+                f"d-{i}",
+                "messages",
+                channel="Aspiring Drag Queens",
+                authored_at=datetime(2023, 3, 4 + i),
+            )
+            for i in range(5)
+        ]
+
+        label = structural_label(cluster)
+
+        assert "Aspiring Drag Queens" in label
+        assert "Mar 2023" in label
+
+    def test_dominant_channel_wins_over_a_minority_channel(self) -> None:
+        """The label names the channel most members came from."""
+        cluster = [
+            _frag(f"maj-{i}", "messages", channel="Aspiring Drag Queens")
+            for i in range(5)
+        ]
+        cluster.append(_frag("min-0", "messages", channel="Side Chat"))
+
+        assert "Aspiring Drag Queens" in structural_label(cluster)
+        assert "Side Chat" not in structural_label(cluster)
+
+    def test_falls_back_to_conversation_id_then_interlocutor(self) -> None:
+        """Without a channel, other source identity fields are used."""
+        by_conversation = [
+            _frag("c-0", "messages", conversation_id="conv-alpha"),
+        ]
+        by_interlocutor = [
+            _frag("i-0", "messages", interlocutor="Dana"),
+        ]
+
+        assert "conv-alpha" in structural_label(by_conversation)
+        assert "Dana" in structural_label(by_interlocutor)
+
+    def test_label_is_non_empty_when_every_member_lacks_a_channel(self) -> None:
+        """Platform plus date span still names the cluster.
+
+        The boundary the demo vault would hit if channel were ever
+        unpopulated: there must be no path to an empty label.
+        """
+        cluster = [
+            _frag(
+                f"p-{i}",
+                "messages",
+                platform=SourcePlatform.EMAIL,
+                authored_at=datetime(2021, 7, 2 + i),
+            )
+            for i in range(4)
+        ]
+
+        label = structural_label(cluster)
+
+        assert label
+        assert "Email" in label
+        assert "Jul 2021" in label
+
+    def test_blank_channel_string_is_ignored(self) -> None:
+        """A whitespace-only channel is not an identity — fall through."""
+        cluster = [_frag("b-0", "messages", channel="   ")]
+
+        assert "Discord" in structural_label(cluster)
+
+    def test_single_member_cluster_produces_a_single_month_span(self) -> None:
+        """Exactly one member: the span is that one month, not a range."""
+        cluster = [
+            _frag(
+                "solo",
+                "messages",
+                channel="Aspiring Drag Queens",
+                authored_at=datetime(2023, 3, 15),
+            ),
+        ]
+
+        assert structural_label(cluster) == "Aspiring Drag Queens, Mar 2023"
+
+    def test_span_within_one_year_shows_both_months_once(self) -> None:
+        """A same-year range collapses to one trailing year."""
+        cluster = [
+            _frag(
+                "s-0", "messages", channel="Studio", authored_at=datetime(2023, 3, 1)
+            ),
+            _frag(
+                "s-1", "messages", channel="Studio", authored_at=datetime(2023, 8, 1)
+            ),
+        ]
+
+        assert structural_label(cluster) == "Studio, Mar-Aug 2023"
+
+    def test_span_across_years_shows_both_years(self) -> None:
+        """A cross-year range names both endpoints in full."""
+        cluster = [
+            _frag(
+                "y-0", "messages", channel="Studio", authored_at=datetime(2023, 3, 1)
+            ),
+            _frag(
+                "y-1", "messages", channel="Studio", authored_at=datetime(2024, 8, 1)
+            ),
+        ]
+
+        assert structural_label(cluster) == "Studio, Mar 2023-Aug 2024"
+
+    def test_empty_cluster_still_returns_a_non_empty_label(self) -> None:
+        """The never-empty contract has no exceptions, not even for []."""
+        assert structural_label([])
+
+
+# ---- Titles ----
+
+
+class TestClusterTitle:
+    """The composed title: distinctive terms, else structural label."""
+
+    def test_message_cluster_is_named_from_channel_not_the_filename(self) -> None:
+        """The headline regression: 'Messages' must never be the title.
+
+        Every member carries the filename-derived ``title: messages``, so
+        after IDF suppression there is no text left — ``Fragment`` has no
+        body field, and the title string is the linker's only text
+        signal. The name has to come from structure.
+        """
+        corpus = _corpus(ubiquitous=87, total=100)
+        cluster = [
+            _frag(
+                f"m-{i}",
+                "messages",
+                channel="Aspiring Drag Queens",
+                authored_at=datetime(2023, 3, 4 + i),
+            )
+            for i in range(12)
+        ]
+        corpus.extend(cluster)
+        df = document_frequency(corpus)
+
+        title = cluster_title(cluster, df, len(corpus))
+
+        assert title != "Messages"
+        assert "Aspiring Drag Queens" in title
+        assert "Mar 2023" in title
+
+    def test_distinctive_terms_are_preferred_and_capitalised(self) -> None:
+        """When real topic words survive, they make the title."""
+        cluster = [_frag(f"g-{i}", "garden harvest journal") for i in range(6)]
+        df = document_frequency(cluster)
+
+        assert cluster_title(cluster, df, len(cluster)) == "Garden Harvest Journal"
+
+    def test_title_is_never_empty(self) -> None:
+        """No corpus shape produces an empty title."""
+        cluster = [_frag("e-0", "the and of")]
+
+        assert cluster_title(cluster, {}, 1)
+
+    def test_title_strips_wiki_link_hostile_characters(self) -> None:
+        """Brackets and pipes would break the ``[[...]]`` link.
+
+        ``assign_fragments_to_eddies`` interpolates the title directly
+        into a wiki-link, so a channel named ``Chat [dev]|main`` must not
+        be able to produce a malformed or ambiguous link target. The
+        member title is all stopwords so the structural path — the one
+        that reads operator-controlled source metadata — is what runs.
+        """
+        cluster = [_frag("w-0", "the and of", channel="Chat [dev]|main#top^x")]
+
+        title = cluster_title(cluster, {}, 1)
+
+        assert not set(title) & set("[]|#^")
+        assert "Chat dev" in title
+
+
+# ---- Descriptions ----
+
+
+class TestClusterDescription:
+    """One-line, always-populated cluster descriptions."""
+
+    def test_description_is_never_empty(self) -> None:
+        """The defect: 212 of 214 linker pages shipped ``description: ''``."""
+        cluster = [_frag("d-0", "the and of")]
+
+        assert cluster_description(cluster, {}, 1).strip()
+
+    def test_description_names_count_source_and_span(self) -> None:
+        """The line carries the facts an operator needs to triage a page."""
+        cluster = [
+            _frag(
+                f"n-{i}",
+                "messages",
+                channel="Aspiring Drag Queens",
+                authored_at=datetime(2023, 3, 4 + i),
+            )
+            for i in range(12)
+        ]
+        df = document_frequency(cluster)
+
+        description = cluster_description(cluster, df, len(cluster))
+
+        assert "12 fragments" in description
+        assert "Aspiring Drag Queens" in description
+        assert "Mar 2023" in description
+
+    def test_description_lists_surviving_distinctive_terms(self) -> None:
+        """Real topic words are surfaced when IDF leaves any standing."""
+        corpus = _corpus(ubiquitous=87, total=100)
+        cluster = [_frag(f"t-{i}", "messages garden harvest") for i in range(12)]
+        corpus.extend(cluster)
+        df = document_frequency(corpus)
+
+        description = cluster_description(cluster, df, len(corpus))
+
+        assert "garden" in description
+        assert "harvest" in description
+        assert "messages" not in description
+
+    def test_single_member_description_uses_the_singular(self) -> None:
+        """Exactly one member reads as '1 fragment', not '1 fragments'."""
+        cluster = [_frag("s-0", "messages", channel="Studio")]
+
+        assert "1 fragment " in cluster_description(cluster, {}, 1)
+
+    def test_description_is_a_single_line(self) -> None:
+        """A frontmatter scalar must not carry embedded newlines."""
+        cluster = [_frag("l-0", "messages", channel="Studio\nInjected")]
+
+        assert "\n" not in cluster_description(cluster, {}, 1)
+
+    def test_empty_cluster_description_is_still_non_empty(self) -> None:
+        """The never-empty contract holds for the degenerate input too."""
+        assert cluster_description([], {}, 0).strip()
+
+
+# ---- Within-run uniqueness ----
+
+
+class TestDisambiguate:
+    """Titles must be unique within one detection run."""
+
+    def test_titles_are_unique_within_one_detection_run(self) -> None:
+        """Colliding titles are separated, so wiki-links stay unambiguous.
+
+        ``assign_fragments_to_eddies`` writes ``[[<title>]]`` on every
+        member fragment. Two eddies sharing a title means thousands of
+        fragments linking to whichever page Obsidian resolves first.
+        """
+        titles = ["Garden Harvest", "Garden Harvest", "Recital Notes"]
+
+        result = disambiguate(titles)
+
+        assert len(set(result)) == len(result)
+        assert result[0] == "Garden Harvest"
+
+    def test_order_and_first_occurrence_are_preserved(self) -> None:
+        """The first claimant keeps the bare title; later ones are suffixed."""
+        assert disambiguate(["A", "B", "A", "A"]) == ["A", "B", "A (2)", "A (3)"]
+
+    def test_a_generated_suffix_never_collides_with_a_real_title(self) -> None:
+        """A pre-existing 'A (2)' does not get silently duplicated."""
+        result = disambiguate(["A", "A (2)", "A"])
+
+        assert len(set(result)) == 3
+        assert result == ["A", "A (2)", "A (3)"]
+
+    def test_empty_input_returns_empty_list(self) -> None:
+        """Nothing in, nothing out."""
+        assert disambiguate([]) == []
+
+    def test_disambiguated_titles_survive_filename_sanitisation(self) -> None:
+        """The suffix must still differ after the writer strips punctuation.
+
+        ``creek.vault.writer._sanitize_title`` drops every non-word,
+        non-space, non-hyphen character, so a suffix made only of
+        punctuation would collapse back into a collision on disk.
+        """
+        from creek.vault.writer import _sanitize_title
+
+        result = disambiguate(["Garden Harvest"] * 3)
+
+        assert len({_sanitize_title(t) for t in result}) == 3

--- a/creek-tools/tests/test_link_segments.py
+++ b/creek-tools/tests/test_link_segments.py
@@ -1,0 +1,418 @@
+"""Tests for creek.link.segments — clustering-domain partitioning (issue #880).
+
+The partitioner is the root fix for the mega-cluster degeneration: a
+continuous chat stream violates DBSCAN's "clusters separated by
+low-density regions" precondition, so the stream is cut into
+conversation episodes *before* any eps-graph is built. These tests pin
+the partition contract itself — channel separation, the inactivity-gap
+boundary, the span backstop, the single shared non-stream domain, and
+the invariant that partitioning never drops or duplicates a fragment.
+"""
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from creek.link.segments import (
+    SHARED_DOMAIN_KEY,
+    _episodes,
+    domain_key,
+    partition,
+)
+from creek.models import (
+    Fragment,
+    FragmentSource,
+    SourcePlatform,
+)
+
+_BASE = datetime(2024, 1, 1, 12, 0, tzinfo=UTC)
+
+
+@dataclass(frozen=True)
+class _Segmentation:
+    """Minimal stand-in for the ``linking`` config block.
+
+    ``partition`` reads three attributes structurally, so this frozen
+    dataclass satisfies the same protocol
+    :class:`~creek.config.LinkingConfig` does without dragging the whole
+    settings tree into a unit test.
+    """
+
+    stream_platforms: tuple[str, ...] = ("discord", "email")
+    stream_episode_max_gap_hours: int = 24
+    stream_episode_max_span_days: int = 30
+
+
+def _fragment(
+    fid: str,
+    *,
+    platform: SourcePlatform = SourcePlatform.DISCORD,
+    channel: str | None = None,
+    conversation_id: str | None = None,
+    interlocutor: str | None = None,
+    authored_at: datetime = _BASE,
+) -> Fragment:
+    """Build a Fragment with the source identity the partitioner keys on.
+
+    ``authored_at`` is set explicitly (not mirrored through ``ingested``)
+    because :func:`creek.time.effective_authored_at` prefers it, and
+    every episode boundary in these tests is expressed in source time.
+    """
+    return Fragment(
+        id=fid,
+        title="messages",
+        source=FragmentSource(
+            platform=platform,
+            channel=channel,
+            conversation_id=conversation_id,
+            interlocutor=interlocutor,
+        ),
+        created=authored_at,
+        ingested=authored_at,
+        authored_at=authored_at,
+    )
+
+
+def _ids(domains: list[list[Fragment]]) -> list[set[str]]:
+    """Return one id-set per domain, for order-insensitive comparison."""
+    return [{frag.id for frag in domain} for domain in domains]
+
+
+# ---- domain_key ----
+
+
+class TestDomainKey:
+    """Tests for the per-fragment clustering-domain key."""
+
+    def test_non_stream_fragment_maps_to_the_shared_domain(self) -> None:
+        """A platform outside ``stream_platforms`` gets the shared key."""
+        frag = _fragment("a", platform=SourcePlatform.CLAUDE)
+        assert (
+            domain_key(frag, stream_platforms=("discord", "email")) == SHARED_DOMAIN_KEY
+        )
+
+    def test_stream_key_carries_platform_series_and_episode(self) -> None:
+        """A stream fragment's key names platform, series and episode."""
+        frag = _fragment("a", channel="general")
+        key = domain_key(frag, stream_platforms=("discord",), episode_index=7)
+        assert key != SHARED_DOMAIN_KEY
+        assert "discord" in key
+        assert "general" in key
+        assert key.endswith("7")
+
+    def test_episode_index_defaults_to_zero(self) -> None:
+        """Omitting ``episode_index`` names the first episode."""
+        frag = _fragment("a", channel="general")
+        assert domain_key(frag, stream_platforms=("discord",)) == domain_key(
+            frag,
+            stream_platforms=("discord",),
+            episode_index=0,
+        )
+
+    def test_channel_falls_back_to_conversation_id(self) -> None:
+        """With no ``channel``, the series identity is ``conversation_id``."""
+        frag = _fragment("a", channel=None, conversation_id="dm-42")
+        assert "dm-42" in domain_key(frag, stream_platforms=("discord",))
+
+    def test_conversation_id_falls_back_to_interlocutor(self) -> None:
+        """With neither channel nor conversation, ``interlocutor`` is used."""
+        frag = _fragment("a", channel=None, interlocutor="alex")
+        assert "alex" in domain_key(frag, stream_platforms=("discord",))
+
+    def test_no_series_identity_still_yields_a_stream_key(self) -> None:
+        """A stream fragment with no identity fields still keys as a stream."""
+        frag = _fragment("a")
+        key = domain_key(frag, stream_platforms=("discord",))
+        assert key != SHARED_DOMAIN_KEY
+        assert "discord" in key
+
+    def test_platform_absent_from_stream_platforms_is_shared(self) -> None:
+        """A Discord fragment is shared when Discord is not configured."""
+        frag = _fragment("a", channel="general")
+        assert domain_key(frag, stream_platforms=("email",)) == SHARED_DOMAIN_KEY
+
+
+# ---- partition: shared (non-stream) domain ----
+
+
+class TestSharedDomain:
+    """Tests that every non-stream fragment stays in one shared domain."""
+
+    def test_empty_input_yields_no_domains(self) -> None:
+        """An empty corpus partitions into zero domains."""
+        assert partition([], config=_Segmentation()) == []
+
+    def test_non_stream_platforms_share_one_domain(self) -> None:
+        """Claude, journal and essay fragments land in a single domain.
+
+        This is the property that keeps cross-source threads and
+        cross-platform eddies working, and the reason every existing
+        detection test — whose fixtures use ``SourcePlatform.CLAUDE`` —
+        is untouched by segmentation.
+        """
+        frags = [
+            _fragment("a", platform=SourcePlatform.CLAUDE),
+            _fragment("b", platform=SourcePlatform.JOURNAL),
+            _fragment("c", platform=SourcePlatform.ESSAY),
+        ]
+        domains = partition(frags, config=_Segmentation())
+        assert len(domains) == 1
+        assert _ids(domains) == [{"a", "b", "c"}]
+
+    def test_non_stream_fragments_are_never_split_by_time(self) -> None:
+        """Years apart, non-stream fragments still share one domain."""
+        frags = [
+            _fragment("a", platform=SourcePlatform.CLAUDE, authored_at=_BASE),
+            _fragment(
+                "b",
+                platform=SourcePlatform.CLAUDE,
+                authored_at=_BASE + timedelta(days=2000),
+            ),
+        ]
+        assert len(partition(frags, config=_Segmentation())) == 1
+
+    def test_stream_platform_list_is_honoured(self) -> None:
+        """Emptying ``stream_platforms`` collapses everything to one domain."""
+        frags = [
+            _fragment("a", channel="general"),
+            _fragment(
+                "b",
+                channel="general",
+                authored_at=_BASE + timedelta(days=400),
+            ),
+        ]
+        domains = partition(frags, config=_Segmentation(stream_platforms=()))
+        assert _ids(domains) == [{"a", "b"}]
+
+
+# ---- partition: stream segmentation ----
+
+
+class TestStreamSegmentation:
+    """Tests for channel separation and episode cutting."""
+
+    def test_stream_fragments_partition_by_channel_and_inactivity_gap(
+        self,
+    ) -> None:
+        """Three channels, each with one multi-day gap, yield six domains."""
+        frags: list[Fragment] = []
+        for channel in ("general", "art", "music"):
+            for index, offset in enumerate(
+                (timedelta(0), timedelta(hours=1), timedelta(days=9)),
+            ):
+                frags.append(
+                    _fragment(
+                        f"{channel}-{index}",
+                        channel=channel,
+                        authored_at=_BASE + offset,
+                    ),
+                )
+        domains = partition(frags, config=_Segmentation())
+        assert len(domains) == 6
+        assert {"general-0", "general-1"} in _ids(domains)
+        assert {"general-2"} in _ids(domains)
+        assert sum(len(domain) for domain in domains) == len(frags)
+
+    def test_gap_equal_to_max_gap_does_not_cut(self) -> None:
+        """The inactivity boundary is inclusive: a gap of exactly max stays."""
+        frags = [
+            _fragment("a", channel="general", authored_at=_BASE),
+            _fragment(
+                "b",
+                channel="general",
+                authored_at=_BASE + timedelta(hours=24),
+            ),
+        ]
+        assert _ids(partition(frags, config=_Segmentation())) == [{"a", "b"}]
+
+    def test_gap_one_second_beyond_max_gap_cuts(self) -> None:
+        """One second past the inactivity boundary starts a new episode."""
+        frags = [
+            _fragment("a", channel="general", authored_at=_BASE),
+            _fragment(
+                "b",
+                channel="general",
+                authored_at=_BASE + timedelta(hours=24, seconds=1),
+            ),
+        ]
+        assert _ids(partition(frags, config=_Segmentation())) == [{"a"}, {"b"}]
+
+    def test_same_channel_name_on_two_platforms_stays_separate(self) -> None:
+        """Series identity includes the platform, not just the channel."""
+        frags = [
+            _fragment("a", platform=SourcePlatform.DISCORD, channel="general"),
+            _fragment("b", platform=SourcePlatform.EMAIL, channel="general"),
+        ]
+        domains = partition(frags, config=_Segmentation())
+        assert len(domains) == 2
+
+    def test_series_identity_falls_through_to_interlocutor(self) -> None:
+        """Two DM partners with no channel form two distinct series."""
+        frags = [
+            _fragment("a", interlocutor="alex"),
+            _fragment("b", interlocutor="robin"),
+        ]
+        assert len(partition(frags, config=_Segmentation())) == 2
+
+    def test_episode_members_are_time_ordered(self) -> None:
+        """Within an episode, fragments are sorted by effective authored time."""
+        frags = [
+            _fragment(
+                "late",
+                channel="general",
+                authored_at=_BASE + timedelta(hours=2),
+            ),
+            _fragment("early", channel="general", authored_at=_BASE),
+        ]
+        domains = partition(frags, config=_Segmentation())
+        assert [frag.id for frag in domains[0]] == ["early", "late"]
+
+
+# ---- partition: span backstop ----
+
+
+class TestSpanBackstop:
+    """Tests for the span backstop on a permanently-busy channel."""
+
+    def test_busy_channel_is_cut_into_span_sized_episodes(self) -> None:
+        """A channel with no idle gap still yields bounded episodes.
+
+        Ninety days of traffic every twelve hours never trips the
+        24-hour inactivity rule, so without the backstop the whole run
+        would be one domain — exactly the seven-year blob issue #880
+        reports. The 30-day span cap splits it into three.
+        """
+        frags = [
+            _fragment(
+                f"m{index}",
+                channel="general",
+                authored_at=_BASE + timedelta(hours=12 * index),
+            )
+            for index in range(181)
+        ]
+        domains = partition(frags, config=_Segmentation())
+        assert len(domains) == 3
+        assert sum(len(domain) for domain in domains) == 181
+        assert max(len(domain) for domain in domains) == 61
+
+    def test_span_equal_to_max_span_does_not_cut(self) -> None:
+        """The span boundary is inclusive: exactly max span stays together."""
+        config = _Segmentation(stream_episode_max_gap_hours=24 * 365)
+        frags = [
+            _fragment("a", channel="general", authored_at=_BASE),
+            _fragment(
+                "b",
+                channel="general",
+                authored_at=_BASE + timedelta(days=30),
+            ),
+        ]
+        assert _ids(partition(frags, config=config)) == [{"a", "b"}]
+
+    def test_span_one_second_beyond_max_span_cuts(self) -> None:
+        """One second past the span boundary starts a new episode."""
+        config = _Segmentation(stream_episode_max_gap_hours=24 * 365)
+        frags = [
+            _fragment("a", channel="general", authored_at=_BASE),
+            _fragment(
+                "b",
+                channel="general",
+                authored_at=_BASE + timedelta(days=30, seconds=1),
+            ),
+        ]
+        assert _ids(partition(frags, config=config)) == [{"a"}, {"b"}]
+
+    def test_span_is_measured_from_the_episode_start_not_the_corpus_start(
+        self,
+    ) -> None:
+        """Each new episode restarts the span clock."""
+        config = _Segmentation(stream_episode_max_gap_hours=24 * 365)
+        frags = [
+            _fragment(
+                f"m{index}",
+                channel="general",
+                authored_at=_BASE + timedelta(days=20 * index),
+            )
+            for index in range(4)
+        ]
+        domains = partition(frags, config=config)
+        assert _ids(domains) == [{"m0", "m1"}, {"m2", "m3"}]
+
+
+# ---- episode cutting, directly ----
+
+
+class TestEpisodes:
+    """Tests for the episode cutter's own defensive contract."""
+
+    def test_empty_series_yields_no_episodes(self) -> None:
+        """An empty series produces no episode rather than raising.
+
+        ``partition`` never builds an empty series, so this is a
+        defensive guard — pinned here so a later refactor cannot turn it
+        into an ``IndexError`` unnoticed.
+        """
+        assert (
+            _episodes([], max_gap=timedelta(hours=24), max_span=timedelta(days=30))
+            == []
+        )
+
+
+# ---- partition: structural invariants ----
+
+
+class TestPartitionInvariants:
+    """Tests that partitioning is a true partition of the input."""
+
+    @staticmethod
+    def _mixed_corpus() -> list[Fragment]:
+        """Return a corpus mixing stream and non-stream fragments."""
+        stream = [
+            _fragment(
+                f"s{index}",
+                channel="general" if index % 2 else "art",
+                authored_at=_BASE + timedelta(days=3 * index),
+            )
+            for index in range(12)
+        ]
+        shared = [
+            _fragment("c0", platform=SourcePlatform.CLAUDE),
+            _fragment("j0", platform=SourcePlatform.JOURNAL),
+        ]
+        return [*stream, *shared]
+
+    def test_every_fragment_appears_in_exactly_one_domain(self) -> None:
+        """No drops and no duplicates — a bug here deletes vault content."""
+        frags = self._mixed_corpus()
+        domains = partition(frags, config=_Segmentation())
+        emitted = [frag.id for domain in domains for frag in domain]
+        assert len(emitted) == len(frags)
+        assert set(emitted) == {frag.id for frag in frags}
+
+    def test_domains_are_never_empty(self) -> None:
+        """A domain with no members is never emitted."""
+        domains = partition(self._mixed_corpus(), config=_Segmentation())
+        assert domains
+        assert all(domain for domain in domains)
+
+    def test_partition_is_deterministic_under_input_reordering(self) -> None:
+        """Domain content does not depend on the input ordering."""
+        frags = self._mixed_corpus()
+        forward = _ids(partition(frags, config=_Segmentation()))
+        reverse = _ids(partition(list(reversed(frags)), config=_Segmentation()))
+        assert forward == reverse
+
+    def test_partition_accepts_any_iterable(self) -> None:
+        """A generator input is consumed exactly once and partitioned."""
+        frags = self._mixed_corpus()
+        domains = partition((frag for frag in frags), config=_Segmentation())
+        assert sum(len(domain) for domain in domains) == len(frags)
+
+    @pytest.mark.parametrize("platform", list(SourcePlatform))
+    def test_every_platform_lands_somewhere(
+        self,
+        platform: SourcePlatform,
+    ) -> None:
+        """The partition is total over ``SourcePlatform`` — nothing vanishes."""
+        frags = [_fragment("a", platform=platform, channel="general")]
+        assert _ids(partition(frags, config=_Segmentation())) == [{"a"}]

--- a/docs/Ontology/creek_ontology_agent_prompt.md
+++ b/docs/Ontology/creek_ontology_agent_prompt.md
@@ -923,9 +923,30 @@ ocr:
   languages: ["eng"]
 
 linking:
-  temporal_window_hours: 168  # 1 week window for temporal proximity
+  temporal_window_hours: 168  # 1 week window for the temporal proximity linker
   thread_min_fragments: 3     # minimum fragments to form a thread
   eddy_min_fragments: 5       # minimum fragments to form an eddy
+
+  # Detector thresholds (defaults equal the constants they replaced)
+  eddy_eps: 0.3                       # max cosine DISTANCE for a DBSCAN neighbour
+  eddy_min_samples: 5                 # neighbours needed to be a core point
+  eddy_correlation_threshold: 0.3     # above this |Spearman|, it is a thread
+  thread_window_days: 30              # sliding window for thread pairing
+  thread_similarity_threshold: 0.6    # cosine a pair must exceed to union
+  thread_union_without_embeddings: false  # never union on frequency alone
+
+  # Cluster-size guardrail — no eddy/thread may swallow the vault
+  cluster_size_ceiling: 500     # never split a cluster below this size
+  cluster_max_fraction: 0.10    # max share of the corpus; 1.0 opts out
+  cluster_split_max_depth: 3    # re-clustering rounds; 0 disables splitting
+  eddy_split_eps_step: 0.05     # eddy_eps tightening per round
+  thread_split_similarity_step: 0.1  # similarity tightening per round
+
+  # Message-stream segmentation — chat has no low-density separator, so it
+  # is cut into conversation episodes BEFORE any similarity graph is built
+  stream_platforms: [discord, email]  # [] disables segmentation
+  stream_episode_max_gap_hours: 24    # silence that ends an episode
+  stream_episode_max_span_days: 30    # backstop for a never-idle channel
 
 classification:
   confidence_threshold: 0.7   # below this, add to review queue


### PR DESCRIPTION
Closes #880.

One eddy and one thread each swallowed **87% of the demo vault**, both titled "Messages". Three mechanisms compound, and the third explains the name.

## 1. DBSCAN's precondition is violated, so no threshold value fixes it

`_expand_cluster` (`creek/link/eddies.py:493`) does unbounded transitive density-reachability across the whole eps-graph. Short chat messages are semantically homogeneous, so adjacent messages sit inside 0.30 cosine distance of each other and every message is a core point — the graph over the 30,795 Discord fragments is a **single connected component**.

DBSCAN requires clusters separated by low-density regions. A continuous chat stream has no separator to find, so DBSCAN returns the whole stream as one cluster — correctly, by its own definition. **This is why tuning `eps` cannot work**, and why `creek/link/segments.py` partitions message-platform fragments into conversation episodes instead.

Non-stream fragments stay in one shared domain, so cross-source threads keep working and all 108 existing tests in `test_link.py` are untouched.

## 2. Threads degenerate independently

The 30-day window at `threads.py:453` bounds *pairing*, but `uf.union` at `:456` is unbounded — overlapping windows take the transitive closure and chain 2020-09-26 through 2026-05-20 into one root of 30,108. `:505-506` additionally **fails open**, unioning on frequency alone when either embedding is missing.

Measured before the fix: thread sizes `[600, 12, 12, 12]`, largest share **0.943**. Fixing only the eddy half would have left this untouched.

## 3. The name was a filename leak — and the docstring already promised the fix

`DiscordIngestor.generate_frontmatter` emits no `title`, so `base.py:447` setdefaults it to `Path(source_path).stem`, and `discover` only ever reads `<channel>/messages.json`. **All 30,795 fragments carry `title: messages` on disk.** `_generate_title` then counts words over titles and nothing else — `Fragment` has no body field, so the title is the only text the linker can see — and `most_common(3)` returns `[("messages", 30795)]`.

The damning detail: that function's docstring claims *"TF-IDF-lite: content-word frequency inside the cluster scaled by inverse document frequency."* Real IDF gives "messages" a document frequency of 30795/35330 and suppresses it entirely. **The documented algorithm would not have produced this bug. The implemented one contains no IDF whatsoever.**

`creek/link/naming.py` implements the IDF that was promised, plus a structural fallback (dominant `source.channel` + date span → "Aspiring Drag Queens, Mar 2023") for when no term survives — exactly the message case — and a never-empty `description`. `grep -rn description creek/link/*.py` previously returned zero hits, which is why 212 of 214 linker-written pages shipped `description: ''`.

## The size cap is a guardrail, not the cure

`creek/link/cluster_limits.py` says so in its own docstring, because a reviewer must not read it as the fix. Recursively tightening eps on a 30,795-member component shatters a continuous semantic manifold into ~60 arbitrary slices with no interpretable identity, all still named from the same identical titles and all colliding on the `f"[[{eddy.title}]]"` wiki-link — **sixty meaningless pages instead of one**. It is kept as the machine-checkable invariant behind acceptance criterion 1 and as protection for corpora we haven't seen.

Applied strictly outside `_dbscan`, so the #790 brute-force-equivalence contract stays green.

## The corpus is the crux

The existing scale generator (`test_link_scale_790.py:102-126`) builds **one-hot vectors**: cross-cluster cosine is exactly 0.0, so transitive bridging is arithmetically impossible; cluster sizes are exact by construction; titles are all distinct; fragments are `UNCLASSIFIED`, which `_frequency_overlap` discards, yielding zero threads. **A test built on it would pass vacuously whether or not the bug existed.**

`_message_stream_corpus` uses a seeded random walk on the unit sphere, so adjacent messages land inside the eps radius and the graph becomes one large-diameter component — reproducing the real failure. Not seed-fragile: seeds 880/1/42/2026/7 all give exactly one cluster of 600.

## Acceptance criteria

| AC | Test | Red proof |
|---|---|---|
| No eddy over ceiling | `test_no_eddy_exceeds_the_configured_corpus_fraction` | `assert 600 <= 63` — 94.3% |
| No **thread** over ceiling | `test_no_thread_exceeds_the_configured_corpus_fraction` | sizes `[600,12,12,12]`, `600 <= 63` false |
| Distinct topics still surface | `test_planted_topics_survive_as_distinct_eddies_and_threads` | see below |
| Non-empty `description` | `test_every_emitted_eddy_and_thread_has_a_non_empty_description` | `AssertionError: assert ''` |
| Wall-clock not regressed | measured, below | — |

**Honest note on the distinct-topics test:** it is **green on unmodified main** and is not a bug reproduction — it is the anti-overcorrection guard. It was proven to have teeth empirically instead: patching `SplitPolicy` to a "shatter everything" configuration makes *this* test fail while **both** ceiling tests still pass. It is the only test in the module that can tell a fix from a shredder.

**Weakest test, flagged rather than dressed up:** `test_recluster_work_is_bounded_by_split_depth` fails on main with a `TypeError` at construction, not on an assertion — there is no pre-fix behaviour for it to contradict. It is kept because it is the only test anywhere bounding the splitter's *aggregate* work (measured: 3 calls, exactly 3 × 600 members, linear in `max_depth`), which the perf criterion rests on. If a reviewer judges it padding, it's the one to drop.

## Performance: faster, not slower

Best-of-3, same machine, identical harness:

| Fragments | threads before | threads after | eddies before | eddies after |
|---|---|---|---|---|
| 636 | 0.150s | **0.077s** | 0.0042s | **0.0039s** |
| 3,036 | 0.862s | **0.435s** | 0.028s | **0.018s** |
| 9,036 | 2.710s | **1.348s** | 0.126s | **0.054s** |

Segmentation is O(n²/d) rather than O(n²), so this improves #857 rather than regressing it. Note the defect **worsens with scale**: at 3k and 9k fragments the entire corpus collapsed into a single thread (`thread_n == 1`).

## Also fixed

- **`Eddy.id` is now content-stable**, mirroring `_stable_thread_id` (#718 did this for threads). It was `uuid4()` per run — latent, but this PR makes it acute by producing many more, smaller eddies, and a vault that rewrites its eddy filenames on every `creek link` is not usable for retrieval.
- **`DiscordIngestor` emits a real title**, so the vault stops manufacturing 30k identical strings at source. Safe: `generate_fragment_id` keys on source_path/timestamp/content, not title, so no fragment ids churn. The naming layer is still required independently — existing vaults keep `title: messages` until re-ingested.

## Out of scope, flagged

`creek_mcp/tools/link.py`'s `_VALID_METHODS` omits `"threads"` entirely, so the thread half of this fix is unreachable via MCP, and the tool's response exposes no eddy/thread counts. Pre-existing and unrelated to the degeneration; widening the MCP contract deserves its own review.

## Verification

`./scripts/check-all.sh` — **12/12**, 8287 passed, 94.16% coverage. New modules: `cluster_limits.py` 100%, `naming.py` 97.6%, `segments.py` 96.5%. Zero suppressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EaHDtyDuNrpGtzUGMJT7Fw