### PR TITLE
feat(classify): free, non-destructive tags backfill for an already-classified vault

### DIFF
--- a/creek-tools/creek/classify/classify_engine.py
+++ b/creek-tools/creek/classify/classify_engine.py
@@ -132,15 +132,27 @@ process`` path, and a second call there would be pure duplication.
   (or the ``low-priority`` literal
   :mod:`creek.clean.context` appends). That makes the pass idempotent: a
   second run over an unchanged vault reports ``0``.
-* **NOT on the preserved short-circuit**, for the same reason as praxis
-  and more so — :func:`_write_tier_only` is not widened, and ``tags`` is
-  a field operators curate by hand. An ``llm``/``manual``-stamped vault
-  backfills it only under an explicit ``creek classify --method llm
-  --force``; ``creek fill`` surfaces the outstanding count
+* **On the preserved short-circuit too, since #1207** — the one place
+  this axis parts company with praxis. #878 originally declined the
+  exception, which left the operator's vault (35,330 fragments, every one
+  of them stamped ``classification_method: llm``) able to gain tags only
+  through a paid ``creek classify --method llm --force``, to recover data
+  already sitting in the fragment bodies on local disk. Two properties
+  make the free pass safe here where the praxis pass is not: hashtag
+  extraction is a lossless mechanical restatement of literal
+  author-written syntax rather than a judgment, so re-deriving it cannot
+  disagree with operator curation; and the merge is a union, so it cannot
+  drop a tag a hand ever wrote. The backfill goes through the **sibling**
+  narrow writer :func:`_write_tags_only` — :func:`_write_tier_only`'s
+  "changes ONLY the privacy-tier fields" promise is untouched, because a
+  writer whose field set is legible from its name survives review of a
+  path that rewrites already-curated user vaults, and one that takes its
+  scope as an argument does not. ``creek fill`` still surfaces the
+  outstanding count, now naming the free command
   (:func:`creek.cli._hint_tags_backfill`).
 
 :attr:`ClassifySummary.tags_extracted` reports how many fragments the run
-actually gained a tag on.
+actually gained a tag on, on both paths.
 
 Known residual (not fixable by ordering)
 ----------------------------------------
@@ -206,7 +218,7 @@ from creek.classify.reatomize import (
     classify_reatomize,
 )
 from creek.classify.rules import RuleClassifier
-from creek.classify.tags_pass import apply_tags
+from creek.classify.tags_pass import TAGS_KEY, apply_tags
 from creek.classify.weighted import classify_weighted
 from creek.ingest.base import IngestedFragment
 from creek.models import Fragment, Frequency, PrivacyTier
@@ -339,9 +351,13 @@ class ClassifySummary:
             genuine additions: re-deriving a hashtag the fragment already
             records is not work the operator needs reported, so the merge
             being a union makes a second run over an unchanged vault
