### PR TITLE
fix(api): log the exception behind a /v1 500, and refuse non-lifespan scopes

### DIFF
--- a/creek-tools/creek_mcp/httpapi/auth.py
+++ b/creek-tools/creek_mcp/httpapi/auth.py
@@ -37,7 +37,7 @@ from typing import TYPE_CHECKING, Final
 from starlette.datastructures import Headers
 
 from creek_mcp.api.models import ErrorCode
-from creek_mcp.httpapi.context import HTTP_SCOPE, context_of
+from creek_mcp.httpapi.context import HTTP_SCOPE, context_of, pass_through
 from creek_mcp.httpapi.errors import error_response
 from creek_mcp.remote_auth import (
     CONSUMER_TOKENS_ENV,
@@ -148,7 +148,7 @@ class BearerAuthMiddleware:
             send: The ASGI send channel.
         """
         if scope["type"] != HTTP_SCOPE:
-            await self.app(scope, receive, send)
+            await pass_through(self.app, scope, receive, send)
             return
         context = context_of(scope)
         token = _presented_token(scope)

--- a/creek-tools/creek_mcp/httpapi/context.py
+++ b/creek-tools/creek_mcp/httpapi/context.py
@@ -20,6 +20,13 @@ travels inward; freezing it would mean rebuilding and re-attaching it at four
 layers, and a rebuild is exactly where a field gets dropped. Nothing here is a
 security decision: :class:`creek_mcp.policy.CallerIdentity`, which *is* one,
 stays frozen and is constructed fresh at the single admission site.
+
+**It also owns which ASGI scopes the stack answers at all.** That belongs here
+for the same reason the record does: every layer has to agree, and seven copies
+of the rule are seven places for it to drift. :data:`HTTP_SCOPE` names what the
+stack acts on, :data:`LIFESPAN_SCOPE` names the one thing it relays, and
+:func:`pass_through` is the single site that decides between them and refuses
+everything else (#1124).
 """
 
 from __future__ import annotations
@@ -31,16 +38,32 @@ from uuid import uuid4
 from creek_mcp.tier_ceiling import TierCeiling
 
 if TYPE_CHECKING:
-    from starlette.types import Scope
+    from starlette.types import ASGIApp, Receive, Scope, Send
 
 HTTP_SCOPE: Final[str] = "http"
 """The ASGI scope type every ``/v1`` middleware acts on.
 
-Stated once and imported by all seven. Each of them passes anything else —
-``lifespan`` above all — straight through untouched: a middleware that assumed
-``http`` would break the startup handshake, and the failure would surface as
-every request failing rather than as a middleware bug.
+Stated once and imported by all seven. Anything else goes to
+:func:`pass_through`, which is where the *allowlist* lives.
 """
+
+LIFESPAN_SCOPE: Final[str] = "lifespan"
+"""The one other scope type the ``/v1`` stack hands downward (#1124).
+
+A middleware that assumed ``http`` would break the startup handshake, and the
+failure would surface as every request failing rather than as a middleware bug.
+That is the whole justification for a passthrough, and it justifies exactly one
+scope type — so the passthrough names it, rather than being written as "anything
+that is not ``http``".
+
+The difference is not cosmetic. Denying by omission means the allowlist is
+implicit, and the first ``websocket`` route anyone mounts inherits a path
+through all seven layers that is unauthenticated, unceilinged and unlogged —
+answered by the router rather than refused, because ``websocket`` is a type
+Starlette already serves. There is no live exposure today, which is precisely
+why it is closed now rather than after there is one.
+"""
+
 
 SCOPE_KEY: Final[str] = "creek_mcp.httpapi.context"
 """Where the record lives on the ASGI scope.
@@ -136,3 +159,63 @@ def context_of(scope: Scope) -> RequestContext:
     """
     context: RequestContext = scope[SCOPE_KEY]
     return context
+
+
+class UnsupportedScopeError(RuntimeError):
+    """A scope type the ``/v1`` stack neither serves nor passes through.
+
+    Raised rather than relayed, and raised rather than answered. Relaying is
+    the hole itself. Answering is not available either: the contract's status
+    set is defined for ``http``, and there is no protocol-independent way to
+    refuse an arbitrary scope type — a ``websocket`` would need a
+    ``websocket.close``, and an unknown type has no defined refusal at all.
+
+    Reaching here at all means something was mounted that this stack was never
+    wired for, which is a deployment bug rather than a request-level failure:
+    the connection is never established, nothing is written to the wire, and
+    the ASGI server records the fault. That is a loud failure at wiring time
+    instead of a quiet bypass in production.
+
+    Attributes:
+        scope_type: The refused ``scope["type"]``. Server-supplied — an ASGI
+            server sets it, never the caller — so naming it in the message
+            carries nothing of the request.
+    """
+
+    def __init__(self, scope_type: str) -> None:
+        """Refuse *scope_type*, naming what the stack does serve.
+
+        Args:
+            scope_type: The ``scope["type"]`` that reached a middleware.
+        """
+        super().__init__(
+            f"the /v1 middleware stack serves {HTTP_SCOPE!r} scopes and passes "
+            f"{LIFESPAN_SCOPE!r} through; it refuses {scope_type!r} rather than "
+            "relay it past authentication, the ceiling gate and the access log"
+        )
+        self.scope_type = scope_type
+
+
+async def pass_through(
+    app: ASGIApp, scope: Scope, receive: Receive, send: Send
+) -> None:
+    """Hand a non-``http`` *scope* to *app*, if it is one the stack allows.
+
+    The single statement of the allowlist. Seven middlewares defer to it, so
+    the rule is written once and cannot be seven rules that drift — the same
+    reason :data:`HTTP_SCOPE` is a constant rather than seven string literals.
+
+    Args:
+        app: The next application in the stack.
+        scope: The ASGI scope, already known not to be ``http``.
+        receive: The ASGI receive channel.
+        send: The ASGI send channel.
+
+    Raises:
+        UnsupportedScopeError: For any scope type other than
+            :data:`LIFESPAN_SCOPE`.
+    """
+    scope_type = str(scope["type"])
+    if scope_type != LIFESPAN_SCOPE:
+        raise UnsupportedScopeError(scope_type)
+    await app(scope, receive, send)

--- a/creek-tools/creek_mcp/httpapi/logging.py
+++ b/creek-tools/creek_mcp/httpapi/logging.py
@@ -1,13 +1,21 @@
-"""The operator-facing name for ``/v1``'s request logging (#1074).
+"""The operator-facing names for ``/v1``'s two logs (#1074, #1122).
 
-An operator configuring log shipping wants one import — "where is the access
-log?" — and should not have to know that the implementation is a middleware and
-therefore lives under :mod:`creek_mcp.httpapi.middleware`. So this module is the
+An operator configuring log shipping wants one import — "where are the logs?" —
+and should not have to know that the implementations are middlewares and
+therefore live under :mod:`creek_mcp.httpapi.middleware`. So this module is the
 facade, and it re-exports rather than redefines: a second copy of
 :data:`ACCESS_LOGGER_NAME` would be a filter that silently stops matching the
 logger it was written for.
 
-The direction of the re-export matters. The constant is *defined* beside the
+**There are two, and they are separate on purpose.**
+:data:`ACCESS_LOGGER_NAME` carries one structured line per request — five safe
+fields and no sixth. :data:`ERROR_LOGGER_NAME` carries the traceback behind a
+``500``, which can include whatever the exception's own message included, and
+therefore wants its own handler, its own destination and its own retention. One
+logger for both would force the safer stream to be handled at the riskier one's
+classification.
+
+The direction of the re-export matters. Each constant is *defined* beside the
 code that logs with it and imported here, not the other way round, because the
 reverse would make the middleware package depend on this one and close an
 import cycle.
@@ -19,5 +27,14 @@ from creek_mcp.httpapi.middleware.access_log import (
     ACCESS_LOGGER_NAME,
     AccessLogMiddleware,
 )
+from creek_mcp.httpapi.middleware.boundary import (
+    ERROR_LOGGER_NAME,
+    ErrorBoundaryMiddleware,
+)
 
-__all__ = ["ACCESS_LOGGER_NAME", "AccessLogMiddleware"]
+__all__ = [
+    "ACCESS_LOGGER_NAME",
+    "ERROR_LOGGER_NAME",
+    "AccessLogMiddleware",
+    "ErrorBoundaryMiddleware",
+]

--- a/creek-tools/creek_mcp/httpapi/middleware/__init__.py
+++ b/creek-tools/creek_mcp/httpapi/middleware/__init__.py
@@ -9,9 +9,12 @@ what :class:`~creek_mcp.httpapi.middleware.limits.RequestTimeoutMiddleware`
 does) cannot cancel a task inside it. The per-request timeout would silently
 stop working, and the failure would look like a hang rather than a bug.
 
