### PR TITLE
fix(ralph): make a do-not-auto-merge hold survive the verdict line, and stop re-assign orphaning a PR

### DIFF
--- a/.claude/skills/await-claude-review/SKILL.md
+++ b/.claude/skills/await-claude-review/SKILL.md
@@ -19,7 +19,7 @@ description: >-
   status polling (use `pull_request_read` directly).
 metadata:
   author: Geoff
-  version: 1.2.0
+  version: 1.3.0
 ---
 
 # Await Claude Review
@@ -77,13 +77,27 @@ This comment is not authored by `claude[bot]` — it's authored by the human use
 **Recognition.** A comment qualifies as an iteration-trigger summary when **all** of:
 
 1. The body contains the literal marker `<!-- iteration-trigger -->`.
-2. A line matches `^\*\*VERDICT\*\*:\s*(LGTM|CHANGES[_ ]REQUESTED|COMMENTS)`.
+2. A line matches `^\*\*VERDICT\*\*:\s*(\S.*)` — capture the value **verbatim**. Do not narrow this to the three review verdicts: the workflow also emits refusal values there (below), and a recogniser that cannot see them reports "malformed" for a comment that is perfectly well-formed and is explicitly refusing.
 3. A line matches `^\*\*CI\*\*:\s*(\d+)/(\d+)\s+Green` (use this to decide `merge` vs `iterate`).