-            report ``0``. Fragments the resume short-circuit preserved are
-            **not** counted — they are not given tags at all without
-            ``--force`` (see the module docstring).
+            report ``0``. Fragments the resume short-circuit preserved
+            **are** counted since #1207: the free backfill runs on them
+            too, through a narrow tags-only write that touches no other
+            frontmatter field (see the module docstring). Like
+            :attr:`privacy_tiers_assigned` this counts the decision, not
+            the bytes — a fragment whose write then fails is counted here
+            *and* reported on :attr:`errors`.
     """
 
     total: int
@@ -892,17 +908,18 @@ def _prepare_fragment(
     # Skip fragments whose previous run already settled the classification.
     # Tracked on distinct counters so the CLI summary can label "manual
     # preserved" and "previously LLM-classified preserved" honestly
-    # (issue #321). A tier assigned above still lands, through the narrow
-    # writer that touches nothing else.
+    # (issue #321). The free, non-destructive passes — the tier assigned
+    # above (#876) and the hashtag backfill (#1207) — still land, each
+    # through a narrow writer that touches nothing else.
     if not force and _record_if_preserved(raw, counts):
-        if owns_tier:
-            _persist_tier_only(
-                md_file=md_file,
-                fragment=fragment,
-                body=body,
-                raw=raw,
-                counts=counts,
-            )
+        _backfill_preserved(
+            md_file=md_file,
+            fragment=fragment,
+            body=body,
+            raw=raw,
+            owns_tier=owns_tier,
+            counts=counts,
+        )
         return None
     return _PreparedFragment(
         fragment=fragment,
@@ -1181,6 +1198,73 @@ def _finalise_fragment_write(
         _record_llm_progress(progress_path, new_fragment.id)
 
 
+def _backfill_preserved(
+    *,
+    md_file: Path,
+    fragment: Fragment,
+    body: str,
+    raw: dict[str, object],
+    owns_tier: bool,
+    counts: _RunCounts,
+) -> None:
+    """Apply the free, non-destructive passes to a preserved fragment.
+
+    The whole of the OPS-001 short-circuit's write surface, and the only
+    place where more than one narrow writer can fire on one file. Both
+    passes are deterministic, local and free, so neither threatens what
+    the short-circuit protects (operator curation and paid tokens):
+
+    * the #876 privacy tier, when this run owns it; then
+    * the #1207 hashtag backfill, when the body carries a tag ``tags``
+      does not already record.
+
+    **The ordering is a data dependency, not a preference.** Each writer
+    rewrites the whole file from the frontmatter it is handed, so the
+    tags write has to build on what the tier write actually left on disk.
+    Handing it the frontmatter as originally *read* would drop the tier
+    that had just been assigned and silently re-open the cloud-egress
+    hole #876 exists to close — which is why :func:`_persist_tier_only`
+    returns its result rather than ``None``.
+
+    Args:
+        md_file: The preserved fragment's file, rewritten in place.
+        fragment: The fragment as loaded, carrying any tier this run
+            assigned.
+        body: Its markdown body; retained byte-identical by both
+            writers, and the input the hashtag extractor reads.
+        raw: Its frontmatter exactly as read from disk.
+        owns_tier: Whether this run assigned the privacy tier (and so
+            has one to persist).
+        counts: Mutable per-run counters; mutated in place.
+    """
+    metadata = raw
+    if owns_tier:
+        written = _persist_tier_only(
+            md_file=md_file,
+            fragment=fragment,
+            body=body,
+            raw=metadata,
+            counts=counts,
+        )
+        if written is not None:
+            metadata = written
+
+    tagged = apply_tags(fragment, body)
+    if tagged is fragment:
+        # ``apply_tags`` returns the same object when the union adds
+        # nothing, so an already-backfilled vault is not rewritten at
+        # all — the pass is idempotent down to the file's bytes.
+        return
+    counts.tags_extracted += 1
+    _persist_tags_only(
+        md_file=md_file,
+        fragment=tagged,
+        body=body,
+        raw=metadata,
+        counts=counts,
+    )
+
+
 def _persist_tier_only(
     *,
     md_file: Path,
@@ -1188,7 +1272,7 @@ def _persist_tier_only(
     body: str,
     raw: dict[str, object],
     counts: _RunCounts,
-) -> None:
+) -> dict[str, object] | None:
     """Write a preserved fragment's new privacy tier, recording any failure.
 
     A single unwritable file must not abort a 35k-file run, so an
