### PR TITLE
wire-in: activate the draft grounding guard on both surfaces

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -4573,6 +4573,7 @@ def draft(
     from creek.generate.ai_style.fingerprint import load_fingerprint
     from creek.generate.ai_style.preamble import build_style_preamble
     from creek.generate.drafts import DraftGenerator
+    from creek.generate.grounding import GroundingThresholds, default_embedding_fn
     from creek.generate.mining import IdeaMiner
 
     vault_path = _resolve_vault(vault)
@@ -4610,6 +4611,13 @@ def draft(
         privacy_override=override,
         bypass_compiled=bypass_compiled,
         ontology_twist=ontology_twist,
+        # FEAT-032 grounding guard. Both kwargs are required together — the
+        # generator skips the guard entirely if either is missing, which is
+        # exactly how it stayed dormant on this path until #1040. The model
+        # loads lazily inside the factory, so an offline host pays nothing
+        # here and the generator degrades with a warning when it does.
+        embedding_fn=default_embedding_fn(vault_config.embeddings),
+        grounding_thresholds=GroundingThresholds.from_config(vault_config.draft),
         fingerprint=fingerprint,
         ai_style_config=ai_style,
         voice_guard_no_llm=no_llm,

--- a/creek-tools/creek/generate/drafts.py
+++ b/creek-tools/creek/generate/drafts.py
@@ -84,6 +84,7 @@ from creek.generate.twist import (
     target_profile_from_spec,
     twist_dimensions,
 )
+from creek.link.embeddings import EmbeddingModelUnavailableError
 from creek.models import (
     CompiledPage,
     Eddy,
@@ -1181,31 +1182,61 @@ class DraftGenerator:
 
         Returns:
             A :class:`GroundingReport`, or ``None`` when the guard is
-            not configured on this generator.
+            not configured on this generator — or when the embedding
+            model turned out to be unloadable at scoring time.
         """
         if self._embedding_fn is None or self._grounding_thresholds is None:
             return None
         source_texts = [
             fragments[fid][1] for fid in source_fragments if fid in fragments
         ]
-        report = score_draft(
-            body,
-            source_texts=source_texts,
-            embedding_fn=self._embedding_fn,
-            thresholds=self._grounding_thresholds,
-        )
-        print(report.summary_line(), file=sys.stderr)
-        # The non-``None`` invariant is established by the guard above; assert
-        # it so ``_warn_ungrounded_biographical``'s non-optional
-        # ``embedding_fn`` contract is explicit and mypy's narrowing is pinned.
-        assert self._embedding_fn is not None
-        self._warn_ungrounded_biographical(
-            body=body,
-            source_texts=source_texts,
-            embedding_fn=self._embedding_fn,
-            thresholds=self._grounding_thresholds,
-        )
+        try:
+            report = score_draft(
+                body,
+                source_texts=source_texts,
+                embedding_fn=self._embedding_fn,
+                thresholds=self._grounding_thresholds,
+            )
+            print(report.summary_line(), file=sys.stderr)
+            # The non-``None`` invariant is established by the guard above;
+            # assert it so ``_warn_ungrounded_biographical``'s non-optional
+            # ``embedding_fn`` contract is explicit and mypy's narrowing is
+            # pinned.
+            assert self._embedding_fn is not None
+            self._warn_ungrounded_biographical(
+                body=body,
+                source_texts=source_texts,
+                embedding_fn=self._embedding_fn,
+                thresholds=self._grounding_thresholds,
+            )
+        except EmbeddingModelUnavailableError as exc:
+            self._disable_grounding(exc)
+            return None
         return report
+
+    def _disable_grounding(self, exc: EmbeddingModelUnavailableError) -> None:
+        """Turn the grounding guard off for the rest of this run, loudly.
+
+        The production ``embedding_fn`` loads a sentence-transformer on
+        first call, so "the model is missing" surfaces mid-draft rather
+        than at construction time. Losing the guard must not lose the
+        draft: the generator drops back to its dormant behaviour (no
+        scores stamped, no veto applied) and says so on stderr, mirroring
+        :meth:`creek.author.agents.RetrievalAgent.retrieve`'s
+        degrade-to-empty handling of the same typed error.
+
+        Clearing both attributes also makes the failure sticky, so the
+        later guard entry points short-circuit on their existing
+        ``is None`` checks instead of re-raising the same load failure
+        once per pass.
+
+        Args:
+            exc: The typed load failure, whose message already carries
+                the model name and the operator's remediation.
+        """
+        self._embedding_fn = None
+        self._grounding_thresholds = None
+        print(f"grounding guard skipped: {exc}", file=sys.stderr)
 
     def _warn_ungrounded_biographical(
         self,
@@ -1376,19 +1407,24 @@ class DraftGenerator:
 
         Returns:
             One finding per ungrounded biographical sentence; empty when the
-            guard is dormant or the body is clean.
+            guard is dormant, the embedding model is unloadable, or the body
+            is clean.
         """
         if self._embedding_fn is None or self._grounding_thresholds is None:
             return []
         corpus = [fragments[fid][1] for fid in source_fragments if fid in fragments]
         if self.voice_core.strip():
             corpus.append(self.voice_core)
-        return scan_biographical_sentences(
-            body,
-            source_texts=corpus,
-            embedding_fn=self._embedding_fn,
-            threshold=self._grounding_thresholds.grounding_lower,
-        )
+        try:
+            return scan_biographical_sentences(
+                body,
+                source_texts=corpus,
+                embedding_fn=self._embedding_fn,
+                threshold=self._grounding_thresholds.grounding_lower,
+            )
+        except EmbeddingModelUnavailableError as exc:
+            self._disable_grounding(exc)
+            return []
 
     def _cohesion_llm(self, prompt: str) -> str:
         """Call the shared draft LLM for the cohesion hop, returning the body.
@@ -2105,6 +2141,16 @@ class DraftGenerator:
         thresholds = self._grounding_thresholds
 
         def _still_grounded(body: str) -> bool:
+            # No ``EmbeddingModelUnavailableError`` handling here, unlike the
+            # two guard entry points that embed before this one. The veto is
+            # built only from ``_apply_voice_fidelity``, which ``save_draft``
+            # calls after ``generate_draft`` / ``generate_seeded_draft`` have
+            # already run ``_build_guard_report``; the other caller,
+            # ``save_outline_draft``, passes no source fragments and exits
+            # above. So an unloadable model has always already tripped
+            # ``_disable_grounding``, and the ``_embedding_fn is None`` check
+            # above returns before this closure is ever built. Catching it
+            # here again would be a branch nothing can reach.
             report = score_draft(
                 body,
                 source_texts=source_texts,

--- a/creek-tools/creek/generate/grounding.py
+++ b/creek-tools/creek/generate/grounding.py
@@ -25,6 +25,15 @@ Surfaces:
   per-paragraph annotations list under the keys exported below — these
   are also what the ``draft-grounding`` lint check reads.
 
+Both surfaces are conditional on the embedding model actually loading.
+``creek draft`` and the MCP ``creek.draft`` tool wire the guard via
+:func:`default_embedding_fn`, which loads a sentence-transformer on
+first call; when that fails,
+:meth:`creek.generate.drafts.DraftGenerator._disable_grounding` skips
+the guard for the rest of the run, prints ``grounding guard skipped:``
+to stderr, and the draft is saved with no scores rather than lost
+(#1040).
+
 The module deliberately exposes its embedding callable so tests (and
 future callers) can inject a deterministic stub instead of loading the
 full sentence-transformer at unit-test time.

--- a/creek-tools/creek/lint/checks/draft_grounding.py
+++ b/creek-tools/creek/lint/checks/draft_grounding.py
@@ -8,11 +8,18 @@ any draft whose stored scores fall outside the configured
 ``draft.derivative_upper`` / ``draft.grounding_fraction_lower``
 thresholds.
 
-Drafts written before issue #355 (and any markdown file that simply
-lacks the scores) are skipped silently — re-running ``creek draft``
-will backfill the metric. The check never deletes, rewrites, or
-auto-redrafts: it only surfaces, in keeping with the non-negotiable
-lint rules pinned by :mod:`creek.lint`.
+Drafts that lack the scores are skipped silently — re-running
+``creek draft`` will backfill the metric. Two populations land there:
+drafts written before issue #355, and drafts written on a host where
+the embedding model could not load (the guard says so on stderr at
+draft time and stamps nothing). Until #1040 wired the guard into the
+production draft paths, *every* draft landed there and this check
+reported every vault clean; that history is why the skip branch is
+worth naming rather than leaving implicit.
+
+The check never deletes, rewrites, or auto-redrafts: it only surfaces,
+in keeping with the non-negotiable lint rules pinned by
+:mod:`creek.lint`.
 """
 
 from __future__ import annotations

--- a/creek-tools/creek_mcp/tools/draft.py
+++ b/creek-tools/creek_mcp/tools/draft.py
@@ -80,8 +80,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Protocol
 
 from creek.classify.privacy_filter import max_source_tier, source_tiers
+from creek.config import load_config, resolve_config_path
 from creek.generate.compile_routing import load_compiled_pages
 from creek.generate.drafts import DraftGenerator
+from creek.generate.grounding import GroundingThresholds, default_embedding_fn
 from creek.generate.mining import IdeaMiner
 from creek.models import Phase, PrivacyTier
 from creek_mcp.audit import MCPAuditLog
@@ -327,10 +329,22 @@ def draft_tool(
             ceiling=privacy_tier_ceiling,
             reason=str(exc),
         )
+    # The vault's own ``creek_config.yaml`` (not the bare process-wide
+    # ``load_config()`` the other tool wrappers use) so an operator's
+    # calibrated grounding thresholds apply to MCP drafts too. The
+    # missing-file warning is suppressed because this is a per-call hot path,
+    # not a setup surface — ``creek init`` is where a missing config is worth
+    # saying out loud, and :mod:`creek.lint.checks.draft_grounding` resolves
+    # the same section the same quiet way.
+    config = load_config(resolve_config_path(vault_path, None), warn_on_missing=False)
     generator = DraftGenerator(
         llm=llm,
         skills_root=skills_dir,
         privacy_override=override,
+        # FEAT-032 grounding guard — supplied as a pair, because
+        # ``DraftGenerator`` skips the guard when either is missing (#1040).
+        embedding_fn=default_embedding_fn(config.embeddings),
+        grounding_thresholds=GroundingThresholds.from_config(config.draft),
     )
     try:
         draft = generator.generate_draft(idea, vault_path=vault_path)

--- a/creek-tools/tests/e2e/test_draft_grounding_e2e.py
+++ b/creek-tools/tests/e2e/test_draft_grounding_e2e.py
@@ -1,0 +1,161 @@
+"""End-to-end: ``creek draft`` feeds ``creek lint --check draft-grounding`` (#1040).
+
+The two commands were shipped as a pair — the guard stamps
+``derivative_score`` / ``grounding_score`` into a saved draft, and the lint
+check audits those scores against the vault's configured thresholds — but
+nothing ever joined them. The guard was never wired into ``creek draft``, so
+the check's "no scores → clean" branch swallowed every vault, and a test that
+only asserted ``creek lint`` exited 0 would have called that a pass.
+
+This harness runs both real commands, in order, over the same throwaway
+vault, and asserts on the **lint report the second command wrote**:
+
+* an ungrounded draft must produce a finding naming its failing metric, and
+* an in-bounds draft from the identical path must produce none.
+
+Only the LLM hop and the sentence-transformer weights are stubbed; the draft
+composition, the grounding scoring, the frontmatter write, the check
+registry, the threshold resolution and the report render are all production
+code. Marked ``e2e`` so it runs in CI's ``integration-e2e`` lane rather than
+the default unit gate; the wiring assertions that must run on every commit
+live in ``tests/test_draft_grounding_wiring.py``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import frontmatter
+import pytest
+from typer.testing import CliRunner
+
+from creek.cli import app
+from creek.link.embeddings import EmbeddingLinker
+from tests.grounding_stubs import (
+    GROUNDED_SOURCE_BODY,
+    IN_BOUNDS_DRAFT_BODY,
+    UNGROUNDED_DRAFT_BODY,
+    BagOfWordsEncoder,
+)
+from tests.helpers import write_raw_fragment_file
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = pytest.mark.e2e
+
+runner = CliRunner()
+
+_SOURCE_ID = "frag-ground-e2e"
+
+
+def _seed() -> Any:
+    """Build the single idea seed the miner is forced to surface.
+
+    Returns ``Any`` because :class:`~creek.generate.mining.IdeaSeed` is
+    imported inside the function, matching
+    ``tests/test_draft_grounding_wiring.py``.
+    """
+    from creek.generate.mining import IdeaSeed, MiningStrategy
+
+    return IdeaSeed(
+        strategy=MiningStrategy.THREAD_TERMINUS,
+        title="Grounding audit chain",
+        source_fragments=(_SOURCE_ID,),
+        threads=(),
+        eddies=(),
+        frequency_affinity=(),
+        brief_description="A draft the lint check must be able to judge.",
+        score=0.8,
+    )
+
+
+def _draft_then_lint(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    body: str,
+) -> tuple[str, dict[str, Any]]:
+    """Run ``creek draft`` then ``creek lint`` over one throwaway vault.
+
+    Args:
+        tmp_path: Pytest's per-test temporary directory.
+        monkeypatch: Patch handle for the LLM and the embedding weights.
+        body: The exact draft body the stubbed LLM emits.
+
+    Returns:
+        ``(lint_report_text, draft_frontmatter)``. Callers assert on both:
+        the report alone cannot distinguish "the check judged this draft
+        clean" from "the check found nothing to judge", which is precisely
+        the ambiguity #1040 was made of.
+    """
+    import creek.cli as cli_module
+
+    vault = tmp_path / "vault"
+    for sub in ("01-Fragments/Notes", "02-Threads", "03-Eddies", "07-Voice/Drafts"):
+        (vault / sub).mkdir(parents=True, exist_ok=True)
+    write_raw_fragment_file(
+        vault,
+        "01-Fragments/Notes",
+        _SOURCE_ID,
+        "Phonetic source",
+        body=GROUNDED_SOURCE_BODY,
+    )
+    monkeypatch.setattr(
+        EmbeddingLinker,
+        "load_model",
+        lambda _self: BagOfWordsEncoder(),
+    )
+    monkeypatch.setattr(
+        cli_module,
+        "_build_draft_llm",
+        lambda *_a, **_k: lambda _prompt: body,
+    )
+    monkeypatch.setattr(
+        "creek.generate.mining.IdeaMiner.mine_all",
+        lambda _self, _vault, *, current_phase=None: [_seed()],
+    )
+
+    drafted = runner.invoke(app, ["draft", "--vault", str(vault)])
+    assert drafted.exit_code == 0, drafted.output
+
+    linted = runner.invoke(
+        app,
+        ["lint", "--vault", str(vault), "--check", "draft-grounding"],
+    )
+    assert linted.exit_code == 0, linted.output
+    reports = sorted((vault / "00-Creek-Meta" / "Processing-Log").glob("lint-*.md"))
+    assert len(reports) == 1, f"expected one lint report, got {reports}"
+    drafts = sorted((vault / "07-Voice" / "Drafts").glob("*.md"))
+    assert len(drafts) == 1, f"expected one saved draft, got {drafts}"
+    return (
+        reports[0].read_text(encoding="utf-8"),
+        dict(frontmatter.load(str(drafts[0])).metadata),
+    )
+
+
+def test_lint_flags_an_ungrounded_draft_the_draft_command_produced(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A draft with no anchor in its sources is surfaced by the audit pass."""
+    report, metadata = _draft_then_lint(tmp_path, monkeypatch, UNGROUNDED_DRAFT_BODY)
+    assert metadata["grounding_score"] == pytest.approx(0.0)
+    assert "1 draft(s) scanned; 1 outside" in report
+    assert "grounding=0.00 < 0.30" in report
+
+
+def test_lint_clears_an_in_bounds_draft_from_the_same_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The check is discriminating, not merely noisy.
+
+    Asserting the scores exist *and* the report is empty is what separates
+    "judged clean" from "found nothing to judge" — without the first
+    assertion this test passes against the dormant guard #1040 fixed.
+    """
+    report, metadata = _draft_then_lint(tmp_path, monkeypatch, IN_BOUNDS_DRAFT_BODY)
+    assert metadata["derivative_score"] == pytest.approx(0.5)
+    assert metadata["grounding_score"] == pytest.approx(1.0)
+    assert "1 draft(s) scanned; 0 outside" in report
+    assert "grounding=" not in report

--- a/creek-tools/tests/grounding_stubs.py
+++ b/creek-tools/tests/grounding_stubs.py
@@ -1,0 +1,103 @@
+"""Deterministic stand-ins for the sentence-transformer the grounding guard uses.
+
+The FEAT-032 grounding guard is wired into ``creek draft`` and the MCP
+``creek.draft`` tool through
+:func:`creek.generate.grounding.default_embedding_fn`, which loads a real
+sentence-transformer via :meth:`creek.link.embeddings.EmbeddingLinker.load_model`.
+Tests that want to prove the guard is *actually reached* must therefore go
+through that same factory rather than injecting a callable of their own —
+otherwise they assert nothing about production wiring.
+
+:class:`BagOfWordsEncoder` is the seam: patching ``load_model`` to return
+one keeps the whole production path (factory → linker → ``generate_embedding``
+→ ``score_draft``) intact while replacing only the model weights with a
+hashing bag-of-words vectoriser. Its similarity behaviour is exact and
+predictable, which is what lets a test say "this draft *must* fail the
+grounding check" instead of "the command exited 0":
+
+* identical text → cosine ``1.0`` (trips ``derivative_upper``),
+* disjoint vocabulary → cosine ``0.0`` (trips ``grounding_fraction_lower``),
+* half-shared vocabulary → cosine ``0.5`` (inside both bounds).
+"""
+
+from __future__ import annotations
+
+import re
+import zlib
+from typing import Final
+
+_DIMENSIONS: Final[int] = 128
+"""Vector width. Comfortably wider than the token vocabulary these tests
+use, so distinct words do not collide into the same bucket and blur the
+similarity arithmetic the assertions depend on."""
+
+_WORD_RE: Final[re.Pattern[str]] = re.compile(r"[a-z0-9']+")
+"""Token pattern. Lowercase-only because :meth:`BagOfWordsEncoder.encode`
+case-folds first."""
+
+
+class BagOfWordsEncoder:
+    """A hashing bag-of-words vectoriser shaped like a SentenceTransformer.
+
+    Only :meth:`encode` is implemented — that is the entire surface
+    :meth:`creek.link.embeddings.EmbeddingLinker.generate_embedding` touches
+    for a single string, so a test can substitute this for the real model
+    without stubbing anything else in the embedding stack.
+    """
+
+    def encode(self, text: str) -> list[float]:
+        """Return a deterministic term-frequency vector for *text*.
+
+        Args:
+            text: The string to encode.
+
+        Returns:
+            A :data:`_DIMENSIONS`-long vector of term frequencies. Bucketing
+            uses :func:`zlib.crc32` rather than :func:`hash` because
+            ``PYTHONHASHSEED`` randomises string hashing per process, which
+            would make similarity scores — and therefore the assertions built
+            on them — vary between runs.
+        """
+        vector = [0.0] * _DIMENSIONS
+        for match in _WORD_RE.finditer(text.lower()):
+            bucket = zlib.crc32(match.group(0).encode("utf-8")) % _DIMENSIONS
+            vector[bucket] += 1.0
+        return vector
+
+
+GROUNDED_SOURCE_BODY: Final[str] = "alpha bravo charlie delta echo foxtrot golf india\n"
+"""Source-fragment body every wiring test grounds its drafts against.
+
+The vocabulary across all three bodies below is drawn from the NATO
+alphabet minus ``hotel`` and ``xray``, which collide with ``delta`` and
+``uniform`` under ``crc32 % 128``. A collision would inflate one term's
+weight and skew the cosine arithmetic these constants promise — the exact
+score assertions in ``tests/test_draft_grounding_wiring.py`` are what keep
+that promise honest, failing loudly rather than drifting silently."""
+
+IN_BOUNDS_DRAFT_BODY: Final[str] = "alpha bravo charlie delta juliett kilo lima mike\n"
+"""Draft sharing four of eight tokens with :data:`GROUNDED_SOURCE_BODY`.
+
+Cosine ``4 / sqrt(8 * 8) == 0.5`` — above ``grounding_lower`` (0.30) so the
+single paragraph counts as grounded, and below ``derivative_upper`` (0.85)
+so it is not flagged as paraphrase. Both default thresholds are cleared."""
+
+UNGROUNDED_DRAFT_BODY: Final[str] = (
+    "november oscar papa quebec romeo sierra tango uniform\n"
+)
+"""Draft sharing no token with :data:`GROUNDED_SOURCE_BODY`.
+
+Cosine ``0.0`` for its only paragraph, so ``grounding_score`` is ``0.0`` —
+below the default ``grounding_fraction_lower`` of 0.30. This is the draft
+that *must* make ``creek lint --check draft-grounding`` report a finding;
+if it does not, the guard never ran."""
+
+BIOGRAPHICAL_DRAFT_BODY: Final[str] = "I grew up around november oscar papa.\n"
+"""Draft carrying a first-person biographical claim.
+
+:func:`creek.generate.grounding.scan_biographical_sentences` returns before
+embedding anything when no sentence matches
+:func:`~creek.generate.grounding.is_biographical_sentence` — so the cohesion
+re-check only reaches the embedding model, and only exercises its failure
+handling, on a body like this one. ``I grew up`` is one of the conservative
+patterns that heuristic matches."""

--- a/creek-tools/tests/test_draft_grounding_wiring.py
+++ b/creek-tools/tests/test_draft_grounding_wiring.py
@@ -1,0 +1,242 @@
+"""The FEAT-032 grounding guard is wired into both production draft paths (#1040).
+
+The guard, its ``default_embedding_fn`` factory, and the ``draft-grounding``
+lint check that consumes its output all shipped complete — and completely
+disconnected. ``DraftGenerator`` skips the guard unless *both* ``embedding_fn``
+and ``grounding_thresholds`` are supplied, and neither production construction
+site supplied them, so every real draft was saved without
+``derivative_score`` / ``grounding_score`` and the lint check's
+"scores absent → clean" branch reported every vault spotless.
+
+Every test here asserts on the **frontmatter the run produced**, never on the
+exit code. A dormant guard exits 0 exactly like a live one; only the stamped
+scores tell them apart. The lint check's own scoring logic is covered by
+``tests/test_lint_draft_grounding.py`` against hand-written frontmatter — what
+was missing, and what these tests supply, is proof that a real draft ever
+carries the frontmatter that check reads.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import frontmatter
+import pytest
+from typer.testing import CliRunner
+
+from creek.cli import app
+from creek.link.embeddings import EmbeddingLinker, EmbeddingModelUnavailableError
+from tests.grounding_stubs import (
+    BIOGRAPHICAL_DRAFT_BODY,
+    GROUNDED_SOURCE_BODY,
+    IN_BOUNDS_DRAFT_BODY,
+    UNGROUNDED_DRAFT_BODY,
+    BagOfWordsEncoder,
+)
+from tests.helpers import write_raw_fragment_file
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+runner = CliRunner()
+
+_SOURCE_ID = "frag-ground-001"
+
+
+def _seed() -> Any:
+    """Build the fixed idea seed both draft surfaces mine.
+
+    Returns ``Any`` because :class:`~creek.generate.mining.IdeaSeed` is
+    imported inside the function — importing the mining module at test-module
+    scope pulls in the draft stack before ``monkeypatch`` can reach it.
+    """
+    from creek.generate.mining import IdeaSeed, MiningStrategy
+
+    return IdeaSeed(
+        strategy=MiningStrategy.THREAD_TERMINUS,
+        title="Grounding wiring probe",
+        source_fragments=(_SOURCE_ID,),
+        threads=(),
+        eddies=(),
+        frequency_affinity=(),
+        brief_description="A draft whose grounding must be measured.",
+        score=0.8,
+    )
+
+
+def _build_vault(tmp_path: Path) -> Path:
+    """Scaffold a vault holding the single source fragment drafts ground against."""
+    vault = tmp_path / "vault"
+    for sub in ("01-Fragments/Notes", "02-Threads", "03-Eddies", "07-Voice/Drafts"):
+        (vault / sub).mkdir(parents=True, exist_ok=True)
+    write_raw_fragment_file(
+        vault,
+        "01-Fragments/Notes",
+        _SOURCE_ID,
+        "Phonetic source",
+        body=GROUNDED_SOURCE_BODY,
+    )
+    return vault
+
+
+def _stub_miner(monkeypatch: pytest.MonkeyPatch, target: str) -> None:
+    """Force *target*'s ``IdeaMiner`` to surface exactly one seed."""
+
+    def _mine_all(
+        _self: object,
+        _vault: object,
+        *,
+        current_phase: object = None,
+    ) -> list[object]:
+        """Return the one fixed seed, ignoring the phase the caller asked for."""
+        del current_phase
+        return [_seed()]
+
+    monkeypatch.setattr(target, _mine_all)
+
+
+def _stub_embedding_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace only the model weights, keeping the production embedding path."""
+    monkeypatch.setattr(
+        EmbeddingLinker,
+        "load_model",
+        lambda _self: BagOfWordsEncoder(),
+    )
+
+
+def _saved_draft_metadata(vault: Path) -> dict[str, Any]:
+    """Return the frontmatter of the single draft saved under ``07-Voice/Drafts``."""
+    drafts = sorted((vault / "07-Voice" / "Drafts").glob("*.md"))
+    assert len(drafts) == 1, f"expected exactly one saved draft, got {drafts}"
+    return dict(frontmatter.load(str(drafts[0])).metadata)
+
+
+def _run_cli_draft(
+    vault: Path,
+    body: str,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    cohesion: bool = False,
+) -> Any:
+    """Drive ``creek draft`` with a fixed LLM emitter, returning click's ``Result``."""
+    import creek.cli as cli_module
+
+    monkeypatch.setattr(
+        cli_module,
+        "_build_draft_llm",
+        lambda *_a, **_k: lambda _prompt: body,
+    )
+    _stub_miner(monkeypatch, "creek.generate.mining.IdeaMiner.mine_all")
+    argv = ["draft", "--vault", str(vault)]
+    if cohesion:
+        argv.append("--cohesion")
+    return runner.invoke(app, argv)
+
+
+def test_cli_draft_stamps_grounding_scores(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``creek draft`` runs the guard and writes both scalars to frontmatter."""
+    vault = _build_vault(tmp_path)
+    _stub_embedding_model(monkeypatch)
+    result = _run_cli_draft(vault, UNGROUNDED_DRAFT_BODY, monkeypatch)
+    assert result.exit_code == 0, result.output
+    metadata = _saved_draft_metadata(vault)
+    assert metadata["derivative_score"] == pytest.approx(0.0)
+    assert metadata["grounding_score"] == pytest.approx(0.0)
+    assert metadata["paragraph_grounding"][0]["is_grounded"] is False
+
+
+def test_cli_draft_scores_an_in_bounds_draft_inside_both_thresholds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A half-overlapping draft scores 0.5 derivative / 1.0 grounded.
+
+    Pins the guard to real numbers rather than mere key presence: a stub that
+    stamped zeros for everything would satisfy the sibling test but fail here.
+    """
+    vault = _build_vault(tmp_path)
+    _stub_embedding_model(monkeypatch)
+    result = _run_cli_draft(vault, IN_BOUNDS_DRAFT_BODY, monkeypatch)
+    assert result.exit_code == 0, result.output
+    metadata = _saved_draft_metadata(vault)
+    assert metadata["derivative_score"] == pytest.approx(0.5)
+    assert metadata["grounding_score"] == pytest.approx(1.0)
+
+
+def test_cli_draft_survives_an_unavailable_embedding_model(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing local model skips the guard instead of crashing the draft."""
+
+    def _explode(_self: object) -> object:
+        """Fail exactly as ``EmbeddingLinker.load_model`` does on an offline host."""
+        raise EmbeddingModelUnavailableError("model weights are missing")
+
+    monkeypatch.setattr(EmbeddingLinker, "load_model", _explode)
+    vault = _build_vault(tmp_path)
+    result = _run_cli_draft(vault, UNGROUNDED_DRAFT_BODY, monkeypatch)
+    assert result.exit_code == 0, result.output
+    # The warning is the load-bearing assertion. Without it this test would
+    # also pass against a guard that was never wired at all — a dormant guard
+    # exits 0 and stamps nothing too, which is the whole defect of #1040.
+    assert "grounding guard skipped" in result.output
+    assert "model weights are missing" in result.output
+    metadata = _saved_draft_metadata(vault)
+    assert "derivative_score" not in metadata
+    assert "grounding_score" not in metadata
+
+
+def test_cohesion_pass_survives_an_unavailable_embedding_model(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The cohesion re-check degrades too — it embeds *before* the guard.
+
+    ``_apply_cohesion`` runs ahead of ``_build_guard_report`` in
+    ``generate_draft``, so under ``--cohesion`` the biographical re-scan is
+    the first thing to touch the model and therefore the first thing an
+    offline host can crash on.
+    """
+
+    def _explode(_self: object) -> object:
+        """Fail exactly as ``EmbeddingLinker.load_model`` does on an offline host."""
+        raise EmbeddingModelUnavailableError("model weights are missing")
+
+    monkeypatch.setattr(EmbeddingLinker, "load_model", _explode)
+    vault = _build_vault(tmp_path)
+    result = _run_cli_draft(
+        vault,
+        BIOGRAPHICAL_DRAFT_BODY,
+        monkeypatch,
+        cohesion=True,
+    )
+    assert result.exit_code == 0, result.output
+    assert "grounding guard skipped" in result.output
+    metadata = _saved_draft_metadata(vault)
+    assert "grounding_score" not in metadata
+
+
+def test_mcp_draft_stamps_grounding_scores(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The MCP ``creek.draft`` surface is not left behind by the CLI wiring."""
+    from creek_mcp.tools.draft import draft_tool
+
+    vault = _build_vault(tmp_path)
+    _stub_embedding_model(monkeypatch)
+    _stub_miner(monkeypatch, "creek_mcp.tools.draft.IdeaMiner.mine_all")
+    result = draft_tool(
+        vault_path=vault,
+        llm_factory=lambda _tier: lambda _prompt: UNGROUNDED_DRAFT_BODY,
+        skills_root=vault / "creek-skills",
+        phase="unclassified",
+    )
+    assert result["status"] == "ok", result
+    metadata = _saved_draft_metadata(vault)
+    assert metadata["derivative_score"] == pytest.approx(0.0)
+    assert metadata["grounding_score"] == pytest.approx(0.0)


### PR DESCRIPTION
Closes #1040. Refs #1024.

The draft grounding guard was dormant on every path, so `creek lint --check draft-grounding` ran, exited 0, and verified nothing. This wires it at both surfaces and pins the chain.

## The issue's own acceptance criterion does not hold

It asks that the new e2e test "fail on main before the change". **For the in-bounds control case, it doesn't** — a test asserting only that the lint report says `0 outside` passes against the dormant guard, because **"judged clean" and "found nothing to judge" render identically**.

Making it genuinely red required asserting the saved draft actually *carries* `derivative_score`/`grounding_score`. That is the #1024 failure mode reappearing one level up, **inside the test written to catch it** — which is worth recording for the rest of that epic.

## Task 5 is based on a false premise

It asks for "a test asserting `creek lint --check draft-grounding` reports a finding for an out-of-bounds draft (i.e. the check is no longer vacuous)" and names `tests/test_lint.py`.

That test **already existed** — `tests/test_lint_draft_grounding.py` writes out-of-bounds frontmatter by hand and asserts findings at lines 145 and 160. (`test_lint.py` contains zero draft-grounding tests.) The check's scoring logic was never vacuous *as a function*; it was vacuous *in production* because nothing ever wrote the frontmatter it reads.

The genuinely missing test is **the chain** — a real `creek draft` producing frontmatter a real `creek lint` then judges. That is what the new e2e module supplies. `tests/test_lint.py` was not modified.

## Two test modules, not one

The issue asks for `tests/e2e/test_draft_grounding_e2e.py`; that exists. I also added `tests/test_draft_grounding_wiring.py` **without** the marker, because the `e2e` marker is deselected from the default unit lane — putting the wiring assertions only there would leave the newly-wired production lines uncovered by the gate that runs on every commit. **The same shape of hole this issue is about.** No assertion is duplicated between them.

## Degradation lives in one place, deliberately

`default_embedding_fn` loads the sentence-transformer **lazily**, so "the model is missing" surfaces mid-draft, not at construction — neither the CLI nor MCP can catch it where they build the generator. So degradation lives in `DraftGenerator._disable_grounding`, which clears both attributes and makes the failure **sticky**: later guard entry points fall through their existing `is None` checks instead of re-raising once per pass. Mirrors `creek/author/agents.py:309`'s handling of the same typed error, as the issue directed.

## A branch I wrote and then deleted

I initially added a try/except to `_voice_grounding_check`'s grounding veto. It is **unreachable** with an unloadable model, so I removed it rather than ship an untestable branch, and documented the invariant in place.

Proof: `_apply_voice_fidelity` has exactly two callers — `save_outline_draft`, which passes `source_fragments=()` and exits at the existing empty-sources guard; and `save_draft`, which only runs after `generate_draft`/`generate_seeded_draft` have already called `_build_guard_report`. A load failure there clears `_embedding_fn`, so the `is None` check returns before the closure is built.

## Two smaller calls worth stating

**The MCP tool resolves the vault's own config**, via `load_config(resolve_config_path(vault_path, None), warn_on_missing=False)` rather than the bare `load_config()` that `tools/link.py` and `classify.py` use. An operator who calibrated `draft.derivative_upper` in their vault should get those thresholds on the MCP surface too; the bare call would silently ignore them.

**The test stub replaces `EmbeddingLinker.load_model`**, not `default_embedding_fn`. That keeps the entire production path — factory → linker → `generate_embedding` → `score_draft` — under test. Patching the factory would have proved only that *a* callable was passed, not that the real one works.

Two details that keep the stub honest: its vocabulary deliberately excludes NATO `hotel` and `xray`, which collide with `delta` and `uniform` under `crc32 % 128` and shifted the expected derivative score from 0.500 to 0.559 — the exact-value assertions are what keep a future collision loud. And the cohesion-degradation test uses a body containing "I grew up", because `scan_biographical_sentences` returns before embedding anything when no sentence matches, so a neutral body never reaches the model and the test would have passed for the wrong reason. Verified by coverage that the cohesion except branch is now executed.

Line numbers were stale as expected: `cli.py:4275` → 4605, `tools/draft.py:263` → 330.

Gate: **12/12**. Zero suppressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EaHDtyDuNrpGtzUGMJT7Fw
