### PR TITLE
fix(lint,generate): stop swallowing two failure modes that reported success

### DIFF
--- a/creek-tools/creek/generate/indexes.py
+++ b/creek-tools/creek/generate/indexes.py
@@ -4,6 +4,20 @@ Generates Obsidian Dataview-powered index notes for frequencies, threads,
 eddies, temporal views, and source statistics. Each generated note contains
 YAML frontmatter and Dataview query blocks that dynamically aggregate
 vault content.
+
+Every write target is created on demand
+(``mkdir(parents=True, exist_ok=True)``), matching the convention in
+:mod:`creek.vault.writer`. A vault whose folders were renamed, removed, or
+never scaffolded is repaired rather than skipped: issue #1231 recorded the
+opposite behaviour, where a missing ``06-Frequencies/<F*>`` made the whole
+command exit ``0`` having written nothing.
+
+The generated notes are Dataview *queries*, not materialised content, so
+they do not depend on how many fragments a frequency holds. A frequency with
+zero fragments still gets an index; it simply renders an empty table in
+Obsidian. There is therefore no "skip" case at all, which is what keeps the
+missing-directory case unambiguous — if a note is absent, the generator
+never ran.
 """
 
 from __future__ import annotations
@@ -11,9 +25,38 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from creek.models import Frequency
+from creek.scaffold import VAULT_TEMPLATE_DIR
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+_FREQUENCY_ROOT = "06-Frequencies"
+"""Vault-relative folder holding the per-frequency subdirectories."""
+
+
+def _canonical_frequency_dirname(freq_code: str) -> str:
+    """Return the folder name ``creek init`` deploys for *freq_code*.
+
+    The canonical names (``F1-Agency``, ``F10-Emptiness``, …) are read from
+    the packaged vault template — the same tree :func:`creek.scaffold
+    .scaffold_vault` copies — rather than restated here, so the two can never
+    drift. A template that carries no folder for *freq_code* falls back to the
+    bare code, which :meth:`IndexGenerator._find_frequency_subdir` also
+    matches, keeping the generator idempotent either way.
+
+    Args:
+        freq_code: Frequency code to resolve (e.g., ``"F1"``).
+
+    Returns:
+        The canonical subdirectory name for *freq_code*.
+    """
+    template_root = VAULT_TEMPLATE_DIR / _FREQUENCY_ROOT
+    if template_root.is_dir():
+        for child in sorted(template_root.iterdir()):
+            if child.is_dir() and child.name.startswith(f"{freq_code}-"):
+                return child.name
+    return freq_code
+
 
 FREQUENCY_NAMES: dict[Frequency, str] = {
     Frequency.F1: "Agency/Survival",
@@ -482,22 +525,25 @@ class IndexGenerator:
     def generate_frequency_indexes(self) -> list[Path]:
         """Generate one index note per frequency in 06-Frequencies/ subdirs.
 