@@ -1204,13 +1288,24 @@ def _persist_tier_only(
         raw: The frontmatter as read from disk.
         counts: Mutable per-run counters; write failures land on
             :attr:`_RunCounts.errors`.
+
+    Returns:
+        The frontmatter now on disk, so the sibling writer that may run
+        after it (see :func:`_backfill_preserved`) composes on this
+        result instead of reverting it; ``None`` when the write failed.
     """
     try:
-        _write_tier_only(md_file=md_file, fragment=fragment, body=body, raw=raw)
+        return _write_tier_only(
+            md_file=md_file,
+            fragment=fragment,
+            body=body,
+            raw=raw,
+        )
     except OSError as exc:
         counts.errors.append(
             f"failed to update privacy tier for {fragment.id} ({md_file}): {exc}",
         )
+        return None
 
 
 def _write_tier_only(
@@ -1219,7 +1314,7 @@ def _write_tier_only(
     fragment: Fragment,
     body: str,
     raw: dict[str, object],
-) -> None:
+) -> dict[str, object]:
     """Rewrite *md_file* changing ONLY the privacy-tier fields (issue #876).
 
     Used exclusively on the preserved short-circuit path, where the whole
@@ -1235,11 +1330,24 @@ def _write_tier_only(
       would let a fragment freshly marked ``intimate`` keep advertising
       itself as voice-proxy eligible.
 
+    That promise is unchanged by #1207: the tags backfill went into the
+    **sibling** :func:`_write_tags_only` rather than widening this
+    function's scope into a parameter. A writer whose scope is its name
+    can be audited from its call site; one whose scope is an argument
+    cannot, and these run over already-classified user vaults. The
+    return value is not a widening — it is exactly the two fields above
+    on top of *raw*, handed back so a sibling writer can compose on what
+    is now on disk rather than clobber it.
+
     Args:
         md_file: Destination file, rewritten in place.
         fragment: The fragment carrying the freshly-assigned tier.
         body: Markdown body to retain unchanged.
         raw: Original frontmatter; every other key is copied verbatim.
+
+    Returns:
+        The frontmatter written, i.e. *raw* with the two tier fields
+        replaced.
 
     Raises:
         OSError: When the file cannot be written. The caller
@@ -1252,8 +1360,108 @@ def _write_tier_only(
     new_metadata[PRIVACY_TIER_KEY] = PrivacyTier(fragment.privacy_tier).value
     new_metadata[_VOICE_PROXY_ELIGIBLE_KEY] = fragment.voice_proxy_eligible
 
+    _rewrite_frontmatter(md_file=md_file, body=body, metadata=new_metadata)
+    return new_metadata
+
+
+def _persist_tags_only(
+    *,
+    md_file: Path,
+    fragment: Fragment,
+    body: str,
+    raw: dict[str, object],
+    counts: _RunCounts,
+) -> None:
+    """Write a preserved fragment's backfilled tags, recording any failure.
+
+    The exact contract :func:`_persist_tier_only` honours, one axis over:
+    an unwritable file is reported on :attr:`_RunCounts.errors` and the
+    rest of the vault still backfills.
+
+    Args:
+        md_file: Destination file, rewritten in place.
+        fragment: The fragment carrying the merged tag list.
+        body: Markdown body to retain, byte-identical, below the
+            frontmatter.
+        raw: The frontmatter to write on top of — the tier writer's
+            result when it ran, otherwise the frontmatter as read.
+        counts: Mutable per-run counters; write failures land on
+            :attr:`_RunCounts.errors`.
+    """
+    try:
+        _write_tags_only(md_file=md_file, fragment=fragment, body=body, raw=raw)
+    except OSError as exc:
+        counts.errors.append(
+            f"failed to update tags for {fragment.id} ({md_file}): {exc}",
+        )
+
+
+def _write_tags_only(
+    *,
+    md_file: Path,
+    fragment: Fragment,
+    body: str,
+    raw: dict[str, object],
+) -> None:
+    """Rewrite *md_file* changing ONLY ``tags`` (issue #1207).
+
+    The deliberate sibling of :func:`_write_tier_only` rather than a
+    widening of it. Both run over vaults that are already classified and
+    already curated, and the property that makes them reviewable is that
+    the set of fields each may touch is legible from its *name* — a
+    field-scoped writer taking its scope as an argument would push that
+    question out to every call site.
+
+    Unlike the tier, ``tags`` has no derived companion key: nothing else
+    in the frontmatter is computed from it, so this writer's field set is
+    exactly one key. ``classification_method``, ``classified_at``, the
+    provider/reasoning stamps and the body are all left byte-identical —
+    the run did not re-classify anything, and must not claim to have.
+
+    Safe on the preserved path only because
+    :func:`~creek.classify.tags_pass.merge` is a union: the value written
+    always contains every tag already on record, so a hand-written
+    Obsidian tag cannot be lost to a pass the operator did not ask for.
+
+    Args:
+        md_file: Destination file, rewritten in place.
+        fragment: The fragment carrying the merged tag list.
+        body: Markdown body to retain unchanged.
+        raw: Frontmatter to write on top of; every other key is copied
+            verbatim.
+
+    Raises:
+        OSError: When the file cannot be written. The caller
+            (:func:`_persist_tags_only`) records it and carries on.
+    """
+    new_metadata = raw.copy()
+    new_metadata[TAGS_KEY] = fragment.tags.copy()
+    _rewrite_frontmatter(md_file=md_file, body=body, metadata=new_metadata)
+
+
+def _rewrite_frontmatter(
+    *,
+    md_file: Path,
+    body: str,
+    metadata: dict[str, object],
+) -> None:
+    """Rewrite *md_file* as *metadata* over an unchanged *body*.
+
+    The shared I/O tail of the narrow writers above. It deliberately
+    decides *nothing* about which fields may change — that is each
+    writer's own, named responsibility — so that keeping the two in
+    lockstep on serialisation cannot blur their scopes.
+
+    Args:
+        md_file: Destination file, rewritten in place.
+        body: Markdown body to retain unchanged.
+        metadata: The complete frontmatter to serialise.
+
+    Raises:
+        OSError: When the file cannot be written.
+    """
     post = frontmatter.Post(content=body)
-    post.metadata.update(new_metadata)
+    post.metadata.update(metadata)
     md_file.write_text(frontmatter.dumps(post), encoding="utf-8")
 
 

--- a/creek-tools/creek/classify/tags_pass.py
+++ b/creek-tools/creek/classify/tags_pass.py
@@ -12,7 +12,13 @@ vault.*``, which left three consumers structurally unreachable:
 :mod:`creek.generate.compost`. This module is the shared,
 side-effect-free policy layer that both writers — the ingest chokepoint
 :func:`creek.ingest.base.assemble_ingested_fragment` and the ``creek
-classify`` engine — call to close that hole:
+classify`` engine — call to close that hole. Since #1207 the engine calls
+it on the OPS-001 resume short-circuit as well, through the narrow
+sibling writer
+:func:`creek.classify.classify_engine._write_tags_only`, so a vault
+already stamped ``classification_method: llm``/``manual`` backfills this
+axis for free rather than through a paid ``--force`` re-classification.
+The functions:
 
 * :func:`extract` — pull hashtags out of a markdown body.
 * :func:`merge` — union two tag lists, never losing one.
@@ -77,20 +83,6 @@ wrote and collides two runaway tokens onto one garden entry.
 Known residuals
 ---------------
 
-* **Preserved fragments need ``--force``.** The classify engine runs this
-  pass only on fragments it actually (re-)classifies; the OPS-001 resume
-  short-circuit's narrow writer
-  (:func:`creek.classify.classify_engine._write_tier_only`) is
-  deliberately *not* widened to carry tags. So a vault already stamped
-  ``classification_method: llm``/``manual`` backfills this axis only
-  under an explicit, paid ``creek classify --method llm --force``. That
-  is the same call #877 made for praxis, and the #876 tier exception does
-  not transfer: an untiered fragment is a live cloud-egress hole, whereas
-  a missing tag is a missing feature — and unlike praxis, ``tags`` is a
-  field operators hand-edit, so rewriting the axis of every curated
-  fragment in a mature vault is not something to do unasked. ``creek
-  fill`` surfaces the outstanding count (see
-  :func:`creek.cli._hint_tags_backfill`).
 * **Removing a hashtag does not un-tag the fragment.** The merge only
   ever adds, so deleting ``#recovery`` from a body leaves ``recovery`` on
   the frontmatter; the operator removes it by hand. That is the price of

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -2213,8 +2213,8 @@ def _scan_fill_gaps(vault_path: Path) -> _FillGapCounts:
     :func:`~creek.classify.tags_pass.has_unrecorded_tags` answers in the
     same normalised space the merge works in — comparing raw strings
     would report ``tags: [Recovery]`` beside a body reading ``#recovery``
-    as a gap and bill the operator for a paid ``--force`` run that
-    changes nothing. Computing it here rather than in its own function is
+    as a gap and send the operator off to run a backfill that changes
+    nothing. Computing it here rather than in its own function is
     what keeps it free — it rides the walk the other two already pay for,
     and must never become a second pass over 35k files.
 
@@ -2430,15 +2430,21 @@ def _hint_tags_backfill(
     config-oracle rule, #846 / #848), and the tags are the most
     disclosive of the three.
 
-    The named remedy is ``creek classify --method llm --force``, and its
-    token cost is stated. It is deliberately **not**
-    ``--method rules --force``, which would be free: on this path
+    The named remedy is a bare ``creek classify`` (#1207), and it is free:
+    the resume short-circuit preserves every ``llm``/``manual``-stamped
+    fragment — no provider call, no re-classification — while
+    :func:`creek.classify.classify_engine._write_tags_only` backfills the
+    ``tags`` key and nothing else.
+
+    Two commands it deliberately does **not** name, both of which it used
+    to. ``--method llm --force`` works but re-sends the vault to the
+    configured provider to recover data already on local disk.
+    ``--method rules --force`` is free but destructive: on that path
     :func:`creek.classify.classify_engine._classify_one` returns
     :meth:`~creek.classify.rules.RuleClassifier.classify`'s answer, which
     overwrites ``frequency`` / ``wavelength`` / ``voice`` wholesale and
-    re-stamps ``classification_method: rules``. On a vault already
-    classified by an LLM that trades every considered classification for
-    keyword output — a catastrophic price for a tag.
+    re-stamps ``classification_method: rules``, trading every considered
+    LLM classification for keyword output.
 
     Args:
         vault_path: Vault root.
@@ -2454,9 +2460,9 @@ def _hint_tags_backfill(
     console.print(
         f"[dim][fill] {backfillable} fragment(s) carry hashtags in their body "
         "that `tags` does not record (ingested before the field had a "
-        "producer). Run `creek classify --method llm --force` to backfill — "
-        "that re-sends those fragments to the configured provider and costs "
-        "tokens.[/dim]",
+        "producer). Run `creek classify` (no --force) to backfill — it is "
+        "free: already-classified fragments keep their classification and "
+        "gain only the tags.[/dim]",
     )
 
 

--- a/creek-tools/tests/test_classify_engine.py
+++ b/creek-tools/tests/test_classify_engine.py
@@ -2759,29 +2759,48 @@ def test_second_run_extracts_no_tags_and_changes_none(tmp_path: Path) -> None:
     assert _tags_map(vault) == after_first
 
 
-@pytest.mark.parametrize(
-    ("force", "expected_tags", "expected_extracted"),
-    [(False, [], 0), (True, ["gardening"], 1)],
-)
-def test_preserved_fragment_gets_tags_only_under_force(
+# ---- Issue #1207: the free, non-destructive tags backfill -------------------
+#
+# #878 left the preserved short-circuit deliberately untagged, which made the
+# operator's 35k-fragment vault — every file of it stamped
+# ``classification_method: llm`` — reachable only through a paid
+# ``creek classify --method llm --force``. The free alternative,
+# ``--method rules --force``, is destructive: ``_classify_one`` returns
+# ``rules.classify(...)`` (``classify_engine.py:1299``), which at
+# ``rules.py:574`` does ``fragment.model_copy(update=updates)`` over
+# ``frequency`` / ``wavelength`` / ``voice`` and then re-stamps
+# ``classification_method: rules``.
+#
+# #1207 closes that with a SIBLING narrow writer — ``_write_tags_only`` beside
+# ``_write_tier_only`` — rather than by widening the tier writer. A writer
+# whose scope is its name is auditable; one whose scope is a parameter is not,
+# and these run over already-classified user vaults. ``_write_tier_only``'s
+# #876 promise ("changes ONLY the privacy-tier fields") is therefore unchanged.
+#
+# The hard constraint is non-destructiveness, and it is what the tests below
+# actually assert: tags land, every other frontmatter field is byte-identical,
+# no classification re-runs, and no LLM is called.
+
+
+@pytest.mark.parametrize("force", [False, True])
+def test_preserved_fragment_gains_tags_without_force(
     tmp_path: Path,
     force: bool,
-    expected_tags: list[str],
-    expected_extracted: int,
 ) -> None:
-    """A preserved ``llm``-stamped fragment gains tags only with ``--force``.
+    """A preserved ``llm``-stamped fragment gains tags with or without ``--force``.
 
-    The same deliberate asymmetry the #877 praxis pass carries.
-    ``_write_tier_only`` is the narrow writer used on the OPS-001 resume
-    short-circuit, and it is **not** widened to carry tags: the #876 tier
-    exception exists because an untiered fragment is a live cloud-egress
-    hole, whereas a missing tag is a missing feature. Widening that
-    writer would rewrite the ``tags`` axis of every already-curated
-    fragment in a mature vault without the operator asking — and unlike
-    praxis, ``tags`` is a field operators hand-edit in Obsidian.
+    This **reverses** #878's residual (and the test that pinned it). The
+    reasoning that justified the asymmetry for praxis does not survive
+    contact with the tags axis: hashtag extraction is a lossless
+    mechanical restatement of literal author-written syntax, not a
+    judgment, and ``tags_pass.merge`` is a union that cannot drop a tag
+    an operator hand-wrote. So the free pass can run on the short-circuit
+    without threatening either of the two things OPS-001 protects —
+    operator curation and paid tokens.
 
-    ``creek fill`` surfaces the outstanding count instead (see
-    ``tests/test_cli_fill.py``).
+    The tier still lands on the same run, which is what proves the
+    short-circuit was genuinely taken rather than the fragment quietly
+    reclassified.
     """
     from creek.models import Authorship
 
@@ -2807,6 +2826,256 @@ def test_preserved_fragment_gets_tags_only_under_force(
         force=force,
     )
 
-    assert _tags_map(vault) == {"frag-tags-presrv1": expected_tags}
-    assert summary.tags_extracted == expected_extracted
+    assert _tags_map(vault) == {"frag-tags-presrv1": ["gardening"]}
+    assert summary.tags_extracted == 1
     assert summary.preserved_llm == (0 if force else 1)
+
+
+def _seed_preserved_tagged_fragment(
+    vault: Path,
+    frag_id: str,
+    *,
+    tags: list[str] | None = None,
+    tier: str | None = "open",
+) -> Path:
+    """Write one ``llm``-stamped fragment carrying :data:`_TAGS_SIGNAL_BODY`.
+
+    Args:
+        vault: Vault root.
+        frag_id: Fragment id (also the file stem).
+        tags: Tags already recorded on the fragment; ``None`` for none.
+        tier: ``privacy_tier`` to stamp. Pass ``"open"`` so the #876 pass
+            has nothing to do and the tags write is the *only* mutation
+            the run can make; pass ``None`` to leave the fragment
+            untiered and exercise both writers on one file.
+
+    Returns:
+        Path to the freshly-written file.
+    """
+    from creek.models import Authorship, PrivacyTier
+
+    fragment = Fragment(
+        id=frag_id,
+        title="Week notes",
+        source=FragmentSource(
+            platform=SourcePlatform.MARKDOWN,
+            author=Authorship.SELF,
+        ),
+        tags=tags or [],
+    )
+    if tier is not None:
+        fragment = fragment.model_copy(update={"privacy_tier": PrivacyTier(tier)})
+    return _write_fragment(
+        vault=vault,
+        fragment=fragment,
+        body=_TAGS_SIGNAL_BODY,
+        method="llm",
+    )
+
+
+def test_preserved_tags_backfill_touches_no_other_frontmatter_field(
+    tmp_path: Path,
+) -> None:
+    """The backfill rewrites ``tags`` and leaves every other byte alone.
+
+    This is the point of the whole issue, not a nicety: the writer runs
+    over already-classified user vaults, so "adds tags" is worth nothing
+    unless "and changes nothing else" is provable. The expectation is
+    built by re-serialising the file's own frontmatter with **only**
+    ``tags`` substituted, so any extra key, any dropped key, any
+    re-ordering, any re-stamped ``classification_method`` /
+    ``classified_at``, and any change to the markdown body all fail the
+    comparison.
+
+    The fragment is seeded with a real ``privacy_tier`` so the #876 pass
+    owns nothing here and the tags write is the only mutation available.
+    """
+    vault = tmp_path / "vault"
+    path = _seed_preserved_tagged_fragment(vault, "frag-tags-narrow1")
+    before = frontmatter.load(str(path))
+    expected = frontmatter.dumps(
+        frontmatter.Post(
+            content=before.content,
+            **{**before.metadata, "tags": ["gardening"]},
+        ),
+    )
+
+    summary = run_classify(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="rules",
+        force=False,
+    )
+
+    assert summary.preserved_llm == 1
+    assert summary.classified == 0
+    assert path.read_text(encoding="utf-8") == expected
+
+
+def test_preserved_tags_backfill_is_idempotent_to_the_byte(
+    tmp_path: Path,
+) -> None:
+    """A second backfill over an unchanged vault rewrites nothing.
+
+    Unlike the non-preserved path — where ``classified_at`` is
+    legitimately re-stamped every run, so only the id→tags mapping can be
+    compared — the preserved path must not touch the file at all once the
+    tags are recorded. A byte comparison is therefore both available and
+    the strongest available statement of idempotence.
+    """
+    vault = tmp_path / "vault"
+    path = _seed_preserved_tagged_fragment(vault, "frag-tags-idemp01")
+
+    first = run_classify(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="rules",
+        force=False,
+    )
+    after_first = path.read_text(encoding="utf-8")
+
+    second = run_classify(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="rules",
+        force=False,
+    )
+
+    assert first.tags_extracted == 1
+    assert second.tags_extracted == 0
+    assert path.read_text(encoding="utf-8") == after_first
+
+
+def test_preserved_tags_backfill_keeps_the_tier_written_on_the_same_run(
+    tmp_path: Path,
+) -> None:
+    """Both narrow writers can fire on one file without clobbering each other.
+
+    An untiered, ``llm``-stamped fragment carrying a hashtag is the one
+    input that makes the #876 tier writer and the #1207 tags writer both
+    run over the same file in the same pass. Each composes on the
+    frontmatter the previous one left behind, so a tags write built from
+    the frontmatter as originally *read* would silently revert the tier —
+    re-opening the cloud-egress hole #876 exists to close. Both fields
+    are asserted on one run.
+    """
+    vault = tmp_path / "vault"
+    _seed_preserved_tagged_fragment(vault, "frag-tags-both001", tier=None)
+
+    summary = run_classify(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="rules",
+        force=False,
+    )
+
+    assert _tags_map(vault) == {"frag-tags-both001": ["gardening"]}
+    assert _tier_map(vault) == {"frag-tags-both001": "personal"}
+    assert summary.privacy_tiers_assigned == 1
+    assert summary.tags_extracted == 1
+
+
+def test_preserved_tags_backfill_never_drops_a_recorded_tag(
+    tmp_path: Path,
+) -> None:
+    """Hand-written tags survive the backfill, re-spelled but never lost.
+
+    ``tags`` is a field operators edit in Obsidian, and the backfill now
+    runs unasked over every preserved fragment in a mature vault, so the
+    union contract has to hold at the engine boundary and not only in
+    ``tags_pass``. Recorded-first ordering is asserted too: a merge that
+    appended the extractor's output ahead of the operator's would churn
+    the frontmatter of every curated fragment.
+    """
+    vault = tmp_path / "vault"
+    _seed_preserved_tagged_fragment(
+        vault,
+        "frag-tags-keep001",
+        tags=["Week_Notes"],
+    )
+
+    run_classify(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="rules",
+        force=False,
+    )
+
+    assert _tags_map(vault) == {"frag-tags-keep001": ["week-notes", "gardening"]}
+
+
+def test_preserved_tags_backfill_makes_no_llm_call(tmp_path: Path) -> None:
+    """The backfill is free: an ``llm``-stamped vault costs zero calls.
+
+    The acceptance criterion of #1207, asserted at the only boundary that
+    can prove it — the provider call itself. Before this change the same
+    vault could only gain tags through ``creek classify --method llm
+    --force``, which re-sends every fragment to the configured provider.
+    """
+    vault = tmp_path / "vault"
+    _seed_preserved_tagged_fragment(vault, "frag-tags-free001")
+
+    with patch.object(
+        LLMClassifier,
+        "classify_with_reasoning",
+        autospec=True,
+    ) as classify_call:
+        summary = run_classify(
+            vault_path=vault,
+            config=CreekConfig(),
+            method="llm",
+            force=False,
+        )
+
+    assert classify_call.call_count == 0
+    assert summary.tags_extracted == 1
+    assert _tags_map(vault) == {"frag-tags-free001": ["gardening"]}
+
+
+def test_tags_only_write_failure_lands_on_errors_without_aborting(
+    tmp_path: Path,
+) -> None:
+    """An ``OSError`` from the tags-only writer is recorded, not fatal.
+
+    Contract note for the implementation: this test patches
+    ``creek.classify.classify_engine._write_tags_only`` — the sibling of
+    ``_write_tier_only``, narrow by *name* rather than by parameter. The
+    same contract the tier writer honours applies: one unwritable file
+    must not abort a 35k-file run, so the failure is appended to
+    ``summary.errors`` naming the fragment, and the rest of the vault
+    still backfills.
+    """
+    from creek.models import Authorship
+
+    vault = tmp_path / "vault"
+    _seed_preserved_tagged_fragment(vault, "frag-tags-ioerr01")
+    _write_fragment(
+        vault=vault,
+        fragment=Fragment(
+            id="frag-tags-ioerr02",
+            title="Week notes",
+            source=FragmentSource(
+                platform=SourcePlatform.MARKDOWN,
+                author=Authorship.SELF,
+            ),
+        ),
+        body=_TAGS_SIGNAL_BODY,
+    )
+
+    with patch(
+        "creek.classify.classify_engine._write_tags_only",
+        side_effect=OSError("read-only file system"),
+    ):
+        summary = run_classify(
+            vault_path=vault,
+            config=CreekConfig(),
+            method="rules",
+            force=False,
+        )
+
+    assert len(summary.errors) == 1
+    assert "read-only file system" in summary.errors[0]
+    assert "frag-tags-ioerr01" in summary.errors[0]
+    # The run continued: the non-preserved fragment still got its tags
+    # through the ordinary write path, which this patch does not touch.
+    assert _tags_map(vault)["frag-tags-ioerr02"] == ["gardening"]

--- a/creek-tools/tests/test_cli_fill.py
+++ b/creek-tools/tests/test_cli_fill.py
@@ -770,6 +770,42 @@ def test_fill_hints_when_tags_can_be_backfilled(
     assert "week ahead" not in out
 
 
+def test_tags_hint_names_the_free_backfill_not_the_paid_one(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The remedy the hint names must be the free one (#1207).
+
+    Under #878 this line said ``creek classify --method llm --force`` and
+    stated its token cost, because the preserved short-circuit did not
+    tag. Since #1207 it does, through a narrow tags-only write, so a bare
+    ``creek classify`` backfills an ``llm``-stamped vault for nothing.
+    Naming ``--force`` now would bill the operator for a full
+    re-classification to recover data already on local disk — asserted
+    absent, alongside the paid framing, because a stale remedy in an
+    advisory line is worse than no line at all.
+    """
+    from creek.cli import _maybe_upgrade_classification
+
+    monkeypatch.setattr(cli_mod, "_detect_classify_upgrade", lambda *_a: None)
+    vault = tmp_path / "vault"
+    _seed_tagged_fragment(vault, "frag-gap", body=_TAGS_SIGNAL_BODY, tags="[]")
+
+    _maybe_upgrade_classification(
+        vault,
+        cli_mod._load_config_for_vault(vault),
+        upgrade=False,
+    )
+
+    # Rich soft-wraps at the console width, so collapse whitespace before
+    # matching — otherwise the assertion is really about line breaks.
+    out = " ".join(capsys.readouterr().out.split())
+    assert "Run `creek classify` (no --force) to backfill" in out
+    assert "--method llm --force" not in out
+    assert "token" not in out.lower()
+
+
 def test_tags_hint_is_silent_when_every_hashtag_is_already_recorded(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Closes #1207.

A free, non-destructive tags backfill for an already-classified vault: a bare `creek classify` now gives llm/manual-stamped fragments their tags through a narrow writer, without re-classifying anything and without a single provider call.

## Took the steer: a sibling writer, not a widened one

`_write_tier_only`'s #876 promise — *"changes ONLY the privacy-tier fields"* — is verbatim unchanged. The tags axis went to a sibling `_write_tags_only`, and that docstring now records **why**: a writer whose field set is legible from its name survives review of a path that rewrites already-curated user vaults; one that takes its scope as an argument pushes that question out to every call site.

## A fork the steer did not anticipate — and it re-opened a closed hole

**Two narrow writers can fire on one file.** An untiered, llm-stamped fragment carrying a hashtag qualifies for both. Each writer rewrites the whole file from the frontmatter it is handed, so the second must compose on what the first actually left on disk.

The naive version — tags writing from the frontmatter as originally *read* — **silently reverts the tier and re-opens #876's cloud-egress hole.** So `_write_tier_only`/`_persist_tier_only` now return the metadata they wrote, and it is threaded to the tags writer.

That is not a widening: the returned dict is still exactly `raw` plus the two tier fields. Proven necessary by an explicit mutation check and pinned by `test_preserved_tags_backfill_keeps_the_tier_written_on_the_same_run`.

`_rewrite_frontmatter` is extracted as the shared I/O tail of both writers and is deliberately **decision-free** — it decides nothing about which fields may change, so sharing serialisation cannot blur the two writers' scopes.

## Three corrections to the issue

- **The cost claim is overstated.** *"`--method llm --force` re-sends all 35,330 fragments to the provider"* — it does not. On the LLM path, `_classify_one` runs the rule classifier **first** and returns without any provider call whenever confidence clears the threshold; only the below-threshold remainder is sent. The argument (paying tokens to recover data already on local disk) stands; the count does not.
- **Extrapolation sold as proof.** *"The field is provably `[]` on 100% of 35,330 fragments"* — the evidence recorded in #878 is **2000/2000 sampled**, not a census. Immaterial to the decision, since `tags_pass.merge` is a union and the backfill is safe either way, but "provably 100%" is not what was measured.
- **Stale line ref**, ~88 lines: `_classify_one` is cited at `classify_engine.py:1211`; it was at 1299. It also does not `return rules.classify(...)` — it returns a 3-tuple. The destructiveness claim itself is correct, and `rules.py:574` is the one reference that was accurate.

## The free command is not the one you would guess

`creek classify --method llm` without `--force` makes zero LLM calls on an all-llm-stamped vault — but `_assert_classifiers_available` raises `LLMProviderUnavailableError` **before** the loop, so it is unusable for an operator with no API key.

The genuinely free, provider-free route is the **bare `creek classify`** (default `--method rules`, no `--force`): every llm/manual fragment short-circuits and gains tags through the narrow writer, and nothing is re-classified. The `creek fill` hint now names that command; it previously named the paid `--method llm --force` and quoted its token cost, which this change makes wrong.

## One reversal, argued rather than silent

`test_preserved_fragment_gets_tags_only_under_force` asserted #878's residual — the exact behaviour #1207 exists to change. Leaving it would have made the issue unimplementable. Renamed to `test_preserved_fragment_gains_tags_without_force`, with the reversal argued in its docstring.

Preserved-path backfills count on `ClassifySummary.tags_extracted` — counting the decision, not the bytes, consistent with `privacy_tiers_assigned` and `praxis_marked`. That attribute's docstring explicitly said preserved fragments are *not* counted; corrected.

## Not done, deliberately

No `creek fill` step and no new command. The issue offered that shape; the sibling writer plus the corrected hint delivers every acceptance criterion with a far smaller review surface, and a bare `creek classify` is already the free entry point.

Gate: **12/12**. Zero suppressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EaHDtyDuNrpGtzUGMJT7Fw
