### PR TITLE
feat(api): serve journal upsert, wheel and reflections over /v1

### DIFF
--- a/creek-tools/creek_mcp/api/models.py
+++ b/creek-tools/creek_mcp/api/models.py
@@ -88,12 +88,18 @@ narrows, and the client needs to see the whole window without a second round
 trip. Drop an entry only when a ``/v1`` shape actually stops being served.
 """
 
-OK_STATUS: Final[str] = "ok"
+OK_STATUS: Final[Literal["ok"]] = "ok"
 """The sole success status on the journal-upsert and wheel envelopes.
 
 Both carry ``status: "ok"`` and nothing else, because every non-success outcome
 is an :class:`ErrorEnvelope` with its own HTTP status. A second success-ish
 status value would give a consumer two places to look for failure.
+
+Typed ``Literal["ok"]`` rather than ``str`` so a handler can *build* a response
+from it: :attr:`JournalUpsertResponse.status` and :attr:`WheelResponse.status`
+are themselves ``Literal["ok"]``, and a plain ``str`` constant would not satisfy
+them under strict typing — leaving a handler to spell the literal a second time,
+which is the drift this constant exists to prevent.
 """
 
 

--- a/creek-tools/creek_mcp/api/routes.py
+++ b/creek-tools/creek_mcp/api/routes.py
@@ -14,11 +14,13 @@ the framework-free half of the surface beside :mod:`creek_mcp.api.models`, is
 what lets the published OpenAPI document outlive whatever serves it.
 
 **Exposed versus implemented.** :data:`ROUTES` says which endpoints exist;
-:data:`IMPLEMENTED_CAPABILITIES` says which of them actually answer. At #1074
-that is the handshake alone — the other three are wired to an honest ``501``
-rather than to a fabricated ``200``, because a stub that looks like success is
-one a consumer integrates against and only discovers in production. #1075—#1077
-each move one capability from the first set into the second.
+:data:`IMPLEMENTED_CAPABILITIES` says which of them actually answer. #1075—#1077
+moved the last three capabilities from the first set into the second, so the two
+now coincide. The distinction is not obsolete: while a capability was unbuilt it
+was wired to an honest ``501`` rather than to a fabricated ``200``, because a
+stub that looks like success is one a consumer integrates against and only
+discovers in production. A fifth capability published before its handler exists
+gets exactly that treatment, from the same constant, with no code change.
 """
 
 from __future__ import annotations
@@ -180,14 +182,16 @@ gate for the same reason — an operator debugging a version mismatch must not
 also lose their monitoring probe.
 """
 
-IMPLEMENTED_CAPABILITIES: Final[frozenset[Capability]] = frozenset(
-    {Capability.CAPABILITIES}
-)
+IMPLEMENTED_CAPABILITIES: Final[frozenset[Capability]] = frozenset(Capability)
 """The capabilities this server actually answers for, as opposed to publishes.
 
-A *strict* subset of ``set(Capability)`` at #1074: the handshake is built, and
-``journal-upsert`` / ``reflections`` / ``wheel`` are mounted to an honest
-``501``. One constant drives both the advertised list in ``GET
+Equal to ``set(Capability)`` since #1077 — spelled ``frozenset(Capability)``
+rather than as four names, so a capability added to the enum is advertised only
+once a handler exists for it: :func:`creek_mcp.httpapi.handlers._handler_for`
+raises at import if it does not, which is the failure mode worth having.
+
+It was a *strict* subset for the whole of #1074—#1076, and the machinery that
+made that safe is unchanged. One constant drives both the advertised list in ``GET
 /v1/capabilities`` and which routes get the stub, so the two cannot disagree —
 adding a capability here without wiring a handler, or wiring a handler without
 adding it here, turns ``tests/test_v1_api_capabilities.py`` red.

--- a/creek-tools/creek_mcp/httpapi/app.py
+++ b/creek-tools/creek_mcp/httpapi/app.py
@@ -63,6 +63,7 @@ from creek_mcp.httpapi.middleware.limits import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
     from starlette.requests import Request
@@ -71,6 +72,7 @@ if TYPE_CHECKING:
     from creek_mcp.api.routes import RouteSpec
     from creek_mcp.httpapi.handlers import Handler
     from creek_mcp.remote_auth import ConsumerTokenVerifier
+    from creek_mcp.tools.reflect import _LLMFactory
 
 
 def _speaks_a_served_minor(request: Request) -> bool:
@@ -198,6 +200,7 @@ def create_app(
     max_body_bytes: int = DEFAULT_MAX_BODY_BYTES,
     timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
     max_concurrency: int = DEFAULT_MAX_CONCURRENCY,
+    reflect_llm_factory: Callable[[], _LLMFactory] | None = None,
 ) -> Starlette:
     """Build the ``/v1`` application.
 
@@ -212,6 +215,14 @@ def create_app(
         max_body_bytes: Inclusive request-body cap.
         timeout_seconds: Per-request deadline.
         max_concurrency: In-flight request limit, process-wide.
+        reflect_llm_factory: Thunk returning the tier-keyed LLM factory
+            ``POST /v1/reflections`` calls, or ``None`` to build the production
+            one lazily on first use. A thunk rather than a factory so a server
+            with no provider configured still boots — only a reflection call
+            then fails, and it fails as a structured refusal. Injectable so the
+            suite can run the whole vertical offline against a stub, which is
+            what keeps the care and ceiling gates testable by *observing that
+            the model was never reached*.
 
     Returns:
         The configured application.
@@ -234,4 +245,5 @@ def create_app(
         exception_handlers={HTTPException: _routing_miss},
     )
     app.state.vault_path = vault_path
+    app.state.reflect_llm_factory = reflect_llm_factory
     return app

--- a/creek-tools/creek_mcp/httpapi/capabilities.py
+++ b/creek-tools/creek_mcp/httpapi/capabilities.py
@@ -36,12 +36,10 @@ until it has already written the integration.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING
 
 from starlette.concurrency import run_in_threadpool
-from yaml import YAMLError
 
-from creek.config import load_config
 from creek_mcp.api.models import (
     CONTRACT_MINOR,
     SUPPORTED_CONTRACT_MINORS,
@@ -60,6 +58,7 @@ from creek_mcp.contract import CONTRACT_VERSION, ONTOLOGY_VERSION
 from creek_mcp.httpapi import SERVER_NAME
 from creek_mcp.httpapi.context import context_of
 from creek_mcp.httpapi.errors import HTTP_OK, json_response
+from creek_mcp.httpapi.vault import UNREADABLE_CONFIG, configured_vault
 from creek_mcp.tools.handshake import handshake_tool, vault_available
 
 if TYPE_CHECKING:
@@ -69,16 +68,6 @@ if TYPE_CHECKING:
     from starlette.responses import Response
 
     from creek_mcp.httpapi.context import RequestContext
-
-_UNREADABLE_CONFIG: Final = (OSError, ValueError, YAMLError)
-"""What "the vault is not usable" looks like when it is raised rather than returned.
-
-:class:`FileNotFoundError` and a permission error are :class:`OSError`; a
-malformed ``vault_path`` and every :class:`pydantic.ValidationError` are
-:class:`ValueError`; an unparseable document is a :class:`yaml.YAMLError`.
-Deliberately not ``Exception``: a bug in this module must surface as a ``500``
-from the error boundary, not as a vault that quietly reports itself missing.
-"""
 
 
 def _implemented_capabilities() -> list[Capability]:
@@ -96,30 +85,6 @@ def _implemented_capabilities() -> list[Capability]:
         for capability in Capability
         if capability in IMPLEMENTED_CAPABILITIES
     ]
-
-
-def _configured_vault(request: Request) -> Path | None:
-    """Return the vault this request should read, resolving config if need be.
-
-    Resolved per request rather than once at construction: an operator who
-    fixes a broken ``creek_config.yaml`` gets a working handshake on the next
-    call rather than after a restart.
-
-    Args:
-        request: The request in flight.
-
-    Returns:
-        The explicitly configured vault path, the one the config names, or
-        ``None`` when the configuration cannot be read at all.
-    """
-    configured: Path | None = request.app.state.vault_path
-    if configured is not None:
-        return configured
-    try:
-        resolved = load_config().vault_path
-    except _UNREADABLE_CONFIG:
-        return None
-    return resolved
 
 
 def _negotiate(vault: Path, context: RequestContext) -> bool:
@@ -150,7 +115,7 @@ def _negotiate(vault: Path, context: RequestContext) -> bool:
             privacy_tier_ceiling=context.ceiling,
             consumer=context.consumer,
         )
-    except _UNREADABLE_CONFIG:
+    except UNREADABLE_CONFIG:
         return False
     return bool(negotiated["available"])
 
@@ -162,7 +127,8 @@ def _vault_is_usable(request: Request, context: RequestContext) -> bool:
     syscall the handshake makes is reachable from here and nowhere else, so
     :func:`handle_capabilities` can hoist the lot off the event loop with a
     single :func:`~starlette.concurrency.run_in_threadpool` call. The three
-    seams underneath are all filesystem I/O — :func:`_configured_vault` reads
+    seams underneath are all filesystem I/O —
+    :func:`~creek_mcp.httpapi.vault.configured_vault` reads
     and parses ``creek_config.yaml``, ``vault_available`` stats the marker, and
     :func:`_negotiate` reaches :meth:`creek_mcp.audit.MCPAuditLog.append`,
     which takes a thread lock and an ``fcntl`` exclusive lock across a full
@@ -178,7 +144,7 @@ def _vault_is_usable(request: Request, context: RequestContext) -> bool:
         ``True`` only when the marker directory exists *and* the handshake tool
         confirms it.
     """
-    vault = _configured_vault(request)
+    vault = configured_vault(request)
     if vault is None or not vault_available(vault):
         return False
     return _negotiate(vault, context)
@@ -294,7 +260,7 @@ async def handle_capabilities(request: Request) -> Response:
     across an ``fsync``. Called inline it would stop the event loop, so one
     consumer's slow audit log would stall every other connection this process is
     serving, on the endpoint every client calls *first*. Exception behaviour is
-    unchanged: the ``_UNREADABLE_CONFIG`` catches sit inside that function and
+    unchanged: the ``UNREADABLE_CONFIG`` catches sit inside that function and
     anything they do not catch propagates back out through the ``await``.
 
     It is also what lets

--- a/creek-tools/creek_mcp/httpapi/handlers.py
+++ b/creek-tools/creek_mcp/httpapi/handlers.py
@@ -1,21 +1,34 @@
 """What each ``/v1`` operation actually does, keyed by ``operation_id`` (#1074).
 
-Three of the five published routes are not built yet, and the dangerous shape
-for that is a route that returns a *plausible* success — an empty wheel, a
-fabricated ``fragment_id``, a ``{"status": "ok"}`` with nothing behind it —
-because a consumer integrating against it writes code that passes CI and
-silently does nothing in production. ``501 unsupported_capability`` is the
-honest answer, and the ADR puts it in the "safe to expose" column precisely
-because it is derived from the server's *static route table* and discloses
-nothing about the vault.
+Every published route is built as of #1077: the handshake and health from
+#1074, the journal upsert from #1075, the wheel from #1076 and the reflection
+from #1077. :data:`HANDLERS` is derived from the route table rather than listed,
+so a route added to :data:`~creek_mcp.api.routes.ROUTES` without a handler fails
+at *import* instead of being mounted to nothing.
 
-**One stub, three mountings.** :func:`unimplemented` is a factory, not three
-hand-written handlers, so the three unbuilt routes cannot drift into three
-different degrees of half-built. It stamps its product with
-``unimplemented_capability``, which makes "is this endpoint the stub?" a fact
-about the mounted route rather than a guess from its behaviour — and that is
-what lets ``tests/test_v1_api_capabilities.py`` hold advertised and implemented
-together in both directions.
+**The honesty stub stays, and stays exercised.** While a route was unbuilt it
+answered ``501 unsupported_capability`` rather than a *plausible* success — an
+empty wheel, a fabricated ``fragment_id``, a ``{"status": "ok"}`` with nothing
+behind it — because a consumer integrating against one of those writes code
+that passes CI and silently does nothing in production. The ADR puts ``501`` in
+the "safe to expose" column precisely because it is derived from the server's
+*static route table* and discloses nothing about the vault.
+
+Nothing in the table reaches :class:`UnimplementedHandler` today, and the
+temptation is to delete it. That would retire the guard along with the interim
+it covered: the *next* capability added to
+:class:`~creek_mcp.api.models.Capability` before its handler exists is the case
+the stub is for, and by then nobody would have run it in months. So it remains,
+and ``tests/test_v1_api_not_implemented.py`` drives it by substituting one entry
+of :data:`HANDLERS` — the same path a genuinely unbuilt capability takes.
+
+**One stub, however many mountings.** :func:`unimplemented` is a factory rather
+than hand-written handlers, so unbuilt routes cannot drift into different
+degrees of half-built. It stamps its product with ``unimplemented_capability``,
+which makes "is this endpoint the stub?" a fact about the mounted route rather
+than a guess from its behaviour — and that is what lets
+``tests/test_v1_api_capabilities.py`` hold advertised and implemented together
+in both directions.
 
 **The capability gate runs before body validation.** The stub reads nothing the
 caller sent. A stub that answered ``422`` for a malformed body and ``501`` for a
@@ -25,9 +38,7 @@ works too.
 
 :data:`HANDLERS` is read by :func:`creek_mcp.httpapi.app.create_app` at call
 time rather than captured at import, so a test can substitute one entry and
-build an app around it. #1075—#1077 each replace one factory product here with a
-real handler and add its capability to
-:data:`creek_mcp.api.routes.IMPLEMENTED_CAPABILITIES`.
+build an app around it.
 """
 
 from __future__ import annotations
@@ -43,11 +54,17 @@ from creek_mcp.api.routes import (
     IMPLEMENTED_CAPABILITIES,
     OP_CAPABILITIES,
     OP_HEALTH,
+    OP_JOURNAL_UPSERT,
+    OP_REFLECTIONS,
+    OP_WHEEL,
     ROUTES,
 )
 from creek_mcp.httpapi.capabilities import handle_capabilities
 from creek_mcp.httpapi.context import context_of
 from creek_mcp.httpapi.errors import HTTP_OK, error_response, json_response
+from creek_mcp.httpapi.journal import handle_journal_upsert
+from creek_mcp.httpapi.reflect import handle_reflection
+from creek_mcp.httpapi.wheel import handle_wheel
 
 if TYPE_CHECKING:
     from creek_mcp.api.models import Capability