-        Scans existing frequency subdirectories (F1 through F10) and creates
-        a markdown index note in each one containing ontology descriptions,
-        Dataview queries for fragments/threads, dosage comparison tables,
-        statistics, and cross-frequency developmental links.
+        Creates a markdown index note in each frequency subdirectory (F1
+        through F10) containing ontology descriptions, Dataview queries for
+        fragments/threads, dosage comparison tables, statistics, and
+        cross-frequency developmental links.
+
+        A frequency subdirectory that does not exist is **created** under its
+        canonical name rather than skipped (#1231), so the return value always
+        has one entry per frequency.
 
         Returns:
-            List of paths to the generated frequency index files.
+            List of paths to the generated frequency index files — one per
+            entry in :data:`FREQUENCY_NAMES`, in that order.
         """
-        freq_dir = self.vault_path / "06-Frequencies"
+        freq_dir = self.vault_path / _FREQUENCY_ROOT
         generated: list[Path] = []
 
         for freq, name in FREQUENCY_NAMES.items():
             freq_code = freq.value
-            subdir = self._find_frequency_subdir(freq_dir, freq_code)
-            if subdir is None:
-                continue
+            subdir = self._ensure_frequency_subdir(freq_dir, freq_code)
 
             color = FREQUENCY_COLORS[freq]
             frontmatter = {
@@ -553,6 +599,7 @@ class IndexGenerator:
         body += "```\n"
 
         note_path = self.vault_path / "02-Threads" / "Thread-Index.md"
+        note_path.parent.mkdir(parents=True, exist_ok=True)
         note_path.write_text(_build_note(frontmatter, body), encoding="utf-8")
         return note_path
 
@@ -587,6 +634,7 @@ class IndexGenerator:
         body += "```\n"
 
         note_path = self.vault_path / "03-Eddies" / "Eddy-Map.md"
+        note_path.parent.mkdir(parents=True, exist_ok=True)
         note_path.write_text(_build_note(frontmatter, body), encoding="utf-8")
         return note_path
 
@@ -628,6 +676,7 @@ class IndexGenerator:
         body += "```\n"
 
         note_path = self.vault_path / "00-Creek-Meta" / "Temporal-Index.md"
+        note_path.parent.mkdir(parents=True, exist_ok=True)
         note_path.write_text(_build_note(frontmatter, body), encoding="utf-8")
         return note_path
 
@@ -662,6 +711,7 @@ class IndexGenerator:
         body += "```\n"
 
         note_path = self.vault_path / "00-Creek-Meta" / "Source-Index.md"
+        note_path.parent.mkdir(parents=True, exist_ok=True)
         note_path.write_text(_build_note(frontmatter, body), encoding="utf-8")
         return note_path
 
@@ -685,12 +735,34 @@ class IndexGenerator:
         )
         return generated
 
+    @classmethod
+    def _ensure_frequency_subdir(cls, freq_dir: Path, freq_code: str) -> Path:
+        """Return the frequency subdirectory, creating it when it is absent.
+
+        A vault that was reorganised — or never scaffolded — has no
+        ``06-Frequencies/<F*>`` folder to write into. Rather than skip the
+        frequency and report success (#1231), the canonical folder is created
+        under the same name ``creek init`` would deploy.
+
+        Args:
+            freq_dir: The ``06-Frequencies`` directory path (need not exist).
+            freq_code: Frequency code to match (e.g., ``"F1"``).
+
+        Returns:
+            Path to an existing directory ready to be written into.
+        """
+        existing = cls._find_frequency_subdir(freq_dir, freq_code)
+        target = existing or freq_dir / _canonical_frequency_dirname(freq_code)
+        target.mkdir(parents=True, exist_ok=True)
+        return target
+
     @staticmethod
     def _find_frequency_subdir(freq_dir: Path, freq_code: str) -> Path | None:
         """Find the subdirectory matching a frequency code.
 
-        Scans ``freq_dir`` for a subdirectory whose name starts with
-        the given frequency code (e.g., ``F1``).
+        Matches both the canonical suffixed form (``F1-Agency``) and the bare
+        code (``F1``), so a vault scaffolded either way is honoured rather
+        than duplicated.
 
         Args:
             freq_dir: The 06-Frequencies directory path.
@@ -702,6 +774,8 @@ class IndexGenerator:
         if not freq_dir.is_dir():
             return None
         for child in sorted(freq_dir.iterdir()):
-            if child.is_dir() and child.name.startswith(f"{freq_code}-"):
+            if not child.is_dir():
+                continue
+            if child.name == freq_code or child.name.startswith(f"{freq_code}-"):
                 return child
         return None

--- a/creek-tools/creek/lint/checks/compost.py
+++ b/creek-tools/creek/lint/checks/compost.py
@@ -13,6 +13,7 @@ from datetime import datetime  # noqa: TC003  # used at runtime as a parameter t
 from pathlib import Path  # noqa: TC003  # plain stdlib import; no lazy benefit
 
 import frontmatter
+import yaml
 
 from creek.lint._result import CheckResult
 
@@ -30,7 +31,7 @@ def run(vault_path: Path, *, since: datetime | None = None) -> CheckResult:
                 continue  # skip the rollup report itself
             try:
                 post = frontmatter.load(str(note))
-            except (OSError, ValueError):
+            except (OSError, ValueError, yaml.YAMLError):
                 continue
             if post.get("type") != "compost":
                 continue

--- a/creek-tools/creek/lint/checks/paradox.py
+++ b/creek-tools/creek/lint/checks/paradox.py
@@ -17,6 +17,7 @@ from datetime import datetime  # noqa: TC003  # used at runtime as a parameter t
 from pathlib import Path  # noqa: TC003  # plain stdlib import; no lazy benefit
 
 import frontmatter
+import yaml
 from pydantic import ValidationError
 
 from creek.config import load_config
@@ -38,7 +39,7 @@ def _load_fragments(vault_path: Path) -> list[Fragment]:
             try:
                 post = frontmatter.load(str(md_file))
                 fragments.append(Fragment.model_validate(post.metadata))
-            except (OSError, ValueError, ValidationError):
+            except (OSError, ValueError, ValidationError, yaml.YAMLError):
                 continue
     return fragments
 

--- a/creek-tools/creek/lint/checks/synchronicity.py
+++ b/creek-tools/creek/lint/checks/synchronicity.py
@@ -15,6 +15,7 @@ from datetime import datetime  # noqa: TC003  # used at runtime as a parameter t
 from pathlib import Path  # noqa: TC003  # plain stdlib import; no lazy benefit
 
 import frontmatter
+import yaml
 
 from creek.lint._result import CheckResult
 
@@ -30,7 +31,7 @@ def run(vault_path: Path, *, since: datetime | None = None) -> CheckResult:
         for note in sorted(sync_dir.glob("*.md")):
             try:
                 post = frontmatter.load(str(note))
-            except (OSError, ValueError):
+            except (OSError, ValueError, yaml.YAMLError):
                 continue
             if post.get("type") != "synchronicity":
                 continue

--- a/creek-tools/tests/test_cli_index.py
+++ b/creek-tools/tests/test_cli_index.py
@@ -94,3 +94,37 @@ def test_index_reports_count_matching_written_files(vault: Path) -> None:
         *vault.rglob("Eddy-Map.md"),
     }
     assert f"Wrote {len(on_disk)} index note" in result.output
+
+
+def test_index_on_vault_missing_frequency_folders_writes_them(tmp_path: Path) -> None:
+    """A vault whose ``06-Frequencies`` folders are absent is not silently skipped.
+
+    Issue #1231: ``_find_frequency_subdir`` returned ``None`` and the loop
+    hit a bare ``continue``, so the command exited 0 having written no
+    frequency index at all.
+    """
+    for folder in _TOP_LEVEL:
+        (tmp_path / folder).mkdir()
+    # 06-Frequencies exists but has been emptied (renamed / reorganised vault).
+
+    result = runner.invoke(app, ["index", "--vault", str(tmp_path)])
+
+    assert result.exit_code == 0, result.output
+    written = sorted((tmp_path / "06-Frequencies").rglob("*-Index.md"))
+    assert len(written) == 10, f"expected 10 frequency indexes, got {written}"
+    assert "F1-Index.md" in result.output
+
+
+def test_index_on_bare_vault_creates_every_write_target(tmp_path: Path) -> None:
+    """``creek index`` scaffolds each write target instead of raising.
+
+    Issue #1231: the thread and eddy writes called no ``mkdir`` at all, so a
+    vault missing ``02-Threads`` died with ``FileNotFoundError``.
+    """
+    result = runner.invoke(app, ["index", "--vault", str(tmp_path)])
+
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "02-Threads" / "Thread-Index.md").is_file()
+    assert (tmp_path / "03-Eddies" / "Eddy-Map.md").is_file()
+    assert (tmp_path / "00-Creek-Meta" / "Temporal-Index.md").is_file()
+    assert (tmp_path / "00-Creek-Meta" / "Source-Index.md").is_file()

