### PR TITLE
fix(ingest): resolve a document's author to the Authorship axis, and keep the name

### DIFF
--- a/creek-tools/creek/ingest/documents.py
+++ b/creek-tools/creek/ingest/documents.py
@@ -17,6 +17,7 @@ Exports:
     _detect_scanned_pdf: Check if a PDF is likely scanned (image-only).
     _extract_docx_metadata: Extract metadata from DOCX bytes.
     _extract_pdf_metadata: Extract metadata from PDF bytes.
+    _resolve_document_author: Split extracted author metadata into axis + name.
     _infer_document_platform: Map file extension to SourcePlatform.
 """
 
@@ -40,7 +41,7 @@ from creek.ingest.base import (
     parse_authored_at,
 )
 from creek.ingest.html import extract_html_authored_at, parse_html_to_markdown
-from creek.models import SourcePlatform
+from creek.models import Authorship, SourcePlatform
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +57,11 @@ _SCANNED_TEXT_THRESHOLD = 100
 
 _DOCUMENT_PLATFORM_EXTENSIONS: frozenset[str] = frozenset({".docx", ".pdf", ".rtf"})
 """Extensions that map to the DOCUMENT source platform."""
+
+_AUTHORSHIP_BY_VALUE: dict[str, Authorship] = {
+    member.value: member for member in Authorship
+}
+"""Lookup from an ``Authorship`` member's wire value to the member itself."""
 
 
 # ---- Helper Functions ----
@@ -490,6 +496,53 @@ def _extract_pdf_metadata(pdf_bytes: bytes) -> dict[str, Any]:
     return _extract_pdf_metadata_from_bytes(pdf_bytes)
 
 
+def _resolve_document_author(
+    raw_author: object,
+) -> tuple[Authorship, str | None] | None:
+    """Split a document's author metadata into an authorship axis and a name.
+
+    ``FragmentSource.author`` answers "whose views does this stand for?" on the
+    ``self|ai|other|collaborative`` axis. A DOCX ``core_properties.author`` or a
+    PDF ``/Author`` answers the different question "what name is on the file".
+    Copying the second into the first was issue #1229: every document Word saves
+    carries an author, so every such document failed Pydantic validation and was
+    dropped at assembly.
+
+    Returns ``None`` when there is no usable value — absent, non-string, or
+    blank — leaving the model's ``self`` default in force. "We know nothing" is
+    not evidence about anybody.
+
+    A value that already names an ``Authorship`` member is honoured as the axis
+    and yields no name; it is a classification, not somebody's name. Any other
+    string resolves the axis to :attr:`Authorship.OTHER` and is returned as the
+    name. ``OTHER`` is both the convention this codebase already applies to an
+    explicit author name
+    (:meth:`creek.clean.authorship.AuthorshipTagger._tag_self_platform`) and the
+    fail-closed choice: ``SELF`` is what unlocks the INTIMATE privacy tier
+    (:mod:`creek.classify.privacy`) and voice/skill generation
+    (:mod:`creek.generate.skills`), so guessing ``SELF`` for a stranger's
+    document would feed both from material that is not the owner's, whereas
+    guessing ``OTHER`` for the owner's own document merely under-uses it — and
+    the returned name is what makes that recoverable.
+
+    Args:
+        raw_author: The ``author`` value an ``_extract_*`` pass put in metadata.
+
+    Returns:
+        ``(authorship, name)`` where ``name`` is ``None`` for a value that was
+        already an axis member, or ``None`` when there is nothing to record.
+    """
+    if not isinstance(raw_author, str):
+        return None
+    name = raw_author.strip()
+    if not name:
+        return None
+    axis = _AUTHORSHIP_BY_VALUE.get(name.lower())
+    if axis is not None:
+        return axis, None
+    return Authorship.OTHER, name
+
+
 def _infer_document_platform(extension: str) -> SourcePlatform:
     """Map a file extension to a SourcePlatform value.
 
@@ -794,8 +847,11 @@ class DocumentIngestor(Ingestor):
         """Generate Creek-compatible YAML frontmatter for a document fragment.
 
         Builds frontmatter with type, title, source (platform, original_file,
-        original_encoding), created timestamp, and optional author/scanned
-        fields from metadata.
+        original_encoding), created timestamp, and optional scanned flag.
+
+        An extracted document author is split by :func:`_resolve_document_author`
+        into ``source.author`` (the ``Authorship`` axis) and ``source.author_name``
+        (the free-text name), never conflated into one slot (#1229).
 
         Args:
             fragment: The parsed fragment with metadata.
@@ -814,8 +870,12 @@ class DocumentIngestor(Ingestor):
         }
 
         # Add optional metadata fields