-Each also passes non-``http`` scopes straight through. A middleware that
-assumed ``http`` would break the ``lifespan`` handshake the test client
-performs on entry, and the whole suite would fail at ``with client(...)``.
+Each also relays a ``lifespan`` scope straight through — a middleware that
+assumed ``http`` would break the handshake the test client performs on entry,
+and the whole suite would fail at ``with client(...)``. It relays *only* that
+one, via :func:`creek_mcp.httpapi.context.pass_through`, and refuses every
+other scope type rather than waving it past authentication, the ceiling gate
+and the access log (#1124).
 
 The order is pinned as data by ``tests/test_v1_api_hardening.py``, because
 every property the modules below promise depends on it:

--- a/creek-tools/creek_mcp/httpapi/middleware/access_log.py
+++ b/creek-tools/creek_mcp/httpapi/middleware/access_log.py
@@ -33,7 +33,7 @@ import logging
 from time import perf_counter
 from typing import TYPE_CHECKING, Final
 
-from creek_mcp.httpapi.context import HTTP_SCOPE, bind_context
+from creek_mcp.httpapi.context import HTTP_SCOPE, bind_context, pass_through
 
 if TYPE_CHECKING:
     from starlette.types import ASGIApp, Message, Receive, Scope, Send
@@ -90,7 +90,7 @@ class AccessLogMiddleware:
             send: The ASGI send channel, wrapped to observe the status line.
         """
         if scope["type"] != HTTP_SCOPE:
-            await self.app(scope, receive, send)
+            await pass_through(self.app, scope, receive, send)
             return
         context = bind_context(scope)
         started_at = perf_counter()

--- a/creek-tools/creek_mcp/httpapi/middleware/boundary.py
+++ b/creek-tools/creek_mcp/httpapi/middleware/boundary.py
@@ -8,11 +8,21 @@ internals handed to a remote consumer, and the third of them can carry vault
 content that arrived in the exception's own message.
 
 So the boundary answers :attr:`~creek_mcp.api.models.ErrorCode.INTERNAL_ERROR`
-with the constant table entry, and discards the exception. Nothing about it is
-logged here either: the access line already records the ``500`` with its
-correlation id, and an operator wanting the traceback runs the server with
-``debug`` disabled but their own handler attached — a decision that belongs to
-deployment, not to this module.
+with the constant table entry, and discards the exception *from the response*.
+
+**Discarding it from the process too was a bug (#1122).** An operator was left
+with a ``500``, a correlation id, and no traceback anywhere — a fault that
+cannot be diagnosed at all, only counted. So the exception is logged here,
+server-side, on :data:`ERROR_LOGGER_NAME`, and the envelope going back to the
+caller is byte-for-byte what it was: the two are different audiences, and the
+whole point is that only one of them gets the internals.
+
+**Not on the access logger.** That log's promise is five safe fields and no
+sixth; a traceback carries whatever the exception's own message carried, which
+can be vault content. Two loggers is what lets an operator ship one off-host
+and hold the other. The record carries the ``request_id`` and nothing else
+about the request — route and consumer are already on the access line, joined
+by that id, and a second copy is a second thing to keep true.
 
 It sits second from the top: below the access log, so the ``500`` it produces is
 still counted, and above everything else, so a fault in any other middleware is
@@ -21,14 +31,27 @@ enveloped too.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import logging
+from typing import TYPE_CHECKING, Final
 
 from creek_mcp.api.models import ErrorCode
-from creek_mcp.httpapi.context import HTTP_SCOPE, context_of
+from creek_mcp.httpapi.context import HTTP_SCOPE, context_of, pass_through
 from creek_mcp.httpapi.errors import error_response
 
 if TYPE_CHECKING:
     from starlette.types import ASGIApp, Receive, Scope, Send
+
+ERROR_LOGGER_NAME: Final[str] = "creek_mcp.httpapi.error"
+"""The logger a ``/v1`` fault's traceback lands on. Stable, and published.
+
+Deliberately not :data:`~creek_mcp.httpapi.middleware.access_log.ACCESS_LOGGER_NAME`.
+An operator routes the two differently because their contents differ in kind,
+and a single logger would force the traceback to be handled at the access log's
+classification or the access log at the traceback's.
+"""
+
+_ERROR_LOGGER: Final[logging.Logger] = logging.getLogger(ERROR_LOGGER_NAME)
+"""The fault logger itself."""
 
 
 class ErrorBoundaryMiddleware:
@@ -51,7 +74,7 @@ class ErrorBoundaryMiddleware:
             send: The ASGI send channel.
         """
         if scope["type"] != HTTP_SCOPE:
-            await self.app(scope, receive, send)
+            await pass_through(self.app, scope, receive, send)
             return
         context = context_of(scope)
         try:
@@ -65,6 +88,18 @@ class ErrorBoundaryMiddleware:
             if context.started:
                 # The response is already on the wire; replacing it now would
                 # raise inside the handler for the original fault and bury it.
+                # Not logged here either: this path does not *discard* the
+                # exception, it keeps unwinding, and the ASGI server records
+                # it. Logging it as well would report one fault twice.
                 raise
+            # ``exception`` rather than ``error``: it is what attaches the
+            # traceback, which is the entire point. The id is passed lazily
+            # and repeated in ``extra`` so it stays machine-readable for an
+            # operator shipping JSON logs, exactly as the access line does.
+            _ERROR_LOGGER.exception(
+                "unhandled fault answering /v1 request_id=%s",
+                context.request_id,
+                extra={"request_id": context.request_id},
+            )
             refusal = error_response(ErrorCode.INTERNAL_ERROR, context)
             await refusal(scope, receive, send)

--- a/creek-tools/creek_mcp/httpapi/middleware/ceiling.py
+++ b/creek-tools/creek_mcp/httpapi/middleware/ceiling.py
@@ -43,7 +43,7 @@ from starlette.datastructures import Headers
 
 from creek_mcp.api.models import ErrorCode
 from creek_mcp.api.routes import CEILING_HEADER
-from creek_mcp.httpapi.context import HTTP_SCOPE, context_of
+from creek_mcp.httpapi.context import HTTP_SCOPE, context_of, pass_through
 from creek_mcp.httpapi.errors import error_response
 from creek_mcp.policy import Admission, CallerIdentity, admitted_ceiling
 from creek_mcp.tier_ceiling import TierCeiling
@@ -78,7 +78,7 @@ class CeilingAdmissionMiddleware:
             send: The ASGI send channel.
         """
         if scope["type"] != HTTP_SCOPE:
-            await self.app(scope, receive, send)
+            await pass_through(self.app, scope, receive, send)
             return
         context = context_of(scope)
         requested = Headers(scope=scope).get(CEILING_HEADER, TierCeiling.OPEN.value)

--- a/creek-tools/creek_mcp/httpapi/middleware/limits.py
+++ b/creek-tools/creek_mcp/httpapi/middleware/limits.py
@@ -33,7 +33,7 @@ from anyio import Semaphore, WouldBlock, fail_after
 from starlette.datastructures import Headers
 
 from creek_mcp.api.models import ErrorCode
-from creek_mcp.httpapi.context import HTTP_SCOPE, context_of
+from creek_mcp.httpapi.context import HTTP_SCOPE, context_of, pass_through
 from creek_mcp.httpapi.errors import error_response
 
 if TYPE_CHECKING:
@@ -165,7 +165,7 @@ class ConcurrencyLimitMiddleware:
             send: The ASGI send channel.
         """
         if scope["type"] != HTTP_SCOPE:
-            await self.app(scope, receive, send)
+            await pass_through(self.app, scope, receive, send)
             return
         try:
             self._slots.acquire_nowait()
@@ -206,7 +206,7 @@ class RequestTimeoutMiddleware:
             send: The ASGI send channel.
         """
         if scope["type"] != HTTP_SCOPE:
-            await self.app(scope, receive, send)
+            await pass_through(self.app, scope, receive, send)
             return
         context = context_of(scope)
         try:
@@ -243,7 +243,7 @@ class BodySizeLimitMiddleware:
             send: The ASGI send channel.
         """
         if scope["type"] != HTTP_SCOPE:
-            await self.app(scope, receive, send)
+            await pass_through(self.app, scope, receive, send)
             return
         declared = _declared_length(scope)
         if declared is not None and declared > self._max_body_bytes:

--- a/creek-tools/docs/api.md
+++ b/creek-tools/docs/api.md
@@ -344,6 +344,35 @@ audit entry per request would put a hash-chained write on an unauthenticated
 path (a denial-of-service amplifier) and would pollute the tool-invocation
 trail.
 
+### Fault logging
+
+A `500` also writes one `ERROR` record, with the traceback, to a **second**
+logger: `creek_mcp.httpapi.error`. It carries the `request_id` and nothing
+else about the request — route and consumer are already on the access line,
+joined by that same id.
+
+The response body does not change: the caller still gets exactly
+`{code, message, request_id}` with the constant `internal_error` message, and
+never the traceback, the exception class or a source path. The traceback is for
+the operator; without it a `500` is a fault that can be counted but not
+diagnosed.
+
+**Route the two loggers separately.** The access line is five fields chosen to
+be safe to ship. A traceback carries whatever the exception's own message
+carried, which can include vault content — so it wants its own handler,
+destination and retention rather than inheriting the access log's.
+
+### ASGI scopes
+
+The server answers `http` and relays `lifespan`. Any other scope type — a
+`websocket`, or anything a future server introduces — is **refused at the
+outermost middleware** rather than passed down. A passthrough written as
+"anything that is not `http`" would hand the first `websocket` route anyone
+mounted a path through the whole stack with no authentication, no ceiling gate
+and no access line, and the router would answer it rather than error. There is
+no `ws://` surface today; the allowlist is what keeps that true by
+construction.
+
 ## OpenAPI
 
 ```bash

--- a/creek-tools/tests/test_v1_api_hardening.py
+++ b/creek-tools/tests/test_v1_api_hardening.py
@@ -64,7 +64,8 @@ from creek_mcp.audit import MCP_AUDIT_RELPATH, verify_mcp_audit_chain
 from creek_mcp.httpapi import capabilities as capabilities_module
 from creek_mcp.httpapi import handlers as handlers_module
 from creek_mcp.httpapi.auth import BearerAuthMiddleware
-from creek_mcp.httpapi.logging import ACCESS_LOGGER_NAME
+from creek_mcp.httpapi.context import LIFESPAN_SCOPE, UnsupportedScopeError
+from creek_mcp.httpapi.logging import ACCESS_LOGGER_NAME, ERROR_LOGGER_NAME
 from creek_mcp.httpapi.middleware.access_log import AccessLogMiddleware
 from creek_mcp.httpapi.middleware.boundary import ErrorBoundaryMiddleware
 from creek_mcp.httpapi.middleware.ceiling import CeilingAdmissionMiddleware
@@ -82,21 +83,24 @@ from tests.v1_api_support import (
     OP_HEALTH,
     REFLECTIONS_PATH,
     STRONG_TOKEN,
+    WHEEL_PATH,
     build_app,
     client,
     contains_a_path,
     envelope,
     headers,
     seed_vault,
+    verifier,
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
     from pathlib import Path
 
     from starlette.applications import Starlette
     from starlette.requests import Request
     from starlette.responses import Response
+    from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 _OK_STATUS: Final[int] = 200
 _INVALID_REQUEST_STATUS: Final[int] = 422
@@ -1043,6 +1047,101 @@ def test_a_handler_fault_becomes_the_published_500(
     assert not contains_a_path(response.text)
 
 
+def _error_records(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    """Return only the fault-logger records captured so far.
+
+    Args:
+        caplog: The capture fixture.
+
+    Returns:
+        The records emitted by the error logger.
+    """
+    return [record for record in caplog.records if record.name == ERROR_LOGGER_NAME]
+
+
+def test_the_error_logger_is_named_as_published() -> None:
+    """A stable name, distinct from the access logger's, for the fault stream.
+
+    Distinct because the two logs have different contents and therefore
+    different handling: the access line is five safe fields and is shipped
+    wherever the operator ships logs, while a traceback can carry whatever the
+    exception's own message carried — which may be vault material. An operator
+    who cannot route them separately cannot apply that difference.
+    """
+    assert ERROR_LOGGER_NAME == "creek_mcp.httpapi.error"
+    assert ERROR_LOGGER_NAME != ACCESS_LOGGER_NAME
+
+
+def test_a_handler_fault_is_logged_with_its_traceback(
+    vault: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The cause reaches the operator; the caller still gets the bare envelope.
+
+    Discarding the exception from the *response* is deliberate — it is a map of
+    the server's internals. Discarding it from the *process* is not: it leaves
+    an operator holding a ``500`` and a correlation id with no traceback
+    anywhere to join them to, which is a fault that cannot be diagnosed at all.
+
+    So both halves are asserted in one place, because it is their *contrast*
+    that is the invariant: the sentinel the handler raised with is present in
+    the log and absent from the body.
+
+    Args:
+        vault: A seeded vault.
+        monkeypatch: Swaps the health handler for a raising one.
+        caplog: Captures the fault log.
+    """
+    monkeypatch.setitem(handlers_module.HANDLERS, OP_HEALTH, _raise_boom)
+    caplog.set_level(logging.ERROR, logger=ERROR_LOGGER_NAME)
+    with client(vault_path=vault) as test_client:
+        response = test_client.get(HEALTH_PATH, headers=headers())
+
+    records = _error_records(caplog)
+    assert len(records) == 1
+    record = records[0]
+    assert record.levelno == logging.ERROR
+    assert record.exc_info is not None
+    assert record.exc_info[0] is RuntimeError
+    assert "Traceback (most recent call last)" in caplog.text
+    assert _SENTINEL_BODY in caplog.text
+    assert _field(record, "request_id") == envelope(response)["request_id"]
+
+    assert response.status_code == _INTERNAL_ERROR_STATUS
+    assert set(envelope(response)) == {"code", "message", "request_id"}
+    assert _SENTINEL_BODY not in response.text
+    assert "Traceback" not in response.text
+    assert "RuntimeError" not in response.text
+
+
+def test_the_fault_does_not_reach_the_access_logger(
+    vault: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The traceback lands on the fault logger and on no other.
+
+    The access log is where content leaks *sideways*, and its promise is that
+    it carries five fields and no sixth. Attaching a traceback to it — or
+    emitting a second access line for the fault — would break that promise
+    with material the exception chose, which is precisely the material the
+    access-log tests spend their time keeping out.
+
+    Args:
+        vault: A seeded vault.
+        monkeypatch: Swaps the health handler for a raising one.
+        caplog: Captures every logger.
+    """
+    monkeypatch.setitem(handlers_module.HANDLERS, OP_HEALTH, _raise_boom)
+    caplog.set_level(logging.DEBUG)
+    with client(vault_path=vault) as test_client:
+        test_client.get(HEALTH_PATH, headers=headers())
+
+    access = _access_records(caplog)
+    assert len(access) == 1
+    assert _field(access[0], "status") == _INTERNAL_ERROR_STATUS
+    assert access[0].exc_info is None
+    assert _SENTINEL_BODY not in str(access[0].__dict__)
+    assert len(_error_records(caplog)) == 1
+
+
 # --------------------------------------------------------------------------- #
 # Access log
 # --------------------------------------------------------------------------- #
@@ -1256,3 +1355,181 @@ def test_the_request_id_is_not_derived_from_anything_the_caller_sent(
     assert envelope(first)["request_id"] != envelope(second)["request_id"]
     assert _SENTINEL_ID not in envelope(first)["request_id"]
     assert _SENTINEL_BODY not in envelope(first)["request_id"]
+
+
+# --------------------------------------------------------------------------- #
+# ASGI scope allowlist
+# --------------------------------------------------------------------------- #
+
+
+_WEBSOCKET_SCOPE: Final[str] = "websocket"
+"""The scope type a ``ws://`` route would arrive under.
+
+The probe of choice, because it is the one non-``http`` type Starlette's router
+*already serves*. A middleware that waves it through does not fail loudly; the
+router answers it — with a ``websocket.close`` today, and with a live socket the
+day anyone mounts a ``WebSocketRoute`` — having passed no authentication, no
+ceiling gate and no access line on the way. That is what makes a passthrough
+written for ``lifespan`` a hole rather than a no-op, and why the test has to
+name a type the framework understands.
+"""
+
+
+class _ScopeSpy:
+    """An ASGI app that records the scope types it was handed.
+
+    Attributes:
+        seen: The ``scope["type"]`` of every call, in arrival order.
+    """
+
+    def __init__(self) -> None:
+        """Start with nothing recorded."""
+        self.seen: list[str] = []
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Record the scope type and answer nothing.
+
+        Args:
+            scope: The ASGI scope.
+            receive: Unused — nothing below reads a body here.
+            send: Unused — the spy exists to be *reached*, not to reply.
+        """
+        self.seen.append(str(scope["type"]))
+
+
+async def _no_messages() -> Message:
+    """Return a disconnect, so no layer can block waiting on the channel.
+
+    Returns:
+        A single ``http.disconnect`` message.
+    """
+    return {"type": "http.disconnect"}
+
+
+async def _discard(message: Message) -> None:
+    """Drop an outgoing ASGI message.
+
+    Args:
+        message: The message a layer tried to send. Deliberately unread: these
+            tests assert on what was *reached*, never on what was written.
+    """
+
+
+_LAYERS: Final[tuple[tuple[str, Callable[[ASGIApp], ASGIApp]], ...]] = (
+    ("access-log", AccessLogMiddleware),
+    ("boundary", ErrorBoundaryMiddleware),
+    ("concurrency", lambda app: ConcurrencyLimitMiddleware(app, max_concurrency=1)),
+    (
+        "timeout",
+        lambda app: RequestTimeoutMiddleware(app, timeout_seconds=_TINY_TIMEOUT),
+    ),
+    ("auth", lambda app: BearerAuthMiddleware(app, verifier=verifier())),
+    (
+        "body-size",
+        lambda app: BodySizeLimitMiddleware(app, max_body_bytes=_SMALL_LIMIT),
+    ),
+    ("ceiling", CeilingAdmissionMiddleware),
+)
+"""Every layer of the stack, as ``(id, factory)``, in mounted order."""
+
+_LAYER_IDS: Final[tuple[str, ...]] = tuple(name for name, _ in _LAYERS)
+_LAYER_FACTORIES: Final[tuple[Callable[[ASGIApp], ASGIApp], ...]] = tuple(
+    factory for _, factory in _LAYERS
+)
+
+
+def test_the_scope_tests_cover_the_whole_pinned_stack() -> None:
+    """The parametrization below *is* the stack, in order — not a subset.
+
+    The non-vacuity twin for the two tests that follow. A scope guard is only
+    as good as its least-covered layer: six middlewares refusing a ``websocket``
+    and a seventh waving it through is a stack that waves it through, and a
+    parametrization that silently stopped covering the seventh would keep
+    reporting six green.
+    """
+    spy = _ScopeSpy()
+    assert tuple(type(build(spy)) for build in _LAYER_FACTORIES) == _EXPECTED_STACK
+
+
+@pytest.mark.parametrize("build", _LAYER_FACTORIES, ids=_LAYER_IDS)
+def test_a_websocket_scope_never_reaches_the_app_below(
+    build: Callable[[ASGIApp], ASGIApp],
+) -> None:
+    """Every layer refuses a scope type it does not serve, rather than relaying.
+
+    The passthrough each middleware carries is justified by exactly one scope
+    type — ``lifespan``, whose handshake a middleware that assumed ``http``
+    would break. Written as "anything that is not ``http``", it denies by
+    omission: the allowlist is implicit, and the first ``websocket`` route ever
+    mounted inherits an unauthenticated, unceilinged, unlogged path through
+    all seven layers by default.
+
+    Args:
+        build: Wraps the spy in one layer of the stack.
+    """
+    spy = _ScopeSpy()
+    scope = {"type": _WEBSOCKET_SCOPE, "path": WHEEL_PATH}
+    with pytest.raises(UnsupportedScopeError):
+        run_async(build(spy), scope, _no_messages, _discard)
+    assert spy.seen == []
+
+
+@pytest.mark.parametrize("build", _LAYER_FACTORIES, ids=_LAYER_IDS)
+def test_a_lifespan_scope_still_passes_through(
+    build: Callable[[ASGIApp], ASGIApp],
+) -> None:
+    """The one allowed passthrough stays allowed.
+
+    The companion to the refusal above, and the reason the fix is an allowlist
+    rather than a blanket ``http``-only assertion: a layer that refused
+    ``lifespan`` would break startup, and every test in this suite would fail
+    at ``with client(...)`` rather than at the assertion that found the bug.
+
+    Args:
+        build: Wraps the spy in one layer of the stack.
+    """
+    spy = _ScopeSpy()
+    run_async(build(spy), {"type": LIFESPAN_SCOPE}, _no_messages, _discard)
+    assert spy.seen == [LIFESPAN_SCOPE]
+
+
+def test_a_websocket_scope_does_not_reach_the_assembled_app(
+    vault: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """End to end: the router never sees it, and nothing goes out on the wire.
+
+    The layer-by-layer tests above prove each middleware refuses. This proves
+    the assembled application does — which is the claim that matters, because
+    it is the assembled application a server calls.
+
+    Args:
+        vault: A seeded vault.
+        caplog: Captures the access log, which must stay silent.
+    """
+    caplog.set_level(logging.DEBUG, logger=ACCESS_LOGGER_NAME)
+    sent: list[str] = []
+
+    async def observed_send(message: Message) -> None:
+        """Record any message the app tried to send.
+
+        Args:
+            message: The outgoing ASGI message.
+        """
+        sent.append(str(message["type"]))
+
+    app = build_app(vault_path=vault)
+    scope: dict[str, Any] = {
+        "type": _WEBSOCKET_SCOPE,
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "path": WHEEL_PATH,
+        "raw_path": WHEEL_PATH.encode(),
+        "query_string": b"",
+        "root_path": "",
+        "headers": [],
+        "client": _LOOPBACK,
+        "server": _LOOPBACK,
+    }
+    with pytest.raises(UnsupportedScopeError):
+        run_async(app, scope, _no_messages, observed_send)
+    assert sent == []
+    assert _access_records(caplog) == []


### PR DESCRIPTION
Closes #1122. Closes #1124. Same middleware tree, same test file — they could never have been parallel.

## #1122 — the traceback wasn't merely unlogged, it was **unreachable**

`boundary.py`'s docstring justified logging nothing by saying an operator wanting the traceback "runs the server with debug disabled but their own handler attached." **That escape hatch does not exist.** Starlette's `ServerErrorMiddleware` is the outermost layer of `build_middleware_stack`, so once `ErrorBoundaryMiddleware` catches the exception it never propagates outward — no handler an operator attaches can ever receive it.

So the issue's premise was right about the consequence and wrong about the cause. I rewrote that paragraph rather than leave a false workaround in the docs.

The response body is unchanged byte-for-byte. The test asserts the contrast directly: the sentinel appears in `caplog.text` and does **not** appear in `response.text`.

## #1124 — a websocket scope was silently **answered**

Verified against the installed Starlette: `Router.app` asserts the scope type is one of http/websocket/lifespan, no `Route` matches a websocket scope, so it falls through to `Router.not_found`, which sends `{"type": "websocket.close"}`. **Nothing raises, logs, or 500s** — which is precisely why the hole is invisible without a test.

**The issue undercounts the sites.** It names six; there are seven — `boundary.py:53` carries the same bare `if scope["type"] != HTTP_SCOPE` passthrough and isn't listed. Every line number it *does* give is correct, which is unusual for this repo.

## Design call, stated as the issue asked

The refusal is a raised `UnsupportedScopeError`, not a protocol-level refusal. There is no protocol-independent way to refuse an arbitrary ASGI scope — a websocket needs `websocket.close`; an unknown type has no defined refusal at all. Reaching the stack with such a scope means something was mounted this app was never wired for: a deployment bug that should fail loudly at wiring time, not a request-level failure. Nothing is written to the wire (asserted).

## Three tests pass against unfixed code, by design

Flagged rather than hidden:
- the published-constant pin (new code — nothing to be "unfixed")
- seven `lifespan` passthrough guards — they'd go red if the allowlist **over**-tightened
- the stack-identity twin, asserting the parametrization equals `_EXPECTED_STACK`, so an eighth middleware can't be added without being dragged through the websocket test

The ten that carry the fix are in the RED proof.

## A note on how RED was produced

`git stash push <file>` does **not** work here — the new symbols live in the same files as the fixes, so a whole-file stash yields only an `ImportError` at collection. That proves the symbols are new and nothing about behaviour. The edits were reverted **in place** instead, keeping imports resolvable and producing genuine behavioural failures (`DID NOT RAISE`, `assert 0 == 1`). Both runs reported; `git status` verified clean afterwards.

## Deliberately out of scope

`creek-tools-api` still starts uvicorn with websocket protocol support enabled. The middleware guard is the durable fix because it doesn't depend on server configuration; passing `ws="none"` as belt-and-braces is a possible follow-up.

Gate: **12/12**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EaHDtyDuNrpGtzUGMJT7Fw