### PR TITLE
fix(clean): delete the --apply flag that mutates nothing, and make OrphanScanner alias-aware

### DIFF
--- a/creek-tools/creek/clean/hygiene.py
+++ b/creek-tools/creek/clean/hygiene.py
@@ -267,6 +267,14 @@ class OrphanScanner:
     no connections after a configurable age threshold (in days) are
     reported as orphans.
 
+    Wiki-links resolve through :func:`creek.vault.links.build_link_index`,
+    the same index :class:`BrokenLinkScanner` and the ``orphan-compiled``
+    lint check use, so a page is credited for links naming it by its
+    frontmatter ``title`` or any ``aliases`` entry. Comparing filename
+    stems alone — the behaviour #887 removed from the lint checks and
+    #1225 removed from here — reported alias-linked pages as orphans,
+    which is a false positive telling the operator to delete live content.
+
     Attributes:
         age_days: Minimum age in days before a fragment is considered
             an orphan candidate (default 30).
@@ -284,10 +292,10 @@ class OrphanScanner:
     def scan(self, vault_path: Path) -> OrphanResult:
         """Scan the vault for orphaned fragments.
 
-        Builds a set of all known filenames (stems), then checks each
-        fragment for outgoing wiki-links. A fragment is orphaned if it
-        has no outgoing links AND no other fragment links to it, and it
-        is older than ``age_days``.
+        Every wiki-link in the vault is resolved to the page it actually
+        names, then counted against that page alone. A fragment is orphaned
+        when nothing links to it, it links to nothing else, and it is older
+        than ``age_days``.
 
         Args:
             vault_path: Root of the Obsidian vault.
@@ -297,65 +305,68 @@ class OrphanScanner:
         """
         fragment_files = _list_fragment_files(vault_path)
         all_md_files = _list_all_md_files(vault_path)
+        link_index = build_link_index(vault_path)
 
-        all_stems = {f.stem for f in all_md_files}
-        incoming: dict[str, set[str]] = {f.stem: set() for f in fragment_files}
-        outgoing: dict[str, list[str]] = {}
-
-        self._build_link_graph(all_md_files, incoming, outgoing)
+        incoming, outgoing = self._build_link_graph(all_md_files, link_index)
 
         now = datetime.now(tz=UTC)
-        orphans = self._find_orphans(
-            fragment_files,
-            incoming,
-            outgoing,
-            all_stems,
-            now,
-        )
+        orphans = self._find_orphans(fragment_files, incoming, outgoing, now)
 
         return OrphanResult(
             orphan_paths=[str(p) for p in orphans],
             total_fragments=len(fragment_files),
         )
 
+    @staticmethod
     def _build_link_graph(
-        self,
         all_md_files: list[Path],
-        incoming: dict[str, set[str]],
-        outgoing: dict[str, list[str]],
-    ) -> None:
-        """Build incoming and outgoing link maps from all markdown files.
+        link_index: LinkIndex,
+    ) -> tuple[dict[Path, set[Path]], dict[Path, set[Path]]]:
+        """Build page-keyed incoming and outgoing link maps for the vault.
+
+        Keys and values are resolved page paths rather than filename stems,
+        so a link written in alias form credits the page that declares the
+        alias — and only that page.
 
         Args:
             all_md_files: All markdown files in the vault.
-            incoming: Mutable dict mapping fragment stems to sets of
-                source stems that link to them.
-            outgoing: Mutable dict mapping file stems to lists of
-                wiki-link targets.
+            link_index: Vault-wide name → page index.
+
+        Returns:
+            A ``(incoming, outgoing)`` pair: ``incoming`` maps a page to the
+            files linking to it, ``outgoing`` maps a file to the pages it
+            links to. Targets that resolve to nothing are dropped from both.
         """
+        incoming: dict[Path, set[Path]] = {}
+        outgoing: dict[Path, set[Path]] = {}
         for md_file in all_md_files:
             content = md_file.read_text(encoding="utf-8", errors="replace")
-            targets = _extract_wikilinks(content)
-            outgoing[md_file.stem] = targets
-            for target in targets:
-                if target in incoming:
-                    incoming[target].add(md_file.stem)
+            resolved = {
+                page
+                for target in _extract_wikilinks(content)
+                if (page := link_index.resolve(target)) is not None
+            }
+            outgoing[md_file] = resolved
+            for page in resolved:
+                incoming.setdefault(page, set()).add(md_file)
+        return incoming, outgoing
 
     def _find_orphans(
         self,
         fragment_files: list[Path],
-        incoming: dict[str, set[str]],
-        outgoing: dict[str, list[str]],
-        all_stems: set[str],
+        incoming: dict[Path, set[Path]],
+        outgoing: dict[Path, set[Path]],
         now: datetime,
     ) -> list[Path]:
         """Filter fragments to those that are orphaned and old enough.
 