-        if "author" in fragment.metadata:
-            source["author"] = fragment.metadata["author"]
+        resolved_author = _resolve_document_author(fragment.metadata.get("author"))
+        if resolved_author is not None:
+            authorship, author_name = resolved_author
+            source["author"] = authorship
+            if author_name is not None:
+                source["author_name"] = author_name
         if fragment.metadata.get("scanned"):
             source["scanned"] = True
 

--- a/creek-tools/creek/models.py
+++ b/creek-tools/creek/models.py
@@ -646,6 +646,17 @@ class FragmentSource(BaseModel):
     channel: str | None = None
     interlocutor: str | None = None
     author: Authorship = Authorship.SELF
+    # Issue #1229: the free-text name a source document carries — a DOCX
+    # ``core_properties.author``, a PDF ``/Author``. It answers "what name is on
+    # the file", which is a *different question* from ``author`` ("whose views
+    # does this stand for?") and from ``author_slug`` (which identity folder
+    # governs it). Keeping the three apart is the whole point: writing a name
+    # into ``author`` fails enum validation, and writing one into ``author_slug``
+    # would silently relocate the fragment into ``11-Other-Authors/<name>/`` and
+    # zero its voice weight. This slot is inert — nothing routes or classifies on
+    # it — so a name can be recorded without deciding anything on the owner's
+    # behalf, and promoted to a real ``author_slug`` later if they choose.
+    author_name: str | None = None
     # FEAT-041 §7.4: the `11-Other-Authors/<slug>/` folder this fragment came
     # from, or ``None`` for a native self/owner fragment. Distinct from
     # ``author`` (the self|ai|other|collaborative axis), which is unchanged.