+
+**Merge-critical fields: `VERDICT` and `CI`, and only those.** `**Action**:` is diagnostic prose and is never parsed for a decision (see Step 4a item 5). `iteration-trigger.yml`'s header states the same contract from the emitter's side, and both files must be updated together — a prose contract between two files is exactly what drifted in #1202.
+
+**The `VERDICT` vocabulary is therefore larger than the reviewer's.** Three values come from the review comment; the rest are the workflow **refusing to clear a merge**, and it sets them precisely so that no consumer reading `VERDICT` + `CI` can mistake the summary for permission:
+
+| `**VERDICT**` value | Meaning | Merge? |
+| ------------------- | ------- | ------ |
+| `LGTM`              | reviewer approved, and the workflow cleared every merge invariant | yes, subject to `CI: N/N` |
+| `CHANGES_REQUESTED` / `CHANGES REQUESTED` | reviewer wants changes | no — fix loop |
+| `COMMENTS`          | reviewer had non-blocking notes | no — caller decides |
+| `HELD`              | a human set `do-not-auto-merge` on the PR (or its labels were unreadable) | **never** — a human owns this PR |
+| `NOT ATTESTED`      | the verdict carries no `<!-- creek-review pr=N -->` marker for THIS PR (#1181) | **never** — surface to a human |
+| `NOT CURRENT`       | the head is behind its base, so its green describes a tree it would not merge into | **never** — sync first |
 
 **Routing.** When this comment wakes the session:
 
-- `VERDICT == LGTM` and `CI: N/N Green` (full match) → caller proceeds to merge gate. The `Action:` line will say "cleared to squash merge…".
+- `VERDICT` is exactly `LGTM` and `CI: N/N Green` (full match) → caller proceeds to merge gate. The `Action:` line will say "cleared to squash merge…".
 - `VERDICT == CHANGES_REQUESTED` or `VERDICT == COMMENTS` → caller enters fix loop. The `Action:` line will reference a comment ID to read for in-depth feedback. Pull that comment via `mcp__github__pull_request_read` `get_comments` and feed the body into `address-feedback`.
+- **Any other value** (`HELD`, `NOT ATTESTED`, `NOT CURRENT`, or one added later) → **do not merge and do not enter the fix loop.** Report the `Action:` line to the user and stop. The list above is not exhaustive by design: the rule is that only an exactly-`LGTM` verdict clears, so a value you do not recognise refuses.
 - `CI: x/y Green` where `x < y` → CI is not actually green; do not merge even on `LGTM`. Investigate the failing run before proceeding.
 
 **Currency check still applies.** The trigger fires on a `workflow_run` for a specific HEAD SHA, but the comment may arrive minutes after the push. Use the standard `created_at >= headPushedAt` guard before treating it as authoritative for the current HEAD.
@@ -149,10 +163,12 @@ Re-fetch the comments to read the full body (the webhook payload may be truncate
 When the wake event is the owner-authored iteration-trigger comment:
 
 1. **Currency check**: require `created_at >= headPushedAt`.
-2. Parse `**VERDICT**:` and `**CI**: x/y Green` from the body.
-3. If `VERDICT == LGTM` AND `x == y` (CI fully green): return `LGTM` to the caller. The follow-up `Action:` line typically reads "cleared to squash merge…". The caller proceeds to merge.
-4. Otherwise: extract the comment ID referenced in `Action: pull comment <id> …`, fetch that comment's body via `get_comments`, and pass the body to the caller (typically `address-feedback`) for triage. Treat the underlying verdict (`CHANGES_REQUESTED` or `COMMENTS`) as authoritative for the next loop.
-5. If the body is malformed (marker present but verdict line missing/unparseable): surface to user. Do not infer a verdict from the `Action:` prose.
+2. Parse `**VERDICT**:` and `**CI**: x/y Green` from the body. These two are the only merge-critical fields; `**Action**:` is prose.
+3. **Merge only on an exactly-`LGTM` verdict.** If the verdict is exactly `LGTM` AND `x == y` (CI fully green): return `LGTM` to the caller. The follow-up `Action:` line will read "cleared to squash merge…". The caller proceeds to merge. Every other value refuses — this is a whitelist, never a blacklist of known-bad verdicts, because the emitter's refusal vocabulary grows and this file learns about the additions late (#1202).
+4. If the verdict is `CHANGES_REQUESTED` or `COMMENTS`: extract the comment ID referenced in `Action: pull comment <id> …`, fetch that comment's body via `get_comments`, and pass the body to the caller (typically `address-feedback`) for triage. Treat that verdict as authoritative for the next loop.
+5. If the verdict is a **refusal** (`HELD`, `NOT ATTESTED`, `NOT CURRENT`, or any value not in items 3–4), or the body is malformed (marker present but verdict line missing/unparseable): surface the `Action:` line to the user and stop. Do not merge, do not dispatch a fix worker, and **do not infer a verdict from the `Action:` prose** — read it to the user, do not parse it for a decision.
+
+   `HELD` in particular means a human set `do-not-auto-merge`, which is the one control a human retains over an autonomous merge loop. Nothing in this skill may route around it. `scripts/ralph/pr-ready.sh` — the orchestrator's own clearance path — enforces the identical invariant independently: it prints `optout` before probing anything else, and it excludes this summary from its verdict selector entirely (`ITER_SUMMARY_RE`), so it can never read one as a verdict at all.
 
 ### Step 5: On CI Failure for Current HEAD
 

--- a/.github/workflows/iteration-trigger.yml
+++ b/.github/workflows/iteration-trigger.yml
@@ -15,9 +15,20 @@ name: Iteration Trigger
 #   * the verdict carries the `<!-- creek-review pr=N -->` provenance marker for
 #     THIS PR (#1181) — the marker pr-ready.sh's MARKER_RE parses, read from the
 #     same comment the verdict came from.
-# All three fail closed on an unreadable answer. Note that only the provenance
-# branch also rewrites `VERDICT`; see the comment at that `elif` for why the
-# other two do not, and #1202 for the gap that leaves.
+# All three fail closed on an unreadable answer.
+#
+# AND EVERY ONE OF THEM REWRITES `VERDICT`, NOT JUST `ACTION` (#1202). `VERDICT`
+# is computed from the review comment ABOVE the clearance chain, so a branch that
+# refuses while leaving it alone still posts `**VERDICT**: LGTM` + `**CI**: N/N
+# Green` — and those two fields are the ONLY ones the merge path reads
+# (`.claude/skills/await-claude-review/SKILL.md` Step 4a; its item 5 says in as
+# many words "Do not infer a verdict from the `Action:` prose"). `ACTION` is
+# diagnostic; `VERDICT` is the gate. The refusal values are chosen for their
+# BYTES — `HELD`, `NOT ATTESTED`, `NOT CURRENT` — none containing an `LGTM`
+# substring and none being one of the three verdicts SKILL.md recognises, so
+# Step 4a falls to item 5 and surfaces to a human instead of merging.
+# scripts/ralph/test_pr_ready.sh walks this chain and fails on any NOT-cleared
+# branch that leaves `VERDICT` alone, including ones added after this comment.
 #
 # Required secrets:
 #   GEOFFE_GA_PAT  - personal access token for the repo owner with `pull-requests: write`.
@@ -155,13 +166,24 @@ jobs:
 
           if [ "$GREEN" = "$TOTAL" ] && [ "$VERDICT" = "LGTM" ]; then
             if [ "$HELD" != "no" ]; then
+              # THE ONE CONTROL A HUMAN RETAINS over an autonomous merge loop, so
+              # this branch is the most important place in the file to get right —
+              # and until #1202 it was the one that failed. Rewriting ACTION alone
+              # left the summary asserting `**VERDICT**: LGTM`, which is half of
+              # what Step 4a merges on, so a webhook-woken session merged the very
+              # PR a human had parked. `HELD` carries no `LGTM` substring and is
+              # not a verdict SKILL.md recognises; see the header for the full
+              # argument about why the VERDICT field, not ACTION, is the gate.
+              VERDICT='HELD'
               ACTION="NOT cleared to merge: the do-not-auto-merge hold is set on this PR (or its labels could not be read). A human owns this one - leave it alone."
             elif [ "$MARKER_PR" != "$PR" ]; then
               # Fails CLOSED: an absent or unparseable marker leaves MARKER_PR
               # empty, which never equals a PR number, so it does not clear.
               #
               # REWRITING `VERDICT` IS WHAT ACTUALLY STOPS THE MERGE; `ACTION` IS
-              # NOT LOAD-BEARING. `.claude/skills/await-claude-review/SKILL.md`
+              # NOT LOAD-BEARING — THE RULE FOR EVERY BRANCH OF THIS CHAIN, argued
+              # here once and referenced from the other two.
+              # `.claude/skills/await-claude-review/SKILL.md`
               # Step 4a parses `**VERDICT**:` and `**CI**: x/y Green` and nothing
               # else — its item 3 returns LGTM to the caller on those two fields
               # alone, and its item 5 says in as many words "Do not infer a
@@ -185,13 +207,23 @@ jobs:
               # been evaluated, and nothing reads VERDICT again before the BODY
               # printf below.
               #
-              # DELIBERATELY NOT DONE ON THE `HELD` AND `BEHIND` BRANCHES. They
-              # carry the identical pre-existing hole — a `do-not-auto-merge` hold
-              # is defeated the same way — and it is filed as #1202 (P1). The
-              # asymmetry is scoped to #1181 on purpose, not an oversight.
+              # THE `HELD` AND `BEHIND` BRANCHES NOW DO THE SAME THING (#1202).
+              # They carried the identical hole for as long as this branch did
+              # not: rewriting ACTION alone, so `**VERDICT**: LGTM` stood and a
+              # `do-not-auto-merge` hold was defeated exactly the way an
+              # unattested verdict was. The asymmetry was scoped to #1181 on
+              # purpose and is now closed; the chain has ONE rule, and
+              # test_pr_ready.sh enforces it structurally rather than by naming
+              # these three branches, so a fourth refusal inherits it.
               VERDICT='NOT ATTESTED'
               ACTION="NOT cleared to merge: the latest verdict does not attest that the reviewer read THIS PR - its provenance marker names '${MARKER_PR}', not ${PR}. Run scripts/ralph/fleet.sh sync (or push any commit) so the marker-emitting review workflow runs on this branch and the re-review is attested; re-running the old review run will not help, it replays the workflow file from the commit that run was launched from. See #1181."
             elif [ "$BEHIND" != "0" ]; then
+              # Same rule, same reason (#1202): this branch's own green proves
+              # nothing about today's base, and pr-ready.sh refuses the lane for
+              # it — so the summary must not hand the merge path an `LGTM` the
+              # sibling clearance path would reject. `NOT CURRENT` carries no
+              # `LGTM` substring and is not a verdict SKILL.md recognises.
+              VERDICT='NOT CURRENT'
               ACTION="NOT cleared to merge: this head is not current with ${BASE:-its base} (behind_by='${BEHIND}'). Run scripts/ralph/fleet.sh sync and let CI re-run first."
             else
               ACTION="You are cleared to squash merge, delete the branch, clean any worktrees, and unsubscribe from webhooks. Please proceed."

--- a/.github/workflows/ralph-recap-tests.yml
+++ b/.github/workflows/ralph-recap-tests.yml
@@ -30,6 +30,15 @@ name: Ralph Tooling Tests
 # marker and never reading it is the same bug with an extra step). Both
 # assertions are as coupled to that file as the round trip is to the emitter, so
 # a PR that edits only iteration-trigger.yml must run this suite as well.
+#
+# .claude/skills/await-claude-review/SKILL.md is the third file here, and it is
+# the CONSUMER half of that same merge contract (#1202). Its Step 4a decides the
+# merge from `**VERDICT**` + `**CI**` alone, so iteration-trigger.yml's refusal
+# vocabulary — `HELD`, `NOT ATTESTED`, `NOT CURRENT` — only means anything if
+# Step 4a refuses those values; test_pr_ready.sh reads the emitter's branches and
+# asserts SKILL.md names every one. Emitter and consumer are two files agreeing
+# in prose, which is exactly what drifted to produce #1202, so a PR that edits
+# either one alone has to run the suite that compares them.
 on:
   push:
     paths:
@@ -37,12 +46,14 @@ on:
       - ".github/workflows/ralph-recap-tests.yml"
       - ".github/workflows/code-review.yml"
       - ".github/workflows/iteration-trigger.yml"
+      - ".claude/skills/await-claude-review/SKILL.md"
   pull_request:
     paths:
       - "scripts/ralph/**"
       - ".github/workflows/ralph-recap-tests.yml"
       - ".github/workflows/code-review.yml"
       - ".github/workflows/iteration-trigger.yml"
+      - ".claude/skills/await-claude-review/SKILL.md"
 
 permissions:
   contents: read

--- a/scripts/ralph/fleet.sh
+++ b/scripts/ralph/fleet.sh
@@ -35,8 +35,13 @@
 #   count            Print the number of active worktrees.
 #   free             Print how many more workers may be started right now.
 #   path <N>         Print the worktree path for issue N (empty + exit 1 if none).
-#   assign <N> <slug>  Create (or reuse) a worktree for issue N off origin/main;
-#                      prints its absolute path. Refuses if the fleet is full.
+#   assign <N> <slug>  Create (or reuse) a worktree for issue N; prints its
+#                      absolute path. Prefers, in order: an existing LOCAL
+#                      branch, then a branch of that name on `origin` (a lane
+#                      `release` deleted locally while its PR lived on — #1180),
+#                      and only then a fresh branch off origin/main. Aborts if
+#                      the remote lookup is unreadable, and refuses if the fleet
+#                      is full.
 #   adopt <N> <PR>   The bot-PR variant of assign: create (or reuse) a worktree
 #                      for issue N attached to PR's EXISTING head branch (e.g.
 #                      Dependabot's), so fixes push to that branch instead of
@@ -46,7 +51,9 @@
 #                      branch by MERGE (no history rewrite ⇒ a plain push updates
 #                      the PR; no force-push, ever). Exit 0 clean, exit 3 on
 #                      conflict (merge aborted, worktree left clean).
-#   release <N>      Remove issue N's worktree and delete its local branch.
+#   release <N>      Remove issue N's worktree and delete its LOCAL branch. The
+#                      remote branch is never touched, so a released lane can be
+#                      re-assigned later and reattaches to it (see assign).
 #   reconcile        Release worktrees whose PR merged/closed or whose issue is
 #                      closed, then `git worktree prune`. Needs the gh CLI.
 #
@@ -207,8 +214,35 @@ acquire_assign_lock() {
   die "assign: could not acquire lock (stale $lock?); remove it if no assign is running" 1
 }
 
+# Does `origin` carry a branch of this name? Prints `found` or `absent`, and
+# returns NON-ZERO when the answer is UNREADABLE — a network blip, an expired
+# credential, a dead remote. The caller must treat that third outcome as an
+# abort, never as `absent`: branching off `main` when a remote branch MAY exist
+# is precisely the failure this function was added to prevent (#1180).
+#
+# `ls-remote` without `--exit-code`, because that flag conflates the two answers
+# this function must keep apart: it exits 2 for "no such ref" and non-zero for a
+# transport failure, and the caller needs "absent" and "unreadable" to take
+# OPPOSITE actions. Empty output with exit 0 is the unambiguous "absent".
+#
+# The pattern is FULLY QUALIFIED (`refs/heads/<branch>`) and the answer is then
+# matched EXACTLY: ls-remote patterns are tail-matched on path components, so a
+# bare `issue/9-x` would also be answered by `refs/heads/wip/issue/9-x` — a
+# different branch, whose commits are not this PR's. awk with a string compare
+# rather than grep, because a branch name is not a regex (`+`, `.` and `[` are
+# all legal in a git ref).
+remote_branch_state() { # remote_branch_state <root> <branch>
+  local root="$1" branch="$2" out
+  out="$(git -C "$root" ls-remote --heads origin "refs/heads/$branch" 2>/dev/null)" || return 1
+  if awk -v want="refs/heads/$branch" '$2 == want { hit = 1 } END { exit !hit }' <<<"$out"; then
+    printf 'found\n'
+  else
+    printf 'absent\n'
+  fi
+}
+
 cmd_assign() {
-  local issue="$1" slug="${2:-}" root dir branch base lock
+  local issue="$1" slug="${2:-}" root dir branch base lock remote_state
   [[ -n "$issue" ]] || die "assign: usage: assign <issue> <slug>"
   [[ "$issue" =~ ^[0-9]+$ ]] || die "assign: issue must be numeric, got '$issue'"
   root="$(repo_root)"
@@ -246,7 +280,41 @@ cmd_assign() {
     # Branch already exists (prior tick) — attach a worktree to it.
     git -C "$root" worktree add "$dir" "$branch" >&2
   else
-    git -C "$root" worktree add "$dir" -b "$branch" "$base" >&2
+    # NO LOCAL REF IS NOT THE SAME AS NO BRANCH (#1180). `cmd_release` below ends
+    # with `git branch -D`, so a lane that was released — to free a slot for a
+    # hotter issue, or because its PR was stalled — leaves the PR's branch alive
+    # on the REMOTE and nothing at all locally. Re-assigning that issue used to
+    # fall straight through to the `-b … origin/main` path below and cut a BRAND
+    # NEW branch of the same name off `main`: tracking `origin/main`, carrying
+    # none of the PR's commits, and indistinguishable from a healthy lane in
+    # `fleet.sh list`. `sync` then answers "Already up to date." — of course it
+    # does, the lane IS main — and the next push is either rejected
+    # (non-fast-forward) or, if somebody reaches for `--force`, destroys every
+    # commit on the PR branch. Only the loop's no-force-push rule kept the live
+    # occurrence (2026-08-06, PR #1117's lane) from being data loss.
+    #
+    # FAIL CLOSED on an unreadable answer. The whole defect is "we assumed no
+    # branch existed when one did", so an answer we cannot read must abort rather
+    # than repeat the assumption. `die` exits, which fires the EXIT trap
+    # `acquire_assign_lock` installed, so the lock is released on this path too.
+    remote_state="$(remote_branch_state "$root" "$branch")" ||
+      die "assign: could not read origin for '$branch'; refusing to guess whether a released lane's branch is still there (branching off main would orphan its PR's commits)"
+    if [[ "$remote_state" == "found" ]]; then
+      # Explicit refspec, exactly as `cmd_adopt` fetches a bot branch: the
+      # tracking ref may not exist yet in this clone, and `--track` needs it.
+      # `+` accepts a force-push upstream; it updates only refs/remotes.
+      git -C "$root" fetch --quiet origin "+refs/heads/$branch:refs/remotes/origin/$branch" ||
+        die "assign: could not fetch origin/$branch"
+      # FULLY QUALIFIED start point for the reason cmd_adopt's divergence guard
+      # documents: a tag sharing the branch's name outranks the branch in
+      # `git rev-parse`'s disambiguation, so an unqualified `origin/$branch`
+      # could resolve to a different object than the one intended. `--track`
+      # sets the upstream to `origin/$branch` — NOT `origin/main`, which is the
+      # wrong-upstream tell the incident report singled out.
+      git -C "$root" worktree add --track -b "$branch" "$dir" "refs/remotes/origin/$branch" >&2
+    else
+      git -C "$root" worktree add "$dir" -b "$branch" "$base" >&2
+    fi
   fi
 
   # Success: release the lock now and clear the trap so a later exit does not try
@@ -424,7 +492,10 @@ cmd_reconcile() {
 }
 
 usage() {
-  sed -n '2,53p' "$0" | sed 's/^# \{0,1\}//'
+  # Line range = the header comment block, ending at the "Exit codes:" line just
+  # above `set -euo pipefail`. Growing the header without moving this range
+  # truncates `--help` mid-sentence; test_fleet.sh pins the last line.
+  sed -n '2,60p' "$0" | sed 's/^# \{0,1\}//'
   exit "${1:-1}"
 }
 

--- a/scripts/ralph/test_fleet.sh
+++ b/scripts/ralph/test_fleet.sh
@@ -509,6 +509,118 @@ check "the adopted lane is the BRANCH tip, not the tag's object" \
   "$( (cd "$SDIR" 2>/dev/null && git rev-parse HEAD) 2>/dev/null || true)"
 run release 304 >/dev/null 2>&1
 
+# --- assign must REATTACH to a remote branch release deleted locally (#1180) --
+# `release` ends with `git branch -D` (fleet.sh's cmd_release), so the local ref
+# is gone while the PR's branch is very much alive on the remote. A later
+# `assign` for the same issue then found no `refs/heads/<branch>`, took the
+# else-path, and cut a BRAND NEW branch of the same name off `origin/main` —
+# tracking `origin/main`, carrying none of the PR's commits, and looking
+# perfectly healthy in `fleet.sh list`.
+#
+# OBSERVED LIVE (2026-08-06, PR #1117 re-attached after its lane was released to
+# free a slot): `sync` answered "Already up to date." — of course it did, the
+# lane WAS main — and `git status -sb` read `issue/1074-…...origin/main`. The
+# next step in the normal flow is a push, which is either rejected
+# (non-fast-forward) or, if somebody reaches for `--force`, destroys every commit
+# on the PR branch. Only the loop's no-force-push rule kept this from being data
+# loss.
+#
+# The round trip below is that incident: commit on the lane, push it, release,
+# re-assign. It FAILS against the pre-fix HEAD with the lane sitting on
+# `origin/main`'s tip and no PRWORK.txt anywhere.
+REMOTE_BRANCH="issue/501-tracer-skeleton"
+D501="$(run assign 501 'Tracer Skeleton' 2>/dev/null)"
+(
+  cd "$D501"
+  echo "the PR's work" > PRWORK.txt
+  git add -A && git commit -qm "the commit the PR is made of"
+  git push -q origin "HEAD:refs/heads/$REMOTE_BRANCH"
+)
+PR_TIP="$( (cd "$D501" && git rev-parse HEAD) )"
+run release 501 >/dev/null 2>&1
+# The precondition the whole case rests on: release really did delete the local
+# ref, so the re-assign genuinely has nothing local to reattach to.
+if (cd "$REPO" && git show-ref --verify --quiet "refs/heads/$REMOTE_BRANCH"); then
+  bad "release left the local ref behind — the #1180 round trip is not being exercised"
+else
+  ok "release deleted the local ref (the precondition for #1180)"
+fi
+if (cd "$WORK/upstream" && git show-ref --verify --quiet "refs/heads/$REMOTE_BRANCH"); then
+  ok "the PR's branch survives on the remote after release"
+else
+  bad "the PR's branch survives on the remote after release"
+fi
+
+D501B="$(run assign 501 'Tracer Skeleton' 2>/dev/null || true)"
+D501B="${D501B:-$WORK/assign-missing}"
+check "re-assign lands on the PR's tip, not on origin/main" \
+  "$PR_TIP" "$( (cd "$D501B" 2>/dev/null && git rev-parse HEAD) 2>/dev/null || true)"
+[[ -f "$D501B/PRWORK.txt" ]] && ok "re-assigned lane carries the PR's commits" \
+  || bad "re-assigned lane carries the PR's commits"
+# The wrong upstream is what turns the silent wrong-state into a push failure —
+# and it is the tell the incident report singled out ("## issue/1074-…...origin/main").
+check "re-assign tracks origin/<branch>, not origin/main" "origin/$REMOTE_BRANCH" \
+  "$( (cd "$D501B" 2>/dev/null &&
+       git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}') 2>/dev/null || true)"
+run release 501 >/dev/null 2>&1
+
+# The other half of the contract: a genuinely new issue has no remote branch, so
+# it must still be cut from origin/main exactly as before. Without this, "prefer
+# the remote" could degenerate into "never create a branch".
+D502="$(run assign 502 'brand new work' 2>/dev/null || true)"
+D502="${D502:-$WORK/assign-missing-new}"
+check "a genuinely new issue still branches from origin/main" \
+  "$( (cd "$REPO" && git rev-parse origin/main) )" \
+  "$( (cd "$D502" 2>/dev/null && git rev-parse HEAD) 2>/dev/null || true)"
+run release 502 >/dev/null 2>&1
+
+# FAIL CLOSED on an unreadable remote. Creating a fresh branch off `main` when a
+# remote branch MAY exist is precisely the failure above, so an lookup that
+# errors (network blip, expired credential, dead remote) must abort — not fall
+# through to the else-path and silently branch from main.
+#
+# A pass-through `git` shim that breaks ONLY `ls-remote`: the `fetch origin main`
+# a few lines earlier in cmd_assign must still succeed, or the abort would prove
+# nothing about the lookup. Absolute path to the real git baked in at generation
+# time, because the shim shadows `git` on PATH and would otherwise re-exec itself.
+REAL_GIT="$(command -v git)"
+cat > "$BIN/git" <<STUB
+#!/usr/bin/env bash
+# fleet.sh invokes it as \`git -C <root> ls-remote …\`; the bare form is covered too.
+if [[ "\${1:-}" == "ls-remote" || "\${3:-}" == "ls-remote" ]]; then
+  echo "fatal: could not read from remote repository" >&2
+  exit 128
+fi
+exec "$REAL_GIT" "\$@"
+STUB
+chmod +x "$BIN/git"
+rc=0
+(cd "$REPO" && PATH="$BIN:$PATH" "$FLEET" assign 503 'unreadable remote') >/dev/null 2>&1 || rc=$?
+[[ "$rc" -ne 0 ]] && ok "assign aborts when the remote branch lookup is unreadable" \
+  || bad "assign aborts when the remote branch lookup is unreadable"
+if run path 503 >/dev/null 2>&1; then
+  bad "an unreadable remote lookup left a worktree behind"
+else
+  ok "an unreadable remote lookup left no worktree behind"
+fi
+if (cd "$REPO" && git show-ref --verify --quiet 'refs/heads/issue/503-unreadable-remote'); then
+  bad "an unreadable remote lookup branched off main anyway — the #1180 failure, fail-open"
+else
+  ok "an unreadable remote lookup created no branch off main"
+fi
+# A refused assign must still release the lock, exactly like the cap refusal above.
+[[ -d "$LOCKDIR" ]] && bad "the unreadable-remote refusal left the assign lock behind" \
+  || ok "the unreadable-remote refusal leaves no assign lock behind"
+rm -f "$BIN/git"
+
+# `usage()` prints a FIXED LINE RANGE of fleet.sh's header comment. Documenting
+# the reattachment above grew that header, and a range left behind truncates
+# `--help` mid-sentence — the silent kind of rot, since `usage` still exits 0.
+# The "Exit codes:" line is the header's last, immediately above `set -euo`.
+check "help prints the whole header (usage()'s line range still reaches the end)" \
+  "Exit codes: 0 ok · 1 usage/not-found · 2 tooling missing · 3 merge conflict." \
+  "$( (run --help 2>&1 || true) | grep -v '^[[:space:]]*$' | tail -n 1)"
+
 # Nothing above may leak a lane: every adopt either released cleanly or refused.
 check "fleet ends with only the two long-lived lanes" "105 201" "$(run active)"
 

--- a/scripts/ralph/test_pr_ready.sh
+++ b/scripts/ralph/test_pr_ready.sh
@@ -1314,6 +1314,23 @@ The wedge is that a ${ITER_MARKER} summary matches VERDICT_RE, so the selector p
 ")")"
   check "W6 review PROSE quoting the summary marker mid-line → ready" "ready" \
     "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H COMMENTS_JSON="$w6_json" run 100)"
+
+  # W7 — A SUMMARY CARRYING A *REFUSAL* VERDICT IS STILL NOT A VERDICT (#1202).
+  # iteration-trigger.yml now writes a non-LGTM `**VERDICT**` on every NOT-cleared
+  # branch, so this shape is one the emitter really produces. pr-ready.sh's answer
+  # must not change: the summary is excluded from the selector whatever it says,
+  # so a PR whose only comment is one reads as "no verdict posted".
+  #
+  # GREEN TODAY (the summary is selected and refused for want of a marker), and
+  # it is a mutant-killer rather than a regression witness — the mutant being the
+  # tempting "accept `<!-- iteration-trigger -->` as a second provenance marker"
+  # that W4 also kills. Under it, this lane's routing would start depending on a
+  # verdict vocabulary pr-ready.sh has no reason to know, and `changes-requested`
+  # (which dispatches a fix worker) is one plausible landing.
+  ITER_ACTION_HELD='NOT cleared to merge: the do-not-auto-merge hold is set on this PR (or its labels could not be read). A human owns this one - leave it alone.'
+  w7_json="$(cj "$(iter_summary "$FRESH" '10/10 Green' 'HELD' "$ITER_ACTION_HELD")")"
+  check "W7 summary carrying a REFUSAL verdict, alone → awaiting-review" "awaiting-review" \
+    "$(CHECKS_EC=0 MERGE_STATE=CLEAN HEAD_DATE=$H COMMENTS_JSON="$w7_json" run 100)"
 }
 
 # The verdict answer is now THREE fields — `<createdAt>|<isLGTM>|<markerPr>` —
@@ -2738,17 +2755,134 @@ fi
 # `**CI**:` ONLY; it never reads `**Action**:` (item 5 says in so many words: "Do
 # not infer a verdict from the `Action:` prose"). So a summary that still carries
 # `**VERDICT**: LGTM` merges no matter how emphatically `**Action**` refuses.
-# The `elif` therefore has to neutralise the VERDICT FIELD, and the value has to
-# be chosen for its BYTES: `NOT ATTESTED` contains no `LGTM` substring, so
-# neither a `*LGTM*` glob nor a `test("LGTM")` can match it.
-# (`HELD` and `BEHIND` still post `**VERDICT**: LGTM` and are defeated exactly
-# this way — pre-existing, filed as #1202, deliberately out of #1181's scope.)
+# Every NOT-cleared branch therefore has to neutralise the VERDICT FIELD, and the
+# value has to be chosen for its BYTES: it must contain no `LGTM` substring (so
+# neither a `*LGTM*` glob nor a `test("LGTM")` can match it) and it must be none
+# of the three verdicts SKILL.md's recognition rule accepts (so Step 4a falls to
+# its item 5 — surface to the user, nobody merges).
 ITER_UNATTESTED_VERDICT="VERDICT='NOT ATTESTED'"
 
 if grep -qF -- "$ITER_UNATTESTED_VERDICT" "$ITER_WORKFLOW"; then
   ok "iteration-trigger.yml also neutralises the VERDICT field, not just ACTION"
 else
   bad "iteration-trigger.yml no longer sets $ITER_UNATTESTED_VERDICT — its summary would still say '**VERDICT**: LGTM' and await-claude-review Step 4a would merge on it (#1202)"
+fi
+
+# --- EVERY not-cleared branch, not just the provenance one (#1202) -----------
+# The assertion above pins ONE branch by its literal, which is exactly how the
+# hole it guards survived on the other two: #1181 added `VERDICT='NOT ATTESTED'`
+# inside its own `elif` and said so in that file's header, while the `HELD`
+# branch (a human's `do-not-auto-merge` hold) and the `BEHIND` branch (a head not
+# current with its base) kept rewriting `ACTION` alone. Both therefore posted
+# `**VERDICT**: LGTM` + `**CI**: N/N Green` — the two fields, and the ONLY two
+# fields, Step 4a reads — so a webhook-woken session merged a PR the workflow had
+# just refused to clear, including one a human had explicitly parked. That hold
+# is the one control a human retains over an autonomous merge loop.
+#
+# THE CHECK IS STRUCTURAL, NOT A LIST OF LITERALS, because a list of literals is
+# what failed: it can only ever cover the branches whoever wrote it thought of,
+# and the NEXT `elif` added to this chain is invisible to it. This walks the
+# emitter's clearance chain instead and demands the invariant of every branch
+# that refuses — including ones that do not exist yet.
+#
+# `v` is reset at every `if`/`elif`/`else` so a value assigned on a SIBLING
+# branch can never be credited to this one; comment lines are skipped first,
+# because the chain's own prose discusses `if`, `else` and `VERDICT=` at length.
+iter_not_cleared_verdicts() {
+  awk '
+    /^[[:space:]]*#/                             { next }
+    /^[[:space:]]*(if|elif|else)([[:space:]]|$)/ { v = "" }
+    /^[[:space:]]*VERDICT=/ {
+      v = $0
+      sub(/^[[:space:]]*VERDICT=/, "", v)
+      gsub(/\047/, "", v)
+      sub(/[[:space:]]*$/, "", v)
+    }
+    /ACTION="NOT cleared to merge/ { print (v == "" ? "<UNSET>" : v) }
+  ' "$ITER_WORKFLOW"
+}
+
+# The three verdicts SKILL.md's recognition rule accepts. A refusal spelled as
+# any of them is READ as a verdict — `COMMENTS` in particular routes to Step 4a
+# item 4 ("caller decides, usually mergeable as-is"), which is not a refusal at
+# all. `CHANGES[_ ]REQUESTED` carries both spellings because this emitter writes
+# the space form and code-review.yml writes the underscore form.
+readonly ITER_RECOGNISED_VERDICT_RE='^(LGTM|CHANGES[_ ]REQUESTED|COMMENTS)$'
+
+iter_refusals="$(iter_not_cleared_verdicts)"
+iter_refusal_count="$(grep -c . <<<"$iter_refusals" || true)"
+
+# THREE is the count at the time of writing (HELD, provenance, BEHIND) and the
+# floor is what is asserted, not the exact number: adding a fourth refusal is a
+# perfectly good change and must not turn this red, while dropping to two means a
+# branch that used to refuse has stopped refusing.
+if [[ "$iter_refusal_count" -ge 3 ]]; then
+  ok "iteration-trigger.yml's clearance chain still has its $iter_refusal_count NOT-cleared branches"
+else
+  bad "iteration-trigger.yml has only $iter_refusal_count 'NOT cleared to merge' branches (expected at least 3: the do-not-auto-merge hold, the provenance marker, and a head behind its base) — a merge refusal has gone missing, or this extraction has drifted from the file"
+fi
+
+iter_refusal_n=0
+while IFS= read -r iter_verdict; do
+  [[ -n "$iter_verdict" ]] || continue
+  iter_refusal_n=$((iter_refusal_n + 1))
+  if [[ "$iter_verdict" == "<UNSET>" ]]; then
+    bad "NOT-cleared branch #$iter_refusal_n of iteration-trigger.yml rewrites ACTION only — it still posts the '**VERDICT**: LGTM' computed above the clearance chain, and await-claude-review Step 4a merges on '**VERDICT**' + '**CI**' alone (#1202)"
+  elif [[ "$iter_verdict" == *LGTM* ]]; then
+    bad "NOT-cleared branch #$iter_refusal_n sets VERDICT='$iter_verdict', which CONTAINS 'LGTM' — a '*LGTM*' glob or a test(\"LGTM\") downstream matches it and the refusal is defeated (#1202)"
+  elif [[ "$iter_verdict" =~ $ITER_RECOGNISED_VERDICT_RE ]]; then
+    bad "NOT-cleared branch #$iter_refusal_n sets VERDICT='$iter_verdict', one of the three verdicts SKILL.md Step 4a RECOGNISES — a refusal must be unrecognisable so Step 4a falls to item 5 and surfaces to a human (#1202)"
+  else
+    ok "NOT-cleared branch #$iter_refusal_n emits VERDICT='$iter_verdict', which no merge path can read as permission"
+  fi
+done <<<"$iter_refusals"
+
+# --- the PARSER side of the same contract (#1202) ----------------------------
+# Fixing the emitter alone is a prose contract between two files, and a prose
+# contract between two files is exactly what drifted here — iteration-trigger.yml
+# has committed itself to pr-ready.sh's invariants in its own header since #1181,
+# and still shipped this hole. So SKILL.md must NAME the values it refuses,
+# rather than refusing them by the accident of not recognising them.
+#
+# Read out of the emitter, never restated: rename a refusal verdict in the
+# workflow without teaching Step 4a and this goes red ON THE RENAMING PR.
+SKILL_MD="$(cd "$(dirname "$0")/../.." && pwd)/.claude/skills/await-claude-review/SKILL.md"
+if [[ ! -f "$SKILL_MD" ]]; then
+  bad "cannot find await-claude-review/SKILL.md — the consumer half of the merge contract is unverified"
+else
+  while IFS= read -r iter_verdict; do
+    [[ -n "$iter_verdict" && "$iter_verdict" != "<UNSET>" ]] || continue
+    if grep -qF -- "$iter_verdict" "$SKILL_MD"; then
+      ok "await-claude-review Step 4a names the '$iter_verdict' refusal verdict"
+    else
+      bad "await-claude-review/SKILL.md never mentions '$iter_verdict', which iteration-trigger.yml emits on a NOT-cleared branch — Step 4a would treat it as merely malformed, and the two files disagree about which fields are merge-critical (#1202)"
+    fi
+  done <<<"$iter_refusals"
+
+  # Step 4a's item 3 is the line that returns LGTM to the caller. It must require
+  # the verdict to be EXACTLY LGTM and say so; "not CHANGES_REQUESTED" is not the
+  # same test, and it is the reading under which `HELD` merges.
+  if grep -qF -- 'exactly `LGTM`' "$SKILL_MD"; then
+    ok "Step 4a requires the verdict to be EXACTLY LGTM before returning a merge"
+  else
+    bad "SKILL.md Step 4a does not state that only an EXACTLY-'LGTM' verdict clears a merge — any value it fails to recognise must refuse, and that has to be written down rather than inferred (#1202)"
+  fi
+
+  # …AND THE CONSUMER-SIDE CHECKS MUST ACTUALLY RUN, the same argument the
+  # `code-review.yml` paths: loop above makes. Without SKILL.md in
+  # ralph-recap-tests.yml's filters, a PR that narrows Step 4a back — or renames
+  # a refusal verdict on the consumer side — edits no `scripts/ralph/**` file and
+  # runs no coupling check, so the two halves of the merge contract drift with CI
+  # green. Both triggers: a `push`-only filter still lets it land through a PR,
+  # and a `pull_request`-only filter misses a direct push to `main`.
+  for trig in push pull_request; do
+    trig_block="$(recap_trigger_block "$trig")"
+    if [[ -n "$trig_block" ]] && grep -q 'await-claude-review/SKILL\.md' <<<"$trig_block"; then
+      ok "ralph-recap-tests.yml runs this suite on $trig changes to await-claude-review/SKILL.md"
+    else
+      bad "ralph-recap-tests.yml's $trig paths: omit .claude/skills/await-claude-review/SKILL.md — a consumer-only PR could narrow Step 4a, or stop naming a refusal verdict, with no coupling check run at all (#1202)"
+    fi
+  done
 fi
 
 # --- cross-file coupling: the SECOND emitter of a VERDICT_RE match (#1181) ---


### PR DESCRIPTION
Closes #1202. Closes #1180.

Two fleet-loop **recovery-path** defects — both correct in the common path, wrong when something goes sideways. Shell and YAML only; no Python touched.

## #1202 — a human's hold was inoperative

In `iteration-trigger.yml`'s clearance chain, **only** the #1181 provenance branch rewrote `VERDICT`. The HELD branch and the BEHIND branch rewrote `ACTION` only.

So a PR a human had explicitly held still posted:

```
**CI**: 10/10 Green
**VERDICT**: LGTM
```

…which is precisely and only the two fields `await-claude-review` Step 4a parses before merging. **A loop draining a queue of PRs would have merged straight through the only veto a human has.** The file's own comment admitted the asymmetry and named this issue.

Every NOT-cleared branch now rewrites `VERDICT`: `HELD`, `NOT CURRENT`, and the existing `NOT ATTESTED`. The values were chosen for their **bytes** — none contains an `LGTM` substring, so no `*LGTM*` glob or `test("LGTM")` can read one as permission.

### Both consumers refuse, for independent reasons

**`SKILL.md` Step 4a is now a whitelist**: merge only on an exactly-`LGTM` verdict; anything unrecognised routes to "surface to the user and stop". It is deliberately **not** a blacklist of known-bad verdicts — the emitter's refusal vocabulary grows, and a blacklist is exactly how this hole survived #1181.

**`pr-ready.sh` is deliberately unchanged**, and that's the honest answer rather than a gap. It cannot merge on this summary by three independent pre-existing routes: `ITER_SUMMARY_RE` excludes the iteration-trigger comment from the verdict selector entirely; it enforces the hold natively via `has_optout_label`, dying exit 2 when the label lookup is unreadable rather than assuming no hold; and it enforces currency natively via `branch_is_current`. Adding a guard for the new strings would be dead code asserting a route that doesn't exist. The claim is **pinned with a test** instead (case W7), which also kills the tempting mutant of accepting `<!-- iteration-trigger -->` as a second provenance marker.

### The test is structural, not a list of literals

This is the part that keeps the fix from rotting. An awk walk of the emitter's clearance chain extracts, for each `ACTION="NOT cleared to merge…"`, the `VERDICT` in force on that branch — reset at every `if`/`elif`/`else` so a sibling's value is never credited — then asserts per branch that it is set at all, contains no `LGTM`, and is not one of `SKILL.md`'s recognised verdicts. A second loop asserts `SKILL.md` names each emitted value verbatim.

**A fourth refusal branch added later inherits the rule automatically**, and renaming a refusal on either side turns CI red on the renaming PR. A list of literals could only ever cover the branches its author thought of — which is what happened the first time.

## #1180 — re-assign silently rebranched from main

`fleet.sh`'s assign else-branch did `worktree add -b $branch origin/main` with **no `ls-remote` check anywhere in the file** (`grep -c ls-remote` returned 0), while `cmd_release` does `git branch -D`. Re-assigning a released lane therefore branched off main and **orphaned that PR's commits** — a full tick plus a re-review lost each time.

Assignment now looks up the remote branch and reuses it, and **fails closed** when the lookup is unreadable rather than falling back to main.

## RED → GREEN

**Before** — targeted witnesses, not blanket failures:

```
FAIL - NOT-cleared branch #1 rewrites ACTION only … (#1202)     ← the HELD branch
  ok - NOT-cleared branch #2 emits VERDICT='NOT ATTESTED'        ← already fixed by #1181
FAIL - NOT-cleared branch #3 rewrites ACTION only … (#1202)     ← the BEHIND branch
pr-ready tests: 245 passed, 4 failed

FAIL - re-assign tracks origin/<branch>, not origin/main (got 'origin/main')
FAIL - an unreadable remote lookup branched off main anyway — the #1180 failure, fail-open
fleet tests: 88 passed, 7 failed
```

That `got 'origin/main'` is the original incident report's own tell, reproduced offline.

**After:** pr-ready **253/0** (+11), fleet **96/0** (+11), and pick-next 30, watch-pr 44, main-health 109, review-quota 190, exec-bits 20 all unchanged. shellcheck clean, both workflows parse, `./scripts/check-all.sh` **12/12**.

## Why these two ship together

~40 lines of shell between them, file-disjoint from each other and from every line of Python, same defect family. Shipping them apart burns two review rounds for no reviewability gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EaHDtyDuNrpGtzUGMJT7Fw