+        Self-references are discounted in both directions: a note that only
+        links to itself is as unconnected as one that links to nothing.
+
         Args:
             fragment_files: Fragment markdown files.
-            incoming: Map of fragment stem to set of linking stems.
-            outgoing: Map of file stem to list of link targets.
-            all_stems: Set of all known file stems.
+            incoming: Map of page to the files linking to it.
+            outgoing: Map of file to the pages it links to.
             now: Current UTC datetime for age calculation.
 
         Returns:
@@ -363,10 +374,9 @@ class OrphanScanner:
         """
         orphans: list[Path] = []
         for frag_file in fragment_files:
-            stem = frag_file.stem
-            has_incoming = bool(incoming.get(stem))
-            out_targets = outgoing.get(stem, [])
-            has_outgoing = any(t in all_stems and t != stem for t in out_targets)
+            self_only = {frag_file}
+            has_incoming = bool(incoming.get(frag_file, set()) - self_only)
+            has_outgoing = bool(outgoing.get(frag_file, set()) - self_only)
 
             if has_incoming or has_outgoing:
                 continue

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -5146,7 +5146,6 @@ def _resolve_vault(vault: Path | None) -> Path:
 def clean_orphans(
     vault: Path | None = typer.Option(None, help="Obsidian vault path"),
     age_days: int = typer.Option(30, help="Minimum age in days for orphan detection"),
-    apply: bool = typer.Option(False, help="Apply changes (default is dry-run)"),
 ) -> None:
     """Identify fragments with zero incoming/outgoing links after N days."""
     from creek.clean.hygiene import OrphanScanner
@@ -5154,8 +5153,7 @@ def clean_orphans(
     vault_path = _resolve_vault(vault)
     result = OrphanScanner(age_days=age_days).scan(vault_path)
 
-    mode = "[red]APPLY[/red]" if apply else "[yellow]DRY-RUN[/yellow]"
-    console.print(f"\n[bold]Orphan Scan[/bold] ({mode})")
+    console.print("\n[bold]Orphan Scan[/bold]")
     console.print(f"Total fragments: {result.total_fragments}")
     console.print(f"Orphans found: {len(result.orphan_paths)}")
 
@@ -5171,7 +5169,6 @@ def clean_orphans(
 def clean_stale_reviews(
     vault: Path | None = typer.Option(None, help="Obsidian vault path"),
     age_days: int = typer.Option(14, help="Maximum age in days for review items"),
-    apply: bool = typer.Option(False, help="Apply changes (default is dry-run)"),
 ) -> None:
     """Find review queue items older than N days."""
     from creek.clean.hygiene import StaleReviewScanner
@@ -5179,8 +5176,7 @@ def clean_stale_reviews(
     vault_path = _resolve_vault(vault)
     result = StaleReviewScanner(age_days=age_days).scan(vault_path)
 
-    mode = "[red]APPLY[/red]" if apply else "[yellow]DRY-RUN[/yellow]"
-    console.print(f"\n[bold]Stale Review Scan[/bold] ({mode})")
+    console.print("\n[bold]Stale Review Scan[/bold]")
     console.print(f"Total review files: {result.total_review_files}")
     console.print(f"Stale files: {len(result.stale_paths)}")
 
@@ -5195,7 +5191,6 @@ def clean_stale_reviews(
 @clean_app.command(name="broken-links")
 def clean_broken_links(
     vault: Path | None = typer.Option(None, help="Obsidian vault path"),
-    apply: bool = typer.Option(False, help="Apply changes (default is dry-run)"),
 ) -> None:
     """Scan fragments for wiki-links pointing to nonexistent files."""
     from creek.clean.hygiene import BrokenLinkScanner
@@ -5203,8 +5198,7 @@ def clean_broken_links(
     vault_path = _resolve_vault(vault)
     result = BrokenLinkScanner().scan(vault_path)
 
-    mode = "[red]APPLY[/red]" if apply else "[yellow]DRY-RUN[/yellow]"
-    console.print(f"\n[bold]Broken Link Scan[/bold] ({mode})")
+    console.print("\n[bold]Broken Link Scan[/bold]")
     console.print(f"Files scanned: {result.total_files_scanned}")
     console.print(f"Broken links: {result.total_broken}")
 
@@ -5223,7 +5217,6 @@ def clean_broken_links(
 @clean_app.command(name="duplicates")
 def clean_duplicates(
     vault: Path | None = typer.Option(None, help="Obsidian vault path"),
-    apply: bool = typer.Option(False, help="Apply changes (default is dry-run)"),
 ) -> None:
     """Execute normalized dedup sweep and output review report."""
     from creek.clean.hygiene import DuplicateScanner
@@ -5231,8 +5224,7 @@ def clean_duplicates(
     vault_path = _resolve_vault(vault)
     result = DuplicateScanner().scan(vault_path)
 
-    mode = "[red]APPLY[/red]" if apply else "[yellow]DRY-RUN[/yellow]"
-    console.print(f"\n[bold]Duplicate Scan[/bold] ({mode})")
+    console.print("\n[bold]Duplicate Scan[/bold]")
     console.print(f"Total fragments: {result.total_fragments}")
     console.print(f"Duplicate candidates: {len(result.candidates)}")
 

--- a/creek-tools/creek/vault/links.py
+++ b/creek-tools/creek/vault/links.py
@@ -17,6 +17,10 @@ that does not exist, because its output still has to be read.
 This module is the single answer to "does this wiki-link resolve, and to
 what". Callers build one :class:`LinkIndex` per run and query it.
 
+``OrphanScanner`` — ``creek clean``'s own orphan check, distinct from the
+``orphan-compiled`` lint check — was the last stem-based holdout and adopted
+this index in #1225.
+
 Resolution follows Obsidian: an exact-case match wins, and a case-insensitive
 match is the fallback. The frontmatter is read **header-only** — a 35k-file
 vault must never pay to load every body into memory just to learn a page's

--- a/creek-tools/docs/cleaning-and-purge.md
+++ b/creek-tools/docs/cleaning-and-purge.md
@@ -7,6 +7,8 @@ Two adjacent command groups handle vault hygiene:
 
 `clean` finds problems and reports them. `purge` deletes things. They're separate tools because mistaking one for the other would be expensive.
 
+`clean` has **no write mode at all** — no `--apply`, no `--fix`. Its scanners expose `scan()` and nothing else. Until #1039 the four scan subcommands each carried an `--apply` flag that printed a red `APPLY` banner and then changed nothing; the flag was removed rather than implemented. Acting on a `clean` report means running `creek purge`, by hand, on the entries you chose.
+
 > Purge does best-effort deletion. It is **not** anti-forensic — modern SSDs and copy-on-write filesystems retain old block contents even after a successful unlink. See the [threat model](security/threat-model.md) for the full set of guarantees Creek does and doesn't make.
 
 ---
@@ -20,6 +22,8 @@ Identifies fragments with **zero incoming and outgoing links** that are older th
 ```bash
 creek clean orphans --vault ~/Obsidian/Creek-Vault --age-days 30
 ```
+
+Links are resolved by every name a page answers to — filename stem, frontmatter `title`, and each `aliases` entry — not by filename alone (#1225, the same fix #887 made for `broken-links`). A fragment linked as `[[Messages]]` credits the page whose file is `2020-09-26-Messages.md`, so it is not reported. A link that only points at its own file does not rescue the page from the list.
 
 Output is a markdown report — orphans are not deleted automatically. Pipe the IDs into `creek purge fragment` if you want them gone.
 

--- a/creek-tools/tests/test_cli_clean.py
+++ b/creek-tools/tests/test_cli_clean.py
@@ -11,6 +11,7 @@ from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
 import frontmatter
+import pytest
 from typer.testing import CliRunner
 
 from creek.cli import app
@@ -19,6 +20,14 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 runner = CliRunner()
+
+SCAN_SUBCOMMANDS: tuple[str, ...] = (
+    "orphans",
+    "stale-reviews",
+    "broken-links",
+    "duplicates",
+)
+"""The ``creek clean`` subcommands that only ever read the vault."""
 
 
 # ---------------------------------------------------------------------------
@@ -148,17 +157,6 @@ def test_clean_orphans_with_age(tmp_path: Path) -> None:
     assert result.exit_code == 0
 
 
-def test_clean_orphans_with_apply(tmp_path: Path) -> None:
-    """Test that ``creek clean orphans --apply`` shows APPLY mode."""
-    vault = _make_vault(tmp_path)
-    result = runner.invoke(
-        app,
-        ["clean", "orphans", "--vault", str(vault), "--apply"],
-    )
-    assert result.exit_code == 0
-    assert "APPLY" in result.output
-
-
 def test_clean_orphans_shows_table(tmp_path: Path) -> None:
     """Test that orphan results display in a table when orphans exist."""
     vault = _make_vault(tmp_path)
@@ -179,17 +177,6 @@ def test_clean_stale_reviews_runs(tmp_path: Path) -> None:
     result = runner.invoke(app, ["clean", "stale-reviews", "--vault", str(vault)])
     assert result.exit_code == 0
     assert "Stale Review Scan" in result.output
-
-
-def test_clean_stale_reviews_with_apply(tmp_path: Path) -> None:
-    """Test that ``creek clean stale-reviews --apply`` shows APPLY mode."""
-    vault = _make_vault(tmp_path)
-    result = runner.invoke(
-        app,
-        ["clean", "stale-reviews", "--vault", str(vault), "--apply"],
-    )
-    assert result.exit_code == 0
-    assert "APPLY" in result.output
 
 
 def test_clean_broken_links_runs(tmp_path: Path) -> None:
@@ -251,3 +238,66 @@ def test_clean_report_shows_quality_distribution(tmp_path: Path) -> None:
     # Rich may wrap the title across lines, so check parts separately
     assert "Quality" in result.output
     assert "Distribution" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Honesty of the read-only scan surface (#1039)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("subcommand", SCAN_SUBCOMMANDS)
+def test_clean_scan_rejects_apply_flag(tmp_path: Path, subcommand: str) -> None:
+    """``--apply`` is gone: the scanners have no mutation path to gate.
+
+    ``creek/clean/hygiene.py`` exposes ``scan()`` and nothing else — no
+    ``apply``, ``fix``, ``remove`` or ``delete`` — so a flag advertising
+    "Apply changes (default is dry-run)" promised a mode that could not
+    exist. Passing it must now fail loudly rather than print a red banner
+    over a read-only scan.
+    """
+    vault = _make_vault(tmp_path)
+    result = runner.invoke(
+        app,
+        ["clean", subcommand, "--vault", str(vault), "--apply"],
+    )
+    assert result.exit_code != 0
+
+
+@pytest.mark.parametrize("subcommand", SCAN_SUBCOMMANDS)
+def test_clean_scan_help_does_not_offer_apply(subcommand: str) -> None:
+    """No ``creek clean`` scan advertises an ``--apply`` flag in its help."""
+    result = runner.invoke(app, ["clean", subcommand, "--help"])
+    assert result.exit_code == 0
+    assert "--apply" not in result.output
+
+
+@pytest.mark.parametrize("subcommand", SCAN_SUBCOMMANDS)
+def test_clean_scan_prints_no_mode_banner(tmp_path: Path, subcommand: str) -> None:
+    """A read-only scan claims neither APPLY nor DRY-RUN.
+
+    ``DRY-RUN`` is as misleading as ``APPLY`` here: it implies a wet run
+    exists. These commands only ever read.
+    """
+    vault = _make_vault(tmp_path)
+    result = runner.invoke(app, ["clean", subcommand, "--vault", str(vault)])
+    assert result.exit_code == 0
+    assert "APPLY" not in result.output
+    assert "DRY-RUN" not in result.output
+
+
+def test_purge_still_reports_apply_mode(tmp_path: Path) -> None:
+    """``creek purge`` keeps its APPLY banner — that one genuinely deletes.
+
+    Guards the deletion in #1039 from over-reaching: ``_render_purge_result``
+    is driven by ``PurgeResult.dry_run`` on a command that really does unlink
+    files, so its banner is honest and must survive.
+    """
+    vault = _make_vault(tmp_path)
+    old = datetime.now(tz=UTC) - timedelta(days=60)
+    _write_fragment(vault, "doomed", created=old)
+    result = runner.invoke(
+        app,
+        ["purge", "fragment", "frag-doomed", "--vault", str(vault), "--yes"],
+    )
+    assert result.exit_code == 0
+    assert "APPLY" in result.output

--- a/creek-tools/tests/test_hygiene.py
+++ b/creek-tools/tests/test_hygiene.py
@@ -56,6 +56,7 @@ def _write_fragment(
     *,
     created: datetime | None = None,
     subfolder: str = "Conversations",
+    aliases: list[str] | None = None,
 ) -> Path:
     """Write a fragment markdown file with frontmatter.
 