@@ -149,6 +166,9 @@ async def handle_health(_request: Request) -> Response:
 _IMPLEMENTED_HANDLERS: Final[dict[str, Handler]] = {
     OP_CAPABILITIES: handle_capabilities,
     OP_HEALTH: handle_health,
+    OP_JOURNAL_UPSERT: handle_journal_upsert,
+    OP_REFLECTIONS: handle_reflection,
+    OP_WHEEL: handle_wheel,
 }
 """The operations that answer for real, keyed by ``operation_id``.
 

--- a/creek-tools/creek_mcp/httpapi/journal.py
+++ b/creek-tools/creek_mcp/httpapi/journal.py
@@ -1,0 +1,275 @@
+"""``PUT /v1/journal-entries/{external_id}`` — parse, delegate, project (#1075).
+
+The first tracer stub replaced by real behaviour, and the shape every later
+vertical copies: this module validates what arrived, hands it to the **existing**
+:func:`creek_mcp.tools.journal.journal_ingest_tool`, and projects that tool's
+return onto the published wire model. It contains no idempotency logic, no
+privacy logic and no audit call of its own.
+
+That is not a style preference. ``journal_ingest_tool`` refuses an entry whose
+tier exceeds the caller's ceiling *before* staging it, refuses an update that
+would destroy a fragment the caller could not have read (#970), and audits both
+the refusal and the success. A route that reached ``run_ingest`` directly, or
+that passed a ceiling the adapter policy had not admitted, would lose every one
+of those guarantees while still answering plausibly — which is exactly the
+divergence epic #1071 exists to prevent.
+
+**What this module *does* own is the path segment.** ``external_id`` arrives as
+URL text rather than as a validated field, and
+:func:`creek_mcp.staged_names.safe_stem` accepts literally any string: it would
+happily mint a stable staged name for a 20 KB id, or for one whose bytes did not
+survive URL decoding. Either mints a fragment under a key the client can never
+address again, so :func:`admissible_external_id` refuses them here, above the
+tool, before anything is written.
+
+**And the refusal projection.** The tool answers in its own structured
+vocabulary — ``{"status": "refused", ..., "reason": ...}`` — which #1072 does not
+publish. :func:`journal_refusal_code` is the single translation into the wire
+taxonomy, and it is deliberately total: an unrecognised reason becomes
+``internal_error`` rather than a plausible refusal, because a reason this adapter
+does not understand is a reason it must not narrate. ``ingest failed: …`` in
+particular can carry a staged file path, and :func:`error_response` renders a
+constant message per code, so nothing of it reaches the wire.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Final
+
+from pydantic import ValidationError
+from starlette.concurrency import run_in_threadpool
+
+from creek_mcp.api.models import (
+    OK_STATUS,
+    ErrorCode,
+    JournalAction,
+    JournalUpsertRequest,
+    JournalUpsertResponse,
+    WireTierCeiling,
+)
+from creek_mcp.httpapi.context import context_of
+from creek_mcp.httpapi.errors import HTTP_OK, error_response, json_response
+from creek_mcp.httpapi.vault import configured_vault
+from creek_mcp.read_gate import GENERIC_ABOVE_CEILING_REASON
+from creek_mcp.tools.journal import journal_ingest_tool
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from starlette.requests import Request
+    from starlette.responses import Response
+
+    from creek_mcp.httpapi.context import RequestContext
+
+MAX_EXTERNAL_ID_CHARS: Final[int] = 512
+"""Inclusive upper bound on an ``external_id`` path segment.
+
+Generous enough for any namespaced consumer id — the published example is 38
+characters — and small enough that the id cannot become a payload. There is no
+bound below this one: ``safe_stem`` truncates only the *readable slug* to 80
+characters and then appends a digest of the whole raw id, so an unbounded id
+would be accepted, stored and echoed at full length.
+"""
+
+REPLACEMENT_CHARACTER: Final[str] = "�"
+"""U+FFFD, the marker that a path segment did not survive URL decoding.
+
+Its presence means the client's bytes and the server's string already differ, so
+the id the client would address the entry by is not the id the entry was written
+under. That is an idempotency key that silently does not work, which is worse
+than a refusal.
+"""
+
+_BLANK_CALL_REASON: Final[str] = "content and external_id are required"
+"""``_validated_entry_tier``'s malformed-call refusal, verbatim."""
+
+_UNKNOWN_TIER_PREFIX: Final[str] = "unknown tier "
+"""``_validated_entry_tier``'s unparseable-tier refusal, by prefix."""
+
+_ABOVE_CEILING_SUFFIX: Final[str] = " exceeds the ceiling"
+"""Gate 1's refusal (``entry tier <tier> exceeds the ceiling``), by suffix."""
+
+_VAULT_UNAVAILABLE_REASON: Final[str] = "vault unavailable"
+"""The refusal a missing vault earns from the ingest runner, verbatim.
+
+Transient rather than terminal: the vault directory reappearing is exactly the
+kind of thing that clears on its own, which is why it maps to
+``temporarily_unavailable`` and not to ``unavailable``.
+"""
+
+
+def journal_refusal_code(reason: str) -> ErrorCode:
+    """Return the wire code for one of the journal tool's refusal reasons.
+
+    Total by construction. Two reasons share the ``internal_error`` fallthrough
+    and neither gets a branch of its own, because a branch that returned what
+    the default already returns is a branch nothing can go wrong in:
+
+    * ``ingest failed: <message>`` — the entry was staged and tier-allowed and
+      the write failed anyway. The message can name a staged file path, which is
+      why this must not reach a body that echoes anything; it does not, because
+      :func:`~creek_mcp.httpapi.errors.error_response` renders one constant per
+      code.
+    * anything this adapter does not recognise. Failing closed to
+      ``internal_error`` rather than to ``privacy_refused`` matters: a refusal
+      this adapter cannot classify is not a privacy decision it may claim to
+      have made on the caller's behalf, and ``internal_error`` is the one code
+      that asserts nothing about the vault.
+
+    The four matched reasons are spelled as constants above rather than imported
+    because :func:`creek_mcp.tools.journal.journal_ingest_tool` composes three of
+    them inline as f-strings, so there is nothing to import. Each live branch is
+    pinned by a behavioural test that drives the real tool through the route, so
+    a reworded reason surfaces as a wrong status code rather than as silence.
+
+    Args:
+        reason: The ``reason`` field of a structured tool refusal.
+
+    Returns:
+        The published :class:`~creek_mcp.api.models.ErrorCode`.
+    """
+    if reason == _BLANK_CALL_REASON or reason.startswith(_UNKNOWN_TIER_PREFIX):
+        return ErrorCode.INVALID_REQUEST
+    if reason == GENERIC_ABOVE_CEILING_REASON or reason.endswith(_ABOVE_CEILING_SUFFIX):
+        return ErrorCode.PRIVACY_REFUSED
+    if reason == _VAULT_UNAVAILABLE_REASON:
+        return ErrorCode.TEMPORARILY_UNAVAILABLE
+    return ErrorCode.INTERNAL_ERROR
+
+
+def admissible_external_id(raw: str) -> bool:
+    """Return whether *raw* can serve as an idempotency key.
+
+    Args:
+        raw: The decoded ``{external_id}`` path segment.
+
+    Returns:
+        ``True`` when the id is non-blank, within
+        :data:`MAX_EXTERNAL_ID_CHARS`, free of the replacement character, and
+        made entirely of printable characters — a control byte would reach both
+        the staged frontmatter and the audit trail.
+    """
+    if not raw.strip() or len(raw) > MAX_EXTERNAL_ID_CHARS:
+        return False
+    if REPLACEMENT_CHARACTER in raw:
+        return False
+    return raw.isprintable()
+
+
+async def _parsed_body(request: Request) -> JournalUpsertRequest | None:
+    """Return the validated request body, or ``None`` when it does not validate.
+
+    Args:
+        request: The request in flight.
+
+    Returns:
+        The parsed model, or ``None``. The caller renders one
+        ``invalid_request`` for both an undecodable body and a schema failure:
+        a caller able to tell those apart learns which half of its request the
+        server got far enough to look at.
+    """
+    try:
+        raw = await request.json()
+        return JournalUpsertRequest.model_validate(raw)
+    except (ValidationError, ValueError, UnicodeDecodeError):
+        return None
+
+
+def _upsert(
+    vault: Path,
+    external_id: str,
+    parsed: JournalUpsertRequest,
+    context: RequestContext,
+) -> dict[str, Any]:
+    """Run the journal tool for this request, off the event loop.
+
+    Every blocking call the route makes is reachable from here and nowhere
+    else — the staging write, the ledger read, the whole ingest run and an audit
+    append that holds an ``fcntl`` lock across an ``fsync`` — so one caller's
+    slow write cannot stall every other connection this process is serving.
+
+    Args:
+        vault: The resolved vault root.
+        external_id: The already-validated path segment.
+        parsed: The validated request body.
+        context: The request's context, supplying the *admitted* ceiling and the
+            authenticated consumer. Both come from the context rather than from
+            anything the handler re-derives: the ceiling was decided once, at
+            the adapter edge, and a second derivation here would be a second
+            gate.
+
+    Returns:
+        The tool's return dict, success or refusal.
+    """
+    return journal_ingest_tool(
+        vault_path=vault,
+        content=parsed.content,
+        external_id=external_id,
+        timestamp=parsed.timestamp,
+        tier=parsed.tier.value,
+        privacy_tier_ceiling=context.ceiling,
+        consumer=context.consumer,
+    )
+
+
+def _render(result: dict[str, Any], context: RequestContext) -> Response:
+    """Project the tool's return onto the published response, or a refusal.
+
+    Args:
+        result: The tool's return dict.
+        context: The request's context.
+
+    Returns:
+        The ``200`` carrying :class:`~creek_mcp.api.models.JournalUpsertResponse`,
+        or the published refusal for the tool's reason.
+    """
+    if result.get("status") != OK_STATUS:
+        reason = str(result.get("reason", ""))
+        return error_response(journal_refusal_code(reason), context)
+    fragment_id = result.get("fragment_id")
+    try:
+        payload = JournalUpsertResponse(
+            status=OK_STATUS,
+            tier_ceiling=WireTierCeiling(result["tier_ceiling"]),
+            external_id=str(result["external_id"]),
+            fragment_id=str(fragment_id),
+            action=JournalAction(result["action"]),
+            tier=WireTierCeiling(result["tier"]),
+        )
+    except (ValidationError, ValueError, KeyError):
+        # The tool reported success in a shape this contract cannot express —
+        # most plausibly an unresolved ``fragment_id``, which means the ledger
+        # and the writer disagree about what was just written. Not something to
+        # paper over with a fabricated id, and not something the caller can act
+        # on, so it is a server fault by the taxonomy's own definition.
+        return error_response(ErrorCode.INTERNAL_ERROR, context)
+    return json_response(payload.model_dump(mode="json"), HTTP_OK)
+
+
+async def handle_journal_upsert(request: Request) -> Response:
+    """Create or update one journal entry, idempotently.
+
+    Four steps, in this order and for this reason: the path segment is checked
+    before the body, because an id that cannot be a key makes the body moot; the
+    body is validated before the vault is resolved, because a malformed request
+    should not depend on the server's configuration to be refused; and the tool
+    is entered last, once there is a vault to enter it against.
+
+    Args:
+        request: The request in flight.
+
+    Returns:
+        The published response or refusal.
+    """
+    context = context_of(request.scope)
+    external_id = str(request.path_params["external_id"])
+    if not admissible_external_id(external_id):
+        return error_response(ErrorCode.INVALID_REQUEST, context)
+    parsed = await _parsed_body(request)
+    if parsed is None:
+        return error_response(ErrorCode.INVALID_REQUEST, context)
+    vault = configured_vault(request)
+    if vault is None:
+        return error_response(ErrorCode.UNAVAILABLE, context)
+    result = await run_in_threadpool(_upsert, vault, external_id, parsed, context)
+    return _render(result, context)

--- a/creek-tools/creek_mcp/httpapi/journal.py
+++ b/creek-tools/creek_mcp/httpapi/journal.py
@@ -54,8 +54,6 @@ from creek_mcp.read_gate import GENERIC_ABOVE_CEILING_REASON
 from creek_mcp.tools.journal import journal_ingest_tool
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from starlette.requests import Request
     from starlette.responses import Response
 
@@ -176,20 +174,29 @@ async def _parsed_body(request: Request) -> JournalUpsertRequest | None:
 
 
 def _upsert(
-    vault: Path,
+    request: Request,
     external_id: str,
     parsed: JournalUpsertRequest,
     context: RequestContext,
-) -> dict[str, Any]:
-    """Run the journal tool for this request, off the event loop.
+) -> dict[str, Any] | None:
+    """Resolve the vault and run the journal tool, both off the event loop.
 
     Every blocking call the route makes is reachable from here and nowhere
-    else — the staging write, the ledger read, the whole ingest run and an audit
-    append that holds an ``fcntl`` lock across an ``fsync`` — so one caller's
-    slow write cannot stall every other connection this process is serving.
+    else — the config read and YAML parse behind
+    :func:`~creek_mcp.httpapi.vault.configured_vault`, the staging write, the
+    ledger read, the whole ingest run and an audit append that holds an
+    ``fcntl`` lock across an ``fsync`` — so one caller's slow write cannot
+    stall every other connection this process is serving.
+
+    Resolution belongs *inside* this seam rather than at the call site because
+    the app is built without a ``vault_path`` in the production entry point, so
+    ``configured_vault`` reads and parses ``creek_config.yaml`` on every
+    request. Hoisting only the tool would leave that file read on the loop —
+    the same narrowed hoist :mod:`creek_mcp.httpapi.capabilities` documents and
+    avoids.
 
     Args:
-        vault: The resolved vault root.
+        request: The request in flight, which names the vault to resolve.
         external_id: The already-validated path segment.
         parsed: The validated request body.
         context: The request's context, supplying the *admitted* ceiling and the
@@ -199,8 +206,13 @@ def _upsert(
             gate.
 
     Returns:
-        The tool's return dict, success or refusal.
+        The tool's return dict, success or refusal — or ``None`` when there is
+        no readable vault to run against, which the caller renders as the
+        ``unavailable`` refusal.
     """
+    vault = configured_vault(request)
+    if vault is None:
+        return None
     return journal_ingest_tool(
         vault_path=vault,
         content=parsed.content,
@@ -221,27 +233,37 @@ def _render(result: dict[str, Any], context: RequestContext) -> Response:
 
     Returns:
         The ``200`` carrying :class:`~creek_mcp.api.models.JournalUpsertResponse`,
-        or the published refusal for the tool's reason.
+        or the published refusal for the tool's reason, or ``internal_error``
+        when the entry was written but cannot be honestly described.
     """
     if result.get("status") != OK_STATUS:
         reason = str(result.get("reason", ""))
         return error_response(journal_refusal_code(reason), context)
-    fragment_id = result.get("fragment_id")
+    if result.get("fragment_id") is None:
+        # `journal_ingest_tool` reports `ok` with a null `fragment_id` when
+        # `_resolve_fragment_id` comes back empty right after a successful
+        # write: the ledger and the writer disagree about what was just
+        # written. This must be checked *before* construction and cannot be
+        # left to the guard below, because `str(None)` raises nothing — it
+        # mints the literal id ``"None"``, which the caller can store, quote
+        # back and never resolve. Fabricating an id is precisely what this
+        # module's docstring forbids, and there is no honest success to render,
+        # so it is a server fault by the taxonomy's own definition.
+        return error_response(ErrorCode.INTERNAL_ERROR, context)
     try:
         payload = JournalUpsertResponse(
             status=OK_STATUS,
             tier_ceiling=WireTierCeiling(result["tier_ceiling"]),
             external_id=str(result["external_id"]),
-            fragment_id=str(fragment_id),
+            fragment_id=str(result["fragment_id"]),
             action=JournalAction(result["action"]),
             tier=WireTierCeiling(result["tier"]),
         )
     except (ValidationError, ValueError, KeyError):
-        # The tool reported success in a shape this contract cannot express —
-        # most plausibly an unresolved ``fragment_id``, which means the ledger
-        # and the writer disagree about what was just written. Not something to
-        # paper over with a fabricated id, and not something the caller can act
-        # on, so it is a server fault by the taxonomy's own definition.
+        # A success in some *other* shape this contract cannot express: a key
+        # the tool did not set, or a `tier_ceiling`/`action`/`tier` value the
+        # wire enums cannot name. Nothing the caller can act on, so it lands in
+        # the same server-fault bucket as the unresolved id above.
         return error_response(ErrorCode.INTERNAL_ERROR, context)
     return json_response(payload.model_dump(mode="json"), HTTP_OK)
 
@@ -249,11 +271,24 @@ def _render(result: dict[str, Any], context: RequestContext) -> Response:
 async def handle_journal_upsert(request: Request) -> Response:
     """Create or update one journal entry, idempotently.
 
-    Four steps, in this order and for this reason: the path segment is checked
+    Three steps, in this order and for this reason: the path segment is checked
     before the body, because an id that cannot be a key makes the body moot; the
-    body is validated before the vault is resolved, because a malformed request
-    should not depend on the server's configuration to be refused; and the tool
-    is entered last, once there is a vault to enter it against.
+    body is validated before anything touches the disk, because a malformed
+    request should not depend on the server's configuration to be refused; and
+    everything blocking — resolving the vault included — happens last, in one
+    worker thread.
+
+    **Nothing here reads the filesystem.** Both checks above are pure, and
+    resolving the vault is not: with no ``vault_path`` on the app — the
+    production default, since :func:`creek_mcp.httpapi.cli.main` never passes
+    one — it reads and parses ``creek_config.yaml`` per request. Done on the
+    loop it would stall every other connection this process is serving and
+    leave :class:`~creek_mcp.httpapi.middleware.limits.RequestTimeoutMiddleware`
+    unable to fire for that window, since its cancel scope is evaluated on the
+    loop. So it sits inside :func:`_upsert` with the rest of the blocking work,
+    matching :mod:`creek_mcp.httpapi.capabilities`. The refusal is unchanged —
+    an unreadable configuration is still ``unavailable``; only the thread that
+    decides it moved.
 
     Args:
         request: The request in flight.
@@ -268,8 +303,7 @@ async def handle_journal_upsert(request: Request) -> Response:
     parsed = await _parsed_body(request)
     if parsed is None:
         return error_response(ErrorCode.INVALID_REQUEST, context)
-    vault = configured_vault(request)
-    if vault is None:
+    result = await run_in_threadpool(_upsert, request, external_id, parsed, context)
+    if result is None:
         return error_response(ErrorCode.UNAVAILABLE, context)
-    result = await run_in_threadpool(_upsert, vault, external_id, parsed, context)
     return _render(result, context)

--- a/creek-tools/creek_mcp/httpapi/reflect.py
+++ b/creek-tools/creek_mcp/httpapi/reflect.py
@@ -1,0 +1,311 @@
+"""``POST /v1/reflections`` — parse, delegate, project, disclose nothing (#1077).
+
+The last vertical, and the one where a shortcut would cost the most.
+:func:`creek_mcp.tools.reflect.reflect_tool` already enforces four guarantees —
+the read-side ceiling gate above the care seam, INTIMATE routed local through
+the tier-keyed factory, verbatim-or-dropped quotes, and care escalation *before*
+any model call — and this module's whole job is to inherit them by delegating
+and to add none of its own. It never picks a provider, never re-derives a tier,
+never validates a quote and never decides whether an entry is in distress.
+
+**The structure is the safety.** Adepthood reads a scalar ``payload["reflection"]``
+today; collapsing the tool's result into a string would discard exactly the
+fields that make it safe — the verbatim-validated ``notes[].quote`` spans, the
+``escalate`` status, and ``essay_grounded: False``, the flag that tells a client
+the essay is free model prose and must not be cited as the writer's own words.
+So ``ok`` / ``empty`` / ``escalate`` / every refusal are distinguishable from a
+closed ``status`` or ``code`` enum, with no prose parsing anywhere.
+
+**An escalation is a ``200``.** There is no ``care_escalation`` member of
+:class:`~creek_mcp.api.models.ErrorCode`, on purpose: a person in acute distress
+must not have their response swallowed by a client's error path.
+
+**``entry_ref not found`` does *not* map to ``not_found``**, despite #1077
+asking for it. :attr:`~creek_mcp.api.models.ErrorCode.NOT_FOUND` is a *routing*
+code — "no such endpoint on this server" — and ``creek_mcp/api/models.py``
+forbids it for a vault object, because a caller who can distinguish "no such
+fragment" from "not for you" can enumerate the corpus one id at a time without
+reading a byte of it. That is the oracle #846 / #970 / #972 / #1090 spent five
+issues collapsing, and ``tests/test_v1_api_structure.py`` AST-pins ``NOT_FOUND``
+to the routing layer so a handler cannot emit it at all. Every vault-object
+non-answer therefore collapses to ``privacy_refused`` with the one generic
+reason — which makes this adapter *stricter* than the MCP tool, whose two
+distinct reasons are a documented accepted residual oracle.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Final, Literal
+
+from pydantic import ValidationError
+from starlette.concurrency import run_in_threadpool
+
+from creek.care.guardrail import acute_distress_guard
+from creek_mcp.api.models import (
+    CareEscalationResponse,
+    CareSignal,
+    ErrorCode,
+    ReflectionNote,
+    ReflectionRequest,
+    ReflectionResponse,
+    ReflectionStatus,
+    WireTierCeiling,
+)
+from creek_mcp.httpapi.context import context_of
+from creek_mcp.httpapi.errors import HTTP_OK, error_response, json_response
+from creek_mcp.httpapi.vault import configured_vault
+from creek_mcp.tools.reflect import reflect_tool
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from starlette.requests import Request
+    from starlette.responses import Response
+
+    from creek_mcp.httpapi.context import RequestContext
+    from creek_mcp.tools.reflect import _LLMFactory
+
+_NOT_FOUND_REASON: Final[str] = "entry_ref not found"
+"""The tool's unresolvable-``entry_ref`` refusal, verbatim."""
+
+_ABOVE_CEILING_REASON: Final[str] = "entry_ref tier exceeds ceiling"
+"""The tool's read-gate refusal, verbatim."""
+
+_NO_CONTENT_REASON: Final[str] = "no entry content supplied"
+"""The tool's empty-source refusal, verbatim.
+
+Unreachable from ``/v1``: :class:`~creek_mcp.api.models.ReflectionRequest`
+already refuses a blank source at the boundary. Mapped anyway, because a
+mapping that only covers what is currently reachable is one that silently stops
+being total when the model relaxes.
+"""
+
+_UNAVAILABLE_PREFIX: Final[str] = "reflection unavailable: "
+"""The tool's provider-failure refusal, by prefix.
+
+Its tail is an exception *type name* — the tool already refuses to carry the
+message, because a ``yaml.MarkedYAMLError`` stringifies with the offending
+source snippet. The wire carries neither: every refusal renders one constant
+per code.
+"""
+
+_NOTE_STATUSES: Final[
+    dict[str, Literal[ReflectionStatus.OK, ReflectionStatus.EMPTY]]
+] = {
+    ReflectionStatus.OK.value: ReflectionStatus.OK,
+    ReflectionStatus.EMPTY.value: ReflectionStatus.EMPTY,
+}
+"""The two note-bearing outcomes, keyed by their wire spelling.
+
+A table rather than ``ReflectionStatus(result["status"])`` because
+:attr:`~creek_mcp.api.models.ReflectionResponse.status` is typed
+``Literal[OK, EMPTY]``: the enum call would widen it to the whole enum and let
+``escalate`` be constructed into the wrong model. ``escalate`` is a success too
+— it is rendered by :func:`_render_escalation`, into a different model — and a
+lookup miss here is caught as an ``internal_error`` rather than coerced.
+"""
+
+
+def reflect_refusal_code(reason: str) -> ErrorCode:
+    """Return the wire code for one of the reflect tool's refusal reasons.
+
+    Total by construction. The two vault-object non-answers deliberately share
+    one code and one message: see the module docstring for why splitting them
+    would rebuild a corpus-enumeration oracle.
+
+    Args:
+        reason: The ``reason`` field of a structured tool refusal.
+
+    Returns:
+        The published :class:`~creek_mcp.api.models.ErrorCode`. An unrecognised
+        reason falls closed to ``internal_error``, which asserts nothing about
+        the vault — never to ``privacy_refused``, which would claim a privacy
+        decision this adapter never made.
+    """
+    if reason in {_NOT_FOUND_REASON, _ABOVE_CEILING_REASON}:
+        return ErrorCode.PRIVACY_REFUSED
+    if reason == _NO_CONTENT_REASON:
+        return ErrorCode.INVALID_REQUEST
+    if reason.startswith(_UNAVAILABLE_PREFIX):
+        return ErrorCode.TEMPORARILY_UNAVAILABLE
+    return ErrorCode.INTERNAL_ERROR
+
+
+async def _parsed_body(request: Request) -> ReflectionRequest | None:
+    """Return the validated request body, or ``None`` when it does not validate.
+
+    Args:
+        request: The request in flight.
+
+    Returns:
+        The parsed model, or ``None`` for an undecodable body, a body supplying
+        both sources or neither, a blank source, or an out-of-range
+        ``max_notes``.
+    """
+    try:
+        raw = await request.json()
+        return ReflectionRequest.model_validate(raw)
+    except (ValidationError, ValueError, UnicodeDecodeError):
+        return None
+
+
+def _default_llm_factory() -> _LLMFactory:
+    """Return the production tier-keyed LLM factory.
+
+    Imported inside the function rather than at module scope: the builder lives
+    beside the MCP server, which pulls in the MCP framework, and the HTTP
+    adapter must stay startable without it. It is nonetheless *that* builder and
+    not a second one — the ``INTIMATE``-never-cloud routing lives in the
+    :class:`~creek.classify.llm.router.ModelRouter` it resolves through, and a
+    parallel factory here would be a second routing policy.
+
+    Returns:
+        The tier-keyed factory.
+    """
+    from creek_mcp.server import _build_reflect_llm_factory
+
+    return _build_reflect_llm_factory()
+
+
+def _reflect(
+    vault: Path,
+    parsed: ReflectionRequest,
+    context: RequestContext,
+    build_factory: Callable[[], _LLMFactory],
+) -> dict[str, Any]:
+    """Run the reflect tool for this request, off the event loop.
+
+    Args:
+        vault: The resolved vault root.
+        parsed: The validated request body.
+        context: The request's context, supplying the *admitted* ceiling and
+            the authenticated consumer.
+        build_factory: A zero-argument thunk returning the tier-keyed LLM
+            factory. Invoked here rather than at request entry so a provider
+            that cannot be built costs nothing on the event loop, and so the
+            failure lands in the same structured vocabulary as every other
+            provider failure.
+
+    Returns:
+        The tool's return dict, or a synthetic refusal when the factory itself
+        could not be built.
+    """
+    try:
+        factory = build_factory()
+    except (RuntimeError, OSError, ValueError) as exc:
+        return {
+            "status": "refused",
+            "reason": f"{_UNAVAILABLE_PREFIX}{type(exc).__name__}",
+        }
+    return reflect_tool(
+        vault_path=vault,
+        llm_factory=factory,
+        content=parsed.content,
+        entry_ref=parsed.entry_ref,
+        # The production guard, named here and nowhere else on this surface.
+        # Care defense-in-depth lives in Creek and stays there even though
+        # Adepthood also gates pre-call: two independent gates is the design,
+        # not redundancy to trim.
+        care_guard=acute_distress_guard,
+        privacy_tier_ceiling=context.ceiling,
+        consumer=context.consumer,
+        max_notes=parsed.max_notes,
+    )
+
+
+def _render_escalation(
+    result: dict[str, Any], context: RequestContext
+) -> Response | None:
+    """Return the escalation response, or ``None`` when this is not one.
+
+    Args:
+        result: The tool's return dict.
+        context: The request's context.
+
+    Returns:
+        A ``200`` carrying
+        :class:`~creek_mcp.api.models.CareEscalationResponse`, the refusal a
+        malformed signal earns, or ``None``.
+    """
+    if result.get("status") != ReflectionStatus.ESCALATE.value:
+        return None
+    try:
+        payload = CareEscalationResponse(
+            status=ReflectionStatus.ESCALATE,
+            tier_ceiling=WireTierCeiling(result["tier_ceiling"]),
+            reason=str(result["reason"]),
+            care_signal=CareSignal.model_validate(result["care_signal"]),
+        )
+    except (ValidationError, ValueError, KeyError):
+        return error_response(ErrorCode.INTERNAL_ERROR, context)
+    return json_response(payload.model_dump(mode="json"), HTTP_OK)
+
+
+def _render_notes(result: dict[str, Any], context: RequestContext) -> Response:
+    """Return the note-bearing response for an ``ok`` or ``empty`` result.
+
+    Args:
+        result: The tool's return dict.
+        context: The request's context.
+
+    Returns:
+        A ``200`` carrying :class:`~creek_mcp.api.models.ReflectionResponse`, or
+        ``internal_error`` when the tool answered in a shape this contract
+        cannot express — most plausibly a ``routed_tier`` of ``intimate``, which
+        :class:`~creek_mcp.api.models.WireTierCeiling` cannot name. Refusing is
+        the whole point: ``intimate`` must not reach the wire even as a label.
+    """
+    try:
+        payload = ReflectionResponse(
+            status=_NOTE_STATUSES[str(result["status"])],
+            tier_ceiling=WireTierCeiling(result["tier_ceiling"]),
+            routed_tier=WireTierCeiling(result["routed_tier"]),
+            notes=[
+                ReflectionNote.model_validate(note) for note in result.get("notes", [])
+            ],
+            essay=result.get("essay"),
+            essay_grounded=False,
+        )
+    except (ValidationError, ValueError, KeyError, TypeError):
+        return error_response(ErrorCode.INTERNAL_ERROR, context)
+    return json_response(payload.model_dump(mode="json"), HTTP_OK)
+
+
+def _render(result: dict[str, Any], context: RequestContext) -> Response:
+    """Project the tool's result onto the published response, or a refusal.
+
+    Args:
+        result: The tool's return dict.
+        context: The request's context.
+
+    Returns:
+        The published response.
+    """
+    escalation = _render_escalation(result, context)
+    if escalation is not None:
+        return escalation
+    if result.get("status") in _NOTE_STATUSES:
+        return _render_notes(result, context)
+    return error_response(reflect_refusal_code(str(result.get("reason", ""))), context)
+
+
+async def handle_reflection(request: Request) -> Response:
+    """Return anchored margin notes for one entry, or the escalation it earns.
+
+    Args:
+        request: The request in flight.
+
+    Returns:
+        The published response or refusal.
+    """
+    context = context_of(request.scope)
+    parsed = await _parsed_body(request)
+    if parsed is None:
+        return error_response(ErrorCode.INVALID_REQUEST, context)
+    vault = configured_vault(request)
+    if vault is None:
+        return error_response(ErrorCode.UNAVAILABLE, context)
+    build_factory = request.app.state.reflect_llm_factory or _default_llm_factory
+    result = await run_in_threadpool(_reflect, vault, parsed, context, build_factory)
+    return _render(result, context)

--- a/creek-tools/creek_mcp/httpapi/reflect.py
+++ b/creek-tools/creek_mcp/httpapi/reflect.py
@@ -58,7 +58,6 @@ from creek_mcp.tools.reflect import reflect_tool
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-    from pathlib import Path
 
     from starlette.requests import Request
     from starlette.responses import Response
@@ -169,15 +168,22 @@ def _default_llm_factory() -> _LLMFactory:
 
 
 def _reflect(
-    vault: Path,
+    request: Request,
     parsed: ReflectionRequest,
     context: RequestContext,
     build_factory: Callable[[], _LLMFactory],
-) -> dict[str, Any]:
-    """Run the reflect tool for this request, off the event loop.
+) -> dict[str, Any] | None:
+    """Resolve the vault and run the reflect tool, both off the event loop.
+
+    Resolution belongs *inside* this seam rather than at the call site: the app
+    is built without a ``vault_path`` in the production entry point, so
+    :func:`~creek_mcp.httpapi.vault.configured_vault` reads and parses
+    ``creek_config.yaml`` on every request. Hoisting only the tool would leave
+    that file read on the loop, which is the narrowed hoist
+    :mod:`creek_mcp.httpapi.capabilities` documents and avoids.
 
     Args:
-        vault: The resolved vault root.
+        request: The request in flight, which names the vault to resolve.
         parsed: The validated request body.
         context: The request's context, supplying the *admitted* ceiling and
             the authenticated consumer.
@@ -188,9 +194,14 @@ def _reflect(
             provider failure.
 
     Returns:
-        The tool's return dict, or a synthetic refusal when the factory itself
-        could not be built.
+        The tool's return dict, a synthetic refusal when the factory itself
+        could not be built, or ``None`` when there is no readable vault to
+        reflect against, which the caller renders as the ``unavailable``
+        refusal.
     """
+    vault = configured_vault(request)
+    if vault is None:
+        return None
     try:
         factory = build_factory()
     except (RuntimeError, OSError, ValueError) as exc:
@@ -293,6 +304,19 @@ def _render(result: dict[str, Any], context: RequestContext) -> Response:
 async def handle_reflection(request: Request) -> Response:
     """Return anchored margin notes for one entry, or the escalation it earns.
 
+    **Only body validation happens on the loop**, because only it is pure.
+    Resolving the vault is not: with no ``vault_path`` on the app — the
+    production default, since :func:`creek_mcp.httpapi.cli.main` never passes
+    one — :func:`~creek_mcp.httpapi.vault.configured_vault` reads and parses
+    ``creek_config.yaml`` per request. Done on the loop it would stall every
+    other connection this process is serving and leave
+    :class:`~creek_mcp.httpapi.middleware.limits.RequestTimeoutMiddleware`
+    unable to fire for that window, since its cancel scope is evaluated on the
+    loop. So it sits inside :func:`_reflect` with the model call and the audit
+    append, matching :mod:`creek_mcp.httpapi.capabilities`. The refusal is
+    unchanged — an unreadable configuration is still ``unavailable``; only the
+    thread that decides it moved.
+
     Args:
         request: The request in flight.
 
@@ -303,9 +327,8 @@ async def handle_reflection(request: Request) -> Response:
     parsed = await _parsed_body(request)
     if parsed is None:
         return error_response(ErrorCode.INVALID_REQUEST, context)
-    vault = configured_vault(request)
-    if vault is None:
-        return error_response(ErrorCode.UNAVAILABLE, context)
     build_factory = request.app.state.reflect_llm_factory or _default_llm_factory
-    result = await run_in_threadpool(_reflect, vault, parsed, context, build_factory)
+    result = await run_in_threadpool(_reflect, request, parsed, context, build_factory)
+    if result is None:
+        return error_response(ErrorCode.UNAVAILABLE, context)
     return _render(result, context)

--- a/creek-tools/creek_mcp/httpapi/vault.py
+++ b/creek-tools/creek_mcp/httpapi/vault.py
@@ -44,6 +44,19 @@ malformed ``vault_path`` and every :class:`pydantic.ValidationError` are
 def configured_vault(request: Request) -> Path | None:
     """Return the vault *request* should read, resolving config if need be.
 
+    **Blocking. Call it from a worker thread, never from a handler coroutine.**
+    The fallback is a file read and a YAML parse, and it is not the rare arm:
+    ``app.state.vault_path`` is ``None`` for the production entry point, since
+    :func:`creek_mcp.httpapi.cli.main` builds the app without one. A caller that
+    resolves the vault before entering
+    :func:`~starlette.concurrency.run_in_threadpool` therefore does file I/O on
+    the event loop for every request, stalling every other connection the
+    process is serving and leaving
+    :class:`~creek_mcp.httpapi.middleware.limits.RequestTimeoutMiddleware`
+    unable to fire for that window — its cancel scope is evaluated on the loop.
+    Every ``/v1`` route calls this from inside its own threadpool-wrapped
+    worker, and ``tests/test_v1_api_hardening.py`` pins each one.
+
     Args:
         request: The request in flight.
 

--- a/creek-tools/creek_mcp/httpapi/vault.py
+++ b/creek-tools/creek_mcp/httpapi/vault.py
@@ -1,0 +1,61 @@
+"""Which vault a ``/v1`` request reads, resolved in one place (#1075).
+
+Every content route needs the same answer to the same question, and the answer
+has two halves that must not be split: the vault the app was *built* with wins,
+and otherwise ``creek_config.yaml`` is read **per request** so an operator who
+repairs a broken config gets a working server on the next call rather than after
+a restart.
+
+Two routes resolving that separately is how one of them ends up caching the
+config while the other re-reads it, at which point "did my fix take effect?"
+depends on which endpoint you ask. It lived inside
+:mod:`creek_mcp.httpapi.capabilities` while the handshake was the only real
+endpoint; #1075 gave it a second caller, so it moved here rather than being
+copied.
+
+:data:`UNREADABLE_CONFIG` is deliberately three concrete exception groups rather
+than ``Exception``. A bug in the resolver must surface as a ``500`` from the
+error boundary; only a genuinely unreadable configuration may degrade to "no
+vault".
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final
+
+from yaml import YAMLError
+
+from creek.config import load_config
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from starlette.requests import Request
+
+UNREADABLE_CONFIG: Final = (OSError, ValueError, YAMLError)
+""""The vault is not usable" when it is raised rather than returned.
+
+:class:`FileNotFoundError` and a permission error are :class:`OSError`; a
+malformed ``vault_path`` and every :class:`pydantic.ValidationError` are
+:class:`ValueError`; an unparseable document is a :class:`yaml.YAMLError`.
+"""
+
+
+def configured_vault(request: Request) -> Path | None:
+    """Return the vault *request* should read, resolving config if need be.
+
+    Args:
+        request: The request in flight.
+
+    Returns:
+        The explicitly configured vault path, the one the config names, or
+        ``None`` when the configuration cannot be read at all.
+    """
+    configured: Path | None = request.app.state.vault_path
+    if configured is not None:
+        return configured
+    try:
+        resolved = load_config().vault_path
+    except UNREADABLE_CONFIG:
+        return None
+    return resolved

--- a/creek-tools/creek_mcp/httpapi/wheel.py
+++ b/creek-tools/creek_mcp/httpapi/wheel.py
@@ -1,0 +1,152 @@
+"""``GET /v1/wheel`` — the corpus fact Creek owns, and nothing else (#1076).
+
+The read vertical. Like :mod:`creek_mcp.httpapi.journal` it parses nothing of
+its own and counts nothing of its own: it resolves the vault, calls the existing
+:func:`creek_mcp.tools.wheel.wheel_tool` at the *admitted* ceiling, and projects
+the tally onto :class:`~creek_mcp.api.models.WheelResponse`.
+
+**The vocabulary boundary is the real content of this module.** Creek's wheel is
+a frequency distribution over the classified corpus — how many admitted
+fragments sit at each APTITUDE frequency, and each frequency's share of the
+classified total. Adepthood's Map validates ``{aspects: [{stage_number, aspect,
+fullness}]}``, per-stage aspect fullness from its own 36-week curriculum. Both
+have ten members. That is a coincidence of cardinality, not a shared meaning,
+and translating one into the other here would ship a Map that renders
+confidently wrong numbers under a name its readers trust. Creek publishes the
+fact it owns; the consumer owns the projection into its own domain
+(Geoffe-Ga/adepthood#1937). No stage or aspect vocabulary appears in this module
+or on this wire, and a test sweeps for each term.
+
+**Ceiling filtering is the tool's, not this module's.** ``wheel_tool`` excludes
+above-ceiling fragments through ``tier_within_override``; the only thing the
+route must not do is hand it a ceiling the adapter policy never admitted, which
+is why the ceiling comes off the request context rather than off a header this
+module re-reads.
+
+**An empty or missing corpus is a ``200``, all zeros.** A freshly initialised
+vault is a legitimate state, and the only error shape available would tell a
+client "broken" about a vault that is merely new — the collapse epic #1071
+exists to stop. That is ``wheel_tool``'s behaviour already
+(``iter_vault_fragments`` yields nothing for a missing directory), inherited here
+rather than re-decided.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from pydantic import ValidationError
+from starlette.concurrency import run_in_threadpool
+
+from creek_mcp.api.models import (
+    OK_STATUS,
+    ErrorCode,
+    WheelFrequencies,
+    WheelResponse,
+    WireTierCeiling,
+)
+from creek_mcp.httpapi.context import context_of
+from creek_mcp.httpapi.errors import HTTP_OK, error_response, json_response
+from creek_mcp.httpapi.vault import configured_vault
+from creek_mcp.tools.wheel import wheel_tool
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from starlette.requests import Request
+    from starlette.responses import Response
+
+    from creek_mcp.httpapi.context import RequestContext
+
+
+def wheel_refusal_code(reason: str) -> ErrorCode:
+    """Return the wire code for a wheel-tool refusal.
+
+    :func:`~creek_mcp.tools.wheel.wheel_tool` has no refusal branch today: it is
+    read-only, LLM-free, and answers an absent corpus with an all-zero tally
+    rather than an error. So this maps everything to ``internal_error`` — and
+    that is the point rather than a placeholder. If the tool ever grows a
+    refusal, an adapter that has never seen it must not narrate it: only
+    ``internal_error`` asserts nothing about the vault, and a wrong-looking
+    ``500`` is what sends someone to add the branch deliberately.
+
+    Args:
+        reason: The ``reason`` field of a structured tool refusal.
+
+    Returns:
+        :attr:`~creek_mcp.api.models.ErrorCode.INTERNAL_ERROR`, always.
+    """
+    del reason
+    return ErrorCode.INTERNAL_ERROR
+
+
+def _tally(vault: Path, context: RequestContext) -> dict[str, Any]:
+    """Run the wheel tool for this request, off the event loop.
+
+    The whole corpus walk and the audit append — which takes a thread lock and
+    an ``fcntl`` exclusive lock across an ``fsync`` — are blocking, and on a
+    large vault the walk dominates. Called inline they would stop the event
+    loop, so one caller's wheel would stall every other connection this process
+    is serving.
+
+    Args:
+        vault: The resolved vault root.
+        context: The request's context, supplying the *admitted* ceiling and the
+            authenticated consumer.
+
+    Returns:
+        The tool's return dict.
+    """
+    return wheel_tool(
+        vault_path=vault,
+        privacy_tier_ceiling=context.ceiling,
+        consumer=context.consumer,
+    )
+
+
+def _render(result: dict[str, Any], context: RequestContext) -> Response:
+    """Project the tool's tally onto the published response.
+
+    Args:
+        result: The tool's return dict.
+        context: The request's context.
+
+    Returns:
+        The ``200`` carrying :class:`~creek_mcp.api.models.WheelResponse`, or a
+        refusal.
+    """
+    if result.get("status") != OK_STATUS:
+        return error_response(
+            wheel_refusal_code(str(result.get("reason", ""))), context
+        )
+    try:
+        payload = WheelResponse(
+            status=OK_STATUS,
+            tier_ceiling=WireTierCeiling(result["tier_ceiling"]),
+            total_classified=int(result["total_classified"]),
+            unclassified=int(result["unclassified"]),
+            # Ten declared fields, so an eleventh frequency is refused here
+            # rather than passed through: an extra member is a change to the
+            # shared ontology vocabulary and therefore a contract change.
+            wheel=WheelFrequencies.model_validate(result["wheel"]),
+        )
+    except (ValidationError, ValueError, KeyError, TypeError):
+        return error_response(ErrorCode.INTERNAL_ERROR, context)
+    return json_response(payload.model_dump(mode="json"), HTTP_OK)
+
+
+async def handle_wheel(request: Request) -> Response:
+    """Return the aggregate APTITUDE frequency distribution of the admitted corpus.
+
+    Args:
+        request: The request in flight.
+
+    Returns:
+        The published wheel, or the refusal an unreadable configuration earns.
+    """
+    context = context_of(request.scope)
+    vault = configured_vault(request)
+    if vault is None:
+        return error_response(ErrorCode.UNAVAILABLE, context)
+    result = await run_in_threadpool(_tally, vault, context)
+    return _render(result, context)

--- a/creek-tools/creek_mcp/httpapi/wheel.py
+++ b/creek-tools/creek_mcp/httpapi/wheel.py
@@ -51,8 +51,6 @@ from creek_mcp.httpapi.vault import configured_vault
 from creek_mcp.tools.wheel import wheel_tool
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from starlette.requests import Request
     from starlette.responses import Response
 
@@ -80,23 +78,33 @@ def wheel_refusal_code(reason: str) -> ErrorCode:
     return ErrorCode.INTERNAL_ERROR
 
 
-def _tally(vault: Path, context: RequestContext) -> dict[str, Any]:
-    """Run the wheel tool for this request, off the event loop.
+def _tally(request: Request, context: RequestContext) -> dict[str, Any] | None:
+    """Resolve the vault and run the wheel tool, both off the event loop.
 
-    The whole corpus walk and the audit append — which takes a thread lock and
-    an ``fcntl`` exclusive lock across an ``fsync`` — are blocking, and on a
-    large vault the walk dominates. Called inline they would stop the event
-    loop, so one caller's wheel would stall every other connection this process
-    is serving.
+    The config read and YAML parse behind
+    :func:`~creek_mcp.httpapi.vault.configured_vault`, the whole corpus walk and
+    the audit append — which takes a thread lock and an ``fcntl`` exclusive lock
+    across an ``fsync`` — are all blocking, and on a large vault the walk
+    dominates. Called inline they would stop the event loop, so one caller's
+    wheel would stall every other connection this process is serving.
+
+    Resolution belongs *inside* this seam rather than at the call site: the app
+    is built without a ``vault_path`` in the production entry point, so
+    ``configured_vault`` reads and parses ``creek_config.yaml`` on every
+    request. Hoisting only the tool would leave that file read on the loop.
 
     Args:
-        vault: The resolved vault root.
+        request: The request in flight, which names the vault to resolve.
         context: The request's context, supplying the *admitted* ceiling and the
             authenticated consumer.
 
     Returns:
-        The tool's return dict.
+        The tool's return dict, or ``None`` when there is no readable vault to
+        tally, which the caller renders as the ``unavailable`` refusal.
     """
+    vault = configured_vault(request)
+    if vault is None:
+        return None
     return wheel_tool(
         vault_path=vault,
         privacy_tier_ceiling=context.ceiling,
@@ -138,6 +146,17 @@ def _render(result: dict[str, Any], context: RequestContext) -> Response:
 async def handle_wheel(request: Request) -> Response:
     """Return the aggregate APTITUDE frequency distribution of the admitted corpus.
 
+    **Every blocking step happens in the worker**, vault resolution included.
+    With no ``vault_path`` on the app — the production default, since
+    :func:`creek_mcp.httpapi.cli.main` never passes one —
+    :func:`~creek_mcp.httpapi.vault.configured_vault` reads and parses
+    ``creek_config.yaml`` per request; done on the loop it would stall every
+    other connection and leave
+    :class:`~creek_mcp.httpapi.middleware.limits.RequestTimeoutMiddleware`
+    unable to fire for that window, since its cancel scope is evaluated on the
+    loop. The refusal is unchanged — an unreadable configuration is still
+    ``unavailable``; only the thread that decides it moved.
+
     Args:
         request: The request in flight.
 
@@ -145,8 +164,7 @@ async def handle_wheel(request: Request) -> Response:
         The published wheel, or the refusal an unreadable configuration earns.
     """
     context = context_of(request.scope)
-    vault = configured_vault(request)
-    if vault is None:
+    result = await run_in_threadpool(_tally, request, context)
+    if result is None:
         return error_response(ErrorCode.UNAVAILABLE, context)
-    result = await run_in_threadpool(_tally, vault, context)
     return _render(result, context)

--- a/creek-tools/docs/api.md
+++ b/creek-tools/docs/api.md
@@ -12,7 +12,7 @@ Where this page and that document disagree, the ADR wins. The wire vocabulary is
 `creek_mcp/api/models.py`; the published fixture bundle Adepthood vendors and
 hash-pins is [`docs/contracts/adepthood-v1/`](../../docs/contracts/adepthood-v1/).
 
-## What is implemented today (#1074)
+## What is implemented today (#1077)
 
 This is a **tracer**: the thinnest end-to-end path that is honest about what it
 does and does not yet do.
@@ -21,20 +21,27 @@ does and does not yet do.
 |---|---|
 | `GET /v1/capabilities` | **Implemented.** Real handshake — versions, vault readiness, tier model, capability list. |
 | `GET /v1/health` | **Implemented.** Readiness only. Not part of the published contract. |
-| `PUT /v1/journal-entries/{external_id}` | `501 unsupported_capability` (#1075). |
-| `POST /v1/reflections` | `501 unsupported_capability` (#1076). |
-| `GET /v1/wheel` | `501 unsupported_capability` (#1077). |
+| `PUT /v1/journal-entries/{external_id}` | **Implemented.** Idempotent journal write over the shared `creek.journal` tool — same tier gates, same audit records, same fragment identity as MCP (#1075). |
+| `POST /v1/reflections` | **Implemented.** Anchored margin notes over the shared `creek.reflect` tool. `ok` / `empty` / `escalate` / every refusal are distinguishable from a closed `status` or `code` enum — **no client needs to parse prose to branch**. `notes[].quote` is the only verbatim-guaranteed field: each is validated as a whitespace-normalised span of the submitted or referenced entry, and a span that is not is dropped rather than returned. `essay` is free model prose and is **never** grounding-checked, which is what `essay_grounded: false` (always present, always `false`) tells you — a client must not present it as the writer's own words. A care-flagged entry returns `status: "escalate"` at HTTP **200** with the full `care_signal`, and the model is never called; an escalation is not an error, because a person in acute distress must not land in a client's error path. An `entry_ref` that is above your ceiling and one that does not resolve are **deliberately indistinguishable** — both are `403 privacy_refused` with the same message, because a caller who could tell them apart could enumerate the corpus (#1077). |
+| `GET /v1/wheel` | **Implemented.** The **frequency distribution over the classified corpus** — how many ceiling-admitted fragments sit at each APTITUDE frequency F1–F10, and each frequency's share of the classified total. **This is not a curriculum-progress or fullness measure.** Adepthood's Map validates a ten-member `{aspects: [{stage_number, aspect, fullness}]}` shape from its own 36-week curriculum; that projection is Adepthood's and is owned there (Geoffe-Ga/adepthood#1937). Ten members on both sides is a coincidence of cardinality, not a shared meaning — reading one as the other renders confidently wrong numbers. An empty or missing corpus is `200` with all ten entries at `count: 0`, never `404` and never an error (#1076). |
 
-**The three unbuilt routes return an error, never a plausible empty success.**
-No fabricated `fragment_id`, no `action: "unchanged"`, no zeroed wheel that
-could be misread as an empty corpus. A stub that looks like success is worse
-than one that admits it is unbuilt: the whole reason epic #1071 exists is that
-every failure used to collapse into "vault unavailable", indistinguishable from
-"no vault configured", and two repositories shipped a contract neither
-implemented.
+**Every published route is now built, and none of them was ever allowed to
+fake it on the way here.** While a route was unbuilt it answered `501
+unsupported_capability` rather than a plausible empty success — no fabricated
+`fragment_id`, no `action: "unchanged"`, no zeroed wheel that could be misread
+as an empty corpus. A stub that looks like success is worse than one that
+admits it is unbuilt: the whole reason epic #1071 exists is that every failure
+used to collapse into "vault unavailable", indistinguishable from "no vault
+configured", and two repositories shipped a contract neither implemented.
+
+The machinery that enforced it is still in place and still tested. A fifth
+capability added to `Capability` before its handler exists is mounted to the
+same honest `501` and is left out of the advertised list, because both are
+driven by the one `IMPLEMENTED_CAPABILITIES` constant.
 
 `GET /v1/capabilities` advertises only the capabilities actually implemented —
-today, `["capabilities"]`. #1075–#1077 each add one. The advertised list and the
+today, all four: `["capabilities", "journal-upsert", "reflections", "wheel"]`.
+The advertised list and the
 set of routes that answer `501` are driven by a single constant,
 `IMPLEMENTED_CAPABILITIES` in `creek_mcp/api/routes.py`, so they cannot
 disagree.
@@ -326,7 +333,7 @@ middleware.** `creek-tools-api` starts uvicorn with `access_log=False`,
 because uvicorn ships its own access logger — on by default — that runs
 *alongside* the middleware above, not instead of it, and writes the client
 address and the concrete path with its query string on every request:
-`INFO: 127.0.0.1:59272 - "PUT /v1/journal-entries/zz-sentinel-external-id-9x7q-zz HTTP/1.1" 501 Not Implemented`.
+`INFO: 127.0.0.1:59272 - "PUT /v1/journal-entries/zz-sentinel-external-id-9x7q-zz HTTP/1.1" 200 OK`.
 Left on, that second logger would republish the caller's IP and a
 consumer-chosen identifier on every sync — making the promise above false
 without a single line of Creek's own code being wrong.

--- a/creek-tools/tests/adapter_parity.py
+++ b/creek-tools/tests/adapter_parity.py
@@ -1,0 +1,268 @@
+"""HTTP<->MCP behavioural parity harness for the ``/v1`` verticals (#1075).
+
+Epic #1071 rests on one claim: ``/v1`` is an *adapter* over the same tools the
+MCP surface calls, not a second implementation. A behavioural suite per adapter
+cannot check that claim — two suites written from the same acceptance criteria
+pass on the day they are written and then drift, which is the whole failure the
+epic exists to stop.
+
+So this module compares the two adapters against each other. It does **not**
+compare envelopes: the wire response and the tool's return dict are deliberately
+different shapes, and demanding byte-identity would only force one of them to
+stop being canonical. What it compares is the *behavioural outcome* — did the
+call succeed, which wire error code did the refusal carry, which facts came back
+(action, fragment identity, tally), and what did the call write to
+``MCPAuditLog``.
+
+**The refusal comparison is not circular.** The MCP side is classified with the
+adapter's own production reason-to-code mapping, and the HTTP side is read off
+the wire. They agree only if the route actually routes the tool's refusal
+through that mapping. A route that grew a privacy check of its own, refused
+before entering the tool, or swallowed a refusal into a plausible success would
+diverge here even though both adapters' own suites stayed green.
+
+**Audit records are projected, not compared whole.** ``timestamp``,
+``entry_hash`` and ``prev_hash`` differ between two runs of the identical call by
+construction. :data:`AUDIT_FIELDS` names the fields that carry meaning — the
+tool, the ceiling it ran at, who ran it, the tier it created and which fragments
+it touched — and a divergence in any of those is a real divergence.
+
+Nothing in this module asserts anything about *correctness*; it asserts only
+that two adapters agree. The per-vertical modules own the scenario tables and
+the correctness assertions.
+
+Named ``tests/adapter_parity.py`` rather than the ``tests/helpers/`` package
+#1075 asked for: ``tests/helpers.py`` already exists as a module, and a package
+of that name shadows it, so ``tests/test_book_report_medium.py`` stops
+importing. The flat spelling also matches ``tests/v1_api_support.py``, the
+suite's other shared, deliberately-not-collected module.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field, replace
+from typing import TYPE_CHECKING, Any, Final
+
+from creek_mcp.audit import MCP_AUDIT_RELPATH
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping, Sequence
+    from pathlib import Path
+
+    import httpx
+
+    from creek_mcp.api.models import ErrorCode
+
+OK_STATUS: Final[int] = 200
+"""The one success status ``/v1`` returns. Spelled, not imported.
+
+The published status set is contract; a helper that read it back out of the
+implementation could not notice the implementation changing it.
+"""
+
+TOOL_OK: Final[str] = "ok"
+"""The ``status`` value an MCP tool returns on success."""
+
+AUDIT_FIELDS: Final[tuple[str, ...]] = (
+    "tool",
+    "tier_ceiling",
+    "consumer",
+    "created_tier",
+    "affected_fragment_ids",
+)
+"""The audit fields two adapters must agree on for the same scenario.
+
+``timestamp``, ``entry_hash`` and ``prev_hash`` are excluded because they differ
+between two runs of the *same* call, so including them would make every
+comparison fail for a reason that is not a divergence. ``args_summary`` is
+excluded because it carries the caller's own arguments, which the two adapters
+legitimately spell differently (a path segment versus a keyword) — the
+behavioural facts it would contribute are already carried by the projected
+fields and by the success payload.
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class Outcome:
+    """What one adapter did, in vocabulary neither adapter owns.
+
+    Attributes:
+        kind: ``"ok"`` for a success, ``"error"`` for anything else.
+        code: The wire :class:`~creek_mcp.api.models.ErrorCode` value for a
+            refusal, and ``None`` for a success.
+        payload: The success facts the scenario cares about, projected onto the
+            keys it named. Empty for a refusal — a refusal that carried facts
+            would be an oracle, and there is nothing to compare.
+        audit: Every audit record the call appended, projected onto
+            :data:`AUDIT_FIELDS`, in write order.
+    """
+
+    kind: str
+    code: str | None = None
+    payload: Mapping[str, Any] = field(default_factory=dict)
+    audit: tuple[Mapping[str, Any], ...] = ()
+
+
+_FRAGMENT_ID: Final[re.Pattern[str]] = re.compile(r"\Afrag-[0-9a-f]{12}\Z")
+"""A vault-side fragment id: the ``frag-`` prefix and twelve hex digits."""
+
+
+def _alias_value(value: Any, aliases: dict[str, str]) -> Any:
+    """Replace fragment ids in *value* with stable, first-seen-order aliases.
+
+    Args:
+        value: A projected field value.
+        aliases: The alias map accumulated so far, mutated in place.
+
+    Returns:
+        *value* with every fragment id replaced by ``fragment#N``.
+    """
+    if isinstance(value, str) and _FRAGMENT_ID.match(value):
+        return aliases.setdefault(value, f"fragment#{len(aliases)}")
+    if isinstance(value, list):
+        return [_alias_value(item, aliases) for item in value]
+    return value
+
+
+def alias_fragment_ids(outcome: Outcome) -> Outcome:
+    """Return *outcome* with its fragment ids replaced by positional aliases.
+
+    Two adapters running the identical scenario against two vaults mint two
+    different fragment ids: the id is derived from where the fragment landed,
+    and the two vaults are different directories. Comparing the raw digests
+    would therefore make every success look like a divergence — and dropping
+    the field would give up the criterion it exists to serve, that HTTP and MCP
+    agree on *fragment identity*.
+
+    So the ids are replaced by ``fragment#0``, ``fragment#1``, … in
+    first-appearance order across the payload and then the audit trail. That
+    preserves exactly the identity facts worth comparing — the id in the
+    response is the id in the audit record; two calls returned the same id, or
+    different ones — while discarding the vault-specific digest that carries no
+    behavioural meaning.
+
+    Args:
+        outcome: The outcome to normalise.
+
+    Returns:
+        The normalised outcome.
+    """
+    aliases: dict[str, str] = {}
+    payload = {
+        name: _alias_value(value, aliases) for name, value in outcome.payload.items()
+    }
+    audit = tuple(
+        {name: _alias_value(value, aliases) for name, value in record.items()}
+        for record in outcome.audit
+    )
+    return replace(outcome, payload=payload, audit=audit)
+
+
+def audit_trail(vault: Path) -> tuple[Mapping[str, Any], ...]:
+    """Return every ``mcp.jsonl`` record under *vault*, projected and in order.
+
+    Args:
+        vault: The vault root.
+
+    Returns:
+        One projected record per appended entry. An absent log is an empty
+        tuple rather than an error: "this call audited nothing" is a legitimate
+        — and frequently asserted — outcome.
+    """
+    log = vault / MCP_AUDIT_RELPATH
+    if not log.exists():
+        return ()
+    return tuple(
+        {name: json.loads(line).get(name) for name in AUDIT_FIELDS}
+        for line in log.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    )
+
+
+def http_outcome(
+    response: httpx.Response, vault: Path, *, keys: Sequence[str]
+) -> Outcome:
+    """Return the :class:`Outcome` of one ``/v1`` call.
+
+    Args:
+        response: The response under test.
+        vault: The vault the app was built over, read for its audit trail.
+        keys: The success-body fields this scenario compares.
+
+    Returns:
+        The normalised outcome.
+    """
+    body: dict[str, Any] = response.json()
+    audit = audit_trail(vault)
+    if response.status_code != OK_STATUS:
+        return Outcome(kind="error", code=str(body.get("code")), audit=audit)
+    return alias_fragment_ids(
+        Outcome(
+            kind="ok",
+            payload={name: body.get(name) for name in keys},
+            audit=audit,
+        )
+    )
+
+
+def mcp_outcome(
+    result: Mapping[str, Any],
+    vault: Path,
+    *,
+    keys: Sequence[str],
+    classify: Callable[[str], ErrorCode],
+    success_statuses: Sequence[str] = (TOOL_OK,),
+) -> Outcome:
+    """Return the :class:`Outcome` of one MCP tool call.
+
+    Args:
+        result: The tool's return dict.
+        vault: The vault the tool ran against, read for its audit trail.
+        keys: The success fields this scenario compares.
+        classify: The adapter's own production reason-to-code mapping. Passed
+            in rather than imported so this harness stays vertical-agnostic —
+            and so a route that classified a refusal differently from the
+            mapping it publishes shows up as a divergence here.
+        success_statuses: Every tool ``status`` that is a success rather than a
+            refusal. Defaults to ``("ok",)``; ``reflect_tool`` also answers
+            ``empty`` and ``escalate``, both of which are ``200`` on the wire —
+            an escalation in particular *must* not be an error, or a person in
+            acute distress lands in a client's error path.
+
+    Returns:
+        The normalised outcome.
+    """
+    audit = audit_trail(vault)
+    if result.get("status") not in success_statuses:
+        return Outcome(
+            kind="error",
+            code=classify(str(result.get("reason", ""))).value,
+            audit=audit,
+        )
+    return alias_fragment_ids(
+        Outcome(
+            kind="ok",
+            payload={name: result.get(name) for name in keys},
+            audit=audit,
+        )
+    )
+
+
+def assert_parity(scenario: str, over_http: Outcome, over_mcp: Outcome) -> None:
+    """Fail unless the two adapters behaved identically in *scenario*.
+
+    Args:
+        scenario: The scenario's name, so a failure names which row diverged
+            rather than only which field.
+        over_http: The outcome observed through ``/v1``.
+        over_mcp: The outcome observed through the MCP tool.
+
+    Raises:
+        AssertionError: When the two outcomes differ in any compared field.
+    """
+    assert over_http == over_mcp, (
+        f"HTTP<->MCP divergence in scenario {scenario!r}: "
+        f"http={over_http!r} mcp={over_mcp!r}"
+    )

--- a/creek-tools/tests/test_api_journal.py
+++ b/creek-tools/tests/test_api_journal.py
@@ -1,0 +1,729 @@
+"""``PUT /v1/journal-entries/{external_id}`` over the shared journal tool (#1075).
+
+The first tracer stub replaced by real behaviour, and the one that has to prove
+the epic's central claim: HTTP is an *adapter* over
+:func:`creek_mcp.tools.journal.journal_ingest_tool`, not a second journal
+implementation. Every idempotency, tier and audit guarantee this module asserts
+is a guarantee the tool already had; what is new is that the route reaches them
+by delegating rather than by re-deriving them.
+
+It is also the write path, which is where a bypass would do durable damage. The
+tool refuses an above-ceiling entry *before* staging and audits both the refusal
+and the success; a route that called ``run_ingest`` directly, or that passed a
+ceiling the adapter policy never admitted, would lose both silently and still
+look correct from the outside. So the filesystem is asserted on, not only the
+response — `test_a_tier_above_the_ceiling_stages_nothing` fails if a staged
+entry appears even when the status line is a correct ``403``.
+
+**Two of the issue's own claims did not survive re-derivation, and the tests
+here follow the code rather than the issue.** See the module-level notes on
+:func:`test_an_intimate_tier_is_not_even_expressible` and
+:func:`test_an_above_ceiling_fragment_body_survives_a_lower_ceiling_overwrite`.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any, Final
+
+import frontmatter
+import pytest
+
+from creek_mcp.api.models import ErrorCode
+from creek_mcp.audit import MCP_AUDIT_RELPATH
+from creek_mcp.httpapi.journal import (
+    MAX_EXTERNAL_ID_CHARS,
+    REPLACEMENT_CHARACTER,
+    journal_refusal_code,
+)
+from creek_mcp.tier_ceiling import TierCeiling
+from creek_mcp.tools.journal import journal_ingest_tool
+from tests.adapter_parity import (
+    Outcome,
+    alias_fragment_ids,
+    assert_parity,
+    audit_trail,
+    http_outcome,
+    mcp_outcome,
+)
+from tests.v1_api_support import (
+    CONSUMER,
+    client,
+    contains_a_path,
+    envelope,
+    headers,
+    seed_vault,
+    snapshot,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+    import httpx
+
+_OK: Final[int] = 200
+_INVALID: Final[int] = 422
+_REFUSED: Final[int] = 403
+
+_ENTRY_ID: Final[str] = "adepthood:entry:2026-07-31T06:12:00Z"
+"""A synthetic consumer-side id in the shape Adepthood mints."""
+
+_CONTENT: Final[str] = "synthetic-journal-sentence-1075 that must never be echoed"
+"""The submitted body. Distinctive, so "did anything echo it?" is checkable."""
+
+_EDITED: Final[str] = "synthetic-journal-sentence-1075 revised on a later sync"
+"""A second body for the same id, so the update path is exercised for real."""
+
+_TIMESTAMP: Final[str] = "2026-07-31T06:12:00+00:00"
+
+_SUCCESS_KEYS: Final[tuple[str, ...]] = (
+    "external_id",
+    "fragment_id",
+    "action",
+    "tier",
+    "tier_ceiling",
+)
+"""The success facts the parity harness compares for this vertical.
+
+The tool returns all five under these exact names, so parity here is a direct
+comparison rather than a translation — which is the point of picking journal as
+the first vertical.
+"""
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> Iterator[Path]:
+    """Yield a freshly seeded vault for the HTTP adapter."""
+    yield seed_vault(tmp_path / "http")
+
+
+@pytest.fixture
+def mcp_vault(tmp_path: Path) -> Iterator[Path]:
+    """Yield a second seeded vault, so the two adapters never share a trail."""
+    yield seed_vault(tmp_path / "mcp")
+
+
+# --------------------------------------------------------------------------- #
+# Request helpers
+# --------------------------------------------------------------------------- #
+
+
+def _body(content: str = _CONTENT, tier: str = "open") -> dict[str, Any]:
+    """Return a ``JournalUpsertRequest``-shaped body.
+
+    Args:
+        content: The entry body.
+        tier: The declared entry tier.
+
+    Returns:
+        The request body.
+    """
+    return {"content": content, "timestamp": _TIMESTAMP, "tier": tier}
+
+
+def _put(
+    vault_path: Path,
+    external_id: str = _ENTRY_ID,
+    *,
+    body: object | None = None,
+    ceiling: str | None = None,
+) -> httpx.Response:
+    """Send one journal upsert and return the raw response.
+
+    Args:
+        vault_path: The vault the app is built over.
+        external_id: The path segment to address.
+        body: The JSON body, or ``None`` for the canonical one.
+        ceiling: The declared tier ceiling, or ``None`` to send no header.
+
+    Returns:
+        The response.
+    """
+    with client(vault_path=vault_path) as test_client:
+        return test_client.put(
+            f"/v1/journal-entries/{external_id}",
+            json=_body() if body is None else body,
+            headers=headers(ceiling=ceiling),
+        )
+
+
+def _fragments(vault_path: Path) -> list[Path]:
+    """Return every fragment file in *vault_path*.
+
+    Args:
+        vault_path: The vault root.
+
+    Returns:
+        The sorted fragment paths.
+    """
+    return sorted((vault_path / "01-Fragments").rglob("*.md"))
+
+
+def _staged(vault_path: Path) -> list[Path]:
+    """Return every staged journal entry in *vault_path*.
+
+    Args:
+        vault_path: The vault root.
+
+    Returns:
+        The sorted staged-entry paths.
+    """
+    return sorted((vault_path / "00-Creek-Meta/adepthood/journal").rglob("*.md"))
+
+
+def _audit_records(vault_path: Path) -> list[dict[str, Any]]:
+    """Return every raw audit record in *vault_path*.
+
+    Args:
+        vault_path: The vault root.
+
+    Returns:
+        The decoded records, in write order.
+    """
+    log = vault_path / MCP_AUDIT_RELPATH
+    if not log.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in log.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# Idempotency — the tracer
+# --------------------------------------------------------------------------- #
+
+
+def test_the_same_entry_twice_is_created_then_unchanged(vault: Path) -> None:
+    """The proposed tracer: one entry, sent twice, one fragment, two audits.
+
+    Args:
+        vault: A seeded vault.
+    """
+    first = _put(vault)
+    second = _put(vault)
+
+    assert first.status_code == _OK
+    assert second.status_code == _OK
+    assert envelope(first)["action"] == "created"
+    assert envelope(second)["action"] == "unchanged"
+    assert envelope(first)["fragment_id"] == envelope(second)["fragment_id"]
+    assert len(_fragments(vault)) == 1
+    assert len(_audit_records(vault)) == 2
+
+
+def test_an_edited_entry_updates_the_same_fragment(vault: Path) -> None:
+    """A new body under the same id rewrites in place, id preserved.
+
+    Args:
+        vault: A seeded vault.
+    """
+    created = envelope(_put(vault))
+    updated = envelope(_put(vault, body=_body(content=_EDITED)))
+
+    assert updated["action"] == "updated"
+    assert updated["fragment_id"] == created["fragment_id"]
+    assert len(_fragments(vault)) == 1
+
+
+def test_ids_that_slug_identically_get_distinct_fragments(vault: Path) -> None:
+    """``_safe_stem``'s hash guarantee survives the route.
+
+    ``"a b"`` and ``"a-b"`` collapse to the same readable slug, so a route that
+    re-derived the staged name from the slug alone would merge two consumers'
+    entries into one fragment. The trailing digest of the *raw* id is what stops
+    that, and it only helps if the route hands the raw id to the tool.
+
+    Args:
+        vault: A seeded vault.
+    """
+    spaced = envelope(_put(vault, "a b"))
+    hyphenated = envelope(_put(vault, "a-b"))
+
+    assert spaced["fragment_id"] != hyphenated["fragment_id"]
+    assert len(_fragments(vault)) == 2
+
+
+# --------------------------------------------------------------------------- #
+# Tier refusal — asserted on the filesystem, not only the status line
+# --------------------------------------------------------------------------- #
+
+
+def test_a_tier_above_the_ceiling_stages_nothing(vault: Path) -> None:
+    """``personal`` under an ``open`` ceiling is refused before persistence.
+
+    The status line alone would not prove it: the tool's gate 1 sits *above*
+    ``_stage_entry`` precisely so a refusal leaves no staged copy, and a route
+    that staged first and refused second would still answer ``403``.
+
+    Args:
+        vault: A seeded vault.
+    """
+    response = _put(vault, body=_body(tier="personal"), ceiling="open")
+
+    assert response.status_code == _REFUSED
+    assert envelope(response)["code"] == ErrorCode.PRIVACY_REFUSED.value
+    assert _staged(vault) == []
+    assert _fragments(vault) == []
+
+
+def test_a_personal_entry_is_admitted_under_a_personal_ceiling(vault: Path) -> None:
+    """The same write succeeds once the caller declares the ceiling for it.
+
+    Pins that the refusal above is about the *ceiling*, not about ``personal``
+    being unwritable over HTTP at all.
+
+    Args:
+        vault: A seeded vault.
+    """
+    response = _put(vault, body=_body(tier="personal"), ceiling="personal")
+
+    assert response.status_code == _OK
+    assert envelope(response)["tier"] == "personal"
+    assert envelope(response)["tier_ceiling"] == "personal"
+
+
+def test_an_intimate_tier_is_not_even_expressible(vault: Path) -> None:
+    """#1075's fourth acceptance criterion is wrong, and this is why.
+
+    The issue asks for ``tier: "intimate"`` under an ``open`` ceiling to answer
+    ``privacy_refused``. It cannot, and it should not: #1072 typed the request's
+    ``tier`` as :class:`~creek_mcp.api.models.WireTierCeiling`, which has two
+    members, so ``intimate`` fails *schema* validation and earns
+    ``invalid_request`` — the body does not satisfy the published schema, which
+    is exactly true. Answering ``privacy_refused`` instead would mean the server
+    had accepted the field, resolved something, and ranked it, none of which
+    happened.
+
+    What the criterion is really protecting — no staged file — is asserted here
+    too, and the reachable tier-exceeds-ceiling path is covered by
+    :func:`test_a_tier_above_the_ceiling_stages_nothing`.
+
+    Args:
+        vault: A seeded vault.
+    """
+    before = snapshot(vault)
+    response = _put(vault, body=_body(tier="intimate"), ceiling="open")
+
+    assert response.status_code == _INVALID
+    assert envelope(response)["code"] == ErrorCode.INVALID_REQUEST.value
+    assert snapshot(vault) == before
+
+
+def test_a_remote_caller_declaring_an_intimate_ceiling_never_reaches_the_route(
+    vault: Path,
+) -> None:
+    """The adapter edge refuses the ceiling before any vault read (#1074).
+
+    Nothing is written — not a fragment, not a staged entry, and not the audit
+    file, whose creation would itself prove the vault had been touched.
+
+    Args:
+        vault: A seeded vault.
+    """
+    before = snapshot(vault)
+    response = _put(vault, ceiling="intimate")
+
+    assert response.status_code == _INVALID
+    assert envelope(response)["code"] == ErrorCode.INVALID_REQUEST.value
+    assert snapshot(vault) == before
+
+
+def test_an_above_ceiling_fragment_body_survives_a_lower_ceiling_overwrite(
+    vault: Path,
+) -> None:
+    """#970's overwrite gate holds through the route — and #970 is *closed*.
+
+    The issue calls this a "known inherited gap" and asks for a test pinning the
+    broken behaviour. It is not a gap: #970 shipped
+    :func:`creek_mcp.tools.journal._refuse_unadmitted_overwrite`, which asks
+    "could this caller have *read* what it is about to destroy?" before staging
+    anything. Pinning the pre-fix behaviour would have pinned a hole that no
+    longer exists. So this pins the fix instead, through the adapter, which is
+    the part #1075 could actually have broken — by passing its own ceiling, or
+    by reaching ``run_ingest`` around the tool.
+
+    Args:
+        vault: A seeded vault.
+    """
+    created = _put(vault, body=_body(tier="personal"), ceiling="personal")
+    assert created.status_code == _OK
+
+    refused = _put(vault, body=_body(content=_EDITED), ceiling="open")
+
+    assert refused.status_code == _REFUSED
+    assert envelope(refused)["code"] == ErrorCode.PRIVACY_REFUSED.value
+    body = frontmatter.load(_fragments(vault)[0]).content
+    assert _CONTENT in body
+    assert _EDITED not in body
+
+
+# --------------------------------------------------------------------------- #
+# The path segment
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("label", "external_id"),
+    [
+        ("blank", "%20%20"),
+        ("oversized", "x" * (MAX_EXTERNAL_ID_CHARS + 1)),
+        ("undecodable", f"broken{REPLACEMENT_CHARACTER}id"),
+        ("control-character", "line%00break"),
+    ],
+)
+def test_an_inadmissible_external_id_is_refused_before_the_tool(
+    vault: Path, label: str, external_id: str
+) -> None:
+    """A path segment that cannot be an idempotency key never reaches staging.
+
+    ``_safe_stem`` accepts literally any string, so nothing below this point
+    would refuse these — an oversized id would become an 80-character slug plus
+    a digest, and an id carrying U+FFFD is one whose bytes did not survive URL
+    decoding, so the client's key and the server's key are already different
+    strings. Both would silently mint a fragment under an id the client cannot
+    address again.
+
+    Args:
+        vault: A seeded vault.
+        label: The refusal being exercised, for the parametrize id.
+        external_id: The path segment to send.
+    """
+    assert label
+    before = snapshot(vault)
+    response = _put(vault, external_id)
+
+    assert response.status_code == _INVALID
+    assert envelope(response)["code"] == ErrorCode.INVALID_REQUEST.value
+    assert snapshot(vault) == before
+
+
+def test_the_longest_admissible_external_id_is_accepted(vault: Path) -> None:
+    """The bound is inclusive, so the cap is a cap and not an off-by-one.
+
+    Args:
+        vault: A seeded vault.
+    """
+    response = _put(vault, "x" * MAX_EXTERNAL_ID_CHARS)
+
+    assert response.status_code == _OK
+
+
+# --------------------------------------------------------------------------- #
+# Timestamps
+# --------------------------------------------------------------------------- #
+
+
+def test_an_omitted_timestamp_defaults_to_now_rather_than_failing(
+    vault: Path,
+) -> None:
+    """``timestamp`` is optional on the wire and optional in the tool.
+
+    Args:
+        vault: A seeded vault.
+    """
+    response = _put(vault, body={"content": _CONTENT, "tier": "open"})
+
+    assert response.status_code == _OK
+    assert envelope(response)["action"] == "created"
+
+
+def test_an_unparseable_timestamp_behaves_as_the_tool_does(
+    vault: Path, mcp_vault: Path
+) -> None:
+    """Whatever the tool makes of a nonsense timestamp, the route makes too.
+
+    Asserting a *specific* outcome here would encode this module's guess about
+    the markdown ingestor's date handling. Asserting parity encodes the only
+    thing #1075 is entitled to promise: the route adds no timestamp behaviour of
+    its own, and in particular does not turn a tool-level oddity into a ``500``.
+
+    Args:
+        vault: The HTTP adapter's vault.
+        mcp_vault: The MCP adapter's vault.
+    """
+    over_http = _put(vault, body=_body() | {"timestamp": "not-a-timestamp"})
+    over_mcp = journal_ingest_tool(
+        vault_path=mcp_vault,
+        content=_CONTENT,
+        external_id=_ENTRY_ID,
+        timestamp="not-a-timestamp",
+        tier="open",
+        privacy_tier_ceiling=TierCeiling.OPEN,
+        consumer=CONSUMER,
+    )
+
+    assert over_http.status_code != 500
+    assert_parity(
+        "unparseable-timestamp",
+        _normalised_http(over_http, vault),
+        _normalised_mcp(over_mcp, mcp_vault),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Audit
+# --------------------------------------------------------------------------- #
+
+
+def test_the_audit_record_carries_the_bearer_consumer(vault: Path) -> None:
+    """The verified token's ``client_id`` reaches the trail, not a default.
+
+    ``journal_ingest_tool``'s ``consumer`` defaults to ``"unknown"``, and the
+    MCP server passes ``CREEK_MCP_CONSUMER``. A route that forgot to pass the
+    authenticated identity would audit every Adepthood write as an anonymous
+    one, which is precisely the fact an investigator would need.
+
+    Args:
+        vault: A seeded vault.
+    """
+    _put(vault)
+
+    assert [record["consumer"] for record in _audit_records(vault)] == [CONSUMER]
+
+
+def test_a_refusal_is_audited_too(vault: Path) -> None:
+    """The tier gate audits before it refuses, and the route does not suppress it.
+
+    Args:
+        vault: A seeded vault.
+    """
+    _put(vault, body=_body(tier="personal"), ceiling="open")
+
+    records = _audit_records(vault)
+    assert [record["tier_ceiling"] for record in records] == ["open"]
+    assert [record["consumer"] for record in records] == [CONSUMER]
+
+
+def test_no_response_or_audit_record_carries_the_submitted_content(
+    vault: Path,
+) -> None:
+    """The entry body appears in the fragment and nowhere else.
+
+    Args:
+        vault: A seeded vault.
+    """
+    response = _put(vault)
+    refusal = _put(vault, body=_body(tier="personal"), ceiling="open")
+
+    assert _CONTENT not in response.text
+    assert _CONTENT not in refusal.text
+    log = (vault / MCP_AUDIT_RELPATH).read_text(encoding="utf-8")
+    assert _CONTENT not in log
+
+
+def test_a_refusal_echoes_neither_the_path_identifier_nor_a_path(
+    vault: Path,
+) -> None:
+    """An error body is a function of the *code*, never of what the caller sent.
+
+    Inherited from ``tests/test_v1_api_not_implemented.py``, which asserted it
+    of the ``501`` stub and could not go on doing so once #1075 made this route
+    real. A refusal that echoed the ``external_id`` is one step from a refusal
+    that echoes what the server resolved from it; a refusal that carried a
+    filesystem path has already taken that step.
+
+    Args:
+        vault: A seeded vault.
+    """
+    sentinel = "zz-sentinel-external-id-zz"
+    refusal = _put(vault, sentinel, body=_body(tier="personal"), ceiling="open")
+
+    assert refusal.status_code == _REFUSED
+    assert sentinel not in refusal.text
+    assert "personal" not in refusal.text
+    assert not contains_a_path(refusal.text)
+
+
+# --------------------------------------------------------------------------- #
+# Refusal mapping
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("reason", "code"),
+    [
+        ("content and external_id are required", ErrorCode.INVALID_REQUEST),
+        ("unknown tier 'nonsense'", ErrorCode.INVALID_REQUEST),
+        ("entry tier personal exceeds the ceiling", ErrorCode.PRIVACY_REFUSED),
+        (
+            "resolved content exceeds the declared tier ceiling",
+            ErrorCode.PRIVACY_REFUSED,
+        ),
+        ("vault unavailable", ErrorCode.TEMPORARILY_UNAVAILABLE),
+        ("ingest failed: /vault/00-Creek-Meta/x.md exploded", ErrorCode.INTERNAL_ERROR),
+        ("something nobody has written yet", ErrorCode.INTERNAL_ERROR),
+    ],
+)
+def test_every_tool_refusal_maps_onto_the_taxonomy(
+    reason: str, code: ErrorCode
+) -> None:
+    """Each refusal the tool can produce has one published code, and an unknown
+    one fails closed to ``internal_error`` rather than to a plausible refusal.
+
+    Args:
+        reason: The tool's structured refusal reason.
+        code: The wire code it must map to.
+    """
+    assert journal_refusal_code(reason) == code
+
+
+def test_an_ingest_failure_does_not_echo_the_underlying_message(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``ingest failed: …`` can carry a staged path; the wire carries none of it.
+
+    Reached by substituting the tool, because a genuine ``result.errors`` needs
+    a corrupted ingest run — and the property under test is the *projection*,
+    not how the tool got there.
+
+    Args:
+        vault: A seeded vault.
+        monkeypatch: The active monkeypatch fixture.
+    """
+    leak = "/private/vault/00-Creek-Meta/adepthood/journal/secret-name.md"
+
+    def _failing(**_kwargs: object) -> dict[str, Any]:
+        return {
+            "status": "refused",
+            "tool": "creek.journal",
+            "tier_ceiling": "open",
+            "reason": f"ingest failed: could not write {leak}",
+        }
+
+    monkeypatch.setattr(
+        "creek_mcp.httpapi.journal.journal_ingest_tool", _failing, raising=True
+    )
+    response = _put(vault)
+
+    assert response.status_code == 500
+    assert envelope(response)["code"] == ErrorCode.INTERNAL_ERROR.value
+    assert leak not in response.text
+    assert "secret-name" not in response.text
+
+
+# --------------------------------------------------------------------------- #
+# HTTP <-> MCP parity
+# --------------------------------------------------------------------------- #
+
+
+def _normalised_http(response: httpx.Response, vault_path: Path) -> Outcome:
+    """Return *response*'s parity outcome.
+
+    Args:
+        response: The response under test.
+        vault_path: The vault the app ran against.
+
+    Returns:
+        The normalised outcome.
+    """
+    return http_outcome(response, vault_path, keys=_SUCCESS_KEYS)
+
+
+def _normalised_mcp(result: dict[str, Any], vault_path: Path) -> Outcome:
+    """Return *result*'s parity outcome.
+
+    Args:
+        result: The tool's return dict.
+        vault_path: The vault the tool ran against.
+
+    Returns:
+        The normalised outcome.
+    """
+    return mcp_outcome(
+        result, vault_path, keys=_SUCCESS_KEYS, classify=journal_refusal_code
+    )
+
+
+_SCENARIOS: Final[tuple[tuple[str, str, str, str], ...]] = (
+    ("create-open", _CONTENT, "open", "open"),
+    ("create-personal", _CONTENT, "personal", "personal"),
+    ("refused-above-ceiling", _CONTENT, "personal", "open"),
+)
+"""``(name, content, entry tier, declared ceiling)`` rows run through both adapters.
+
+Three rows, chosen so the table covers a success, a success at the *other*
+admissible ceiling, and a refusal — the wheel and reflection verticals extend
+this same table shape rather than building a second harness.
+"""
+
+
+@pytest.mark.parametrize(
+    ("name", "content", "tier", "ceiling"),
+    _SCENARIOS,
+    ids=[row[0] for row in _SCENARIOS],
+)
+def test_http_and_mcp_agree_on_every_scenario(
+    vault: Path,
+    mcp_vault: Path,
+    name: str,
+    content: str,
+    tier: str,
+    ceiling: str,
+) -> None:
+    """The same scenario, both adapters, identical behavioural outcome.
+
+    Args:
+        vault: The HTTP adapter's vault.
+        mcp_vault: The MCP adapter's vault.
+        name: The scenario name, surfaced in a divergence message.
+        content: The entry body.
+        tier: The declared entry tier.
+        ceiling: The declared tier ceiling.
+    """
+    over_http = _put(vault, body=_body(content=content, tier=tier), ceiling=ceiling)
+    over_mcp = journal_ingest_tool(
+        vault_path=mcp_vault,
+        content=content,
+        external_id=_ENTRY_ID,
+        timestamp=_TIMESTAMP,
+        tier=tier,
+        privacy_tier_ceiling=TierCeiling(ceiling),
+        consumer=CONSUMER,
+    )
+
+    assert_parity(
+        name,
+        _normalised_http(over_http, vault),
+        _normalised_mcp(over_mcp, mcp_vault),
+    )
+
+
+def test_the_two_adapters_audit_the_same_facts(vault: Path, mcp_vault: Path) -> None:
+    """Tool, ceiling, created tier and affected fragment ids all agree.
+
+    Args:
+        vault: The HTTP adapter's vault.
+        mcp_vault: The MCP adapter's vault.
+    """
+    _put(vault)
+    journal_ingest_tool(
+        vault_path=mcp_vault,
+        content=_CONTENT,
+        external_id=_ENTRY_ID,
+        timestamp=_TIMESTAMP,
+        tier="open",
+        privacy_tier_ceiling=TierCeiling.OPEN,
+        consumer=CONSUMER,
+    )
+
+    assert alias_fragment_ids(
+        Outcome(kind="ok", audit=audit_trail(vault))
+    ) == alias_fragment_ids(Outcome(kind="ok", audit=audit_trail(mcp_vault)))
+
+
+def test_the_parity_harness_can_actually_fail() -> None:
+    """The harness is not vacuous: two different outcomes are not parity.
+
+    Every parity assertion above is an equality between two values this module
+    computes. If :func:`assert_parity` compared nothing, the whole table would
+    stay green forever.
+    """
+    with pytest.raises(AssertionError, match="divergence"):
+        assert_parity(
+            "synthetic",
+            Outcome(kind="ok", payload={"action": "created"}),
+            Outcome(kind="ok", payload={"action": "unchanged"}),
+        )

--- a/creek-tools/tests/test_api_journal.py
+++ b/creek-tools/tests/test_api_journal.py
@@ -604,6 +604,49 @@ def test_an_ingest_failure_does_not_echo_the_underlying_message(
     assert "secret-name" not in response.text
 
 
+def _no_source_ledger(*_args: object, **_kwargs: object) -> None:
+    """Stand in for a source ledger that has no record of the staged entry.
+
+    Args:
+        *_args: ``ledger_for_source``'s source type and vault path, unused.
+        **_kwargs: Ditto, by keyword.
+    """
+
+
+def test_a_written_entry_whose_fragment_id_will_not_resolve_is_a_fault(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unresolved ``fragment_id`` is a ``500``, never the literal ``"None"``.
+
+    :func:`~creek_mcp.tools.journal.journal_ingest_tool` answers ``status: ok``
+    with ``fragment_id=None`` when the source ledger cannot map the staged entry
+    back to a fragment immediately after a successful write — the writer and the
+    ledger disagree about what was just written. ``str(None)`` raises nothing, so
+    a projection that guarded only with ``try``/``except`` would answer ``200``
+    carrying the id ``"None"``: something the caller can store, quote back and
+    never resolve. Minting an id no vault object answers to is the one thing
+    this module's docstring says it must not do, so the check is explicit and
+    precedes construction rather than being inferred from a failure to validate.
+
+    Driven through the real tool rather than a substitute, because the property
+    is that the race is *reachable*: ``ledger_for_source`` answering ``None`` is
+    exactly how ``_resolve_fragment_id`` comes back empty on a successful write.
+
+    Args:
+        vault: A seeded vault.
+        monkeypatch: Removes the source ledger the resolver reads.
+    """
+    monkeypatch.setattr(
+        "creek_mcp.tools.journal.ledger_for_source", _no_source_ledger, raising=True
+    )
+    response = _put(vault)
+
+    assert response.status_code == 500
+    assert envelope(response)["code"] == ErrorCode.INTERNAL_ERROR.value
+    assert "None" not in response.text
+    assert "fragment_id" not in response.text
+
+
 # --------------------------------------------------------------------------- #
 # HTTP <-> MCP parity
 # --------------------------------------------------------------------------- #

--- a/creek-tools/tests/test_api_reflect.py
+++ b/creek-tools/tests/test_api_reflect.py
@@ -1,0 +1,757 @@
+"""``POST /v1/reflections`` over the shared reflect tool (#1077).
+
+The last and most safety-sensitive vertical. It touches acute-distress
+escalation, model routing and content the caller may not be admitted to, and
+:func:`creek_mcp.tools.reflect.reflect_tool` already enforces four guarantees
+over all of it: the read-side ceiling gate sits *above* the care seam, INTIMATE
+routes local through the tier-keyed factory, quotes are verbatim or dropped, and
+care escalation happens *before* any model call.
+
+This module asserts that the route inherits every one of them by delegating and
+adds none of its own — and it asserts the negative half on spies rather than by
+inference. "The model was not called" is a fact about the factory, not something
+to read off a response that merely looks like a refusal.
+
+**One of the issue's mapping instructions is refused here, deliberately.** See
+:func:`test_an_unresolvable_entry_ref_is_privacy_refused_not_not_found`.
+
+Every test stubs ``llm_factory``: no live model call, so the suite stays
+deterministic and offline.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any, Final
+
+import frontmatter
+import pytest
+from starlette.testclient import TestClient
+
+from creek.care.guardrail import CARE_SIGNAL, acute_distress_guard
+from creek.models import PrivacyTier
+from creek_mcp.api.models import ErrorCode, ReflectionStatus
+from creek_mcp.audit import MCP_AUDIT_RELPATH
+from creek_mcp.httpapi.reflect import reflect_refusal_code
+from creek_mcp.tier_ceiling import TierCeiling
+from creek_mcp.tools.reflect import reflect_tool
+from tests.adapter_parity import assert_parity, http_outcome, mcp_outcome
+from tests.v1_api_support import (
+    CONSUMER,
+    REFLECTIONS_PATH,
+    build_app,
+    contains_a_path,
+    envelope,
+    headers,
+    seed_vault,
+    snapshot,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+    from pathlib import Path
+
+    import httpx
+
+_OK: Final[int] = 200
+_INVALID: Final[int] = 422
+_REFUSED: Final[int] = 403
+_UNAVAILABLE: Final[int] = 503
+
+_ENTRY: Final[str] = (
+    "zz-reflect-1077-zz I keep saying yes to things I do not want, and then "
+    "resenting the person who asked."
+)
+"""The submitted entry. Distinctive, so "did anything echo it?" is checkable."""
+
+_VERBATIM: Final[str] = "I keep saying yes to things I do not want"
+"""A span that really is in :data:`_ENTRY`, so a well-behaved note survives."""
+
+_HALLUCINATED: Final[str] = "I have always known exactly what I wanted"
+"""A span that is *not* in :data:`_ENTRY`, so a fabricated note is dropped."""
+
+_FRAGMENT_TITLE: Final[str] = "zz-grounding-title-1077-zz"
+"""A grounding fragment's title, which must never reach the wire."""
+
+_SUCCESS_KEYS: Final[tuple[str, ...]] = (
+    "status",
+    "tier_ceiling",
+    "routed_tier",
+    "notes",
+    "essay_grounded",
+)
+"""The success facts the parity harness compares for this vertical."""
+
+
+class _FactorySpy:
+    """A stub tier-keyed LLM factory that records whether it was ever entered.
+
+    "The model was not called" is the load-bearing half of both the care gate
+    and the ceiling gate, and it cannot be read off a response — a route that
+    called the model and *then* refused would answer identically. So it is
+    observed on the seam.
+
+    Attributes:
+        tiers: One entry per ``factory(tier)`` call, in order.
+        prompts: One entry per completion, in order.
+    """
+
+    def __init__(self, response: str = "") -> None:
+        """Return *response* from every completion.
+
+        Args:
+            response: The raw model turn to hand back.
+        """
+        self._response = response
+        self.tiers: list[PrivacyTier] = []
+        self.prompts: list[str] = []
+
+    def __call__(self, tier: PrivacyTier) -> Callable[[str], str]:
+        """Return the completion callable for *tier*, recording the tier.
+
+        Args:
+            tier: The routing tier the tool derived.
+
+        Returns:
+            The stub completion callable.
+        """
+        self.tiers.append(tier)
+
+        def _complete(prompt: str) -> str:
+            self.prompts.append(prompt)
+            return self._response
+
+        return _complete
+
+    @property
+    def called(self) -> bool:
+        """Whether the factory was entered at all.
+
+        Returns:
+            ``True`` once :meth:`__call__` has run.
+        """
+        return bool(self.tiers)
+
+
+def _turn(*notes: dict[str, str], essay: str | None = None) -> str:
+    """Return a model turn carrying *notes* in the shape the tool parses.
+
+    Args:
+        *notes: The raw notes the model claims to have found.
+        essay: Optional free prose.
+
+    Returns:
+        The serialised turn.
+    """
+    payload: dict[str, Any] = {"notes": list(notes)}
+    if essay is not None:
+        payload["essay"] = essay
+    return json.dumps(payload)
+
+
+_GOOD_TURN: Final[str] = _turn(
+    {"quote": _VERBATIM, "kind": "pattern", "note": "You notice the cost later."}
+)
+"""One well-formed note whose quote really is a span of the entry."""
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> Iterator[Path]:
+    """Yield a freshly seeded vault for the HTTP adapter."""
+    yield seed_vault(tmp_path / "http")
+
+
+@pytest.fixture
+def mcp_vault(tmp_path: Path) -> Iterator[Path]:
+    """Yield a second seeded vault, so the two adapters never share a trail."""
+    yield seed_vault(tmp_path / "mcp")
+
+
+# --------------------------------------------------------------------------- #
+# Corpus + request helpers
+# --------------------------------------------------------------------------- #
+
+
+def _write_fragment(
+    vault_path: Path,
+    *,
+    frag_id: str,
+    body: str,
+    privacy_tier: str = "open",
+    title: str = _FRAGMENT_TITLE,
+) -> None:
+    """Write one fragment an ``entry_ref`` can resolve to.
+
+    Args:
+        vault_path: The vault root.
+        frag_id: The fragment id, which is also the ``entry_ref``.
+        body: The fragment body, which becomes the entry.
+        privacy_tier: The tier to stamp.
+        title: The fragment title.
+    """
+    folder = vault_path / "01-Fragments" / "Notes"
+    folder.mkdir(parents=True, exist_ok=True)
+    (folder / f"{frag_id}.md").write_text(
+        frontmatter.dumps(
+            frontmatter.Post(
+                content=body,
+                type="fragment",
+                id=frag_id,
+                title=title,
+                source={"platform": "journal", "author": "self"},
+                privacy_tier=privacy_tier,
+            )
+        ),
+        encoding="utf-8",
+    )
+
+
+def _post(
+    vault_path: Path,
+    *,
+    body: dict[str, Any] | None = None,
+    ceiling: str | None = None,
+    factory: _FactorySpy | None = None,
+) -> httpx.Response:
+    """Send one reflection request and return the raw response.
+
+    Args:
+        vault_path: The vault the app is built over.
+        body: The JSON body, or ``None`` for a canonical inline-content one.
+        ceiling: The declared tier ceiling, or ``None`` to send no header.
+        factory: The stub LLM factory, or ``None`` for a silent one.
+
+    Returns:
+        The response.
+    """
+    spy = factory if factory is not None else _FactorySpy(_GOOD_TURN)
+    app = build_app(vault_path=vault_path, reflect_llm_factory=lambda: spy)
+    with TestClient(app) as test_client:
+        return test_client.post(
+            REFLECTIONS_PATH,
+            json={"content": _ENTRY} if body is None else body,
+            headers=headers(ceiling=ceiling),
+        )
+
+
+def _audit_records(vault_path: Path) -> list[dict[str, Any]]:
+    """Return every raw audit record in *vault_path*.
+
+    Args:
+        vault_path: The vault root.
+
+    Returns:
+        The decoded records, in write order.
+    """
+    log = vault_path / MCP_AUDIT_RELPATH
+    if not log.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in log.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# The tracer
+# --------------------------------------------------------------------------- #
+
+
+def test_an_open_inline_reflection_returns_verbatim_anchored_notes(
+    vault: Path,
+) -> None:
+    """The proposed tracer, with a stubbed factory and no live model call.
+
+    Args:
+        vault: A seeded vault.
+    """
+    response = _post(vault, ceiling="open")
+    body = envelope(response)
+
+    assert response.status_code == _OK
+    assert body["status"] == ReflectionStatus.OK.value
+    assert [note["quote"] for note in body["notes"]] == [_VERBATIM]
+    assert body["notes"][0]["kind"] == "pattern"
+    assert body["essay_grounded"] is False
+
+
+def test_a_hallucinated_span_is_dropped(vault: Path) -> None:
+    """A quote that is not a span of the entry never reaches the client.
+
+    The client re-anchors quotes to character offsets, so a fabricated span is
+    not merely wrong — it is unanchorable, and would surface as the client
+    highlighting the wrong words of the writer's own entry.
+
+    Args:
+        vault: A seeded vault.
+    """
+    factory = _FactorySpy(
+        _turn(
+            {"quote": _HALLUCINATED, "kind": "fear", "note": "Invented."},
+            {"quote": _VERBATIM, "kind": "pattern", "note": "Real."},
+        )
+    )
+    body = envelope(_post(vault, ceiling="open", factory=factory))
+
+    assert [note["quote"] for note in body["notes"]] == [_VERBATIM]
+    assert _HALLUCINATED not in json.dumps(body)
+
+
+def test_a_turn_with_nothing_usable_is_an_explicit_empty_and_a_200(
+    vault: Path,
+) -> None:
+    """``empty`` is a success carrying an empty list, not an error.
+
+    Args:
+        vault: A seeded vault.
+    """
+    factory = _FactorySpy(_turn({"quote": _HALLUCINATED, "kind": "fear", "note": "x"}))
+    response = _post(vault, ceiling="open", factory=factory)
+    body = envelope(response)
+
+    assert response.status_code == _OK
+    assert body["status"] == ReflectionStatus.EMPTY.value
+    assert body["notes"] == []
+
+
+def test_essay_grounded_is_always_present_and_false(vault: Path) -> None:
+    """The serializer cannot omit the flag, and cannot claim ``True``.
+
+    ``essay`` is free model prose and is never verbatim-checked the way
+    ``notes[].quote`` is. A client that read a missing field as "unknown", or a
+    ``True`` as "safe to cite", would present ungrounded text as the writer's
+    own.
+
+    Args:
+        vault: A seeded vault.
+    """
+    factory = _FactorySpy(
+        _turn(
+            {"quote": _VERBATIM, "kind": "pattern", "note": "Real."},
+            essay="Some free prose the model wrote.",
+        )
+    )
+    body = envelope(_post(vault, ceiling="open", factory=factory))
+
+    assert "essay_grounded" in body
+    assert body["essay_grounded"] is False
+    assert body["essay"] == "Some free prose the model wrote."
+
+
+# --------------------------------------------------------------------------- #
+# Care escalation — asserted on the spy
+# --------------------------------------------------------------------------- #
+
+
+_CARE_ENTRY: Final[str] = "I want to kill myself and I have a plan for tonight."
+"""Synthetic acute-distress text, shaped to trip the production guard."""
+
+
+def test_a_care_flagged_entry_escalates_without_ever_calling_the_model(
+    vault: Path,
+) -> None:
+    """``escalate`` carries the real ``CARE_SIGNAL`` and the factory stays cold.
+
+    The response alone cannot prove the model was skipped — a route that called
+    it and discarded the answer would look the same. The spy can.
+
+    Args:
+        vault: A seeded vault.
+    """
+    factory = _FactorySpy(_GOOD_TURN)
+    response = _post(
+        vault, body={"content": _CARE_ENTRY}, ceiling="open", factory=factory
+    )
+    body = envelope(response)
+
+    assert response.status_code == _OK
+    assert body["status"] == ReflectionStatus.ESCALATE.value
+    # The guard's own reason, read off the guard rather than off
+    # ``CARE_SIGNAL["kind"]``. The two differ — the guard answers
+    # ``acute_distress_markers`` and the signal is kinded ``acute_distress`` —
+    # so the committed fixture at
+    # ``docs/contracts/adepthood-v1/examples/reflections/care-escalation.json``,
+    # which builds ``reason`` from the signal's kind, publishes a value the
+    # server never sends. Filed as a fixture defect rather than papered over
+    # here: the route must carry what the guard decided, not what a fixture
+    # guessed.
+    assert body["reason"] == acute_distress_guard(_CARE_ENTRY)
+    assert body["care_signal"] == CARE_SIGNAL
+    assert not factory.called
+
+
+def test_the_escalation_is_not_an_error_code(vault: Path) -> None:
+    """A person in acute distress must not land in a client's error path.
+
+    Args:
+        vault: A seeded vault.
+    """
+    body = envelope(_post(vault, body={"content": _CARE_ENTRY}, ceiling="open"))
+
+    assert "code" not in body
+    assert ReflectionStatus.ESCALATE.value not in {code.value for code in ErrorCode}
+
+
+# --------------------------------------------------------------------------- #
+# The ceiling gate
+# --------------------------------------------------------------------------- #
+
+
+def test_an_above_ceiling_entry_ref_is_refused_without_a_model_call(
+    vault: Path,
+) -> None:
+    """The read gate refuses, the model stays cold, and the tier is not echoed.
+
+    Args:
+        vault: A seeded vault.
+    """
+    _write_fragment(vault, frag_id="frag-secret", body=_ENTRY, privacy_tier="personal")
+    factory = _FactorySpy(_GOOD_TURN)
+
+    response = _post(
+        vault, body={"entry_ref": "frag-secret"}, ceiling="open", factory=factory
+    )
+
+    assert response.status_code == _REFUSED
+    assert envelope(response)["code"] == ErrorCode.PRIVACY_REFUSED.value
+    assert not factory.called
+    assert "personal" not in response.text
+    assert "intimate" not in response.text
+
+
+def test_an_unresolvable_entry_ref_is_privacy_refused_not_not_found(
+    vault: Path,
+) -> None:
+    """#1077 asks for ``not_found`` here. That instruction is refused.
+
+    :class:`~creek_mcp.api.models.ErrorCode.NOT_FOUND` is documented in
+    ``creek_mcp/api/models.py`` as a **routing** code — "no such endpoint on
+    this server" — and is explicitly forbidden for a vault object, because a
+    caller who can tell "no such fragment" from "not for you" can enumerate the
+    corpus one id at a time without reading a byte of it. That is precisely the
+    oracle #846 / #970 / #972 / #1090 spent five issues collapsing, and
+    ``tests/test_v1_api_structure.py`` AST-pins ``NOT_FOUND`` to the routing
+    layer so a handler cannot emit it at all.
+
+    So every vault-object non-answer collapses to ``privacy_refused``, exactly
+    as that module prescribes. The adapter is therefore *stricter* than the MCP
+    tool, which keeps ``"entry_ref not found"`` and ``"entry_ref tier exceeds
+    ceiling"`` distinct as a documented accepted residual oracle; over HTTP the
+    two are indistinguishable.
+
+    Args:
+        vault: A seeded vault.
+    """
+    _write_fragment(vault, frag_id="frag-real", body=_ENTRY, privacy_tier="personal")
+
+    missing = _post(vault, body={"entry_ref": "frag-nothing"}, ceiling="open")
+    above = _post(vault, body={"entry_ref": "frag-real"}, ceiling="open")
+
+    assert missing.status_code == above.status_code == _REFUSED
+    assert (
+        envelope(missing)["code"]
+        == envelope(above)["code"]
+        == ErrorCode.PRIVACY_REFUSED.value
+    )
+    assert envelope(missing)["message"] == envelope(above)["message"]
+
+
+def test_an_admitted_entry_ref_is_reflected(vault: Path) -> None:
+    """The converse, so the refusals above are about the ceiling and not the ref.
+
+    Args:
+        vault: A seeded vault.
+    """
+    _write_fragment(vault, frag_id="frag-open", body=_ENTRY, privacy_tier="open")
+
+    body = envelope(_post(vault, body={"entry_ref": "frag-open"}, ceiling="open"))
+
+    assert body["status"] == ReflectionStatus.OK.value
+    assert [note["quote"] for note in body["notes"]] == [_VERBATIM]
+
+
+def test_a_remote_caller_declaring_an_intimate_ceiling_reads_nothing(
+    vault: Path,
+) -> None:
+    """The adapter edge refuses first: no vault read, no model call, no trace.
+
+    Args:
+        vault: A seeded vault.
+    """
+    _write_fragment(vault, frag_id="frag-open", body=_ENTRY)
+    before = snapshot(vault)
+    factory = _FactorySpy(_GOOD_TURN)
+
+    response = _post(vault, ceiling="intimate", factory=factory)
+
+    assert response.status_code == _INVALID
+    assert envelope(response)["code"] == ErrorCode.INVALID_REQUEST.value
+    assert not factory.called
+    assert snapshot(vault) == before
+
+
+@pytest.mark.parametrize(
+    ("ceiling", "expected"),
+    [("open", PrivacyTier.OPEN), ("personal", PrivacyTier.PERSONAL)],
+)
+def test_the_routing_tier_dominates_the_admitted_entrys_tier(
+    vault: Path, ceiling: str, expected: PrivacyTier
+) -> None:
+    """The tier handed to the factory is never below what the ceiling admits.
+
+    The wire's ``routed_tier`` is safe to publish precisely because it is a
+    constant function of the caller's own declared ceiling. This pins both
+    halves for an HTTP caller: the value on the wire, and the value the factory
+    was actually keyed with.
+
+    Args:
+        vault: A seeded vault.
+        ceiling: The declared tier ceiling.
+        expected: The routing tier the factory must be keyed with.
+    """
+    _write_fragment(vault, frag_id="frag-open", body=_ENTRY, privacy_tier="open")
+    factory = _FactorySpy(_GOOD_TURN)
+
+    body = envelope(
+        _post(
+            vault,
+            body={"entry_ref": "frag-open"},
+            ceiling=ceiling,
+            factory=factory,
+        )
+    )
+
+    assert factory.tiers == [expected]
+    assert body["routed_tier"] == ceiling
+
+
+# --------------------------------------------------------------------------- #
+# Refusal mapping
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("reason", "code"),
+    [
+        ("entry_ref not found", ErrorCode.PRIVACY_REFUSED),
+        ("entry_ref tier exceeds ceiling", ErrorCode.PRIVACY_REFUSED),
+        ("no entry content supplied", ErrorCode.INVALID_REQUEST),
+        ("reflection unavailable: RuntimeError", ErrorCode.TEMPORARILY_UNAVAILABLE),
+        ("something nobody has written yet", ErrorCode.INTERNAL_ERROR),
+    ],
+)
+def test_every_tool_refusal_maps_onto_the_taxonomy(
+    reason: str, code: ErrorCode
+) -> None:
+    """Each refusal the tool can produce has one published code.
+
+    Args:
+        reason: The tool's structured refusal reason.
+        code: The wire code it must map to.
+    """
+    assert reflect_refusal_code(reason) == code
+
+
+def test_an_unavailable_provider_is_temporarily_unavailable_and_names_no_message(
+    vault: Path,
+) -> None:
+    """A raising factory becomes ``503``, carrying nothing of the exception.
+
+    ``reflect_tool`` already reduces the exception to its *type name*; the wire
+    keeps not even that, because :func:`error_response` renders one constant per
+    code.
+
+    Args:
+        vault: A seeded vault.
+    """
+    secret = "zz-provider-internals-1077-zz"
+
+    class _Raising(_FactorySpy):
+        """A factory that refuses to build a model callable."""
+
+        def __call__(self, tier: PrivacyTier) -> Callable[[str], str]:
+            """Refuse, naming an internal detail that must not travel.
+
+            Args:
+                tier: The routing tier, recorded before refusing.
+
+            Returns:
+                Never returns.
+
+            Raises:
+                RuntimeError: Always.
+            """
+            self.tiers.append(tier)
+            raise RuntimeError(secret)
+
+    response = _post(vault, ceiling="open", factory=_Raising())
+
+    assert response.status_code == _UNAVAILABLE
+    assert envelope(response)["code"] == ErrorCode.TEMPORARILY_UNAVAILABLE.value
+    assert secret not in response.text
+    assert "RuntimeError" not in response.text
+
+
+# --------------------------------------------------------------------------- #
+# Request validation
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("label", "body"),
+    [
+        ("both-sources", {"content": "x", "entry_ref": "y"}),
+        ("neither-source", {}),
+        ("blank-content", {"content": "   "}),
+        ("max-notes-too-low", {"content": _ENTRY, "max_notes": 0}),
+        ("max-notes-too-high", {"content": _ENTRY, "max_notes": 11}),
+    ],
+)
+def test_a_malformed_request_is_refused_before_the_vault(
+    vault: Path, label: str, body: dict[str, Any]
+) -> None:
+    """Exactly one source, bounded ``max_notes``, and nothing written.
+
+    Args:
+        vault: A seeded vault.
+        label: The refusal being exercised, for the parametrize id.
+        body: The request body.
+    """
+    assert label
+    before = snapshot(vault)
+    factory = _FactorySpy(_GOOD_TURN)
+    response = _post(vault, body=body, ceiling="open", factory=factory)
+
+    assert response.status_code == _INVALID
+    assert envelope(response)["code"] == ErrorCode.INVALID_REQUEST.value
+    assert not factory.called
+    assert snapshot(vault) == before
+
+
+# --------------------------------------------------------------------------- #
+# Disclosure
+# --------------------------------------------------------------------------- #
+
+
+def test_nothing_echoes_the_entry_a_grounding_title_or_a_fragment_id(
+    vault: Path,
+) -> None:
+    """Not the response, not a refusal, not the audit trail.
+
+    Args:
+        vault: A seeded vault.
+    """
+    _write_fragment(vault, frag_id="frag-open", body=_ENTRY, privacy_tier="open")
+    ok = _post(vault, body={"entry_ref": "frag-open"}, ceiling="open")
+    refused = _post(vault, body={"entry_ref": "frag-missing"}, ceiling="open")
+    log = (vault / MCP_AUDIT_RELPATH).read_text(encoding="utf-8")
+
+    assert _FRAGMENT_TITLE not in ok.text
+    assert _FRAGMENT_TITLE not in log
+    assert "frag-open" not in ok.text
+    assert "frag-missing" not in refused.text
+    assert _ENTRY not in log
+    assert not contains_a_path(refused.text)
+
+
+def test_the_audit_record_names_the_consumer_and_stays_a_non_oracle(
+    vault: Path,
+) -> None:
+    """``has_entry_ref`` and nothing else — never the probed id, never the outcome.
+
+    ``reflect_tool`` logs once, above the ceiling gate, so a refused probe is
+    still recorded; what it must never record is *which* id was probed or
+    whether the probe succeeded. A record carrying either would answer "did
+    consumer X read fragment F?" — the question the whole design withholds.
+
+    Args:
+        vault: A seeded vault.
+    """
+    _post(vault, body={"entry_ref": "frag-missing"}, ceiling="open")
+
+    records = _audit_records(vault)
+    assert [record["consumer"] for record in records] == [CONSUMER]
+    assert [record["args_summary"] for record in records] == [{"has_entry_ref": True}]
+    assert all("frag-missing" not in json.dumps(record) for record in records)
+    assert all("status" not in record for record in records)
+
+
+# --------------------------------------------------------------------------- #
+# HTTP <-> MCP parity
+# --------------------------------------------------------------------------- #
+
+
+_SCENARIOS: Final[tuple[tuple[str, dict[str, Any], str], ...]] = (
+    ("inline-open", {"content": _ENTRY}, "open"),
+    ("inline-personal", {"content": _ENTRY}, "personal"),
+    ("entry-ref-admitted", {"entry_ref": "frag-open"}, "open"),
+    ("entry-ref-above-ceiling", {"entry_ref": "frag-secret"}, "open"),
+    ("entry-ref-missing", {"entry_ref": "frag-nothing"}, "open"),
+    ("care-escalation", {"content": _CARE_ENTRY}, "open"),
+)
+"""``(name, request body, declared ceiling)`` rows run through both adapters.
+
+Every refusal branch is present, which is what #1077 asks of the harness: the
+ceiling gate, the unresolvable ref, and the escalation that must not be an
+error at all.
+"""
+
+
+@pytest.mark.parametrize(
+    ("name", "body", "ceiling"), _SCENARIOS, ids=[row[0] for row in _SCENARIOS]
+)
+def test_http_and_mcp_agree_on_every_scenario(
+    vault: Path,
+    mcp_vault: Path,
+    name: str,
+    body: dict[str, Any],
+    ceiling: str,
+) -> None:
+    """The same scenario, both adapters, identical behavioural outcome.
+
+    Args:
+        vault: The HTTP adapter's vault.
+        mcp_vault: The MCP adapter's vault.
+        name: The scenario name, surfaced in a divergence message.
+        body: The request body.
+        ceiling: The declared tier ceiling.
+    """
+    for root in (vault, mcp_vault):
+        _write_fragment(root, frag_id="frag-open", body=_ENTRY, privacy_tier="open")
+        _write_fragment(
+            root, frag_id="frag-secret", body=_ENTRY, privacy_tier="personal"
+        )
+
+    over_http = _post(
+        vault, body=body, ceiling=ceiling, factory=_FactorySpy(_GOOD_TURN)
+    )
+    over_mcp = reflect_tool(
+        vault_path=mcp_vault,
+        llm_factory=_FactorySpy(_GOOD_TURN),
+        content=body.get("content"),
+        entry_ref=body.get("entry_ref"),
+        care_guard=acute_distress_guard,
+        privacy_tier_ceiling=TierCeiling(ceiling),
+        consumer=CONSUMER,
+        max_notes=3,
+    )
+
+    assert_parity(
+        name,
+        http_outcome(over_http, vault, keys=_SUCCESS_KEYS),
+        mcp_outcome(
+            over_mcp,
+            mcp_vault,
+            keys=_SUCCESS_KEYS,
+            classify=reflect_refusal_code,
+            # ``escalate`` is a 200 on the wire, so it must normalise as a
+            # success here too; classifying it as an error would make the
+            # harness demand the very collapse the design forbids.
+            success_statuses=(
+                ReflectionStatus.OK.value,
+                ReflectionStatus.EMPTY.value,
+                ReflectionStatus.ESCALATE.value,
+            ),
+        ),
+    )

--- a/creek-tools/tests/test_api_wheel.py
+++ b/creek-tools/tests/test_api_wheel.py
@@ -1,0 +1,701 @@
+"""``GET /v1/wheel`` over the shared wheel tool (#1076).
+
+The read vertical, and the one whose whole risk is *vocabulary* rather than
+behaviour. Creek's wheel is a frequency distribution over the classified corpus:
+how many admitted fragments sit at each APTITUDE frequency, and each frequency's
+share of the classified total. Adepthood's Map validates a different ten-member
+shape — per-stage aspect *fullness* from its own 36-week curriculum. Both have
+ten members, which is a coincidence of cardinality and not a shared meaning, and
+serving one under the other's name is how a Map renders confidently wrong
+numbers.
+
+So this module asserts the boundary as well as the numbers: the response is
+``wheel_tool``'s tally verbatim, the ten canonical frequency names come off
+:data:`creek.generate.indexes.CANONICAL_FREQUENCY_NAMES`, and no stage or aspect
+vocabulary appears anywhere. The projection into Adepthood's domain is
+Adepthood's, and stays there.
+
+The aggregate is also the one shape where a privacy failure would be silent: a
+count is not a body, so an above-ceiling fragment leaking into the tally shows up
+as a number being one larger rather than as text appearing where it should not.
+:func:`test_an_open_caller_never_counts_a_personal_fragment` is therefore an
+equality against a *known* tally, not a "greater than zero" check.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, Final
+
+import frontmatter
+import pytest
+
+from creek.generate.indexes import CANONICAL_FREQUENCY_NAMES
+from creek_mcp.api.models import ERROR_MESSAGES, ErrorCode
+from creek_mcp.audit import MCP_AUDIT_RELPATH
+from creek_mcp.httpapi import vault as vault_module
+from creek_mcp.httpapi import wheel as wheel_module
+from creek_mcp.httpapi.wheel import wheel_refusal_code
+from creek_mcp.tier_ceiling import TierCeiling
+from creek_mcp.tools.wheel import wheel_tool
+from tests.adapter_parity import assert_parity, http_outcome, mcp_outcome
+from tests.v1_api_support import (
+    CONSUMER,
+    WHEEL_PATH,
+    client,
+    contains_a_path,
+    envelope,
+    headers,
+    seed_vault,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+    import httpx
+
+_OK: Final[int] = 200
+_INVALID: Final[int] = 422
+_INTERNAL: Final[int] = 500
+_UNAVAILABLE: Final[int] = 503
+
+_ENVELOPE_KEYS: Final[frozenset[str]] = frozenset({"code", "message", "request_id"})
+"""Every key an error body may carry. A fourth is a leak channel."""
+
+_CODES: Final[tuple[str, ...]] = tuple(
+    frequency.value for frequency in CANONICAL_FREQUENCY_NAMES
+)
+"""The ten canonical frequency codes, in the one published order."""
+
+_SHARE_TOLERANCE: Final[float] = 1e-9
+"""How far the ten shares may sum from ``1.0``. Float addition, not slack."""
+
+_TITLE: Final[str] = "zz-synthetic-fragment-title-1076-zz"
+"""A fragment title distinctive enough that any echo of it is unmissable."""
+
+_BODY: Final[str] = "zz-synthetic-fragment-body-1076-zz"
+"""A fragment body, likewise."""
+
+_SUCCESS_KEYS: Final[tuple[str, ...]] = (
+    "tier_ceiling",
+    "total_classified",
+    "unclassified",
+    "wheel",
+)
+"""The success facts the parity harness compares for this vertical."""
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> Iterator[Path]:
+    """Yield a freshly seeded vault for the HTTP adapter."""
+    yield seed_vault(tmp_path / "http")
+
+
+@pytest.fixture
+def mcp_vault(tmp_path: Path) -> Iterator[Path]:
+    """Yield a second seeded vault, so the two adapters never share a trail."""
+    yield seed_vault(tmp_path / "mcp")
+
+
+# --------------------------------------------------------------------------- #
+# Corpus + request helpers
+# --------------------------------------------------------------------------- #
+
+
+def _write_fragment(
+    vault_path: Path,
+    *,
+    frag_id: str,
+    primary: str = "F1",
+    privacy_tier: str = "open",
+) -> None:
+    """Write one classified fragment under ``01-Fragments/Notes``.
+
+    Args:
+        vault_path: The vault root.
+        frag_id: The fragment id and file stem.
+        primary: The primary frequency code, or an unrecognised string.
+        privacy_tier: The tier to stamp.
+    """
+    stamped = datetime(2026, 5, 1, tzinfo=UTC).isoformat()
+    metadata: dict[str, Any] = {
+        "type": "fragment",
+        "id": frag_id,
+        "title": _TITLE,
+        "created": stamped,
+        "ingested": stamped,
+        "source": {"platform": "journal", "author": "self"},
+        "frequency": {"primary": primary, "secondary": []},
+        "privacy_tier": privacy_tier,
+        "eddies": [],
+    }
+    folder = vault_path / "01-Fragments" / "Notes"
+    folder.mkdir(parents=True, exist_ok=True)
+    (folder / f"{frag_id}.md").write_text(
+        frontmatter.dumps(frontmatter.Post(content=_BODY, **metadata)),
+        encoding="utf-8",
+    )
+
+
+def _seed_corpus(vault_path: Path) -> None:
+    """Write the three-fragment OPEN corpus the tracer describes.
+
+    Args:
+        vault_path: The vault root.
+    """
+    _write_fragment(vault_path, frag_id="a", primary="F1")
+    _write_fragment(vault_path, frag_id="b", primary="F1")
+    _write_fragment(vault_path, frag_id="c", primary="F5")
+
+
+def _get(vault_path: Path, *, ceiling: str | None = None) -> httpx.Response:
+    """Request the wheel and return the raw response.
+
+    Args:
+        vault_path: The vault the app is built over.
+        ceiling: The declared tier ceiling, or ``None`` to send no header.
+
+    Returns:
+        The response.
+    """
+    with client(vault_path=vault_path) as test_client:
+        return test_client.get(WHEEL_PATH, headers=headers(ceiling=ceiling))
+
+
+# --------------------------------------------------------------------------- #
+# Shape: ten entries, canonical names, one order
+# --------------------------------------------------------------------------- #
+
+
+def test_a_populated_vault_returns_all_ten_canonical_frequencies(
+    vault: Path,
+) -> None:
+    """Ten entries, the canonical names, and the counts the corpus implies.
+
+    Args:
+        vault: A seeded vault.
+    """
+    _seed_corpus(vault)
+    body = envelope(_get(vault))
+
+    assert body["status"] == "ok"
+    assert list(body["wheel"]) == list(_CODES)
+    assert body["wheel"]["F1"] == {
+        "name": CANONICAL_FREQUENCY_NAMES[next(iter(CANONICAL_FREQUENCY_NAMES))],
+        "count": 2,
+        "share": pytest.approx(2 / 3),
+    }
+    assert body["wheel"]["F5"]["count"] == 1
+    assert body["wheel"]["F7"]["count"] == 0
+    assert body["total_classified"] == 3
+
+
+def test_the_order_is_the_same_on_every_call(vault: Path) -> None:
+    """Determinism, asserted across calls rather than within one.
+
+    A single call cannot tell a fixed order from an accidental one. Ten
+    declared model fields are what make the emission order the canonical one;
+    a mapping would have made it whatever the tally happened to insert first.
+
+    Args:
+        vault: A seeded vault.
+    """
+    _seed_corpus(vault)
+    orders = {tuple(envelope(_get(vault))["wheel"]) for _ in range(3)}
+
+    assert orders == {_CODES}
+
+
+def test_the_shares_sum_to_one_when_anything_is_classified(vault: Path) -> None:
+    """The ten shares are a distribution, not ten independent ratios.
+
+    Args:
+        vault: A seeded vault.
+    """
+    _seed_corpus(vault)
+    body = envelope(_get(vault))
+
+    total = sum(slice_["share"] for slice_ in body["wheel"].values())
+    assert abs(total - 1.0) < _SHARE_TOLERANCE
+
+
+@pytest.mark.parametrize("populated", [False, True], ids=["empty", "missing"])
+def test_an_empty_or_missing_corpus_is_an_all_zero_wheel_and_a_200(
+    vault: Path, populated: bool
+) -> None:
+    """A new vault is a legitimate state, not a 404 and not an error.
+
+    Answering an unclassified corpus with an error would make every client
+    treat "new" as "broken" — the exact collapse epic #1071 exists to stop.
+
+    Args:
+        vault: A seeded vault.
+        populated: Whether to create the fragments directory at all.
+    """
+    if populated:
+        (vault / "01-Fragments").mkdir(parents=True, exist_ok=True)
+    response = _get(vault)
+    body = envelope(response)
+
+    assert response.status_code == _OK
+    assert body["total_classified"] == 0
+    assert list(body["wheel"]) == list(_CODES)
+    assert all(slice_["count"] == 0 for slice_ in body["wheel"].values())
+    assert all(slice_["share"] == 0.0 for slice_ in body["wheel"].values())
+
+
+# --------------------------------------------------------------------------- #
+# Ceiling filtering — the silent failure
+# --------------------------------------------------------------------------- #
+
+
+def test_an_open_caller_never_counts_a_personal_fragment(vault: Path) -> None:
+    """Above-ceiling fragments are excluded from the tally, exactly.
+
+    An equality against a known tally, not a "greater than zero" check: a
+    count is not a body, so a leak here shows up only as a number being one
+    larger than it should be.
+
+    Args:
+        vault: A seeded vault.
+    """
+    _write_fragment(vault, frag_id="open-one", primary="F1")
+    _write_fragment(
+        vault, frag_id="personal-one", primary="F1", privacy_tier="personal"
+    )
+
+    body = envelope(_get(vault, ceiling="open"))
+
+    assert body["wheel"]["F1"]["count"] == 1
+    assert body["total_classified"] == 1
+    assert body["tier_ceiling"] == "open"
+
+
+def test_a_personal_caller_counts_both(vault: Path) -> None:
+    """The converse, so the exclusion above is about the ceiling and not the file.
+
+    Args:
+        vault: A seeded vault.
+    """
+    _write_fragment(vault, frag_id="open-one", primary="F1")
+    _write_fragment(
+        vault, frag_id="personal-one", primary="F1", privacy_tier="personal"
+    )
+
+    body = envelope(_get(vault, ceiling="personal"))
+
+    assert body["wheel"]["F1"]["count"] == 2
+    assert body["total_classified"] == 2
+
+
+def test_a_remote_caller_declaring_an_intimate_ceiling_is_refused_at_the_edge(
+    vault: Path,
+) -> None:
+    """No intimate-inclusive tally is obtainable over ``/v1``, at any status.
+
+    Args:
+        vault: A seeded vault.
+    """
+    _seed_corpus(vault)
+    response = _get(vault, ceiling="intimate")
+
+    assert response.status_code == _INVALID
+    assert envelope(response)["code"] == ErrorCode.INVALID_REQUEST.value
+    assert "wheel" not in response.text
+
+
+# --------------------------------------------------------------------------- #
+# The fail-closed frequency branch
+# --------------------------------------------------------------------------- #
+
+
+def test_an_unclassified_fragment_is_counted_apart_from_the_classified_total(
+    vault: Path,
+) -> None:
+    """A fragment nobody has classified yet is ``unclassified``, not a frequency.
+
+    :attr:`creek.models.Frequency.UNCLASSIFIED` is a *member* of the enum but
+    not a member of :data:`~creek.generate.indexes.CANONICAL_FREQUENCY_NAMES`,
+    which is what makes this the reachable version of the fail-closed branch:
+    the fragment loads, is admitted, and is deliberately kept out of the
+    denominator so the ten shares describe the classified corpus rather than
+    the whole vault.
+
+    Args:
+        vault: A seeded vault.
+    """
+    _write_fragment(vault, frag_id="known", primary="F1")
+    _write_fragment(vault, frag_id="pending", primary="unclassified")
+
+    body = envelope(_get(vault))
+
+    assert body["unclassified"] == 1
+    assert body["total_classified"] == 1
+    assert sum(slice_["count"] for slice_ in body["wheel"].values()) == 1
+    assert body["wheel"]["F1"]["share"] == 1.0
+
+
+def test_an_invented_frequency_never_reaches_the_tally_at_all(vault: Path) -> None:
+    """#1076's fifth acceptance criterion describes an unreachable branch.
+
+    The issue asks for a fragment with an "unrecognised frequency" to land in
+    ``unclassified`` via ``_frequency_counts``' ``except ValueError`` branch
+    (``tools/wheel.py:53-57``). It cannot get there. ``Fragment`` validates
+    ``frequency.primary`` against :class:`creek.models.Frequency` at load, so a
+    file carrying ``F11`` is schema-invalid and
+    :func:`creek.vault.reader.iter_vault_fragments` drops it *before*
+    ``wheel_tool`` sees anything — it is absent from the wheel, from
+    ``unclassified``, and from ``total_classified`` alike.
+
+    That is the safer of the two behaviours and is worth pinning rather than
+    "fixing": an eleventh frequency is a change to the shared ontology
+    vocabulary, and counting a file that claims one would let a producer expand
+    the published enum by writing a fragment. The genuinely reachable
+    fail-closed path is the test above.
+
+    Args:
+        vault: A seeded vault.
+    """
+    _write_fragment(vault, frag_id="known", primary="F1")
+    _write_fragment(vault, frag_id="invented", primary="F11")
+
+    body = envelope(_get(vault))
+
+    assert body["total_classified"] == 1
+    assert body["unclassified"] == 0
+    assert "F11" not in body["wheel"]
+
+
+# --------------------------------------------------------------------------- #
+# The projection boundary
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "borrowed", ["stage_number", "aspect", "fullness", "aspects", "stage"]
+)
+def test_the_response_borrows_no_curriculum_vocabulary(
+    vault: Path, borrowed: str
+) -> None:
+    """Creek publishes the corpus fact it owns and invents no stage/aspect words.
+
+    Adepthood's ``{aspects: [{stage_number, aspect, fullness}]}`` is a different
+    concept that happens to have ten members. Its projection is owned and tested
+    in Adepthood (their #1937); adopting its vocabulary here would make a
+    frequency tally look like curriculum progress to every reader of the wire.
+
+    Args:
+        vault: A seeded vault.
+        borrowed: The forbidden term.
+    """
+    _seed_corpus(vault)
+
+    assert borrowed not in _get(vault).text
+
+
+def test_no_fragment_title_body_or_id_reaches_the_wire(vault: Path) -> None:
+    """The wheel is aggregate-only.
+
+    Args:
+        vault: A seeded vault.
+    """
+    _seed_corpus(vault)
+    text = _get(vault).text
+
+    assert _TITLE not in text
+    assert _BODY not in text
+    assert not contains_a_path(text)
+
+
+# --------------------------------------------------------------------------- #
+# Audit
+# --------------------------------------------------------------------------- #
+
+
+def test_the_audit_record_carries_the_bearer_consumer(vault: Path) -> None:
+    """The verified token's ``client_id`` reaches the trail, not a default.
+
+    Args:
+        vault: A seeded vault.
+    """
+    _seed_corpus(vault)
+    _get(vault)
+
+    log = (vault / MCP_AUDIT_RELPATH).read_text(encoding="utf-8")
+    assert f'"consumer": "{CONSUMER}"' in log
+    assert '"tool": "creek.wheel"' in log
+
+
+# --------------------------------------------------------------------------- #
+# Refusal mapping
+# --------------------------------------------------------------------------- #
+
+
+def test_any_wheel_refusal_fails_closed_to_internal_error() -> None:
+    """``wheel_tool`` has no refusal branch, so an adapter must invent none.
+
+    The mapping exists because the parity harness needs one and because a
+    future refusal must not be narrated by an adapter that has never seen it.
+    ``internal_error`` asserts nothing about the vault, which is the only honest
+    answer to a refusal this adapter does not understand.
+    """
+    assert wheel_refusal_code("anything at all") is ErrorCode.INTERNAL_ERROR
+
+
+def test_a_tool_refusal_becomes_a_500_carrying_none_of_its_reason(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A refusal the adapter has never seen is a ``500`` that narrates nothing.
+
+    ``wheel_tool`` has no refusal branch today, so the only way to reach the
+    adapter's non-``ok`` arm is to substitute the tool — and the property under
+    test is the *projection*, not how the tool got there. A structured refusal
+    can carry a vault path in its ``reason``; the wire carries the constant
+    message for ``internal_error`` and nothing else.
+
+    Args:
+        vault: A seeded vault.
+        monkeypatch: Substitutes the tool for a refusing one.
+    """
+    leak = "/private/vault/01-Fragments/Notes/zz-secret-name-zz.md"
+
+    def _refusing(**_kwargs: object) -> dict[str, Any]:
+        """Refuse the way a future ``wheel_tool`` might.
+
+        Args:
+            **_kwargs: The real tool's keyword arguments, unused.
+
+        Returns:
+            A structured refusal whose reason names a path.
+        """
+        return {
+            "status": "refused",
+            "tool": "creek.wheel",
+            "tier_ceiling": "open",
+            "reason": f"tally failed: could not read {leak}",
+        }
+
+    monkeypatch.setattr(wheel_module, "wheel_tool", _refusing)
+    response = _get(vault)
+    body = envelope(response)
+
+    assert response.status_code == _INTERNAL
+    assert set(body) == _ENVELOPE_KEYS
+    assert body["code"] == ErrorCode.INTERNAL_ERROR.value
+    assert body["message"] == ERROR_MESSAGES[ErrorCode.INTERNAL_ERROR]
+    assert leak not in response.text
+    assert "zz-secret-name-zz" not in response.text
+
+
+# --------------------------------------------------------------------------- #
+# Projection: a tally that does not fit the contract
+# --------------------------------------------------------------------------- #
+
+
+def _ok_tally(**overrides: Any) -> dict[str, Any]:
+    """Return a well-formed ``wheel_tool`` result with *overrides* applied.
+
+    Args:
+        **overrides: Keys to replace on the canonical all-zero result.
+
+    Returns:
+        The result dict the adapter would normally project onto
+        :class:`~creek_mcp.api.models.WheelResponse`.
+    """
+    tally: dict[str, Any] = {
+        "status": "ok",
+        "tool": "creek.wheel",
+        "tier_ceiling": "open",
+        "total_classified": 0,
+        "unclassified": 0,
+        "wheel": {
+            code.value: {"name": name, "count": 0, "share": 0.0}
+            for code, name in CANONICAL_FREQUENCY_NAMES.items()
+        },
+    }
+    tally.update(overrides)
+    return tally
+
+
+_ELEVENTH: Final[str] = "F11"
+"""A frequency the published vocabulary does not contain."""
+
+_MALFORMED: Final[tuple[tuple[str, dict[str, Any], str], ...]] = (
+    (
+        "eleventh-frequency",
+        _ok_tally(
+            wheel={
+                **_ok_tally()["wheel"],
+                _ELEVENTH: {"name": "Invention", "count": 7, "share": 1.0},
+            }
+        ),
+        _ELEVENTH,
+    ),
+    (
+        "missing-total",
+        {key: value for key, value in _ok_tally().items() if key != "total_classified"},
+        "total_classified",
+    ),
+    ("unparseable-total", _ok_tally(total_classified="seventeen"), "seventeen"),
+    ("unknown-ceiling", _ok_tally(tier_ceiling="cosmic"), "cosmic"),
+    ("null-unclassified", _ok_tally(unclassified=None), "null"),
+)
+"""``(id, tool result, token that must not echo)`` — one row per caught type.
+
+In order: :class:`pydantic.ValidationError` (``extra="forbid"`` rejects an
+eleventh member), :class:`KeyError` (an absent field), :class:`ValueError`
+(twice — an uncoercible integer, and a ceiling outside
+:class:`~creek_mcp.api.models.WireTierCeiling`) and :class:`TypeError`
+(``int(None)``). Each is a member of the tuple ``_render`` catches, so a row
+that stopped being refused would mean a partially-projected wheel had reached
+the wire.
+"""
+
+
+@pytest.mark.parametrize(
+    ("tally", "forbidden"),
+    [(row[1], row[2]) for row in _MALFORMED],
+    ids=[row[0] for row in _MALFORMED],
+)
+def test_a_tally_that_does_not_fit_the_contract_is_refused_not_reshaped(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tally: dict[str, Any],
+    forbidden: str,
+) -> None:
+    """A result the response model rejects becomes a ``500``, never a partial 200.
+
+    The ``eleventh-frequency`` row is the one that matters most and is the
+    reason ``WheelFrequencies`` is ten declared fields rather than a mapping: an
+    extra member is a change to the shared ontology vocabulary, so a producer
+    must not be able to widen the published enum by emitting one. The other
+    rows pin that the same closed refusal covers a missing field, an uncoercible
+    count and a ceiling outside the wire vocabulary — the adapter has no
+    salvage path that would serve some of the tally and quietly drop the rest.
+
+    Args:
+        vault: A seeded vault.
+        monkeypatch: Substitutes the tool for one returning *tally*.
+        tally: A result that cannot be projected onto ``WheelResponse``.
+        forbidden: A token from *tally* that must not reach the wire.
+    """
+
+    def _malformed(**_kwargs: object) -> dict[str, Any]:
+        """Return the parametrized result.
+
+        Args:
+            **_kwargs: The real tool's keyword arguments, unused.
+
+        Returns:
+            The malformed tally under test.
+        """
+        return tally
+
+    monkeypatch.setattr(wheel_module, "wheel_tool", _malformed)
+    response = _get(vault)
+    body = envelope(response)
+
+    assert response.status_code == _INTERNAL
+    assert set(body) == _ENVELOPE_KEYS
+    assert body["code"] == ErrorCode.INTERNAL_ERROR.value
+    assert body["message"] == ERROR_MESSAGES[ErrorCode.INTERNAL_ERROR]
+    assert forbidden not in response.text
+
+
+# --------------------------------------------------------------------------- #
+# Vault resolution
+# --------------------------------------------------------------------------- #
+
+
+def test_an_unreadable_configuration_is_unavailable_and_names_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No configured vault and no readable config is ``503 unavailable``.
+
+    With ``vault_path=None`` the route resolves through
+    :func:`~creek_mcp.httpapi.vault.configured_vault`, which degrades an
+    unreadable ``creek_config.yaml`` to ``None``. The route has to refuse
+    *before* calling the tool: ``wheel_tool`` over an unresolved vault answers
+    an all-zero wheel, which would render a broken installation as an empty
+    corpus — a ``200`` saying "you have written nothing" to someone whose
+    config is simply unopenable.
+
+    ``unavailable`` rather than ``temporarily_unavailable`` because its retry
+    disposition is ``retry_after_operator_action``: backing off will not repair
+    a config file.
+
+    Args:
+        monkeypatch: Substitutes the config loader for a raising one.
+    """
+    leak = "/private/operator/00-Creek-Meta/creek_config.yaml"
+
+    def _unreadable() -> object:
+        """Fail the way an unopenable configuration file fails.
+
+        Returns:
+            Never returns.
+
+        Raises:
+            OSError: Always, naming a path that must not travel.
+        """
+        raise OSError(leak)
+
+    monkeypatch.setattr(vault_module, "load_config", _unreadable)
+    with client(vault_path=None) as test_client:
+        response = test_client.get(WHEEL_PATH, headers=headers())
+    body = envelope(response)
+
+    assert response.status_code == _UNAVAILABLE
+    assert set(body) == _ENVELOPE_KEYS
+    assert body["code"] == ErrorCode.UNAVAILABLE.value
+    assert body["message"] == ERROR_MESSAGES[ErrorCode.UNAVAILABLE]
+    assert leak not in response.text
+    assert not contains_a_path(response.text)
+
+
+# --------------------------------------------------------------------------- #
+# HTTP <-> MCP parity
+# --------------------------------------------------------------------------- #
+
+
+_SCENARIOS: Final[tuple[tuple[str, str], ...]] = (
+    ("open-ceiling", "open"),
+    ("personal-ceiling", "personal"),
+)
+"""``(name, declared ceiling)`` rows run through both adapters."""
+
+
+@pytest.mark.parametrize(
+    ("name", "ceiling"), _SCENARIOS, ids=[row[0] for row in _SCENARIOS]
+)
+def test_http_and_mcp_agree_on_counts_shares_and_ordering(
+    vault: Path, mcp_vault: Path, name: str, ceiling: str
+) -> None:
+    """The same mixed-tier vault, both adapters, identical tally and order.
+
+    Args:
+        vault: The HTTP adapter's vault.
+        mcp_vault: The MCP adapter's vault.
+        name: The scenario name, surfaced in a divergence message.
+        ceiling: The declared tier ceiling.
+    """
+    for root in (vault, mcp_vault):
+        _seed_corpus(root)
+        _write_fragment(root, frag_id="p", primary="F5", privacy_tier="personal")
+        _write_fragment(root, frag_id="bogus", primary="F11")
+
+    over_http = _get(vault, ceiling=ceiling)
+    over_mcp = wheel_tool(
+        vault_path=mcp_vault,
+        privacy_tier_ceiling=TierCeiling(ceiling),
+        consumer=CONSUMER,
+    )
+
+    assert_parity(
+        name,
+        http_outcome(over_http, vault, keys=_SUCCESS_KEYS),
+        mcp_outcome(
+            over_mcp, mcp_vault, keys=_SUCCESS_KEYS, classify=wheel_refusal_code
+        ),
+    )

--- a/creek-tools/tests/test_v1_api_admission.py
+++ b/creek-tools/tests/test_v1_api_admission.py
@@ -478,8 +478,16 @@ def _vary_cases() -> tuple[tuple[str, dict[str, str], str, int], ...]:
 
     Returns:
         One case per published status an intermediary could cache: the
-        ``401``, the routing ``404``, the ceiling ``422``, the honest ``501``
-        and the ``200``.
+        ``401``, the routing ``404``, the ceiling ``422``, the vault-object
+        ``403`` and the ``200``.
+
+        The ``501`` this sweep used to carry is gone: #1077 built the last
+        capability, so no route answers ``unsupported_capability`` any more
+        (``tests/test_v1_api_not_implemented.py`` drives the stub directly
+        instead). It is replaced by the ``403`` an above-ceiling journal write
+        earns — a *reachable* refusal, and a more interesting one to cache
+        wrongly, since it is the one status whose correctness depends on the
+        ceiling the response varies on.
     """
     return (
         ("/v1/capabilities", headers(token=None), "GET", _UNAUTHENTICATED_STATUS),
@@ -490,7 +498,7 @@ def _vary_cases() -> tuple[tuple[str, dict[str, str], str, int], ...]:
             "GET",
             _INVALID_REQUEST_STATUS,
         ),
-        ("/v1/wheel", headers(), "GET", 501),
+        ("/v1/journal-entries/vary-probe", headers(ceiling="open"), "PUT", 403),
         ("/v1/capabilities", headers(), "GET", 200),
     )
 
@@ -498,7 +506,7 @@ def _vary_cases() -> tuple[tuple[str, dict[str, str], str, int], ...]:
 @pytest.mark.parametrize(
     ("path", "request_headers", "method", "expected"),
     _vary_cases(),
-    ids=["401", "404", "422", "501", "200"],
+    ids=["401", "404", "422", "403", "200"],
 )
 def test_vary_is_set_on_every_response(
     vault: Path,
@@ -522,8 +530,11 @@ def test_vary_is_set_on_every_response(
         method: HTTP method.
         expected: The status this case must produce.
     """
+    # ``PUT`` is the one case needing a body; the others take none, and a
+    # body on a ``GET`` would be refused before the header under test is set.
+    body = {"content": "vary probe", "tier": "personal"} if method == "PUT" else None
     with client(vault_path=vault) as test_client:
-        response = test_client.request(method, path, headers=request_headers)
+        response = test_client.request(method, path, headers=request_headers, json=body)
     assert response.status_code == expected
     assert CEILING_HEADER.lower() in response.headers.get("vary", "").lower()
 

--- a/creek-tools/tests/test_v1_api_capabilities.py
+++ b/creek-tools/tests/test_v1_api_capabilities.py
@@ -43,6 +43,7 @@ from typing import TYPE_CHECKING, Final
 
 import pytest
 import yaml
+from starlette.testclient import TestClient
 
 from creek_mcp.api.models import (
     CONTRACT_MINOR,
@@ -56,12 +57,14 @@ from creek_mcp.api.models import (
 from creek_mcp.api.openapi import build_openapi
 from creek_mcp.api.routes import IMPLEMENTED_CAPABILITIES, ROUTES
 from creek_mcp.contract import CONTRACT_VERSION, ONTOLOGY_VERSION
-from creek_mcp.httpapi import capabilities as capabilities_module
 from creek_mcp.httpapi import handlers as handlers_module
+from creek_mcp.httpapi import vault as vault_module
 from creek_mcp.tools import handshake as handshake_module
 from creek_mcp.tools.handshake import CREEK_MARKER, vault_available
 from tests.v1_api_support import (
     CAPABILITIES_PATH,
+    OP_REFLECTIONS,
+    REFLECTIONS_PATH,
     build_app,
     client,
     envelope,
@@ -77,6 +80,7 @@ REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[2]
 """``<repo-root>``: ``tests`` -> ``creek-tools`` -> the root that owns ``docs``."""
 
 _OK_STATUS: Final[int] = 200
+_UNSUPPORTED_STATUS: Final[int] = 501
 """The only status a reachable, authenticated, well-formed handshake returns."""
 
 _INVALID_REQUEST_STATUS: Final[int] = 422
@@ -175,12 +179,23 @@ def test_the_tier_model_is_the_standing_promise(vault: Path) -> None:
 def test_a_present_vault_advertises_only_the_built_capabilities(
     vault: Path,
 ) -> None:
-    """At #1074 that is exactly ``["capabilities"]``.
+    """At #1077 that is every published capability.
+
+    Spelled as a literal rather than derived from
+    ``IMPLEMENTED_CAPABILITIES`` — that derivation already has its own test
+    below. This one is the pin that makes a capability's landing *visible* in
+    a diff: a fifth capability has to add its name here, and a handler wired
+    without the constant (or vice versa) cannot slip past both.
 
     Args:
         vault: A seeded vault.
     """
-    assert _get(vault)["capabilities"] == ["capabilities"]
+    assert _get(vault)["capabilities"] == [
+        "capabilities",
+        "journal-upsert",
+        "reflections",
+        "wheel",
+    ]
 
 
 def test_the_response_carries_no_field_beyond_the_published_model(
@@ -320,14 +335,15 @@ def test_an_unreadable_config_degrades_to_uninitialized(
     down, sending them to look at the wrong thing.
 
     Args:
-        monkeypatch: Replaces ``load_config`` with a raiser.
+        monkeypatch: Replaces ``load_config`` with a raiser, on the module
+            that now owns vault resolution for every route (#1075).
         error: The exception ``load_config`` raises.
     """
 
     def _raise() -> None:
         raise error
 
-    monkeypatch.setattr(capabilities_module, "load_config", _raise)
+    monkeypatch.setattr(vault_module, "load_config", _raise)
     with client(vault_path=None) as test_client:
         response = test_client.get(CAPABILITIES_PATH, headers=headers())
     assert response.status_code == 200
@@ -383,28 +399,6 @@ def test_every_implemented_capability_has_a_real_handler(
     assert getattr(endpoint, "unimplemented_capability", None) is None
 
 
-@pytest.mark.parametrize(
-    "capability", _UNIMPLEMENTED_CAPABILITIES, ids=lambda c: str(c.value)
-)
-def test_every_unimplemented_capability_is_mounted_to_the_stub(
-    vault: Path, capability: Capability
-) -> None:
-    """The converse. An unbuilt capability answers ``501``, honestly stubbed.
-
-    This is what turns #1075/#1076/#1077 red: wiring a real handler without
-    adding the capability to ``IMPLEMENTED_CAPABILITIES`` fails here, and
-    adding it to the constant without wiring a handler fails the test above.
-
-    Args:
-        vault: A seeded vault.
-        capability: The unbuilt capability under test.
-    """
-    spec = next(entry for entry in ROUTES if entry.capability is capability)
-    app = build_app(vault_path=vault)
-    endpoint = route_for(app, spec.path, spec.method).endpoint
-    assert getattr(endpoint, "unimplemented_capability", None) is capability
-
-
 def test_the_unimplemented_factory_marks_its_product() -> None:
     """The marker check above is not vacuous.
 
@@ -417,14 +411,59 @@ def test_the_unimplemented_factory_marks_its_product() -> None:
     assert getattr(stub, "unimplemented_capability", None) is Capability.WHEEL
 
 
-def test_there_is_at_least_one_unimplemented_capability() -> None:
-    """The stub parametrize above has cases to run.
+def test_no_published_capability_is_mounted_to_the_stub() -> None:
+    """#1077 finished the epic, so the unimplemented set is empty. On purpose.
 
-    When #1075—#1077 land this becomes an empty set and this test goes red on
-    purpose: at that point the honesty machinery has done its job and the
-    parametrized converse has nothing left to guard.
+    Until now this module held a parametrized converse — one case per
+    published-but-unbuilt capability, asserting it was mounted to the honest
+    ``501`` — plus a guard asserting that set was non-empty so the parametrize
+    had rows. Both are gone, because both were about the *interim*: #1075,
+    #1076 and #1077 each built one handler, and there is no longer a capability
+    that is advertised and unbuilt.
+
+    Deleting them without replacement would have retired the machinery along
+    with the interim, which is the wrong trade — the machinery is what stops the
+    *next* capability being advertised before it works. So the guard is
+    restated as the invariant that actually matters now, and
+    :func:`test_the_stub_still_answers_501_for_an_unbuilt_capability` below
+    keeps the stub itself exercised against the day a fifth capability lands.
     """
-    assert _UNIMPLEMENTED_CAPABILITIES
+    assert _UNIMPLEMENTED_CAPABILITIES == ()
+
+
+def test_the_stub_still_answers_501_for_an_unbuilt_capability(vault: Path) -> None:
+    """The honesty stub is kept alive by exercising it, not by having a victim.
+
+    With every capability built, nothing in the *route table* reaches
+    :class:`~creek_mcp.httpapi.handlers.UnimplementedHandler` any more. That is
+    exactly when an unused guard rots: the next capability added to
+    ``Capability`` before its handler exists would be mounted to a stub nobody
+    had run in months.
+
+    So the machinery is driven directly — the route table's handler map is
+    substituted for one operation, the app is built around it, and the mounted
+    endpoint is asserted to be both *stamped* and *answering* the published
+    ``501``. That is the same path a genuinely unbuilt capability would take.
+
+    Args:
+        vault: A seeded vault.
+    """
+    stub = handlers_module.unimplemented(Capability.REFLECTIONS)
+    substituted = {**handlers_module.HANDLERS, OP_REFLECTIONS: stub}
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(handlers_module, "HANDLERS", substituted)
+        app = build_app(vault_path=vault)
+        endpoint = route_for(app, REFLECTIONS_PATH, "POST").endpoint
+        with TestClient(app) as test_client:
+            response = test_client.post(
+                REFLECTIONS_PATH,
+                json={"content": "anything at all"},
+                headers=headers(ceiling="open"),
+            )
+
+    assert getattr(endpoint, "unimplemented_capability", None) is Capability.REFLECTIONS
+    assert response.status_code == _UNSUPPORTED_STATUS
+    assert envelope(response)["code"] == ErrorCode.UNSUPPORTED_CAPABILITY.value
 
 
 def test_capabilities_fixture_documents_the_completed_steady_state() -> None:

--- a/creek-tools/tests/test_v1_api_hardening.py
+++ b/creek-tools/tests/test_v1_api_hardening.py
@@ -63,6 +63,7 @@ from creek_mcp.api.models import ERROR_MESSAGES, ErrorCode
 from creek_mcp.audit import MCP_AUDIT_RELPATH, verify_mcp_audit_chain
 from creek_mcp.httpapi import capabilities as capabilities_module
 from creek_mcp.httpapi import handlers as handlers_module
+from creek_mcp.httpapi import vault as vault_module
 from creek_mcp.httpapi.auth import BearerAuthMiddleware
 from creek_mcp.httpapi.context import LIFESPAN_SCOPE, UnsupportedScopeError
 from creek_mcp.httpapi.logging import ACCESS_LOGGER_NAME, ERROR_LOGGER_NAME
@@ -104,6 +105,7 @@ if TYPE_CHECKING:
 
 _OK_STATUS: Final[int] = 200
 _INVALID_REQUEST_STATUS: Final[int] = 422
+_TEMPORARILY_UNAVAILABLE_STATUS: Final[int] = 503
 _UNAVAILABLE_STATUS: Final[int] = 503
 _INTERNAL_ERROR_STATUS: Final[int] = 500
 _UNSUPPORTED_STATUS: Final[int] = 501
@@ -298,19 +300,39 @@ def test_a_body_at_exactly_the_limit_is_accepted(vault: Path) -> None:
     """The cap is inclusive, so a body of exactly *n* bytes reaches the route.
 
     Without this, an off-by-one that refused everything would satisfy both
-    tests above. ``501`` is the proof it got past the limit: it is the
-    capability gate's answer, which lives below the router.
+    tests above. What proves it got through is which *layer* answered: the
+    body-size gate refuses with ``invalid_request`` before the router runs,
+    whereas this body travels all the way into the reflection route and is
+    refused by the LLM factory, which answers ``temporarily_unavailable``.
+    Two different codes, so the boundary is unambiguous.
+
+    Until #1077 the proof was a ``501`` from the capability gate; that gate has
+    no unbuilt route left to answer for, so the evidence moved one layer deeper
+    — which is a strictly stronger claim about how far the body travelled.
+
+    The factory is injected and raises deterministically, so the assertion does
+    not depend on whether a local provider happens to be running.
 
     Args:
         vault: A seeded vault.
     """
-    with client(vault_path=vault, max_body_bytes=_SMALL_LIMIT) as test_client:
+
+    def _refusing_factory() -> object:
+        msg = "no provider in this test"
+        raise RuntimeError(msg)
+
+    with client(
+        vault_path=vault,
+        max_body_bytes=_SMALL_LIMIT,
+        reflect_llm_factory=_refusing_factory,
+    ) as test_client:
         response = test_client.post(
             REFLECTIONS_PATH,
             content=_body_of_exactly(_SMALL_LIMIT),
             headers={**headers(ceiling="open"), "Content-Type": "application/json"},
         )
-    assert response.status_code == _UNSUPPORTED_STATUS
+    assert response.status_code == _TEMPORARILY_UNAVAILABLE_STATUS
+    assert envelope(response)["code"] == ErrorCode.TEMPORARILY_UNAVAILABLE.value
 
 
 def test_an_oversize_body_writes_no_log_line_carrying_its_content(
@@ -938,8 +960,11 @@ def test_every_blocking_seam_of_the_readiness_probe_runs_off_the_event_loop(
     looks wrong at the call site, and no other test in the suite can tell.
 
     ``vault_path=None`` is what routes the request through ``load_config`` at
-    all; with a vault configured on the app, ``_configured_vault`` returns early
-    and that seam is never reached.
+    all; with a vault configured on the app,
+    :func:`~creek_mcp.httpapi.vault.configured_vault` returns early and that
+    seam is never reached. ``load_config`` is patched on
+    :mod:`creek_mcp.httpapi.vault`, which has owned resolution for every route
+    since #1075; the other two seams stay on the handshake's own module.
 
     Args:
         vault: A seeded vault, named by the stubbed configuration.
@@ -950,8 +975,9 @@ def test_every_blocking_seam_of_the_readiness_probe_runs_off_the_event_loop(
         "vault_available": _SeamProbe(True),
         "handshake_tool": _SeamProbe({"available": True}),
     }
-    for name, probe in probes.items():
-        monkeypatch.setattr(capabilities_module, name, probe)
+    monkeypatch.setattr(vault_module, "load_config", probes["load_config"])
+    for name in ("vault_available", "handshake_tool"):
+        monkeypatch.setattr(capabilities_module, name, probes[name])
 
     with client(vault_path=None) as test_client:
         response = test_client.get(CAPABILITIES_PATH, headers=headers())
@@ -1337,10 +1363,15 @@ def test_the_request_id_is_not_derived_from_anything_the_caller_sent(
     the one variable field of the error envelope a channel for exactly the
     material every other assertion in this suite keeps out of it.
 
+    Driven through a *refusal*, because only an error envelope carries a
+    ``request_id`` at all. A ``personal`` entry under an ``open`` ceiling is the
+    smallest reachable one now that #1075 has built this route; before it, the
+    route's ``501`` served the same purpose.
+
     Args:
         vault: A seeded vault.
     """
-    sent: dict[str, Any] = {"content": _SENTINEL_BODY, "tier": "open"}
+    sent: dict[str, Any] = {"content": _SENTINEL_BODY, "tier": "personal"}
     with client(vault_path=vault) as test_client:
         first = test_client.put(
             f"/v1/journal-entries/{_SENTINEL_ID}",

--- a/creek-tools/tests/test_v1_api_hardening.py
+++ b/creek-tools/tests/test_v1_api_hardening.py
@@ -80,10 +80,13 @@ from tests.v1_api_support import (
     CAPABILITIES_PATH,
     CONSUMER,
     HEALTH_PATH,
+    JOURNAL_PATH,
     JOURNAL_TEMPLATE,
     OP_HEALTH,
     REFLECTIONS_PATH,
     STRONG_TOKEN,
+    VALID_JOURNAL_BODY,
+    VALID_REFLECTION_BODY,
     WHEEL_PATH,
     build_app,
     client,
@@ -1038,6 +1041,133 @@ def test_the_event_loop_serves_another_request_while_the_handshake_blocks(
     assert not holder.is_alive()
     assert health.status_code == _OK_STATUS
     assert order == ["health", "capabilities"]
+
+
+def _config_read_probe(monkeypatch: pytest.MonkeyPatch, vault: Path) -> _SeamProbe:
+    """Swap the per-request configuration read for a probe that reports its thread.
+
+    :func:`~creek_mcp.httpapi.vault.configured_vault` falls through to
+    ``load_config`` — a file read and a YAML parse — whenever the app was built
+    without an explicit ``vault_path``, which is exactly what
+    :func:`creek_mcp.httpapi.cli.main` does. So every content route inherits the
+    handshake's hazard, and every content test below drives it the same way:
+    ``vault_path=None`` on the app is what reaches this seam at all.
+
+    Args:
+        monkeypatch: Swaps ``load_config`` on the shared resolver module.
+        vault: The vault the stubbed configuration names.
+
+    Returns:
+        The installed probe, whose ``ran_on_the_event_loop`` is the assertion.
+    """
+    probe = _SeamProbe(SimpleNamespace(vault_path=vault))
+    monkeypatch.setattr(vault_module, "load_config", probe)
+    return probe
+
+
+def _silent_llm_factory() -> Callable[[Any], Callable[[str], str]]:
+    """Return a tier-keyed LLM factory whose model finds nothing.
+
+    ``POST /v1/reflections`` cannot be driven without one, and the reflection's
+    *content* is irrelevant to where the config read happened — so this is the
+    cheapest factory that keeps the request on the success path.
+
+    Returns:
+        A factory returning a completion callable that answers with no notes.
+    """
+
+    def _for_tier(_tier: Any) -> Callable[[str], str]:
+        """Return the completion callable for any routing tier.
+
+        Args:
+            _tier: The tier the tool derived, which this stub ignores.
+
+        Returns:
+            The stub completion callable.
+        """
+
+        def _complete(_prompt: str) -> str:
+            """Answer with a well-formed turn carrying no notes.
+
+            Args:
+                _prompt: The composed prompt, unused.
+
+            Returns:
+                The serialised turn.
+            """
+            return '{"notes": []}'
+
+        return _complete
+
+    return _for_tier
+
+
+def test_the_journal_upsert_resolves_its_vault_off_the_event_loop(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``PUT /v1/journal-entries/{external_id}`` must not read config on the loop.
+
+    The route already hoists the ingest run into a worker, so the *slow* part
+    looks handled — but resolving which vault to run against is itself a file
+    read and a YAML parse, and doing it before the hoist puts it back on the
+    loop for every request. Same failure as the handshake's, on a route that
+    writes.
+
+    A status assertion alone cannot see this: the blocking arrangement returns
+    the identical ``200``. What separates them is which thread ran the read, so
+    that is what is asserted — and the ``200`` is the non-vacuity half, proving
+    the probe's answer was consumed by the production path.
+
+    Args:
+        vault: A seeded vault, named by the stubbed configuration.
+        monkeypatch: Swaps the configuration read for a probe.
+    """
+    probe = _config_read_probe(monkeypatch, vault)
+    with client(vault_path=None) as test_client:
+        response = test_client.put(
+            JOURNAL_PATH, json=VALID_JOURNAL_BODY, headers=headers()
+        )
+
+    assert response.status_code == _OK_STATUS
+    assert probe.ran_on_the_event_loop is False
+
+
+def test_the_wheel_resolves_its_vault_off_the_event_loop(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``GET /v1/wheel`` must not read config on the loop either.
+
+    Args:
+        vault: A seeded vault, named by the stubbed configuration.
+        monkeypatch: Swaps the configuration read for a probe.
+    """
+    probe = _config_read_probe(monkeypatch, vault)
+    with client(vault_path=None) as test_client:
+        response = test_client.get(WHEEL_PATH, headers=headers())
+
+    assert response.status_code == _OK_STATUS
+    assert probe.ran_on_the_event_loop is False
+
+
+def test_the_reflection_route_resolves_its_vault_off_the_event_loop(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``POST /v1/reflections`` must not read config on the loop either.
+
+    Args:
+        vault: A seeded vault, named by the stubbed configuration.
+        monkeypatch: Swaps the configuration read for a probe.
+    """
+    probe = _config_read_probe(monkeypatch, vault)
+    with client(
+        vault_path=None, reflect_llm_factory=_silent_llm_factory
+    ) as test_client:
+        response = test_client.post(
+            REFLECTIONS_PATH, json=VALID_REFLECTION_BODY, headers=headers()
+        )
+
+    assert response.status_code == _OK_STATUS
+    assert probe.ran_on_the_event_loop is False
 
 
 # --------------------------------------------------------------------------- #

--- a/creek-tools/tests/test_v1_api_not_implemented.py
+++ b/creek-tools/tests/test_v1_api_not_implemented.py
@@ -42,7 +42,8 @@ from tests.v1_api_support import (
     HEALTH_PATH,
     JOURNAL_PATH,
     MOUNTED,
-    REFLECTIONS_PATH,
+    STUB_METHOD,
+    STUB_PATH,
     VALID_JOURNAL_BODY,
     VALID_REFLECTION_BODY,
     VERSIONED,
@@ -54,12 +55,14 @@ from tests.v1_api_support import (
     headers,
     seed_vault,
     snapshot,
+    stubbed_client,
 )
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
     from pathlib import Path
 
+_OK_STATUS: Final[int] = 200
 _UNSUPPORTED_STATUS: Final[int] = 501
 _INCOMPATIBLE_STATUS: Final[int] = 409
 _NOT_FOUND_STATUS: Final[int] = 404
@@ -69,9 +72,6 @@ ALLOWED_HTTP_STATUSES: Final[frozenset[int]] = frozenset(
     set(ERROR_STATUS.values()) | {200}
 )
 """The closed status set the contract publishes, derived not restated."""
-
-# A distinctive id, so "did the body echo the path?" is unmissable.
-_SENTINEL_ID: Final[str] = "zz-sentinel-external-id-zz"
 
 _BODIES: Final[dict[str, dict[str, Any]]] = {
     "PUT": VALID_JOURNAL_BODY,
@@ -128,6 +128,39 @@ def vault(tmp_path: Path) -> Iterator[Path]:
     yield seed_vault(tmp_path)
 
 
+def _send_stubbed(
+    vault_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    body: object = None,
+    **header_kwargs: str | None,
+) -> tuple[int, str, dict[str, Any]]:
+    """Issue one request to a *synthetically* unbuilt route.
+
+    #1077 built the last capability, so no route in the real table answers
+    ``501`` any more and a sweep over "the unbuilt routes" would have no rows —
+    a silently-skipped test, which is a guard that has stopped guarding. The
+    substitution reproduces the state a genuinely unbuilt capability would be
+    in, so these assertions keep applying to the *next* one.
+
+    Args:
+        vault_path: The vault the app is built over.
+        monkeypatch: The active monkeypatch fixture.
+        body: JSON body to send, or ``None`` for the route's canonical one.
+        **header_kwargs: Passed to :func:`tests.v1_api_support.headers`.
+
+    Returns:
+        The status code, the raw response text, and the decoded JSON body.
+    """
+    payload = _BODIES.get(STUB_METHOD) if body is None else body
+    kwargs: dict[str, Any] = {"headers": headers(**header_kwargs)}
+    if payload is not None:
+        kwargs["json"] = payload
+    with stubbed_client(vault_path, monkeypatch) as test_client:
+        response = test_client.request(STUB_METHOD, STUB_PATH, **kwargs)
+    return response.status_code, response.text, envelope(response)
+
+
 def _send(
     vault_path: Path,
     method: str,
@@ -162,105 +195,63 @@ def _send(
 # --------------------------------------------------------------------------- #
 
 
-@pytest.mark.parametrize(("method", "path"), VERSIONED, ids=VERSIONED_IDS)
-def test_unbuilt_routes_answer_501(vault: Path, method: str, path: str) -> None:
+def test_an_unbuilt_route_answers_501(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Exactly ``501``, the published code, the constant message.
 
     Args:
         vault: A seeded vault.
-        method: HTTP method under test.
-        path: Request path under test.
+        monkeypatch: Substitutes the stub for one route's handler.
     """
-    status, _text, body = _send(vault, method, path, ceiling="open")
+    status, _text, body = _send_stubbed(vault, monkeypatch, ceiling="open")
     assert status == _UNSUPPORTED_STATUS
     assert body["code"] == ErrorCode.UNSUPPORTED_CAPABILITY.value
     assert body["message"] == ERROR_MESSAGES[ErrorCode.UNSUPPORTED_CAPABILITY]
 
 
-@pytest.mark.parametrize(("method", "path"), VERSIONED, ids=VERSIONED_IDS)
 def test_the_501_body_is_exactly_the_envelope(
-    vault: Path, method: str, path: str
+    vault: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Three keys, never a fourth.
 
-    A stub that added ``"capability": "wheel"`` would be echoing the route
-    table into an error body the contract declares closed.
+    A stub that added ``"capability": "reflections"`` would be echoing the
+    route table into an error body the contract declares closed.
 
     Args:
         vault: A seeded vault.
-        method: HTTP method under test.
-        path: Request path under test.
+        monkeypatch: Substitutes the stub for one route's handler.
     """
-    _status, _text, body = _send(vault, method, path, ceiling="open")
+    _status, _text, body = _send_stubbed(vault, monkeypatch, ceiling="open")
     assert set(body) == {"code", "message", "request_id"}
 
 
-@pytest.mark.parametrize(("method", "path"), VERSIONED, ids=VERSIONED_IDS)
 @pytest.mark.parametrize("marker", _FAKE_SUCCESS_MARKERS)
 def test_the_501_body_contains_no_fake_success(
-    vault: Path, method: str, path: str, marker: str
+    vault: Path, monkeypatch: pytest.MonkeyPatch, marker: str
 ) -> None:
     """No word a fabricated success would carry appears anywhere in the body.
 
     Args:
         vault: A seeded vault.
-        method: HTTP method under test.
-        path: Request path under test.
+        monkeypatch: Substitutes the stub for one route's handler.
         marker: The forbidden substring.
     """
-    _status, text, _body = _send(vault, method, path, ceiling="open")
+    _status, text, _body = _send_stubbed(vault, monkeypatch, ceiling="open")
     assert marker not in text
 
 
-def test_the_501_body_never_echoes_the_path_identifier(vault: Path) -> None:
-    """A ``501`` for ``/v1/journal-entries/<id>`` does not name the ``<id>``.
-
-    Echoing the identifier would make an error body a function of caller
-    input — the first step towards a body that is a function of *vault*
-    input.
-
-    Args:
-        vault: A seeded vault.
-    """
-    path = f"/v1/journal-entries/{_SENTINEL_ID}"
-    _status, text, _body = _send(vault, "PUT", path, ceiling="open")
-    assert _SENTINEL_ID not in text
-    assert not contains_a_path(text)
-
-
-def test_the_501_body_never_echoes_the_request_body(vault: Path) -> None:
-    """Nothing the caller sent comes back.
-
-    Args:
-        vault: A seeded vault.
-    """
-    sent = {"content": "a private sentence about my week", "tier": "personal"}
-    _status, text, _body = _send(vault, "PUT", JOURNAL_PATH, body=sent, ceiling="open")
-    assert "private sentence" not in text
-    assert "personal" not in text
-
-
 @pytest.mark.parametrize(
-    ("method", "path", "body"),
+    "body",
     [
-        ("PUT", JOURNAL_PATH, VALID_JOURNAL_BODY),
-        ("PUT", JOURNAL_PATH, {"content": "   ", "tier": "intimate"}),
-        ("PUT", JOURNAL_PATH, {"nonsense": True}),
-        ("POST", REFLECTIONS_PATH, VALID_REFLECTION_BODY),
-        ("POST", REFLECTIONS_PATH, {"content": "x", "entry_ref": "y"}),
-        ("POST", REFLECTIONS_PATH, {}),
+        VALID_REFLECTION_BODY,
+        {"content": "x", "entry_ref": "y"},
+        {},
     ],
-    ids=[
-        "journal-valid",
-        "journal-intimate-tier",
-        "journal-garbage",
-        "reflection-valid",
-        "reflection-both-sources",
-        "reflection-neither-source",
-    ],
+    ids=["valid", "both-sources", "neither-source"],
 )
 def test_the_route_is_unbuilt_for_valid_and_invalid_bodies_alike(
-    vault: Path, method: str, path: str, body: dict[str, Any]
+    vault: Path, monkeypatch: pytest.MonkeyPatch, body: dict[str, Any]
 ) -> None:
     """The capability gate runs before body validation, so ``501`` either way.
 
@@ -271,28 +262,27 @@ def test_the_route_is_unbuilt_for_valid_and_invalid_bodies_alike(
 
     Args:
         vault: A seeded vault.
-        method: HTTP method under test.
-        path: Request path under test.
+        monkeypatch: Substitutes the stub for one route's handler.
         body: The payload to send.
     """
-    status, _text, envelope_body = _send(vault, method, path, body=body, ceiling="open")
+    status, _text, envelope_body = _send_stubbed(
+        vault, monkeypatch, body=body, ceiling="open"
+    )
     assert status == _UNSUPPORTED_STATUS
     assert envelope_body["code"] == ErrorCode.UNSUPPORTED_CAPABILITY.value
 
 
-@pytest.mark.parametrize(("method", "path"), VERSIONED, ids=VERSIONED_IDS)
 def test_an_unbuilt_route_writes_nothing_to_the_vault(
-    vault: Path, method: str, path: str
+    vault: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A ``501`` leaves no fragment, no ledger row and no audit line.
 
     Args:
         vault: A seeded vault.
-        method: HTTP method under test.
-        path: Request path under test.
+        monkeypatch: Substitutes the stub for one route's handler.
     """
     before = snapshot(vault)
-    _send(vault, method, path, ceiling="open")
+    _send_stubbed(vault, monkeypatch, ceiling="open")
     assert snapshot(vault) == before
 
 
@@ -332,8 +322,8 @@ def test_a_missing_version_header_is_409(vault: Path, method: str, path: str) ->
 @pytest.mark.parametrize(
     ("minor", "expected"),
     [
-        ("0.3", _UNSUPPORTED_STATUS),
-        ("0.2", _UNSUPPORTED_STATUS),
+        ("0.3", _OK_STATUS),
+        ("0.2", _OK_STATUS),
         ("0.2.0", _INCOMPATIBLE_STATUS),
         ("0.2.1", _INCOMPATIBLE_STATUS),
         ("0.20", _INCOMPATIBLE_STATUS),
@@ -356,6 +346,12 @@ def test_the_version_header_is_matched_strictly(
     vault: Path, minor: str, expected: int
 ) -> None:
     """``major.minor`` exactly — no liberal parsing, no whitespace repair.
+
+    Driven against ``GET /v1/wheel``, which #1076 built, so a served minor now
+    reaches a real handler and answers ``200`` where it used to answer the
+    honest ``501``. The distinction under test is unchanged and in fact
+    sharper: the gate either lets the request through to the route or refuses
+    it with ``409``.
 
     Both served minors reach the handler: ``0.3`` is the current one and
     ``0.2`` is retained by :data:`creek_mcp.api.models.SUPPORTED_CONTRACT_MINORS`

--- a/creek-tools/tests/test_v1_api_routes.py
+++ b/creek-tools/tests/test_v1_api_routes.py
@@ -280,19 +280,49 @@ def test_exactly_one_route_declares_no_capability() -> None:
     assert uncapable == ["/v1/health"]
 
 
-def test_implemented_capabilities_is_exactly_the_handshake() -> None:
-    """At #1074 only the handshake answers for real."""
-    assert frozenset({Capability.CAPABILITIES}) == IMPLEMENTED_CAPABILITIES
+def test_implemented_capabilities_is_exactly_the_published_four() -> None:
+    """At #1077 every published capability answers for real.
 
-
-def test_implemented_capabilities_is_a_strict_subset() -> None:
-    """Three capabilities are published-but-unbuilt, and the constant says so.
-
-    If this ever becomes an equality by *shrinking* ``Capability`` rather than
-    by #1075—#1077 building the handlers, the contract would have quietly
-    dropped three endpoints Adepthood already codes against.
+    An exhaustive literal, not a containment check, and still named one by
+    one: a fifth capability added to ``Capability`` has to change this line
+    before it can be advertised, which is what keeps a new endpoint's landing a
+    visible edit rather than a silent widening.
     """
-    assert set(Capability) > IMPLEMENTED_CAPABILITIES
+    assert (
+        frozenset(
+            {
+                Capability.CAPABILITIES,
+                Capability.JOURNAL_UPSERT,
+                Capability.REFLECTIONS,
+                Capability.WHEEL,
+            }
+        )
+        == IMPLEMENTED_CAPABILITIES
+    )
+
+
+def test_every_published_capability_is_implemented() -> None:
+    """The epic is finished, so the subset became an equality. Read this carefully.
+
+    Until #1077 this asserted ``set(Capability) > IMPLEMENTED_CAPABILITIES`` — a
+    *strict* superset — because three capabilities were published-but-unbuilt
+    and the constant had to say so out loud. Equality is now the correct claim,
+    and the reason it may be asserted is that it was reached the intended way:
+    #1075, #1076 and #1077 each built a handler and moved one name across. The
+    failure mode the old assertion guarded against was reaching equality by
+    *shrinking* ``Capability`` instead — quietly dropping endpoints Adepthood
+    already codes against — and that is now guarded by
+    :func:`test_implemented_capabilities_is_exactly_the_published_four` above,
+    which names all four and would go red on a removal.
+
+    **What must not happen is this assertion being relaxed in the other
+    direction.** ``>=`` here would let a capability be advertised with no
+    handler behind it, which is the dishonesty the whole constant exists to
+    prevent. If a fifth capability is published before its handler exists, this
+    test is supposed to go red, and the fix is to restore the strict-superset
+    form for the interim — not to weaken the operator.
+    """
+    assert set(Capability) == IMPLEMENTED_CAPABILITIES
 
 
 def test_implemented_capabilities_is_a_frozenset() -> None:

--- a/creek-tools/tests/test_v1_api_uvicorn_logging.py
+++ b/creek-tools/tests/test_v1_api_uvicorn_logging.py
@@ -79,11 +79,13 @@ Stands in for a real ``external_id``: consumer-side identifying material that
 the caller chose and the operator never should see in a log.
 """
 
-_UNSUPPORTED_STATUS: Final[int] = 501
-"""What ``PUT /v1/journal-entries/{external_id}`` answers until #1075 lands.
+_SERVED_STATUS: Final[int] = 200
+"""What ``PUT /v1/journal-entries/{external_id}`` answers since #1075 built it.
 
 Asserted so that a run which never reached the server cannot pass by simply
-logging nothing.
+logging nothing — and now a stronger non-vacuity claim than the ``501`` it
+replaced, because the request travels the whole route rather than stopping at
+the stub.
 """
 
 _LOOPBACK: Final[str] = "127.0.0.1"
@@ -329,7 +331,7 @@ def test_a_served_request_leaves_no_path_identifier_on_the_process_streams(
     config = build_uvicorn_config(_built_app(vault), _args_for(_EPHEMERAL_PORT))
     response = _serve_one_request(config, _sentinel_path())
     captured = capsys.readouterr()
-    assert response.status_code == _UNSUPPORTED_STATUS
+    assert response.status_code == _SERVED_STATUS
     assert _SENTINEL_ID not in captured.out
     assert _SENTINEL_ID not in captured.err
 
@@ -365,5 +367,5 @@ def test_the_stream_capture_sees_the_identifier_when_uvicorn_logs_it(
     )
     response = _serve_one_request(config, _sentinel_path())
     captured = capsys.readouterr()
-    assert response.status_code == _UNSUPPORTED_STATUS
+    assert response.status_code == _SERVED_STATUS
     assert _SENTINEL_ID in captured.out

--- a/creek-tools/tests/v1_api_support.py
+++ b/creek-tools/tests/v1_api_support.py
@@ -29,7 +29,7 @@ from starlette.routing import Route
 from starlette.testclient import TestClient
 
 from creek_mcp import policy
-from creek_mcp.api.models import CONTRACT_MINOR
+from creek_mcp.api.models import CONTRACT_MINOR, Capability
 from creek_mcp.httpapi.app import create_app
 from creek_mcp.httpapi.middleware import ceiling as ceiling_middleware
 from creek_mcp.remote_auth import ConsumerTokenVerifier
@@ -157,6 +157,47 @@ VERSIONED: Final[tuple[tuple[str, str], ...]] = (
 
 VERSIONED_IDS: Final[tuple[str, ...]] = ("journal-upsert", "reflections", "wheel")
 """Stable parametrize ids for :data:`VERSIONED`."""
+
+STUB_METHOD: Final[str] = "POST"
+"""The verb of the route the honesty-stub tests mount a synthetic stub on."""
+
+STUB_PATH: Final[str] = REFLECTIONS_PATH
+"""The path of that route.
+
+#1077 built the last capability, so *no* entry in the real route table reaches
+:class:`~creek_mcp.httpapi.handlers.UnimplementedHandler` any more. The stub is
+still the machinery that keeps the *next* capability honest, and an unexercised
+guard rots, so the tests that used to sweep the genuinely-unbuilt routes now
+substitute one handler and drive the same path. ``reflections`` is chosen
+because it was the last route to be built, so the substitution reproduces the
+exact state the suite was asserting the day before.
+"""
+
+STUB_CAPABILITY: Final[Capability] = Capability.REFLECTIONS
+"""The capability :data:`STUB_PATH` serves, for the stamp assertion."""
+
+
+def stubbed_client(vault_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    """Return a client over an app whose :data:`STUB_PATH` is the honest ``501``.
+
+    Args:
+        vault_path: The vault the app is built over.
+        monkeypatch: The active monkeypatch fixture; the substitution is undone
+            with the test, so no other module sees a stubbed route table.
+
+    Returns:
+        A test client over the substituted application.
+    """
+    from creek_mcp.httpapi import handlers as handlers_module
+
+    stub = handlers_module.unimplemented(STUB_CAPABILITY)
+    monkeypatch.setattr(
+        handlers_module,
+        "HANDLERS",
+        {**handlers_module.HANDLERS, OP_REFLECTIONS: stub},
+    )
+    return TestClient(build_app(vault_path=vault_path))
+
 
 VALID_JOURNAL_BODY: Final[dict[str, Any]] = {
     "content": "a sentence the server must never echo",


### PR DESCRIPTION
Closes #1075. Closes #1076. Closes #1077. Completes epic #1071.

The three remaining `/v1` verticals as a **serial train** — they all mutate `IMPLEMENTED_CAPABILITIES` and `_IMPLEMENTED_HANDLERS`, so they could never be parallel. Each shares **one** behavioral implementation with its MCP tool; no logic is forked.

## The honesty guard was preserved, then rewritten by the right PR

`set(Capability) > IMPLEMENTED_CAPABILITIES` (a **strict** superset) and the `_UNIMPLEMENTED_CAPABILITIES` non-emptiness assertion stayed **intact and green** through #1075 and #1076. Equality is only reached when the third handler lands, so **#1077 alone** rewrote them — to `==`, with a docstring recording that equality was reached the intended way (three handlers built) and that **`>=` here would be the actual relaxation and must never be introduced**. An exhaustive four-name literal now guards the shrink direction the strict superset used to.

## #1077 refuses the issue's error mapping — the most consequential correction

The issue instructs: *"entry_ref not found" → `not_found`*.

`ErrorCode.NOT_FOUND` is documented in `api/models.py` as a **routing** code ("no such endpoint on this server") and is **AST-pinned to the routing layer** by `tests/test_v1_api_structure.py`. The reason is explicit: a caller who can distinguish *"no such fragment"* from *"not for you"* can enumerate the corpus one id at a time — the oracle that **#846/#970/#972/#1090 spent five issues collapsing**. Following the instruction would have turned that guard red.

Both vault-object non-answers collapse to `privacy_refused` with one identical message, making the **HTTP adapter stricter than the MCP tool** (whose two distinct reasons are a documented accepted residual). #1077's first acceptance criterion, listing `not_found` as separately distinguishable, is **deliberately not met**.

## Three more acceptance criteria that were wrong

**#1075 AC4** asks `tier: "intimate"` under an `open` ceiling to answer `privacy_refused`. It cannot — #1072 typed the field as `WireTierCeiling`, which has exactly two members, so `intimate` fails **schema** validation and correctly earns `invalid_request` (422). Answering `privacy_refused` would imply the server accepted the field, resolved something and ranked it. The reachable path (`personal` under `open` → 403, nothing staged, asserted on the filesystem) is covered separately.

**#1075's "Known inherited gap: #970"** is false — #970 is **closed**, and `_refuse_unadmitted_overwrite` already ships. The issue asked for a test *"pinning current behavior"* of a hole that no longer exists; the test pins the **fix** through the adapter instead.

**#1076 AC5** describes an unreachable branch. A fragment with frequency `F11` is schema-invalid and dropped by `iter_vault_fragments` **before** `wheel_tool` sees it — absent from the wheel, from `unclassified` and from `total_classified` alike. That is the safer behaviour and is pinned as such. The genuinely reachable fail-closed path is `primary: unclassified`, which has its own test.

**#1075's requested test path** `tests/helpers/adapter_parity.py` is unusable — `tests/helpers.py` already exists as a module, and a package shadows it, breaking `test_book_report_medium.py`. Hit for real mid-run. The harness lives at `tests/adapter_parity.py`, matching `tests/v1_api_support.py`.

## The 501 machinery is kept alive, not deleted

Once all four capabilities are implemented nothing reaches the not-implemented path. Rather than delete it, `stubbed_client()` substitutes one handler with `unimplemented(...)`, so the four ex-swept 501 tests plus a new one still drive it. Without this, **16 tests would have silently become empty-parametrize skips** — a guard that stopped guarding exactly when the next capability will need it.

## Coverage gap closed properly

`creek_mcp/httpapi/wheel.py` came in at **72.50%** against the 80% per-file gate. Closed to **87.5%** with real behavioural tests — **no waiver, no pragma**. The uncovered arms were worth having:

- **`vault is None`** — an unreadable `creek_config.yaml` degrades to `None`, and `wheel_tool` over an unresolved vault answers an **all-zero wheel**. Without this arm the route renders a broken install as *"you have written nothing"*. Now 503 `unavailable`, with the config path asserted absent from the body.
- **the projection guard** — refuses an eleventh frequency (`extra="forbid"`), a missing field, an uncoercible count, or an out-of-range ceiling, rather than serving a partial 200. Five parametrised rows, one per member of the caught exception tuple.
- **the tool-refusal arm** — maps to 500 and is asserted **not** to echo the structured `reason`, which can carry a vault path.

The only remaining uncovered lines are the `if TYPE_CHECKING:` block, which every sibling adapter also carries and which is unreachable by construction.

## Found, not fixed

`docs/contracts/adepthood-v1/examples/reflections/care-escalation.json` builds `reason` from `CARE_SIGNAL["kind"]` (`acute_distress`), but the runtime carries the **guard's** reason (`acute_distress_markers`). The route carries what the guard decided and the test asserts against the guard, not the fixture. **The published fixture is wrong** — flagged in a comment rather than silently papered over. Worth a follow-up against the bundle.

## One refactor, called out

`configured_vault` / `UNREADABLE_CONFIG` moved out of `httpapi/capabilities.py` into a new `httpapi/vault.py`, because journal/wheel/reflect all need per-request vault resolution and three copies would drift. Consequence: two tests' `monkeypatch` target moved — a real test change caused by a real refactor, named here rather than buried.

Gate: **12/12**, 8437 passed, 94.14% aggregate, per-file gate 254 files ≥ 80%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EaHDtyDuNrpGtzUGMJT7Fw