--- a/creek-tools/docs/ingestion.md
+++ b/creek-tools/docs/ingestion.md
@@ -105,6 +105,16 @@ creek ingest --refresh-ai-chat --vault ~/Vault
 
 It walks `01-Fragments/`, re-splits each merged Claude/ChatGPT fragment into a human (`self`) and a quarantined AI (`ai`, `voice_weight=0.0`) fragment, and removes the merged file. Running it twice is a no-op; a vault with no merged chat fragments is unchanged. Afterwards, `creek voice-authenticity` (see [generation](./generation.md#voice-fidelity-feat-040)) should report a near-zero AI-corpus leak.
 
+## Document attribution (the name on the file)
+
+A DOCX carries `core_properties.author` and a PDF carries `/Author` — Word stamps one on every save. That name answers "what name is on the file", which is **not** the question `source.author` answers ("whose views does this stand for?", on the `self|ai|other|collaborative` axis). Ingest keeps the two apart:
+
+- `source.author` gets `other` whenever a document carries a non-empty author name. Same rule the cleaning pass already applies to an explicit author name, and it fails closed: `self` is what unlocks the `intimate` privacy tier and voice/skill generation, so guessing `self` for a document that came from someone else would feed both from material that isn't yours. Guessing `other` for your own document only under-uses it, and the name below is what lets you correct it. A document with **no** author (or a blank one) keeps the `self` default — absence of a name is not evidence about anyone.
+- `source.author_name` gets the extracted name verbatim. It is inert: nothing routes, classifies, or weights voice on it. It exists so the name is queryable rather than discarded.
+- `source.author_slug` is **not** set from an extracted name. That field names an `11-Other-Authors/<slug>/` folder, and setting it would relocate the fragment out of `01-Fragments/` and zero its `voice_weight` from the folder manifest — too consequential to infer from a "Created by" field. Promote an `author_name` to a real `author_slug` deliberately, when you actually mean it.
+
+RTF and HTML never populate an author at all: `DocumentIngestor` reads embedded metadata only for `.docx` and `.pdf`, so an RTF `\author` group and an HTML `<meta name="author">` are ignored and those fragments keep the `self` default.
+
 ## Writing a new ingestor
 
 Implement the four-stage contract from `creek.ingest.base.Ingestor`:

--- a/creek-tools/tests/test_ingest_documents.py
+++ b/creek-tools/tests/test_ingest_documents.py
@@ -17,7 +17,11 @@ if TYPE_CHECKING:
 
 import pytest
 
-from creek.ingest.base import ParsedFragment, RawDocument
+from creek.ingest.base import (
+    ParsedFragment,
+    RawDocument,
+    assemble_ingested_fragment,
+)
 from creek.ingest.documents import (
     DocumentIngestor,
     _detect_scanned_pdf,
@@ -29,7 +33,7 @@ from creek.ingest.documents import (
     _parse_pdf_to_text,
     _wrap_txt_with_structure,
 )
-from creek.models import SourcePlatform
+from creek.models import Authorship, SourcePlatform
 
 LA_TZ = ZoneInfo("America/Los_Angeles")
 
@@ -656,7 +660,7 @@ class TestDocumentIngestorFrontmatter:
     def test_frontmatter_includes_author_from_metadata(
         self, doc_ingestor: DocumentIngestor
     ) -> None:
-        """Frontmatter includes author when present in metadata."""
+        """A free-text author name is preserved under ``source.author_name``."""
         fragment = _make_fragment(
             "Content.",
             "/path/test.docx",
@@ -667,7 +671,7 @@ class TestDocumentIngestorFrontmatter:
             },
         )
         fm = doc_ingestor.generate_frontmatter(fragment)
-        assert fm["source"]["author"] == "Jane Doe"
+        assert fm["source"]["author_name"] == "Jane Doe"
 
     def test_frontmatter_includes_title_from_metadata(
         self, doc_ingestor: DocumentIngestor
@@ -935,3 +939,179 @@ class TestDocumentIngestorAuthoredAtPerFormat:
         parsed = self._ingest_one(doc_ingestor, txt)
         fm = doc_ingestor.generate_frontmatter(parsed)
         assert "authored_at" not in fm
+
+
+# ---- Document author metadata (issue #1229) ----
+
+
+def _real_docx_bytes(path: Path, author: str) -> Path:
+    """Write a genuine ``.docx`` at *path* stamped with *author*, and return it.
+
+    Word stamps ``core_properties.author`` on every save, so a fixture without
+    one is not a realistic document.
+    """
+    from docx import Document as DocxDocument
+
+    document = DocxDocument()
+    document.core_properties.author = author
+    document.add_paragraph("A real Word document.")
+    document.save(path)
+    return path
+
+
+def _real_pdf_bytes(path: Path, author: str) -> Path:
+    """Write a minimal but genuine PDF at *path* with ``/Author`` set.
+
+    Hand-assembled (rather than mocked) so the ``/Info``-dictionary path in
+    :func:`creek.ingest.documents._extract_pdf_metadata` is exercised for real:
+    a mocked extractor could not have caught issue #1229.
+    """
+    objects = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>",
+        b"<< /Author (" + author.encode("ascii") + b") /Title (Notes) >>",
+    ]
+    body = bytearray(b"%PDF-1.4\n")
+    offsets: list[int] = []
+    for number, obj in enumerate(objects, start=1):
+        offsets.append(len(body))
+        body += b"%d 0 obj\n" % number + obj + b"\nendobj\n"
+    xref_offset = len(body)
+    body += b"xref\n0 %d\n0000000000 65535 f \n" % (len(objects) + 1)
+    for offset in offsets:
+        body += b"%010d 00000 n \n" % offset
+    body += (
+        b"trailer\n<< /Size %d /Root 1 0 R /Info 4 0 R >>\nstartxref\n%d\n%%%%EOF\n"
+        % (len(objects) + 1, xref_offset)
+    )
+    path.write_bytes(bytes(body))
+    return path
+
+
+class TestDocumentAuthorMetadata:
+    """A document's free-text author must never land in the Authorship enum.
+
+    ``FragmentSource.author`` answers "whose views does this stand for?" on the
+    ``self|ai|other|collaborative`` axis. A DOCX ``core_properties.author`` or a
+    PDF ``/Author`` answers the different question "what name is on the file".
+    Issue #1229: writing the second into the first made every real Word document
+    fail Pydantic validation and get dropped at assembly.
+    """
+
+    def _assemble_one(
+        self, doc_ingestor: DocumentIngestor, file_path: Path
+    ) -> ParsedFragment:
+        """Ingest *file_path* and return its single ``ParsedFragment``."""
+        result = doc_ingestor.ingest(file_path)
+        assert result.errors == []
+        assert len(result.fragments) == 1
+        return result.fragments[0]
+
+    def test_word_document_with_author_ingests(
+        self, doc_ingestor: DocumentIngestor, tmp_path: Path
+    ) -> None:
+        """A ``.docx`` carrying an author assembles into a valid Fragment."""
+        path = _real_docx_bytes(tmp_path / "real.docx", "Jane Q. Author")
+        parsed = self._assemble_one(doc_ingestor, path)
+
+        assembled = assemble_ingested_fragment(parsed)
+
+        assert assembled.fragment.source.author == Authorship.OTHER
+        assert assembled.fragment.source.author_name == "Jane Q. Author"
+
+    def test_pdf_with_author_ingests(
+        self, doc_ingestor: DocumentIngestor, tmp_path: Path
+    ) -> None:
+        """A ``.pdf`` carrying ``/Author`` assembles into a valid Fragment."""
+        path = _real_pdf_bytes(tmp_path / "real.pdf", "Ada Lovelace")
+        parsed = self._assemble_one(doc_ingestor, path)
+
+        assembled = assemble_ingested_fragment(parsed)
+
+        assert assembled.fragment.source.author == Authorship.OTHER
+        assert assembled.fragment.source.author_name == "Ada Lovelace"
+
+    def test_rtf_and_html_carry_no_extracted_author(
+        self, doc_ingestor: DocumentIngestor, tmp_path: Path
+    ) -> None:
+        """RTF and HTML never populate ``author``, so they keep the self default.
+
+        Issue #1229 asserted these two shared the DOCX/PDF defect. They do not:
+        ``DocumentIngestor._extract_metadata`` branches only on ``.docx`` and
+        ``.pdf``, so an RTF ``\\author`` group and an HTML ``<meta name=author>``
+        are never read. This pins that, so a future author-extraction branch for
+        either format cannot reintroduce the enum collision unnoticed.
+        """
+        rtf = tmp_path / "note.rtf"
+        rtf.write_text(
+            "{\\rtf1\\ansi{\\info{\\author Ada Lovelace}}Body text.}",
+            encoding="ascii",
+        )
+        html = tmp_path / "note.html"
+        html.write_text(
+            '<html><head><meta name="author" content="Ada Lovelace">'
+            "</head><body><p>Body text.</p></body></html>",
+            encoding="utf-8",
+        )
+
+        for path in (rtf, html):
+            parsed = self._assemble_one(doc_ingestor, path)
+            assembled = assemble_ingested_fragment(parsed)
+            assert assembled.fragment.source.author == Authorship.SELF
+            assert assembled.fragment.source.author_name is None
+
+    def test_named_author_maps_to_other(self, doc_ingestor: DocumentIngestor) -> None:
+        """A person's name resolves the axis to ``other``, not ``self``."""
+        fragment = _make_fragment(
+            "Content.",
+            "/path/test.docx",
+            {
+                "file_type": ".docx",
+                "source_encoding": "utf-8",
+                "author": "Jane Doe",
+            },
+        )
+
+        fm = doc_ingestor.generate_frontmatter(fragment)
+
+        assert fm["source"]["author"] == Authorship.OTHER
+        assert fm["source"]["author_name"] == "Jane Doe"
+
+    def test_valid_authorship_value_is_honoured(
+        self, doc_ingestor: DocumentIngestor
+    ) -> None:
+        """A metadata author that already names an axis member is kept as one."""
+        fragment = _make_fragment(
+            "Content.",
+            "/path/test.docx",
+            {
+                "file_type": ".docx",
+                "source_encoding": "utf-8",
+                "author": "ai",
+            },
+        )
+
+        fm = doc_ingestor.generate_frontmatter(fragment)
+
+        assert fm["source"]["author"] == Authorship.AI
+        assert "author_name" not in fm["source"]
+
+    def test_blank_author_leaves_the_self_default(
+        self, doc_ingestor: DocumentIngestor
+    ) -> None:
+        """A whitespace-only author is no evidence, so nothing is written."""
+        fragment = _make_fragment(
+            "Content.",
+            "/path/test.docx",
+            {
+                "file_type": ".docx",
+                "source_encoding": "utf-8",
+                "author": "   ",
+            },
+        )
+
+        fm = doc_ingestor.generate_frontmatter(fragment)
+
+        assert "author" not in fm["source"]
+        assert "author_name" not in fm["source"]

--- a/creek-tools/tests/test_mcp_upload.py
+++ b/creek-tools/tests/test_mcp_upload.py
@@ -101,19 +101,22 @@ def _b64(payload: bytes) -> str:
     return base64.b64encode(payload).decode("ascii")
 
 
+_DOCX_AUTHOR = "Dana Rivers"
+"""The author name the ``.docx`` fixture carries, as every real Word save does."""
+
+
 def _docx_bytes(tmp_path: Path) -> bytes:
     """Build a genuine ``.docx`` ZIP container in-process and return its bytes.
 
-    ``core_properties.author`` is cleared because ``DocumentIngestor`` copies
-    a DOCX's author string straight onto ``Fragment.source.author``, which is
-    an enum of ``self``/``ai``/``other``/``collaborative`` — so any DOCX
-    carrying a real author name fails to assemble. That is a pre-existing
-    ingest defect, unrelated to staging, and clearing the property keeps this
-    test aimed at what it is actually pinning: byte-exact staging.
+    ``core_properties.author`` is stamped rather than cleared: Word writes one on
+    every save, so a document without it is not the document users upload. It
+    used to be cleared here to route around issue #1229 (the ingestor copied the
+    name onto the ``Authorship`` enum, so any real document failed to assemble);
+    that workaround is gone with the defect.
     """
     path = tmp_path / "source.docx"
     document = DocxDocument()
-    document.core_properties.author = ""
+    document.core_properties.author = _DOCX_AUTHOR
     document.add_heading("Quarterly notes", level=1)
     document.add_paragraph("The creek runs steady through the autumn.")
     document.save(path)
@@ -297,8 +300,13 @@ def test_a_real_docx_survives_staging_byte_identical(tmp_path: Path) -> None:
     assert staged[0].read_bytes() == raw
     fragments = _fragments(vault)
     assert len(fragments) == 1
+    # The document's author name must not relocate the fragment out of
+    # 01-Fragments/ — only an explicit author_slug does that (#1229).
     assert fragments[0].parent == vault / "01-Fragments" / "Documents"
-    assert frontmatter.load(fragments[0])["privacy_tier"] == "personal"
+    written = frontmatter.load(fragments[0])
+    assert written["privacy_tier"] == "personal"
+    assert written["source"]["author"] == "other"
+    assert written["source"]["author_name"] == _DOCX_AUTHOR
 
 
 def test_extension_routes_to_the_matching_source_type(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #1229.

Every real Word document failed to ingest. `DocumentIngestor` copied a document's free-text author onto `Fragment.source.author`, which is the `Authorship` StrEnum (`self`|`ai`|`other`|`collaborative`), so any file carrying an author failed Pydantic validation and was dropped. It predates #1023 — `creek ingest --type document` fails identically on main — but it made `creek.upload`'s headline use case non-functional.

## Two decisions, and I declined the issue's steer on the second

**Which enum member** — a non-empty extracted author resolves to `Authorship.OTHER`, not `SELF`. Two independent reasons:

1. **Precedent.** `creek/clean/authorship.py::_tag_self_platform` already applies exactly this rule — *"Explicit author `<name>` in metadata"* → `other`. Ingest now agrees with the cleaning pass instead of contradicting it.
2. **Fail-closed.** `SELF` is the key that unlocks the INTIMATE privacy tier and voice/skill generation. Guessing `SELF` for a stranger's document feeds both from material that isn't the owner's; guessing `OTHER` for the owner's own document merely under-uses it — recoverable, and the preserved name is what makes it recoverable.

**Where the name goes** — a new inert `FragmentSource.author_name`, **not** `author_slug`.

The issue suggests routing it into the `AuthorManifest`/`author_slug` machinery. I did not, and this is the load-bearing call: setting `author_slug` from a Word "Created by" field would, via `creek/vault/writer.py:728` and `_apply_other_author_attribution`, **relocate the fragment out of `01-Fragments/` into `11-Other-Authors/<name>/` and zero its `voice_weight`** from a manifest that does not exist. That infers an entire identity-folder commitment from a metadata string — for the "upload my own documents" case.

`author_name` is inert: nothing routes, classifies, or weights voice on it. It records the fact without deciding anything on the owner's behalf, and it is exactly the input needed to promote it to a real `author_slug` deliberately later. Pinned by an assertion that an uploaded `.docx` still lands in `01-Fragments/Documents`.

Two edge rules fall out:
- An author string that already names an `Authorship` member (case-insensitive) is honoured as the axis and yields no name — it is a classification, not somebody's name. Without this, a correct `author='ai'` from another caller would be clobbered to `other` with a bogus `author_name: 'ai'`.
- A blank author writes nothing, leaving the model's `self` default. Absence of a name is not evidence about anybody.

## The issue's scope claim was wrong in one direction and understated in the other

**FALSE: "PDF, RTF and HTML share the same `_extract_*` metadata path."** `_extract_metadata` branches only on `.docx` and `.pdf` — there is no RTF or HTML branch, so `metadata['author']` is never populated for them. Verified by running both through the ingestor: an RTF with `{\info{\author Ada Lovelace}}` and an HTML with `<meta name="author">` both yield `author: None`. A regression test pins the `self` default for both anyway, so a future author-extraction branch cannot reintroduce the collision unnoticed.

**CONFIRMED and strengthened for PDF.** The repo's only PDF-metadata test *mocks* the extractor — *"Mock pdfminer since we can't easily create real PDFs in tests"*. A mocked extractor could never have caught this bug. I hand-assembled a genuine minimal PDF with an `/Info` dict and confirmed the real defect, and the new test builds that real PDF rather than mocking it.

## An existing test was pinning the bug

`test_frontmatter_includes_author_from_metadata` asserted `fm['source']['author'] == 'Jane Doe'` — i.e. it asserted the exact frontmatter that fails validation downstream. Rewritten.

And `tests/test_mcp_upload.py::_docx_bytes`, which had been *clearing* `core_properties.author` with a docstring explaining this very bug, now stamps a real author and asserts `source.author == 'other'` / `source.author_name == 'Dana Rivers'`. That test now pins the fix instead of routing around it.

## Where the reasoning lives

Three places rather than an ADR — the `author_name` field comment (why the three author slots are distinct), the `_resolve_document_author` docstring (the axis/fail-closed argument with citations), and a new "Document attribution (the name on the file)" section in `docs/ingestion.md`, sited next to the existing "AI-chat attribution (per turn)" section where a reader already goes for this question. An ADR would duplicate the docstrings (§1.2 DRY).

Gate: **12/12**. Zero suppressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EaHDtyDuNrpGtzUGMJT7Fw