@@ -65,6 +66,8 @@ def _write_fragment(
         content: Body content of the fragment.
         created: Optional created datetime for frontmatter.
         subfolder: Subfolder under 01-Fragments.
+        aliases: Optional ``aliases`` entries — the extra names Obsidian
+            lets the page be wiki-linked by.
 
     Returns:
         Path to the written file.
@@ -76,6 +79,8 @@ def _write_fragment(
         "type": "fragment",
         "source": {"platform": "claude", "original_file": f"{name}.json"},
     }
+    if aliases is not None:
+        metadata["aliases"] = aliases
     if created is not None:
         metadata["created"] = created.isoformat()
     post = frontmatter.Post(content=content, **metadata)
@@ -218,6 +223,111 @@ class TestOrphanScanner:
         scanner = OrphanScanner(age_days=30)
         result = scanner.scan(vault)
         assert result.orphan_paths == []
+
+    def test_inbound_alias_link_is_not_orphan(self, tmp_path: Path) -> None:
+        """An alias-form inbound link saves a page from the orphan list (#1225).
+
+        Since #730 the linkers write date-prefixed filenames and put the
+        human-readable name in ``aliases``, so fragments link ``[[Messages]]``
+        at a file called ``2020-09-26-messages.md``. Resolving against
+        filename stems alone — the behaviour #887 removed from
+        ``BrokenLinkScanner`` but not from here — calls that page an orphan
+        and tells the operator to delete live content.
+
+        The genuinely unreferenced ``lonely`` fragment must still be
+        reported, so alias-awareness cannot be bought by falling silent.
+        """
+        vault = _make_vault(tmp_path)
+        old = datetime.now(tz=UTC) - timedelta(days=60)
+        aliased = _write_fragment(
+            vault,
+            "2020-09-26-messages",
+            created=old,
+            aliases=["Messages"],
+        )
+        _write_fragment(
+            vault,
+            "referrer",
+            content="Filed under [[Messages]].",
+            created=old,
+        )
+        lonely = _write_fragment(vault, "lonely", created=old)
+
+        result = OrphanScanner(age_days=30).scan(vault)
+
+        assert str(aliased) not in result.orphan_paths
+        assert result.orphan_paths == [str(lonely)]
+
+    def test_outbound_alias_link_is_not_orphan(self, tmp_path: Path) -> None:
+        """A fragment linking a compiled page by alias has outgoing links.
+
+        The thread page's filename carries a date prefix; the fragment links
+        the alias. Stem-only matching found no such target and therefore
+        credited the fragment with no outgoing links at all.
+        """
+        vault = _make_vault(tmp_path)
+        old = datetime.now(tz=UTC) - timedelta(days=60)
+        thread = vault / "02-Threads" / "Active" / "2020-09-26-messages.md"
+        _write_md_file(
+            thread,
+            "---\naliases:\n  - Messages\n---\n\nThread body.\n",
+        )
+        _write_fragment(
+            vault,
+            "linker",
+            content="Belongs to [[Messages]].",
+            created=old,
+        )
+
+        result = OrphanScanner(age_days=30).scan(vault)
+
+        assert result.orphan_paths == []
+
+    def test_alias_resolution_credits_only_the_named_page(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Resolution is per-page: a resolving link credits one page only.
+
+        ``referrer`` names ``beta`` by alias. ``alpha`` also declares an
+        alias but nothing links it, so it stays orphaned — a check that
+        credited every aliased page as soon as *some* link resolved would
+        fall silent, which is the same end state as the bug being fixed.
+        """
+        vault = _make_vault(tmp_path)
+        old = datetime.now(tz=UTC) - timedelta(days=60)
+        alpha = _write_fragment(vault, "alpha", created=old, aliases=["Alpha Page"])
+        _write_fragment(vault, "beta", created=old, aliases=["Beta Page"])
+        _write_fragment(
+            vault,
+            "referrer",
+            content="See [[Beta Page]].",
+            created=old,
+        )
+
+        result = OrphanScanner(age_days=30).scan(vault)
+
+        assert result.orphan_paths == [str(alpha)]
+
+    def test_self_link_does_not_rescue_a_fragment(self, tmp_path: Path) -> None:
+        """A fragment whose only link points at itself is still an orphan.
+
+        Outgoing links already excluded self-references; incoming links did
+        not, so ``[[selfref]]`` inside ``selfref.md`` silently exempted the
+        page. Per-page resolution makes both directions agree.
+        """
+        vault = _make_vault(tmp_path)
+        old = datetime.now(tz=UTC) - timedelta(days=60)
+        selfref = _write_fragment(
+            vault,
+            "selfref",
+            content="Written about in [[selfref]].",
+            created=old,
+        )
+
+        result = OrphanScanner(age_days=30).scan(vault)
+
+        assert result.orphan_paths == [str(selfref)]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1039. Closes #1225.

## #1039 — Option B, per the operator's decision

`creek clean --apply` printed a red APPLY banner across four subcommands and **mutated nothing** — `hygiene.py` exposes only `scan()`. The flag, banner and mode ternary are deleted.

I removed the **DRY-RUN half too**, not just APPLY: "DRY-RUN" implies a wet run exists, so keeping it leaves a smaller version of the same lie. The AC only demanded APPLY go.

### The brief's warning about the fifth banner was wrong about whose it is

The fifth `APPLY` string (`cli.py:5295`) is in `_render_purge_result`, serving **`creek purge`** — a command that really unlinks files. It is *not* `creek redact`. (`creek redact --apply` **is** genuinely wired, at `cli.py:1447`, but prints no banner at all.) Both left untouched, and `test_purge_still_reports_apply_mode` now pins the purge banner so a future cleanup can't delete it by pattern-match.

### The issue undercounts the tests pinning the flag

It names one (`test_clean_orphans_with_apply`). There were **two** — `test_clean_stale_reviews_with_apply` asserts the same bare `'APPLY' in result.output`. Fixing only the named one would have silently violated the AC *"No test asserts merely that the string APPLY appears in the output."*

Line numbers were ~330 stale: 5149/5174/5198/5226, not 4819/4844/4868/4896.

## #1225 — the last stem-based holdout

#887 gave `BrokenLinkScanner` a `LinkIndex` resolving titles and aliases. `OrphanScanner` kept building stem-keyed maps, so **a note reachable only via an alias was reported as an orphan** — telling a user to delete live content. It now uses the same `build_link_index`, which `hygiene.py` already imported at line 26. No second resolution notion was written.

## A defect in neither issue

Self-references were excluded from **outgoing** links (`t != stem`) but not from **incoming**, so a fragment containing `[[itself]]` was silently exempted from the orphan list while an identical fragment with no links at all was reported. Fixed symmetrically and pinned by `test_self_link_does_not_rescue_a_fragment`. A deliberate behaviour change beyond the literal issue text — flagged for the reviewer rather than buried.

## RED proof

`git stash push creek/clean/hygiene.py creek/cli.py` → **16 failed, 69 passed**. Representative:

```
test_inbound_alias_link_is_not_orphan
  assert [...2020-09-26-messages.md, ...referrer.md, ...lonely.md] == [...lonely.md]
test_clean_scan_prints_no_mode_banner[duplicates]
  assert 'DRY-RUN' not in '...' — 'DRY-RUN' is contained here: Duplicate Scan (DRY-RUN)
```

**Honesty flag:** `test_purge_still_reports_apply_mode` passes both before and after and is **not** counted as a RED test — it exists to prove the deletion didn't over-reach.

GREEN: 85 passed; wider sweep across hygiene/cli_clean/state/lint/dedup: 569 passed.

## Judgement call, flagged

Did **not** fold the four near-identical command bodies into a parametrised helper (#1039 task 2). Once the shared `mode` line was gone they share nothing but shape — different scanner, result fields, and table columns. A helper would be parametrised on all three, trading four readable commands for one indirection. Open to disagreement.

Gate: **12/12**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EaHDtyDuNrpGtzUGMJT7Fw