### PR TITLE
fix(privacy): make the mining corpus read 10-Liminal tiers the way the state report does

### DIFF
--- a/creek-tools/creek/generate/mining.py
+++ b/creek-tools/creek/generate/mining.py
@@ -40,6 +40,8 @@ from pydantic import ValidationError
 from creek.classify.privacy_filter import (
     PrivacyTierOverride,
     filter_fragments_by_tier,
+    raw_privacy_tier,
+    within_ceiling,
 )
 from creek.generate.compile_routing import (
     COMPILE_GAPS_RELPATH,
@@ -399,6 +401,47 @@ def _liminal_kind(md_file: Path, liminal_root: Path) -> str | None:
     return kind
 
 
+def _admitted_liminal_entry(
+    md_file: Path,
+    liminal_root: Path,
+    ceiling: PrivacyTierOverride,
+) -> tuple[Fragment, str, str] | None:
+    """Return one admitted ``(fragment, body, kind)`` entry, or ``None`` to skip.
+
+    The per-file half of :func:`_load_liminal_fragments` — see that function
+    for why the tier is read off the raw frontmatter (#1079). ``None`` covers
+    every reason a ``10-Liminal`` file contributes nothing: it is a
+    Synchronicities reflection note, it does not parse, it is above the
+    ceiling, or it is not a valid fragment.
+
+    The ceiling is checked *before* validation deliberately. An above-ceiling
+    note should not be parsed into a model at all, and ``_validate_fragment``
+    logs the path of anything it rejects.
+
+    Args:
+        md_file: The candidate note.
+        liminal_root: ``<vault>/10-Liminal``, used to derive *kind*.
+        ceiling: The admission ceiling, already defaulted.
+
+    Returns:
+        The entry, with :func:`~creek.classify.privacy_filter.raw_privacy_tier`
+        materialised onto the fragment, or ``None``.
+    """
+    kind = _liminal_kind(md_file, liminal_root)
+    if kind is None:
+        return None
+    post = _safe_post(md_file)
+    if post is None or not within_ceiling(post.metadata, ceiling):
+        return None
+    fragment = _validate_fragment(post, md_file)
+    if fragment is None:
+        return None
+    declared = fragment.model_copy(
+        update={"privacy_tier": raw_privacy_tier(post.metadata)},
+    )
+    return declared, post.content, kind
+
+
 def _load_liminal_fragments(
     liminal_root: Path,
     *,
@@ -410,21 +453,64 @@ def _load_liminal_fragments(
     ``"Unnamed"`` or ``"Compost"``. The Synchronicities subfolder is
     excluded because its records are reflection notes, not fragments.
 
-    ``privacy_override`` is forwarded to the shared tier filter.
+    **The tier is read off the raw frontmatter, not off the validated model**
+    (#1079). ``10-Liminal`` notes are the one corpus two tools admit
+    independently: ``## Liminal Watch`` gates the same physical file through
+    :func:`creek.generate.state._admitted_liminal_notes`, which reads
+    :func:`~creek.classify.privacy_filter.within_ceiling` on the raw
+    frontmatter, while this loader reached the same file through the model.
+    A note with *no* ``privacy_tier`` key at all therefore came out
+    ``intimate`` on one side (fail-closed, absent means unvouched-for) and
+    ``unclassified`` on the other (the model's default, which ranks with
+    ``personal`` per #876/#961) — so one ``10-Liminal/Unnamed`` note needed
+    ``ceiling=intimate`` for its stem and only ``ceiling=open`` for its
+    generated id, inside one rendered document. That is the "two tools that
+    disagree about the same file" bug class
+    :mod:`creek.classify.privacy_filter` names in its own module docstring.
+
+    The divergence is closed by tightening this side up to the report's
+    reader rather than by loosening the report's down to this one, so the
+    change is a strict narrowing at every ceiling:
+
+    * :func:`~creek.classify.privacy_filter.raw_privacy_tier` is materialised
+      onto the loaded fragment, which is what makes every downstream reader —
+      :func:`~creek.classify.privacy_filter.filter_fragments_by_tier` below,
+      :func:`~creek.classify.privacy_filter.tier_of` in
+      :meth:`creek.generate.state.StateReportGenerator._content_tier` — see
+      one tier for one file instead of each re-deriving its own. It is a
+      narrowing because a raw read never answers *below* the model's: a
+      missing key escalates ``unclassified`` to ``intimate``, and an
+      unrecognised value never reaches here at all (the model refuses to
+      validate it, so :func:`_validate_fragment` has already dropped the
+      note).
+    * ``within_ceiling`` is applied as a hard rank cutoff *in addition to*
+      the body-level filter below, because the two answer different
+      questions: the filter *summarises* a personal body as
+      ``[Personal-tier summary: <title>]`` rather than excluding the note, so
+      at ``ceiling=open`` a personal liminal **title** entered the corpus
+      while the report refused the same file outright.
+
+    ``tests/test_liminal_tier_reader_agreement.py`` pins the two call sites
+    against each other note by note, at every ceiling.
+
+    Args:
+        liminal_root: ``<vault>/10-Liminal``.
+        privacy_override: The admission ceiling. ``None`` means ``OPEN``,
+            matching what it already meant to the body-level filter.
+
+    Returns:
+        The admitted ``(fragment, body, kind)`` tuples, each fragment
+        carrying the tier its raw frontmatter declares.
     """
     if not liminal_root.exists():
         return []
-    collected: list[tuple[Fragment, str, str]] = []
-    for md_file in sorted(liminal_root.rglob("*.md")):
-        kind = _liminal_kind(md_file, liminal_root)
-        if kind is None:
-            continue
-        post = _safe_post(md_file)
-        if post is None:
-            continue
-        fragment = _validate_fragment(post, md_file)
-        if fragment is not None:
-            collected.append((fragment, post.content, kind))
+    ceiling = privacy_override or PrivacyTierOverride.OPEN
+    collected = [
+        entry
+        for md_file in sorted(liminal_root.rglob("*.md"))
+        if (entry := _admitted_liminal_entry(md_file, liminal_root, ceiling))
+        is not None
+    ]
     kind_by_id: dict[str, str] = {f.id: kind for f, _body, kind in collected}
     pairs = [(f, body) for f, body, _kind in collected]
     filtered = list(filter_fragments_by_tier(pairs, override=privacy_override))

--- a/creek-tools/creek/generate/state.py
+++ b/creek-tools/creek/generate/state.py
@@ -536,6 +536,13 @@ def _admitted_liminal_notes(
     serve both: the paradox note fails closed to ``intimate`` because nobody
     vouched for it, not because it was classified.
 
+    This is one of two readers admitting ``10-Liminal`` notes into one
+    document; the other is
+    ``creek.generate.mining._load_liminal_fragments``, which backs
+    ``## Suggested questions`` and calls the same two functions for the same
+    reason (#1079). ``tests/test_liminal_tier_reader_agreement.py`` asserts
+    the two agree note by note rather than leaving it to coincidence.
+
     Sorting is unchanged from FEAT-007 and is applied before admission so the
     displayed order does not shift with the ceiling. ``st_mtime`` is
     best-effort — CI containers and fresh clones flatten it to the checkout
@@ -1075,20 +1082,28 @@ class StateReportGenerator:
         tiers — the maximum over the fragments naming each title — so it can
         narrow precisely.
 
-        **Fragments are intersected by id** with the admitted slice. The miner
-        reads ``privacy_tier`` off the validated :class:`~creek.models.Fragment`,
-        which defaults a *missing* key to ``unclassified`` and so admits at
-        ``ceiling=personal`` a file this report's raw-frontmatter cutoff failed
-        closed to ``intimate``. Without the intersection a wavelength-window
-        seed could carry such a fragment's **title**. Note the intersection is
-        by id and not by object: the miner's copy of an admitted fragment may
-        carry a summarised body, which is stricter and is kept.
+        **Fragments are intersected by id** with the admitted slice.
+        ``creek.generate.mining._load_fragments`` reads ``privacy_tier`` off
+        the validated :class:`~creek.models.Fragment`, which defaults a
+        *missing* key to ``unclassified`` and so admits at ``ceiling=personal``
+        a file this report's raw-frontmatter cutoff failed closed to
+        ``intimate``. Without the intersection a wavelength-window seed could
+        carry such a fragment's **title**. Note the intersection is by id and
+        not by object: the miner's copy of an admitted fragment may carry a
+        summarised body, which is stricter and is kept.
 
-        **Liminal fragments are left as the miner filtered them**, and that is
-        the one axis this report cannot narrow: they come from ``10-Liminal``
-        subfolders (notably ``Compost``) that ``_load_liminal_watch`` does not
-        walk, so there is no admitted list to intersect against. They are
-        instead accounted for on the stamp — see :meth:`_content_tier`.
+        **Liminal fragments are left as the miner filtered them**, and since
+        #1079 that is no longer a gap: ``_load_liminal_fragments`` applies the
+        same :func:`~creek.classify.privacy_filter.within_ceiling` cutoff on
+        the same raw frontmatter that :func:`_admitted_liminal_notes` reads,
+        and materialises
+        :func:`~creek.classify.privacy_filter.raw_privacy_tier` onto the
+        fragment it returns, so the two halves of this document cannot admit
+        one ``10-Liminal`` note at two different ceilings. An intersection
+        would be unavailable anyway: the miner walks ``10-Liminal`` subfolders
+        (notably ``Compost``) that ``_load_liminal_watch`` does not, so there
+        is no admitted list to intersect against. Those are accounted for on
+        the stamp instead — see :meth:`_content_tier`.
 
         Returns:
             The snapshot to hand :func:`phase_filtered_seeds`.
@@ -1560,15 +1575,18 @@ class StateReportGenerator:
         the stamp, which is the same fail-open the hyperedge intersection
         closed. Its tier is added here instead.
 
-        That tier is read off the validated model rather than the raw
-        frontmatter, because the snapshot no longer holds the file. The
-        divergence is one case, and it does not fail open: a liminal note with
-        *no* ``privacy_tier`` key resolves to ``unclassified`` here where a raw
-        read would say ``intimate``, and
-        :func:`~creek.classify.privacy_filter.tier_sensitivity` ranks
-        ``unclassified`` *with* ``personal`` — so the stamp still refuses the
-        artifact at ``ceiling=open``, which is the only ceiling at which the
-        section did not render.
+        That tier is read through :func:`~creek.classify.privacy_filter.tier_of`
+        because the snapshot no longer holds the file — but it is nonetheless
+        the *raw* tier, not the model's default. Since #1079
+        ``creek.generate.mining._load_liminal_fragments`` materialises
+        :func:`~creek.classify.privacy_filter.raw_privacy_tier` onto every
+        fragment it returns, so a liminal note with *no* ``privacy_tier`` key
+        arrives here already reading ``intimate`` rather than the
+        ``unclassified`` the model would default it to. Before that it read
+        one rank low, and a stamp that under-reports is a read gate that fails
+        open: an untiered ``10-Liminal/Compost`` note is admitted only from
+        ``ceiling=intimate`` upward, yet stamped the artifact ``unclassified``,
+        which ``ceiling=personal`` would then have been allowed to read.
 
         **Addition two is the lint summary**, derived from the *rendered
         strings* rather than from a flag the section sets. A flag would create

--- a/creek-tools/tests/test_liminal_tier_reader_agreement.py
+++ b/creek-tools/tests/test_liminal_tier_reader_agreement.py
@@ -1,0 +1,271 @@
+"""One ``10-Liminal`` note must get one tier from both readers (#1079).
+
+The state report admits a liminal note through
+:func:`creek.generate.state._admitted_liminal_notes`, which reads the note's
+*raw* frontmatter through
+:func:`~creek.classify.privacy_filter.within_ceiling` /
+:func:`~creek.classify.privacy_filter.raw_privacy_tier`. The mining corpus
+behind ``## Suggested questions`` admits the same physical file through
+:func:`creek.generate.mining._load_liminal_fragments`, which read the tier off
+the *validated* :class:`~creek.models.Fragment`.
+
+A note with **no** ``privacy_tier`` key therefore came out ``intimate`` on one
+side and ``unclassified`` on the other: refused below ``ceiling=intimate`` by
+the report, admitted from ``ceiling=open`` upward by the corpus — inside one
+rendered document. That is the "two tools that disagree about the same file"
+failure ``creek/classify/privacy_filter.py``'s own module docstring names, and
+that ``tests/test_mcp_report_tier_ceiling.py``'s
+``test_raw_and_model_tier_readers_agree_on_every_fragment`` already pins for
+``01-Fragments``. This module pins it for ``10-Liminal``.
+
+:func:`~creek.classify.privacy_filter.raw_privacy_tier` is the single
+definition; the miner now calls it. Every assertion below therefore compares
+the two call sites *against each other* over the same files rather than
+against a hard-coded expectation of either one — a pin on the agreement, not
+on an implementation. The one exception is the untiered note, checked
+explicitly against ``INTIMATE``, because agreeing on the fail-closed answer
+(rather than merely agreeing) is the whole point: an agreement on
+``unclassified`` would be the two readers drifting together in the permissive
+direction.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import frontmatter
+import pytest
+
+from creek.classify.privacy_filter import PrivacyTierOverride, tier_of
+from creek.generate.mining import _load_liminal_fragments
+from creek.generate.state import (
+    _LIMINAL_ROOT,
+    _LIMINAL_SUBDIRS,
+    EMPTY_PLACEHOLDER,
+    StateReportGenerator,
+    _admitted_liminal_notes,
+)
+from creek.generate.state_tiers import TIER_STAMP_KEY
+from creek.models import PrivacyTier
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# Every ceiling the two readers can be asked about. ``ALL`` is included
+# because "no ceiling declared" is a real production value — it is the
+# ``StateReportGenerator`` default — and an agreement that only holds under a
+# restriction is not an agreement.
+_CEILINGS: tuple[PrivacyTierOverride, ...] = (
+    PrivacyTierOverride.OPEN,
+    PrivacyTierOverride.PERSONAL,
+    PrivacyTierOverride.INTIMATE,
+    PrivacyTierOverride.ALL,
+)
+
+# Stems restricted to ``[A-Za-z0-9-]`` so the join key below survives being
+# used as both a filename and a frontmatter ``title``.
+_NO_KEY_STEM = "LiminalNoKeyCanary"
+_NOTES: tuple[tuple[str, str | None], ...] = (
+    (_NO_KEY_STEM, None),
+    ("LiminalOpenCanary", "open"),
+    ("LiminalPersonalCanary", "personal"),
+    ("LiminalIntimateCanary", "intimate"),
+    ("LiminalUnclassifiedCanary", "unclassified"),
+)
+
+
+def _write_liminal_note(folder: Path, stem: str, tier: str | None) -> None:
+    """Write one ``type: fragment`` liminal note, with or without a tier key.
+
+    The file *stem* and the frontmatter ``title`` are deliberately the same
+    string: the state reader keys its result by stem and the mining reader by
+    the validated fragment, so one shared value is what lets the two results
+    be compared note by note.
+
+    Args:
+        folder: Directory to write into; created if absent.
+        stem: Filename stem, also used as the fragment title.
+        tier: The ``privacy_tier`` value to declare, or ``None`` to omit the
+            key entirely — the case the two readers disagreed about.
+    """
+    folder.mkdir(parents=True, exist_ok=True)
+    tier_line = "" if tier is None else f"privacy_tier: {tier}\n"
+    folder.joinpath(f"{stem}.md").write_text(
+        "---\n"
+        "type: fragment\n"
+        f"id: {stem.lower()[:12]}\n"
+        f"title: {stem}\n"
+        "source:\n"
+        "  platform: journal\n"
+        "created: 2026-01-01T00:00:00Z\n"
+        f"{tier_line}"
+        "---\n\n"
+        "Body text about eddies and rivers.\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def liminal_vault(tmp_path: Path) -> Path:
+    """Return a vault whose ``10-Liminal/Unnamed`` holds one note per tier.
+
+    Both readers walk this one folder: ``_admitted_liminal_notes`` is called
+    on it directly, and ``_load_liminal_fragments`` reaches it by walking
+    ``10-Liminal``. Keeping every note in the single subfolder both readers
+    cover is what makes their two results comparable as sets.
+
+    Args:
+        tmp_path: pytest's per-test temporary directory.
+
+    Returns:
+        The vault root.
+    """
+    for stem, tier in _NOTES:
+        _write_liminal_note(tmp_path / _LIMINAL_ROOT / "Unnamed", stem, tier)
+    return tmp_path
+
+
+def _state_reader(vault: Path, ceiling: PrivacyTierOverride) -> dict[str, PrivacyTier]:
+    """Return ``{stem: tier}`` as the ``## Liminal Watch`` side reads it."""
+    return dict(_admitted_liminal_notes(vault / _LIMINAL_ROOT / "Unnamed", ceiling))
+
+
+def _mining_reader(vault: Path, ceiling: PrivacyTierOverride) -> dict[str, PrivacyTier]:
+    """Return ``{title: tier}`` as the ``## Suggested questions`` side reads it."""
+    return {
+        fragment.title: tier_of(fragment)
+        for fragment, _body, _kind in _load_liminal_fragments(
+            vault / _LIMINAL_ROOT,
+            privacy_override=ceiling,
+        )
+    }
+
+
+@pytest.mark.parametrize("ceiling", _CEILINGS)
+def test_both_liminal_readers_admit_the_same_notes(
+    liminal_vault: Path,
+    ceiling: PrivacyTierOverride,
+) -> None:
+    """The two readers admit the same set of files under the same ceiling.
+
+    Before #1079 the untiered note was admitted by the miner at every ceiling
+    (``filter_fragments_by_tier`` *summarises* rather than excludes, so even
+    ``ceiling=open`` kept it) while the report refused it below
+    ``ceiling=intimate``.
+
+    Args:
+        liminal_vault: Vault holding one liminal note per tier.
+        ceiling: The admission ceiling both readers are asked about.
+    """
+    assert set(_mining_reader(liminal_vault, ceiling)) == set(
+        _state_reader(liminal_vault, ceiling),
+    ), (
+        f"the two liminal readers disagree about which notes {ceiling.value!r} "
+        f"admits: the miner says {sorted(_mining_reader(liminal_vault, ceiling))}, "
+        f"the report says {sorted(_state_reader(liminal_vault, ceiling))}"
+    )
+
+
+@pytest.mark.parametrize("ceiling", _CEILINGS)
+def test_both_liminal_readers_report_the_same_tier(
+    liminal_vault: Path,
+    ceiling: PrivacyTierOverride,
+) -> None:
+    """For every commonly-admitted note the two readers name the same tier.
+
+    Asserted per note rather than as a whole-mapping comparison so a failure
+    names the file that diverged.
+
+    Args:
+        liminal_vault: Vault holding one liminal note per tier.
+        ceiling: The admission ceiling both readers are asked about.
+    """
+    mined = _mining_reader(liminal_vault, ceiling)
+    reported = _state_reader(liminal_vault, ceiling)
+    shared = sorted(set(mined) & set(reported))
+    for stem in shared:
+        assert mined[stem] is reported[stem], (
+            f"the two liminal readers disagree about the tier of {stem!r} at "
+            f"ceiling={ceiling.value!r}: the miner says {mined[stem].value!r}, "
+            f"the report says {reported[stem].value!r}"
+        )
+
+
+def test_untiered_liminal_note_is_intimate_to_both_readers(
+    liminal_vault: Path,
+) -> None:
+    """A note with no ``privacy_tier`` key fails closed on *both* sides.
+
+    The positive control for the two tests above: agreeing on ``unclassified``
+    would satisfy them while being the two readers drifting together in the
+    permissive direction, which is exactly what the one-way ratchet forbids.
+
+    Args:
+        liminal_vault: Vault holding one liminal note per tier.
+    """
+    ceiling = PrivacyTierOverride.ALL
+    assert _mining_reader(liminal_vault, ceiling)[_NO_KEY_STEM] is PrivacyTier.INTIMATE
+    assert _state_reader(liminal_vault, ceiling)[_NO_KEY_STEM] is PrivacyTier.INTIMATE
+
+
+@pytest.mark.parametrize(
+    "ceiling",
+    [PrivacyTierOverride.OPEN, PrivacyTierOverride.PERSONAL],
+)
+def test_untiered_liminal_note_is_refused_by_the_miner_below_intimate(
+    liminal_vault: Path,
+    ceiling: PrivacyTierOverride,
+) -> None:
+    """The untiered note leaves the mining corpus below ``ceiling=intimate``.
+
+    Stated as its own assertion because it is the *direction* of the fix: the
+    divergence is closed by tightening the miner up to the report, never by
+    loosening the report down to the miner. The miner's opaque 12-hex seed id
+    is the only liminal field a prompt renders, so this is the surface that
+    was reachable.
+
+    Args:
+        liminal_vault: Vault holding one liminal note per tier.
+        ceiling: A ceiling below ``intimate``.
+    """
+    assert _NO_KEY_STEM not in _mining_reader(liminal_vault, ceiling)
+    assert _NO_KEY_STEM not in _state_reader(liminal_vault, ceiling)
+
+
+def test_untiered_compost_note_stamps_the_state_report_intimate(
+    tmp_path: Path,
+) -> None:
+    """``10-Liminal/Compost`` is the axis the report cannot intersect (#1078).
+
+    ``_LIMINAL_SUBDIRS`` covers only ``Unnamed`` and ``Paradoxes``, so a
+    ``Compost`` note reaches ``## Suggested questions`` with no admitted list
+    to narrow it against; ``_content_tier`` accounts for it on the artifact
+    stamp instead. Reading that tier off the validated model stamped an
+    untiered Compost note ``unclassified`` — one rank below the ``intimate``
+    the raw frontmatter says — which under-reports the stamp the read gate
+    trusts.
+
+    The stamp is read back off the written artifact rather than from
+    ``_content_tier``, so the assertion describes the file the read gate
+    actually opens. The vault holds nothing but the one Compost note, so the
+    only other contributor that could reach ``intimate`` — the lint summary's
+    unconditional escalation — has no Processing-Log artifact to render and
+    is asserted absent below.
+
+    Args:
+        tmp_path: pytest's per-test temporary directory.
+    """
+    assert "Compost" not in _LIMINAL_SUBDIRS
+    _write_liminal_note(tmp_path / _LIMINAL_ROOT / "Compost", "CompostNoKey", None)
+    written = StateReportGenerator(
+        vault_path=tmp_path,
+        override=PrivacyTierOverride.INTIMATE,
+    ).write()
+    stamp = frontmatter.load(str(written)).metadata
+    assert (
+        EMPTY_PLACEHOLDER
+        in written.read_text(encoding="utf-8").split(
+            "## Lint summary",
+        )[1]
+    ), "the lint summary rendered content, so the stamp is not the note's"
+    assert stamp[TIER_STAMP_KEY] == PrivacyTier.INTIMATE.value


### PR DESCRIPTION
Closes #1079.

Two readers disagreed about the same note:

| Side | Reader | Missing key resolves to |
|---|---|---|
| State report (`state.py:526`) | `raw_privacy_tier` + `within_ceiling` | **INTIMATE** |
| Mining corpus (`mining.py:402`) | `tier_of(fragment)` — the model | UNCLASSIFIED |

The raw reader is correct, and `raw_privacy_tier`'s own docstring says why: a missing key must resolve to INTIMATE, and *"reading a missing key through the model would therefore fail open relative to what the file actually says."*

The fix is entirely on the mining side, calling the definition the state side already used. **No third reader, nothing averaged.**

## Correction 1 — the issue understates the exposure by one ceiling

It says the miner admitted the untiered note *"at ceiling=personal"*. It admitted it at **ceiling=open**. `filter_fragments_by_tier` is a **body** filter, not a rank cutoff — it excludes only INTIMATE and *summarises* PERSONAL. Measured at HEAD: at `ceiling=open` the miner returned NoKey, Open, Personal and Unclassified notes while the report returned only the Open one — and the untiered note's body carried its literal **title**, not just a 12-hex id.

## Correction 2 — the issue's central claim is wrong for one path

It asserts *"the stamp does not under-report. Verified end to end in the #1078 re-review."* **It does under-report for `10-Liminal/Compost`.** `StateReportGenerator._content_tier` folded the miner's liminal tiers in via `tier_of`, so an untiered Compost note stamped the artifact `unclassified` (rank 1) though the raw frontmatter says `intimate` (rank 2) — and `creek.state.read` at `ceiling=personal` **accepts an `unclassified` stamp**.

Proven RED: `assert 'unclassified' == 'intimate'`.

The HEAD docstring on `_content_tier` makes the same error — it reasons only about `ceiling=open` ("the only ceiling at which the section did not render") and never checks that the **note** required intimate. Both the docstring and the issue text are corrected in place.

## Correction 3 — a suggested adjacency is unnecessary

The issue says narrowing the mining side means state needs an admitted list for Compost too: *"a second 10-Liminal walk and a new `_TierIndex` field."* Not required. Materialising `raw_privacy_tier` onto the fragment at load makes the miner's entry self-describing, so `_content_tier` reads the correct tier with no second walk and no new field.

## Ratchet check — explicitly required, and it passes

The unification is a **strict narrowing at every ceiling**. Nothing became less restrictive for any note, so no operator decision is needed:

| Frontmatter | Was admitted from | Now needs |
|---|---|---|
| missing key | `open` | **`intimate`** |
| `unclassified` | `open` (summarised) | **`personal`** |
| `personal` | `open` (summarised) | **`personal`** |
| `intimate` / `open` | unchanged | unchanged |

And the stamp can only **rise**, since a raw read never answers below the model's.

## Also verified

`tests/test_mcp_report_tier_ceiling.py::test_raw_and_model_tier_readers_agree_on_every_fragment` exists at line 1270 and does exactly what the issue claims — the new module is its `10-Liminal` counterpart. The two readers already agree on every explicit value including the legacy `public` alias (both funnel through `PrivacyTier(...)`), so **the missing key was the only disagreement**.

## Refactor, not suppression

Adding the ceiling gate pushed `_load_liminal_fragments` to cyclomatic complexity 11, over the ≤10 gate. The per-file half was extracted to `_admitted_liminal_entry` rather than suppressed. Zero suppressions anywhere in the change.

## Deliberately not done

Persisting a derived `privacy_tier` on Eddy/Thread/Praxis with a vault migration — the issue marks it explicitly splittable, and #1078's render-time derivation is correct on day one with no migration. Belongs to the #969 follow-on.

Gate: **12/12**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EaHDtyDuNrpGtzUGMJT7Fw