### PR TITLE
ci: make integration + e2e blocking, and free the `integration` marker from live-API tests

### DIFF
--- a/.claude/skills/model-setup/SKILL.md
+++ b/.claude/skills/model-setup/SKILL.md
@@ -135,8 +135,8 @@ system package without asking.
 2. Optional live smoke (only with the key + consent set), per the README — run
    it from the `creek-tools/` subproject directory (the `scripts/` live there,
    not at the repo root):
-   `cd <repo>/creek-tools && ./scripts/test.sh --integration -k anthropic` (or
-   `CREEK_SMOKE_MODEL=<id> ./scripts/test.sh --integration -k <provider>`).
+   `cd <repo>/creek-tools && ./scripts/test.sh --live -k anthropic` (or
+   `CREEK_SMOKE_MODEL=<id> ./scripts/test.sh --live -k <provider>`).
 3. Print a **per-stage summary table**: stage → provider → model → ready? Then
    tell the user the Intimate guarantee below is already in force.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,74 @@ jobs:
             creek-tools/reports/pip-audit-report.json
           retention-days: 30
 
+  integration-e2e:
+    name: Integration & E2E Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: creek-tools
+    # Deliberately NO `needs:` — this lane is independent of `quality` and runs
+    # in parallel with it. A tree that fails lint should still report whether
+    # its cross-component wiring holds; serialising behind `quality` would hide
+    # that until the lint fix lands, costing a whole extra round trip. The lane
+    # is seconds of tests, so the parallel runner is nearly all setup cost.
+    #
+    # Single Python version, unlike `quality`'s 3.11/3.12/3.13 matrix. These
+    # tests exercise wiring between components, not version-sensitive syntax or
+    # stdlib behaviour; a version-specific break surfaces in the unit matrix
+    # first, and on the same commit. Fanning this lane across three versions
+    # would triple the runner minutes for no additional signal.
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_DEFAULT_VERSION }}
+
+      - name: Cache uv
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-uv-${{ env.PYTHON_DEFAULT_VERSION }}-${{ hashFiles('creek-tools/uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-${{ env.PYTHON_DEFAULT_VERSION }}-
+            ${{ runner.os }}-uv-
+
+      - name: Install uv
+        # Same pin as the `quality` job — see the rationale there.
+        run: python -m pip install 'uv==0.11.16'
+
+      - name: Install dependencies (locked)
+        run: |
+          uv export --locked --all-extras --no-emit-project --no-hashes \
+            -o /tmp/locked-requirements.txt
+          uv pip install --system -r /tmp/locked-requirements.txt
+          uv pip install --system --no-deps -e .
+
+      - name: Run integration tests (hermetic, blocking)
+        # No provider credentials are set for this step, and none may be added:
+        # both lanes are hermetic by definition, so a test that needs a key is
+        # `live` and belongs outside CI. Withholding the keys is what keeps that
+        # honest — a leaked key here would let a live test pass silently.
+        #
+        # ./scripts/test.sh passes --no-cov for this lane. That is deliberate,
+        # not an oversight: a marker-only selection touches a fraction of the
+        # package, so pyproject's --cov-fail-under=90 would fail every run.
+        # Coverage is the unit lane's job and is enforced there.
+        run: ./scripts/test.sh --integration
+
+      - name: Run e2e tests (hermetic, blocking)
+        # `!cancelled()` so a failing integration step above does not mask this
+        # lane: both results land in one run instead of costing a round trip to
+        # discover the second failure. This does NOT weaken the gate — a failed
+        # step still fails the job, and `quality-gate` checks the job result.
+        if: ${{ !cancelled() }}
+        # --no-cov here too, for the same reason as the integration step above.
+        run: ./scripts/test.sh --e2e
+
   crawdad:
     name: CrawDad Quality
     runs-on: ubuntu-latest
@@ -359,7 +427,13 @@ jobs:
   quality-gate:
     name: Quality Gate
     runs-on: ubuntu-latest
-    needs: [quality, crawdad, complexity-analysis, build]
+    needs: [quality, integration-e2e, crawdad, complexity-analysis, build]
+    # `if: always()` defeats GitHub's default skip-on-upstream-failure, so
+    # `needs:` alone gates NOTHING here — it only makes `needs.<job>.result`
+    # readable. Every job listed above MUST also have an explicit
+    # `!= "success"` check below. A job added to `needs:` but not to the script
+    # is the classic silent no-op: the gate waits for it, then passes whatever
+    # it reported.
     if: always()
 
     steps:
@@ -367,6 +441,10 @@ jobs:
         run: |
           if [ "${{ needs.quality.result }}" != "success" ]; then
             echo "Quality checks failed"
+            exit 1
+          fi
+          if [ "${{ needs.integration-e2e.result }}" != "success" ]; then
+            echo "Integration/e2e tests failed"
             exit 1
           fi
           if [ "${{ needs.crawdad.result }}" != "success" ]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,10 @@ install -r requirements-dev.txt` still works as an unpinned fallback.
 ./scripts/check-all.sh          # Run ALL quality checks (do this before every commit)
 ./scripts/fix-all.sh            # Auto-fix linting + formatting
 ./scripts/test.sh               # Run unit tests
-./scripts/test.sh --all         # Run all test types (unit, integration, e2e)
+./scripts/test.sh --all         # Run all lanes (unit, integration, e2e, live)
+./scripts/test.sh --integration # Hermetic cross-component lane (blocking in CI)
+./scripts/test.sh --e2e         # Hermetic end-to-end lane (blocking in CI)
+./scripts/test.sh --live        # Live API/service smokes (needs keys; not in CI)
 ./scripts/test.sh --coverage    # Unit tests with coverage report
 ./scripts/coverage.sh           # Coverage report (--html for HTML output)
 ./scripts/lint.sh               # Ruff linting (--fix to auto-fix)
@@ -75,7 +78,9 @@ pytest tests/test_main.py::test_main_runs -v
 ### creek-tools
 - **Python >=3.11** (CI tests 3.11, 3.12, 3.13)
 - Package source: `creek/` (flat layout, not src/)
-- Tests: `tests/` (pytest with markers: `integration`, `e2e`)
+- Tests: `tests/` (pytest lane markers: `integration`, `e2e` — both hermetic
+  and blocking in CI; `live` — needs real keys/services, never run in CI;
+  `slow` — benchmarks. See the `markers` table in `pyproject.toml`.)
 - Config: `pyproject.toml` contains all tool configs (pytest, coverage, mypy, ruff, bandit)
 - CI: `/.github/workflows/ci.yml` (at repo root; jobs use `working-directory: creek-tools`)
 - Pre-commit: `creek-tools/.pre-commit-config.yaml` (install with `pre-commit install -c creek-tools/.pre-commit-config.yaml`)

--- a/creek-tools/CLAUDE.md
+++ b/creek-tools/CLAUDE.md
@@ -491,9 +491,12 @@ describe.
 
 - **Development workflow**: [`../.claude/agents/shared/house-rules.md`](../.claude/agents/shared/house-rules.md)
   (the four gates, commit/PR conventions); [`.pre-commit-config.yaml`](.pre-commit-config.yaml).
-- **Testing strategy**: [`scripts/test.sh`](scripts/test.sh); the
-  `[tool.pytest.ini_options]` table in [`pyproject.toml`](pyproject.toml)
-  for markers and testpaths.
+- **Testing strategy**: [`scripts/test.sh`](scripts/test.sh) — `--help` names
+  every lane and which ones block a merge; the `[tool.pytest.ini_options]`
+  table in [`pyproject.toml`](pyproject.toml) for the marker definitions and
+  testpaths; [`../.github/workflows/ci.yml`](../.github/workflows/ci.yml) for
+  which lanes actually gate (jobs `quality` and `integration-e2e`, aggregated
+  by `quality-gate`) — that workflow, not this file, is the authority.
 - **Tool usage & code standards**: [`scripts/check-all.sh`](scripts/check-all.sh)
   for the gates, in order; the tool sections of [`pyproject.toml`](pyproject.toml).
 - **Common pitfalls & troubleshooting**: the Troubleshooting section of

--- a/creek-tools/README.md
+++ b/creek-tools/README.md
@@ -228,11 +228,11 @@ For the Writing Desk voice roles (`voice_drafter` / `voice_line_editor`), an exp
 **Live smoke test (model onboarding).** Unit tests mock every vendor SDK, so a model id is only proven by a real call. With the provider's key (and consent) in the env, one command makes a single tiny live request and asserts the normalized round-trip:
 
 ```bash
-./scripts/test.sh --integration -k openai                                  # smoke the provider's default model
-CREEK_SMOKE_MODEL=some-new-model ./scripts/test.sh --integration -k gemini # smoke a candidate model id
+./scripts/test.sh --live -k openai                                  # smoke the provider's default model
+CREEK_SMOKE_MODEL=some-new-model ./scripts/test.sh --live -k gemini # smoke a candidate model id
 ```
 
-Each smoke skips cleanly when its key is absent, and the `integration` marker keeps them out of the default test selection and CI entirely.
+Each smoke skips cleanly when its key is absent, and the `live` marker keeps them out of the default test selection and CI entirely — CI holds no provider credentials, and a merge gate that depends on a paid third-party API is a flaky gate.
 
 ---
 
@@ -258,7 +258,10 @@ All quality gates run from `creek-tools/` via the project scripts:
 ./scripts/check-all.sh          # Run all 7 gates (lint, format, typecheck, complexity, security, tests, coverage)
 ./scripts/fix-all.sh             # Auto-fix lint + format
 ./scripts/test.sh                # Unit tests (default)
-./scripts/test.sh --all          # Unit + integration + e2e
+./scripts/test.sh --integration  # Hermetic cross-component lane (blocking in CI)
+./scripts/test.sh --e2e          # Hermetic end-to-end lane (blocking in CI)
+./scripts/test.sh --live         # Live API/service smokes (needs keys; not in CI)
+./scripts/test.sh --all          # Every lane, live smokes included
 ./scripts/test.sh --coverage     # With coverage report
 ./scripts/lint.sh --fix          # Ruff lint with auto-fix
 ./scripts/format.sh --check      # Format check

--- a/creek-tools/pyproject.toml
+++ b/creek-tools/pyproject.toml
@@ -202,7 +202,24 @@ include = ["creek", "creek.*", "creek_mcp", "creek_mcp.*"]
 "creek.generate.exemplars" = ["*.yaml"]
 
 [tool.pytest.ini_options]
-minversion = "7.0"
+# pytest 9 is required: this config uses the `strict_markers` / `strict_config`
+# ini options introduced there. uv.lock pins 9.0.3, so this only bites an
+# unpinned fallback install, and it bites with a clear pytest error rather than
+# silently ignoring the strictness settings below.
+minversion = "9.0"
+
+# Strictness is set as INI OPTIONS, not only as the `--strict-markers` /
+# `--strict-config` flags in `addopts` below. Under pytest 9 those flags are
+# honoured when typed on the command line but do NOT take effect from
+# `addopts`: an unregistered marker degraded to a PytestUnknownMarkWarning and
+# the run still exited 0. That made the strictness illusory — a typo'd
+# `@pytest.mark.integraton` would silently drop a test out of the blocking
+# lane, which is precisely the "gate that looks green but tests nothing"
+# failure this suite's CI lanes exist to prevent. The flags stay in `addopts`
+# for anyone invoking pytest directly; these two lines are what actually bind.
+strict_markers = true
+strict_config = true
+
 addopts = [
     "-ra",
     "--strict-markers",
@@ -215,9 +232,22 @@ addopts = [
     "--cov-report=xml",
     "--cov-fail-under=90",
 ]
+# Lane markers. A test carries at most one of integration/e2e/live; anything
+# unmarked is a unit test. `--strict-markers` (above) makes a typo'd or retired
+# marker name a collection error rather than a silently-empty selection.
+#
+#   BLOCKING IN CI (.github/workflows/ci.yml, job `integration-e2e`):
+#     integration, e2e — both must be hermetic, or the merge gate is flaky.
+#   NOT IN CI:
+#     live  — needs credentials/services CI does not have (run it by hand).
+#     slow  — benchmarks, too slow for the merge path.
+#
+# Run each lane through ./scripts/test.sh (--integration/--e2e/--live), which
+# owns the marker expressions and the --no-cov policy for the non-unit lanes.
 markers = [
-    "integration: marks tests as integration tests (deselect with '-m \"not integration\"')",
-    "e2e: marks tests as end-to-end tests (deselect with '-m \"not e2e\"')",
+    "integration: hermetic cross-component tests — no network, no API keys, no real vault; BLOCKING in CI (deselect with '-m \"not integration\"')",
+    "e2e: hermetic end-to-end journeys through the CLI against a synthetic vault; BLOCKING in CI (deselect with '-m \"not e2e\"')",
+    "live: opt-in smokes needing a real provider key or a reachable local service; never run in CI, and each skips cleanly when its credential/service is absent (deselect with '-m \"not live\"')",
     "slow: marks tests as slow benchmarks (deselect with '-m \"not slow\"')",
 ]
 testpaths = ["tests"]

--- a/creek-tools/scripts/test.sh
+++ b/creek-tools/scripts/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # scripts/test.sh - Run tests with Pytest
-# Usage: ./scripts/test.sh [--unit|--integration|--e2e|--all] [--coverage]
+# Usage: ./scripts/test.sh [--unit|--integration|--e2e|--live|--all] [--coverage]
 #                          [-k EXPRESSION] [--verbose] [--help]
 
 set -euo pipefail
@@ -31,6 +31,10 @@ while [[ $# -gt 0 ]]; do
             TEST_TYPE="e2e"
             shift
             ;;
+        --live)
+            TEST_TYPE="live"
+            shift
+            ;;
         --all)
             TEST_TYPE="all"
             shift
@@ -58,14 +62,27 @@ Usage: $(basename "$0") [OPTIONS]
 Run tests using Pytest.
 
 OPTIONS:
-    --unit          Run unit tests only (default)
-    --integration   Run integration tests only (live smokes; coverage gate off)
-    --e2e           Run end-to-end tests only (coverage gate off)
-    --all           Run all test types
+    --unit          Run unit tests only (default) — everything unmarked.
+                    Carries the 90% coverage gate.
+    --integration   Run the hermetic cross-component lane. No network, no API
+                    keys, no real vault. BLOCKING in CI. Coverage gate off.
+    --e2e           Run the hermetic end-to-end lane: full journeys through the
+                    CLI against a synthetic vault. BLOCKING in CI. Coverage
+                    gate off.
+    --live          Run the live smokes: real provider APIs and local services.
+                    Needs credentials; NOT run in CI. Each test skips cleanly
+                    when its key or service is absent. Coverage gate off.
+    --all           Run every test type, live smokes included
     --coverage      Generate coverage report
     -k EXPRESSION   Only run tests matching the pytest keyword expression
     --verbose       Show detailed output
     --help          Display this help message
+
+WHICH LANE BLOCKS A MERGE:
+    --unit, --integration and --e2e all gate the Quality Gate in
+    .github/workflows/ci.yml. --live and the 'slow' benchmarks do not: CI holds
+    no provider credentials, and a gate that depends on a paid third-party API
+    or a local daemon is a flaky gate.
 
 EXIT CODES:
     0               All tests passed
@@ -76,6 +93,7 @@ EXAMPLES:
     $(basename "$0")                     # Run unit tests
     $(basename "$0") --all               # Run all tests
     $(basename "$0") --unit --coverage   # Unit tests with coverage
+    $(basename "$0") --live -k openai    # Smoke one provider's live API
 EOF
             exit 0
             ;;
@@ -103,21 +121,40 @@ PYTEST_ARGS=(-v)
 case "$TEST_TYPE" in
     unit)
         echo "=== Running Unit Tests ==="
-        PYTEST_ARGS+=(-m "not integration and not e2e and not slow")
+        # Every lane marker is excluded by name. `live` in particular: those
+        # tests skip themselves when a key is absent, so omitting it here would
+        # look fine in CI and quietly bill a real API on a developer's machine.
+        PYTEST_ARGS+=(-m "not integration and not e2e and not slow and not live")
         ;;
     integration)
-        echo "=== Running Integration Tests ==="
-        # A marker-only selection runs a handful of tests, so the project-wide
-        # --cov-fail-under from pyproject addopts would always fail; live
-        # smokes are about API round-trips, not coverage.
+        echo "=== Running Integration Tests (hermetic, blocking) ==="
+        # Hermetic cross-component tests: no network, no API keys, no real
+        # vault. --no-cov because a marker-only selection exercises a fraction
+        # of the package, so the project-wide --cov-fail-under from pyproject
+        # addopts would always fail. Coverage is the unit lane's job; this lane
+        # is about wiring between components.
         PYTEST_ARGS+=(-m "integration" --no-cov)
         ;;
     e2e)
-        echo "=== Running End-to-End Tests ==="
+        echo "=== Running End-to-End Tests (hermetic, blocking) ==="
+        # Full journeys through the CLI against a synthetic vault. --no-cov for
+        # the same reason as the integration lane above.
         PYTEST_ARGS+=(-m "e2e" --no-cov)
+        ;;
+    live)
+        echo "=== Running Live Smokes (needs credentials; not run in CI) ==="
+        # Real provider APIs and local services. Never wired into CI: it holds
+        # no provider credentials, and each test skips when its key or service
+        # is missing — a lane that skips everything is not a gate. --no-cov for
+        # the same reason as the lanes above.
+        PYTEST_ARGS+=(-m "live" --no-cov)
         ;;
     all)
         echo "=== Running All Tests ==="
+        # Deliberately no -m expression: "all" means every marker, live smokes
+        # and slow benchmarks included. Any new lane marker is picked up here
+        # for free, which is the point — do not turn this into a union of the
+        # lanes above, or a future marker silently stops being covered.
         ;;
 esac
 

--- a/creek-tools/tests/e2e/__init__.py
+++ b/creek-tools/tests/e2e/__init__.py
@@ -2,8 +2,14 @@
 
 These tests use real disk I/O against ``tmp_path`` to exercise the full
 pipeline against synthetic vaults and source directories. They are
-deliberately heavier than the unit suite and are excluded from
-``./scripts/test.sh`` (and CI's default job) per CI-003.
+deliberately heavier than the unit suite and stay out of the default
+``./scripts/test.sh`` selection (and out of CI's unit job) per CI-003.
+
+They are **not** ungated: the ``integration-e2e`` job in
+``.github/workflows/ci.yml`` runs this lane on every PR and blocks the Quality
+Gate on it. That makes hermeticity a hard requirement here — no network, no API
+keys, no real vault. A test needing a real provider key is ``live``, not
+``e2e``, and belongs in ``tests/test_live_smoke.py``.
 
 Run them locally with:
 

--- a/creek-tools/tests/test_classify.py
+++ b/creek-tools/tests/test_classify.py
@@ -1950,13 +1950,20 @@ class TestLLMClassifierAnthropicDispatch:
         mock_call.assert_called_once()
 
 
-# ---- Integration test (requires running Ollama) ----
+# ---- Live smoke (requires a running Ollama) ----
 
 
-class TestLLMClassifierIntegration:
-    """Integration tests for LLMClassifier with real Ollama."""
+class TestLLMClassifierLive:
+    """Live smoke for LLMClassifier against a real Ollama instance.
 
-    @pytest.mark.integration
+    ``live``, not ``integration``: ``LLMClassifier.available`` performs an
+    outbound HTTP probe of the Ollama endpoint, so this needs a reachable
+    service. The blocking ``integration`` lane is hermetic by definition, and
+    CI runs no Ollama. Every other LLMClassifier test in this module mocks
+    ``httpx.Client`` and stays in the unit lane.
+    """
+
+    @pytest.mark.live
     def test_classify_with_real_ollama(self) -> None:
         """classify should work with a real Ollama instance."""
         config = LLMConfig()

--- a/creek-tools/tests/test_live_smoke.py
+++ b/creek-tools/tests/test_live_smoke.py
@@ -6,12 +6,14 @@ the things mocks paper over (valid model ids, stop-reason enums, usage field
 names) are exactly what drift. Each test here proves the full round-trip
 (auth → request → normalized ``Completion``) against the live API.
 
-These tests are ``integration``-marked, so the default test selection and CI
-never run (or bill) them. Each one also skips cleanly when its provider's
-API key is absent. To smoke a provider when onboarding a new model id::
+These tests are ``live``-marked, so neither the default test selection nor any
+CI lane runs (or bills) them — CI holds no provider credentials, and a gate
+that depends on a paid third-party API is a flaky gate. Each one also skips
+cleanly when its provider's API key is absent. To smoke a provider when
+onboarding a new model id::
 
-    ./scripts/test.sh --integration -k openai
-    CREEK_SMOKE_MODEL=some-new-model ./scripts/test.sh --integration -k openai
+    ./scripts/test.sh --live -k openai
+    CREEK_SMOKE_MODEL=some-new-model ./scripts/test.sh --live -k openai
 
 ``CREEK_SMOKE_MODEL`` overrides the provider's default model for the run;
 unset, each provider exercises its own ``DEFAULT_MODELS`` entry.
@@ -36,7 +38,7 @@ from creek.config import LLMConfig
 if TYPE_CHECKING:
     from creek.classify.llm.completion import Completion
 
-pytestmark = pytest.mark.integration
+pytestmark = pytest.mark.live
 
 _PROMPT = "Reply with exactly the word OK and nothing else."
 


### PR DESCRIPTION
Closes #1026. Epic #1024.

**12 e2e tests existed and none of them gated a merge.** `ci.yml`'s only test step ran `./scripts/test.sh --unit` → `-m "not integration and not e2e and not slow"`, and `grep -rn "e2e" .github/workflows/` found only prose in `deslop.yml`. They ran when a human typed the flag. That is why features wired to nothing get found late, by hand.

## The marker collision, resolved from the code rather than the issue text

`integration` meant *live API smoke*, not *cross-component* — `--integration` ran `--no-cov` and the help text called them "live smokes". A gate that needs a paid API key is a flaky gate, so the name had to be freed.

The issue's list of what to move was **wrong in both directions**, so every `integration`-marked test was swept individually:

| Test | Issue said | Reality | Action |
|---|---|---|---|
| `test_live_smoke.py` (4 tests) | needs keys | correct — real vendor calls | → `live` |
| `test_real_agents.py` | "needs real provider keys" | **false.** No marker at all; uses the deterministic `mock_sentence_transformer` fixture; already a unit test. Only match was docstring prose at `:376` | **left alone** |
| `test_classify.py::test_classify_with_real_ollama` | not mentioned | `LLMClassifier.available` probes `localhost:11434` over HTTP — same flakiness class as a key, and CI runs no Ollama | → `live` |

13 hermetic integration tests across 6 files stay in the blocking lane.

## Why a separate job, not a step in `quality`

1. **Matrix duplication** — `quality` is a 3-version matrix (3.11/3.12/3.13). A step there runs the lane three times for one signal. These tests exercise wiring between components, not version-sensitive syntax; a version-specific break surfaces in the unit matrix first, on the same commit.
2. **Failure signal** — a red check named "Integration & E2E Tests" is unambiguous. A failing step inside "Code Quality & Testing (3.12)" is indistinguishable from a lint, mypy, bandit, or coverage failure in the same job.
3. **Coupling** — `quality`'s coverage steps read the `.coverage` file the unit run writes. A `--no-cov` lane sitting among them writes no data and adds needless order-dependence.

It carries **no `needs:`**, so it runs in parallel with `quality`: a tree failing lint should still report whether its cross-component wiring holds, rather than hiding that for a whole extra round trip. Within the job the e2e step carries `if: ${{ !cancelled() }}` so a failing integration step doesn't mask the e2e result — both land in one run. A failed step still fails the job.

## The Quality Gate needed *both* halves

This is the part that would silently not work. The gate is `if: always()`, which defeats GitHub's skip-on-upstream-failure, so `needs:` only makes `needs.<id>.result` *readable* — **all gating is done in shell**. A job added to `needs:` without a matching `!= "success"` check is a no-op that leaves this issue's entire premise unfixed while looking done.

```yaml
needs: [quality, integration-e2e, crawdad, complexity-analysis, build]
```
```bash
if [ "${{ needs.integration-e2e.result }}" != "success" ]; then
  echo "Integration/e2e tests failed"
  exit 1
fi
```

Verified mechanically by parsing the YAML and diffing the two sets:

```
needs    : ['quality', 'integration-e2e', 'crawdad', 'complexity-analysis', 'build']
checked  : ['build', 'complexity-analysis', 'crawdad', 'integration-e2e', 'quality']
unchecked: NONE
```

A comment above `if: always()` now records the rule for the next person.

## Hermeticity: proven in two layers, not asserted

**Layer 1 — keys unset** (confirmed with `env | grep -cE "ANTHROPIC|OPENAI|GOOGLE_API|GEMINI|CREEK_CLOUD|CREEK_ANTHROPIC"` → `0`):
```
--integration → 13 passed, 8162 deselected  (exit 0)
--e2e         → 12 passed, 8163 deselected  (exit 0)
```
The integration lane's skip count dropped **5 → 0** — a clean signal that every credential-dependent test left.

**Layer 2 — keys unset AND a socket guard**, because "no keys" does not prove "no network". A throwaway plugin (kept outside the repo) raises on any non-loopback `connect` / `connect_ex` / `getaddrinfo`: 13 and 12 passed respectively.

The guard was proven to bite, since a proof that cannot fail proves nothing:
```
connect(('api.anthropic.com', 443)) → guard bites: outbound connection attempted
getaddrinfo('api.openai.com', 443)  → guard bites: DNS resolution attempted
```

**Gate teeth proven** by appending a deliberately failing e2e test: `--e2e` exits 1, the job goes red, the gate's `!= "success"` check exits 1. File restored; `git diff --stat` on it is empty.

## Budget and coverage

Blocking lane: **12s**, against the issue's ≤5 min budget. Deliberately **not** under `--cov-fail-under` — these lanes use `--no-cov` for good reason and coverage is the unit lane's job, as the issue asked be stated explicitly rather than silently dropped.

## Deviation: CLAUDE.md §8 was not created

The issue asks for "`creek-tools/CLAUDE.md` §8 (Testing Strategy)". **§8 does not exist**, and §7 records that those sections were retired under #1190 specifically to stop docs drifting from their source — it states *"this section only points, it does not describe."*

Writing a prose Testing Strategy section would reverse a deliberate decision and recreate exactly the drift class #1025 just spent a PR eliminating. The three markers and which lane blocks are documented at the source §7 points to (`scripts/test.sh` help text and the pyproject markers table), with §7's pointer updated to name the new lane.

## Verification

`./scripts/check-all.sh` — **12/12 passed**. `--unit`, `--integration`, `--e2e`, `--live` and `--all` each verified to do what their help text now claims. `--live` with keys unset: 5 skipped, exactly the moved tests. shellcheck clean. Zero suppressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EaHDtyDuNrpGtzUGMJT7Fw