--- a/creek-tools/tests/test_generate.py
+++ b/creek-tools/tests/test_generate.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import pytest
 
+from creek.generate import indexes
 from creek.generate.indexes import (
     FREQUENCY_COLORS,
     FREQUENCY_NAMES,
@@ -644,10 +645,15 @@ class TestGenerateAll:
 class TestEdgeCases:
     """Tests for edge cases and error handling."""
 
-    def test_missing_frequency_subdirs_creates_files_only_for_existing(
+    def test_missing_frequency_subdirs_are_created_not_skipped(
         self, tmp_path: Path
     ) -> None:
-        """If some frequency subdirs are missing, only generate for existing ones."""
+        """A partial ``06-Frequencies`` scaffold is filled in, not silently skipped.
+
+        Issue #1231: this test previously asserted ``len(result) == 2`` — it
+        pinned the silent no-op. A missing folder must be created (or
+        reported), never quietly passed over.
+        """
         # Create vault with only some frequency subdirs
         (tmp_path / "06-Frequencies").mkdir()
         (tmp_path / "06-Frequencies" / "F1-Agency").mkdir()
@@ -659,7 +665,120 @@ class TestEdgeCases:
 
         gen = IndexGenerator(tmp_path)
         result = gen.generate_frequency_indexes()
-        assert len(result) == 2
+
+        assert len(result) == 10
+        assert all(path.is_file() for path in result)
+        # The two pre-existing folders are reused, not duplicated.
+        assert (tmp_path / "06-Frequencies" / "F1-Agency" / "F1-Index.md").is_file()
+        assert (
+            tmp_path / "06-Frequencies" / "F2-Receptivity" / "F2-Index.md"
+        ).is_file()
+        matches_f1 = [
+            child
+            for child in (tmp_path / "06-Frequencies").iterdir()
+            if child.name.startswith("F1") and not child.name.startswith("F10")
+        ]
+        assert len(matches_f1) == 1, matches_f1
+
+    def test_empty_frequency_root_is_populated(self, tmp_path: Path) -> None:
+        """An empty ``06-Frequencies`` yields ten indexes under canonical folders."""
+        (tmp_path / "06-Frequencies").mkdir()
+
+        result = IndexGenerator(tmp_path).generate_frequency_indexes()
+
+        assert len(result) == 10
+        assert (tmp_path / "06-Frequencies" / "F1-Agency" / "F1-Index.md").is_file()
+        f10 = tmp_path / "06-Frequencies" / "F10-Emptiness" / "F10-Index.md"
+        assert f10.is_file()
+
+    def test_absent_frequency_root_is_created(self, tmp_path: Path) -> None:
+        """A vault with no ``06-Frequencies`` at all still gets its indexes."""
+        result = IndexGenerator(tmp_path).generate_frequency_indexes()
+
+        assert len(result) == 10
+        assert (tmp_path / "06-Frequencies").is_dir()
+
+    def test_frequency_indexes_are_idempotent_after_self_healing(
+        self, tmp_path: Path
+    ) -> None:
+        """A second run reuses the folders the first run created."""
+        gen = IndexGenerator(tmp_path)
+        first = gen.generate_frequency_indexes()
+        second = gen.generate_frequency_indexes()
+
+        assert [path.parent.name for path in first] == [
+            path.parent.name for path in second
+        ]
+        assert len(list((tmp_path / "06-Frequencies").iterdir())) == 10
+
+    def test_bare_frequency_folder_name_is_honoured(self, tmp_path: Path) -> None:
+        """A vault scaffolded with a bare ``F1`` folder is used as-is (#1231/#1025)."""
+        (tmp_path / "06-Frequencies" / "F1").mkdir(parents=True)
+
+        IndexGenerator(tmp_path).generate_frequency_indexes()
+
+        assert (tmp_path / "06-Frequencies" / "F1" / "F1-Index.md").is_file()
+        assert not (tmp_path / "06-Frequencies" / "F1-Agency").exists()
+
+    def test_thread_index_creates_its_directory(self, tmp_path: Path) -> None:
+        """``generate_thread_index`` mkdirs ``02-Threads`` like every other writer."""
+        written = IndexGenerator(tmp_path).generate_thread_index()
+
+        assert written.is_file()
+        assert written == tmp_path / "02-Threads" / "Thread-Index.md"
+
+    def test_eddy_map_creates_its_directory(self, tmp_path: Path) -> None:
+        """``generate_eddy_map`` mkdirs ``03-Eddies`` like every other writer."""
+        written = IndexGenerator(tmp_path).generate_eddy_map()
+
+        assert written.is_file()
+        assert written == tmp_path / "03-Eddies" / "Eddy-Map.md"
+
+    def test_temporal_index_creates_its_directory(self, tmp_path: Path) -> None:
+        """``generate_temporal_index`` mkdirs ``00-Creek-Meta``."""
+        written = IndexGenerator(tmp_path).generate_temporal_index()
+
+        assert written.is_file()
+
+    def test_source_index_creates_its_directory(self, tmp_path: Path) -> None:
+        """``generate_source_index`` mkdirs ``00-Creek-Meta``."""
+        written = IndexGenerator(tmp_path).generate_source_index()
+
+        assert written.is_file()
+
+    def test_absent_template_tree_falls_back_to_the_bare_code(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With no packaged template to read, folders are named by code alone."""
+        monkeypatch.setattr(indexes, "VAULT_TEMPLATE_DIR", tmp_path / "no-template")
+        vault = tmp_path / "vault"
+
+        result = IndexGenerator(vault).generate_frequency_indexes()
+
+        assert len(result) == 10
+        assert (vault / "06-Frequencies" / "F1" / "F1-Index.md").is_file()
+
+    def test_template_without_a_matching_folder_falls_back(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A template missing one frequency still yields that frequency's index."""
+        template = tmp_path / "template"
+        (template / "06-Frequencies" / "F2-Receptivity").mkdir(parents=True)
+        monkeypatch.setattr(indexes, "VAULT_TEMPLATE_DIR", template)
+        vault = tmp_path / "vault"
+
+        result = IndexGenerator(vault).generate_frequency_indexes()
+
+        assert len(result) == 10
+        assert (vault / "06-Frequencies" / "F1" / "F1-Index.md").is_file()
+        assert (vault / "06-Frequencies" / "F2-Receptivity" / "F2-Index.md").is_file()
+
+    def test_generate_all_on_a_bare_vault(self, tmp_path: Path) -> None:
+        """``generate_all`` on an empty directory writes every index note."""
+        result = IndexGenerator(tmp_path).generate_all()
+
+        assert len(result) == 14
+        assert all(path.is_file() for path in result)
 
     def test_frequency_index_content_structure(self, generator: IndexGenerator) -> None:
         """Frequency index notes should have well-structured content."""

--- a/creek-tools/tests/test_lint_malformed_yaml.py
+++ b/creek-tools/tests/test_lint_malformed_yaml.py
@@ -1,0 +1,221 @@
+"""Regression tests: one malformed-YAML note must not take down ``creek lint``.
+
+``yaml.YAMLError`` is **not** a :class:`ValueError` subclass, so an
+``except (OSError, ValueError)`` guard around ``frontmatter.load`` never
+catches a note whose frontmatter fails to parse. The ``continue`` that
+each guard was written to reach is therefore dead, and the parser error
+escapes to the operator as a raw traceback.
+
+These tests pin the contract already honoured by
+``creek/lint/checks/draft_grounding.py`` and ``creek/vault/reader.py``:
+an unparseable note is skipped, every other note is still reported, and
+the command exits cleanly.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from typer.testing import CliRunner
+
+from creek.cli import app
+from creek.lint.checks import (
+    compost as compost_check,
+)
+from creek.lint.checks import (
+    paradox as paradox_check,
+)
+from creek.lint.checks import (
+    synchronicity as synchronicity_check,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+runner = CliRunner()
+
+_MALFORMED = "---\ntags: [a, b\ntitle: unclosed flow sequence\n---\n\nBody.\n"
+"""Frontmatter with an unterminated flow sequence — raises ``yaml.ParserError``."""
+
+
+def _seed_vault(vault: Path) -> None:
+    """Create the canonical vault folders the lint checks walk."""
+    for sub in (
+        "00-Creek-Meta/Skills",
+        "00-Creek-Meta/Processing-Log",
+        "00-Creek-Meta/State",
+        "01-Fragments/Notes",
+        "02-Threads/Active",
+        "03-Eddies",
+        "04-Praxis",
+        "10-Liminal/Paradoxes",
+        "10-Liminal/Unnamed",
+        "10-Liminal/Synchronicities",
+        "10-Liminal/Compost",
+    ):
+        (vault / sub).mkdir(parents=True, exist_ok=True)
+
+
+def _write_malformed(vault: Path, relative: str) -> Path:
+    """Write a note whose YAML frontmatter cannot be parsed."""
+    target = vault / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(_MALFORMED, encoding="utf-8")
+    return target
+
+
+def _write_compost_note(vault: Path, *, stem: str, title: str) -> Path:
+    """Write a well-formed compost note under ``10-Liminal/Compost/``."""
+    target = vault / "10-Liminal" / "Compost" / f"{stem}.md"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        f'---\ntype: compost\ntitle: "{title}"\n---\n\nDormant.\n',
+        encoding="utf-8",
+    )
+    return target
+
+
+def _write_sync_note(vault: Path, *, stem: str, sync_id: str) -> Path:
+    """Write a well-formed synchronicity note under ``10-Liminal/``."""
+    target = vault / "10-Liminal" / "Synchronicities" / f"{stem}.md"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        f'---\ntype: synchronicity\nid: "{sync_id}"\n---\n\nEcho.\n',
+        encoding="utf-8",
+    )
+    return target
+
+
+class TestCompostCheckSkipsMalformedYaml:
+    """``compost`` must skip an unparseable note, not crash on it."""
+
+    def test_malformed_note_is_skipped(self, tmp_path: Path) -> None:
+        """A note with unclosed frontmatter does not raise out of the check."""
+        _seed_vault(tmp_path)
+        _write_malformed(tmp_path, "10-Liminal/Compost/broken.md")
+
+        result = compost_check.run(tmp_path)
+
+        assert result.name == "compost"
+        assert result.findings == []
+
+    def test_healthy_notes_still_reported(self, tmp_path: Path) -> None:
+        """The good notes either side of the bad one are still counted."""
+        _seed_vault(tmp_path)
+        _write_compost_note(tmp_path, stem="a-note", title="Alpha")
+        _write_malformed(tmp_path, "10-Liminal/Compost/broken.md")
+        _write_compost_note(tmp_path, stem="z-note", title="Zeta")
+
+        result = compost_check.run(tmp_path)
+
+        assert len(result.findings) == 2
+        assert result.summary == "2 recorded compost note(s)"
+        assert any("Alpha" in line for line in result.findings)
+        assert any("Zeta" in line for line in result.findings)
+
+
+class TestSynchronicityCheckSkipsMalformedYaml:
+    """``synchronicity`` must skip an unparseable note, not crash on it."""
+
+    def test_malformed_note_is_skipped(self, tmp_path: Path) -> None:
+        """A note with unclosed frontmatter does not raise out of the check."""
+        _seed_vault(tmp_path)
+        _write_malformed(tmp_path, "10-Liminal/Synchronicities/broken.md")
+
+        result = synchronicity_check.run(tmp_path)
+
+        assert result.name == "synchronicity"
+        assert result.findings == []
+
+    def test_healthy_notes_still_reported(self, tmp_path: Path) -> None:
+        """The good notes either side of the bad one are still counted."""
+        _seed_vault(tmp_path)
+        _write_sync_note(tmp_path, stem="a-sync", sync_id="sync-alpha")
+        _write_malformed(tmp_path, "10-Liminal/Synchronicities/broken.md")
+        _write_sync_note(tmp_path, stem="z-sync", sync_id="sync-zeta")
+
+        result = synchronicity_check.run(tmp_path)
+
+        assert len(result.findings) == 2
+        assert result.summary == "2 recorded synchronicity note(s)"
+        assert any("sync-alpha" in line for line in result.findings)
+        assert any("sync-zeta" in line for line in result.findings)
+
+
+class TestParadoxCheckSkipsMalformedYaml:
+    """``paradox`` must skip an unparseable fragment, not crash on it."""
+
+    def test_malformed_fragment_is_skipped(self, tmp_path: Path) -> None:
+        """A fragment with unclosed frontmatter does not raise out of the check."""
+        _seed_vault(tmp_path)
+        _write_malformed(tmp_path, "01-Fragments/Notes/broken.md")
+
+        result = paradox_check.run(tmp_path)
+
+        assert result.name == "paradox"
+        assert result.findings == []
+
+    def test_malformed_liminal_note_is_skipped(self, tmp_path: Path) -> None:
+        """The ``10-Liminal`` half of the fragment sweep is guarded too."""
+        _seed_vault(tmp_path)
+        _write_malformed(tmp_path, "10-Liminal/Unnamed/broken.md")
+
+        result = paradox_check.run(tmp_path)
+
+        assert result.name == "paradox"
+        assert result.findings == []
+        assert result.summary.startswith("0 paradox(es) detected")
+
+
+class TestLintCliSurvivesMalformedYaml:
+    """The real Typer entry point must exit cleanly on a malformed note."""
+
+    def test_default_lint_exits_zero(self, tmp_path: Path) -> None:
+        """``creek lint`` with no flags survives a malformed compost note."""
+        _seed_vault(tmp_path)
+        _write_compost_note(tmp_path, stem="a-note", title="Alpha")
+        _write_malformed(tmp_path, "10-Liminal/Compost/broken.md")
+
+        result = runner.invoke(app, ["lint", "--vault", str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        report = next(
+            (tmp_path / "00-Creek-Meta" / "Processing-Log").glob("lint-*.md"),
+        ).read_text(encoding="utf-8")
+        assert "1 recorded compost note(s)" in report
+
+    def test_check_compost_exits_zero(self, tmp_path: Path) -> None:
+        """``--check compost`` survives a malformed compost note."""
+        _seed_vault(tmp_path)
+        _write_malformed(tmp_path, "10-Liminal/Compost/broken.md")
+
+        result = runner.invoke(
+            app,
+            ["lint", "--vault", str(tmp_path), "--check", "compost"],
+        )
+
+        assert result.exit_code == 0, result.output
+
+    def test_check_synchronicity_exits_zero(self, tmp_path: Path) -> None:
+        """``--check synchronicity`` survives a malformed synchronicity note."""
+        _seed_vault(tmp_path)
+        _write_malformed(tmp_path, "10-Liminal/Synchronicities/broken.md")
+
+        result = runner.invoke(
+            app,
+            ["lint", "--vault", str(tmp_path), "--check", "synchronicity"],
+        )
+
+        assert result.exit_code == 0, result.output
+
+    def test_check_paradox_exits_zero(self, tmp_path: Path) -> None:
+        """``--check paradox`` survives a malformed fragment."""
+        _seed_vault(tmp_path)
+        _write_malformed(tmp_path, "01-Fragments/Notes/broken.md")
+
+        result = runner.invoke(
+            app,
+            ["lint", "--vault", str(tmp_path), "--check", "paradox"],
+        )
+
+        assert result.exit_code == 0, result.output


### PR DESCRIPTION
Closes #1038. Closes #1231.

Two issues, one PR — same defect class (a failure swallowed with no report), disjoint modules, ~40 lines of production change between them.

## #1038 — one malformed note crashed `creek lint`

`compost.py` and `synchronicity.py` caught `(OSError, ValueError)`; `paradox.py` added `ValidationError`. **None catches `yaml.YAMLError`** — and it is *not* a `ValueError` subclass (verified: MRO is `YAMLError -> Exception -> BaseException`). So one malformed frontmatter block took the whole command down. `draft_grounding.py` already had the correct contract; the three now match it.

## #1231 — `creek index` exited 0 having written nothing

A missing `06-Frequencies/<F*>` made the resolver return `None`; the code hit a bare `continue`. The command reported success and produced nothing.

## Three corrections to the issues

- **There is no `creek generate indexes` command.** It is `creek index`, and the same generator also runs inside `creek process` and `_sync_index`.
- **The missing-mkdir defect is wider than reported.** The issue names 02-Threads and 03-Eddies; `generate_temporal_index` and `generate_source_index` write to 00-Creek-Meta with no mkdir either. Fixed all four.
- **A latent *second* silent-skip.** The packaged template ships suffixed folders (`F1-Agency` … `F10-Emptiness`) while the resolver matched only `startswith("F1-")`. A vault scaffolded with a bare `F1` folder would never have been found. Now matched by exact name as well.

## An existing test asserted the bug was correct

`test_missing_frequency_subdirs_creates_files_only_for_existing` asserted `len(result) == 2` on a partial scaffold — it pinned the silent skip as *intended*. It had to be rewritten, not supplemented. **That is the #1024 failure mode living inside the test suite itself**, and worth noting for the rest of that epic.

## Design call

Create-the-directory over fail-with-a-message (the AC permits either): failing hard would newly break `creek process` on a reorganised vault. Canonical folder names are read from `creek.scaffold.VAULT_TEMPLATE_DIR` at runtime rather than restated, so the two cannot drift.

## RED proof

- #1038 stashed → `10 failed`, `assert 1 == 0 ... ParserError`
- #1231 stashed → `14 failed`, `assert 1 == 0 ... FileNotFoundError`

**Honest caveat:** 2 of those 14 monkeypatch a constant the unfixed module doesn't define, so they fail with `AttributeError` — they are branch-coverage tests for the new fallback, **not** regression proofs. Flagged rather than counted as reproductions.

## Found, not fixed

A note whose frontmatter contains a `content:` key makes `frontmatter.load` raise `TypeError`, which none of these guards catch — nor do the correct-contract siblings. Deserves its own issue.

Gate: **12/12**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EaHDtyDuNrpGtzUGMJT7Fw