### PR TITLE
feat(author): add the LLM injection seam, and assert the wire past the desk

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -41,6 +41,7 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from creek.author.conductor import VoiceClientFactory
     from creek.classify.prompt import PromptOntology
     from creek.config import CreekConfig
     from creek.generate.ai_style.model import ScanReport, VoiceFingerprint
@@ -4832,6 +4833,26 @@ def _resolve_save_tier(
     return PrivacyTier.OPEN
 
 
+author_llm_factory: VoiceClientFactory | None = None
+"""Injection seam for the ``author`` command's voice client (#1254).
+
+The CLI twin of ``build_server(author_llm_factory=...)``, and it exists for
+the same reason: ``creek author`` otherwise builds its voice client from the
+vault's own config, so on a host with no provider it prints "rendering the
+deterministic stub", exits ``0`` and writes nothing — and *no hermetic test
+could tell that apart from a live run*, because a Typer command has no
+argument through which a Python callable can be handed in. That gap is why
+#1027's wiring contract could only record #460/#649/#658 as an exemption
+instead of asserting against it.
+
+A module attribute rather than a parameter because the seam has to survive
+``CliRunner.invoke(app, argv)``, which passes strings and nothing else;
+``tests/test_wiring_contract.py`` patches it for the length of one run.
+``None`` — the production value, never assigned anywhere in ``creek/`` — keeps
+the config-built factory, so the shipped behaviour is byte-identical.
+"""
+
+
 def _validate_author_inputs(
     medium: str, query: str | None, work: Path | None, supported: frozenset[str]
 ) -> None:
@@ -5000,12 +5021,17 @@ def author(
     # tier* so live voicing of Intimate content is redirected to a local
     # provider by the chokepoint. The factory falls back to ``None``
     # (deterministic stub) when the provider is unavailable.
-    def _voice_client(tier: PrivacyTier | None) -> AuthorLLMClient | None:
+    def _config_voice_client(tier: PrivacyTier | None) -> AuthorLLMClient | None:
         return AuthorLLMClient.for_voice_or_none(
             config.model_router,
             author=config.author,
             tier=tier,
         )
+
+    # #1254: an injected factory wins, which is the only way a test can reach
+    # past the desk. Production never assigns it, so this reads as the config
+    # factory on every real run.
+    _voice_client = author_llm_factory or _config_voice_client
 
     if _voice_client(None) is None:
         console.print(

--- a/creek-tools/creek_mcp/server.py
+++ b/creek-tools/creek_mcp/server.py
@@ -75,8 +75,10 @@ if TYPE_CHECKING:
     from mcp.server.auth.provider import AccessToken, TokenVerifier
     from mcp.types import ContentBlock
 
+    from creek.author.client import AuthorLLMClient
     from creek.compile.engine import CompileLLM
     from creek.models import PrivacyTier
+    from creek_mcp.tools.author import AuthorLLMFactory
     from creek_mcp.tools.compile import CompileLLMFactory
     from creek_mcp.tools.draft import DraftLLMFactory
     from creek_mcp.tools.reflect import _LLM, _LLMFactory
@@ -327,9 +329,48 @@ def _build_reflect_llm_factory() -> _LLMFactory:
     return _factory
 
 
+def _build_author_llm(tier: PrivacyTier | None) -> AuthorLLMClient | None:
+    """Return the Writing Desk's voice client, routed for *tier* (#658/#661).
+
+    The author-side sibling of :func:`_build_draft_llm`, extracted from
+    ``author_tool`` by #1254 so ``build_server`` can be handed a different one.
+    Same chokepoint, same laziness: the router resolves the voice role for the
+    run's content tier, so Intimate content is redirected to a local provider
+    rather than egressing, and the config is read inside the call so a server
+    with no provider configured still boots and still serves every other verb.
+
+    Unlike its draft/compile siblings it does not raise on an unavailable
+    provider: ``for_voice_or_none`` answers ``None``, which the desk reads as
+    "render deterministically". That fallback is exactly what #460/#649/#658
+    made unobservable — the honest reading is that it is a *degradation*, not a
+    failure, and the caller is told so in prose rather than by an exception.
+
+    Args:
+        tier: The run's content tier, or ``None`` when the evidence carries no
+            classification to route on.
+
+    Returns:
+        The resolved :class:`~creek.author.client.AuthorLLMClient`, or ``None``
+        when no provider is available.
+
+    Raises:
+        IntimateRoutingError: When Intimate content has no local backend to
+            fall back to. ``author_tool`` turns it into a structured error.
+    """
+    from creek.author.client import AuthorLLMClient
+
+    config = load_config()
+    return AuthorLLMClient.for_voice_or_none(
+        config.model_router,
+        author=config.author,
+        tier=tier,
+    )
+
+
 def build_server(
     *,
     vault_path: Path | None = None,
+    author_llm_factory: AuthorLLMFactory | None = None,
     draft_llm_factory: DraftLLMFactory | None = None,
     compile_llm_factory: CompileLLMFactory | None = None,
     reflect_llm_factory: Callable[[], _LLMFactory] | None = None,
@@ -341,6 +382,12 @@ def build_server(
         vault_path: Override vault root. Defaults to
             ``load_config().vault_path`` so the MCP surface honours the
             same configuration as the CLI.
+        author_llm_factory: Optional tier-keyed factory for the Writing Desk's
+            voice client — ``factory(tier)``. Passed straight to
+            ``creek.author``, which invokes it lazily inside the run (and not
+            at all on the ``dry_run`` path), so only ``creek.author`` needs an
+            LLM provider. Added by #1254: without it the verb's stubbed and
+            live bodies were indistinguishable from outside.
         draft_llm_factory: Optional tier-keyed factory for the draft LLM —
             ``factory(tier)``. Passed straight to ``creek.draft``, which
             invokes it lazily (and only once it knows which seed it is
@@ -368,6 +415,7 @@ def build_server(
     vault = _resolve_vault(vault_path)
     consumer = _consumer_from_env()
     factory = draft_llm_factory or _build_draft_llm
+    author_factory = author_llm_factory or _build_author_llm
     compile_factory = compile_llm_factory or _build_compile_llm
     reflect_factory = reflect_llm_factory or _build_reflect_llm_factory
 
@@ -529,10 +577,11 @@ def build_server(
         dry_run: bool = False,
         privacy_tier_ceiling: TierCeiling = TierCeiling.OPEN,
     ) -> dict[str, Any]:
-        """Author a draft for a query via the Writing Desk (stub shape)."""
+        """Author a draft for a query via the Writing Desk."""
         return author_tool(
             vault_path=vault,
             query=query,
+            llm_factory=author_factory,
             medium=medium,
             max_rounds=max_rounds,
             dry_run=dry_run,

--- a/creek-tools/creek_mcp/tools/author.py
+++ b/creek-tools/creek_mcp/tools/author.py
@@ -10,11 +10,9 @@ verdict, per-claim provenance, and the cited ``claims`` (each with its
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 from creek.author import plan_author, require_supported_medium, run_author
-from creek.author.client import AuthorLLMClient
-from creek.config import load_config
 from creek_mcp.audit import MCPAuditLog
 from creek_mcp.tier_ceiling import TierCeiling, to_privacy_override
 
@@ -22,9 +20,33 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from creek.author import AuthoredDraft
+    from creek.author.client import AuthorLLMClient
     from creek.models import PrivacyTier
 
 TOOL_NAME = "creek.author"
+
+
+class AuthorLLMFactory(Protocol):
+    """Tier-keyed builder for the Writing Desk's voice client.
+
+    ``factory(tier)`` returns the client the voice node speaks through for a
+    run whose evidence carries *tier* content, or ``None`` to keep the desk's
+    deterministic rendering. The production factory resolves through
+    :class:`creek.classify.llm.router.ModelRouter`, so Intimate content is
+    redirected to a local provider by the chokepoint (#658/#661); this module
+    never picks a provider itself.
+
+    The sibling of :class:`creek_mcp.tools.draft.DraftLLMFactory` and
+    :class:`creek_mcp.tools.compile.CompileLLMFactory`, and added for the same
+    reason (#1254): with no seam, ``creek.author`` answered ``status: ok``
+    carrying a deterministically-stubbed body that no hermetic test could tell
+    apart from a live one — the #460/#649/#658 signature.
+
+    Invoked lazily, inside the run, so an unconfigured provider fails only an
+    actual authoring call and never server startup.
+    """
+
+    def __call__(self, tier: PrivacyTier | None) -> AuthorLLMClient | None: ...
 
 
 def _error_response(
@@ -75,6 +97,7 @@ def author_tool(
     *,
     vault_path: Path,
     query: str,
+    llm_factory: AuthorLLMFactory | None = None,
     medium: str = "research",
     max_rounds: int | None = None,
     dry_run: bool = False,
@@ -93,6 +116,11 @@ def author_tool(
     Args:
         vault_path: The vault to author from.
         query: The user query to author about.
+        llm_factory: Tier-keyed builder for the desk's voice client (#1254).
+            ``None`` — the value a caller that never speaks to a model wants —
+            keeps the desk's deterministic rendering. The server bootstrap
+            supplies :func:`creek_mcp.server._build_author_llm`; tests pass a
+            stub, which is what makes the wire past the desk assertable.
         medium: Target medium (``research`` or ``chat``).
         max_rounds: Optional override for the voice/reflect round bound.
         dry_run: When set, return the plan + evidence summary, not a draft.
@@ -151,28 +179,16 @@ def author_tool(
                 "plan": plan["plan"],
                 "evidence": plan["evidence"],
             }
-        # #658/#661: build the router-resolved voice client per the run's content
-        # tier so live voicing of Intimate content is redirected to a local
-        # provider by the chokepoint. ``for_voice_or_none`` returns ``None``
-        # (deterministic stub) when the provider is unavailable, so the tool
-        # never hard-fails on a missing/unconsented backend.
-        config = load_config()
-        router = config.model_router
-        author_config = config.author
-
-        def _voice_client(tier: PrivacyTier | None) -> AuthorLLMClient | None:
-            return AuthorLLMClient.for_voice_or_none(
-                router,
-                author=author_config,
-                tier=tier,
-            )
-
+        # #658/#661: the injected factory is tier-keyed so live voicing of
+        # Intimate content is redirected to a local provider by the chokepoint,
+        # and may answer ``None`` (deterministic stub) for an unavailable
+        # provider — so the tool never hard-fails on a missing backend.
         draft = run_author(
             medium=medium,
             query=query,
             vault=vault_path,
             max_rounds=max_rounds,
-            voice_client_factory=_voice_client,
+            voice_client_factory=llm_factory,
             override=override,
         )
     except Exception as exc:

--- a/creek-tools/tests/test_mcp_server.py
+++ b/creek-tools/tests/test_mcp_server.py
@@ -691,9 +691,12 @@ def _patch_build_provider(monkeypatch: pytest.MonkeyPatch, spy: _ProviderSpy) ->
     (the router/reflect import) and via the ``creek.classify.llm`` re-export
     (what :func:`creek.compile.engine.default_llm` imports), so both names are
     patched and the spy records whichever path production actually takes.
+    ``creek.author.client`` binds a third copy at import time, which is the one
+    the Writing Desk's voice factory calls.
     """
     monkeypatch.setattr("creek.classify.llm.providers.build_provider", spy.build)
     monkeypatch.setattr("creek.classify.llm.build_provider", spy.build)
+    monkeypatch.setattr("creek.author.client.build_provider", spy.build)
 
 
 def _split_routing_config() -> object:
@@ -704,7 +707,7 @@ def _split_routing_config() -> object:
     proves the ``generation`` stage (not the ``default``) was consulted.
     """
     from creek.classify.llm.router import ModelRouter
-    from creek.config import LLMConfig, LLMRoutingConfig
+    from creek.config import AuthorConfig, LLMConfig, LLMRoutingConfig
 
     routing = LLMRoutingConfig(
         default=LLMConfig(provider="ollama"),
@@ -716,6 +719,10 @@ def _split_routing_config() -> object:
 
         llm = routing
         model_router = ModelRouter(routing)
+        # ``_build_author_llm`` reads the author block for the legacy
+        # ``voice_model`` fallback; the defaults leave the routing above in
+        # charge, which is what these assertions are about.
+        author = AuthorConfig()
 
     return _Config()
 
@@ -777,6 +784,78 @@ def test_build_compile_llm_routes_by_tier_then_degrades(
     with pytest.raises(RuntimeError) as excinfo:
         server_mod._build_compile_llm(PrivacyTier.OPEN)
     assert "unavailable" in str(excinfo.value).lower()
+
+
+def test_build_author_llm_routes_the_voice_role_through_the_router(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The production author factory obeys the same chokepoint as its siblings.
+
+    ``_build_author_llm`` is the seam #1254 extracted out of ``author_tool`` so
+    ``build_server`` could be handed a different one. Extracting it must not
+    quietly change what production does, so the same two-arm assertion the
+    draft and compile factories carry is made here: an ``Intimate`` run is
+    redirected onto the local ``default`` model, and an ``Open`` run resolves
+    the cloud ``generation`` stage.
+
+    The third arm has no sibling. Where draft and compile raise on an
+    unavailable provider, the desk *degrades*: the factory answers ``None`` and
+    the voice node renders deterministically. That is the fallback #460/#649/
+    #658 hid behind, so it is asserted rather than assumed.
+    """
+    from creek.models import PrivacyTier
+    from creek_mcp import server as server_mod
+
+    monkeypatch.setattr(server_mod, "load_config", _split_routing_config)
+    spy = _ProviderSpy()
+    _patch_build_provider(monkeypatch, spy)
+
+    assert server_mod._build_author_llm(PrivacyTier.INTIMATE) is not None
+    assert spy.provider_names == ["ollama"]
+
+    assert server_mod._build_author_llm(PrivacyTier.OPEN) is not None
+    assert spy.provider_names == ["ollama", "anthropic"]
+
+    _patch_build_provider(monkeypatch, _ProviderSpy(available=False))
+    assert server_mod._build_author_llm(None) is None
+
+
+def test_build_server_wires_the_production_author_llm_factory(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``creek.author`` reaches the production factory with none injected (#1254).
+
+    #958's lesson applied to the seam that closes #1254: every other test of
+    this verb now injects ``author_llm_factory``, and an injected factory is
+    exactly what lets a production builder rot while the suite stays green. So
+    the injection point is deliberately left empty and the recording stand-in
+    is installed one level down, on the module attribute ``build_server``
+    resolves — proving the fallback is wired, not merely written.
+
+    The stand-in answers ``None`` (the "no provider" reply), because what is
+    under test is that the factory is *reached*; what it resolves to is the
+    subject of the router test above.
+    """
+    from creek_mcp import server as server_mod
+
+    reached: list[object] = []
+
+    def _recording(tier: object) -> None:
+        """Record the tier the desk asked for and decline to voice."""
+        reached.append(tier)
+        return None
+
+    monkeypatch.setattr(server_mod, "_build_author_llm", _recording)
+
+    server = build_server(vault_path=vault)
+    result = _structured(asyncio.run(server.call_tool("creek.author", {"query": "q"})))
+
+    assert result["status"] == "ok", result
+    assert reached, (
+        "creek.author never called the production voice factory — the verb is "
+        "wired to whatever build_server was handed and nothing else."
+    )
 
 
 def test_build_server_wires_the_production_compile_llm_factory(

--- a/creek-tools/tests/test_wiring_contract.py
+++ b/creek-tools/tests/test_wiring_contract.py
@@ -85,6 +85,7 @@ from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final
+from unittest import mock
 
 import click
 import frontmatter
@@ -93,6 +94,9 @@ import typer
 from typer import rich_utils
 from typer.testing import CliRunner
 
+from creek import cli as creek_cli
+from creek.author.client import AuthorLLMClient
+from creek.classify.llm.completion import Completion
 from creek.cli import (
     _CLASSIFY_METHODS,
     _LINK_METHODS,
@@ -105,7 +109,13 @@ from creek.generate.grounding import (
 )
 from creek.ingest import INGESTOR_REGISTRY
 from creek.ingest.discord_dispatch import DiscordMode
-from creek.models import Authorship, Fragment, FragmentSource, SourcePlatform
+from creek.models import (
+    Authorship,
+    Fragment,
+    FragmentSource,
+    PrivacyTier,
+    SourcePlatform,
+)
 from creek.save import SaveTarget
 from creek_mcp.auth import ELEVATED_TOKEN_ENV
 from creek_mcp.server import build_server
@@ -757,11 +767,17 @@ class Bench:
         for step in prepare:
             self._runner.invoke(app, [part.format(**slots) for part in step])
         before = _digest_tree(target)
-        result = self._runner.invoke(
-            app,
-            [*command.split(), *(part.format(**slots) for part in argv)],
-            input=stdin,
-        )
+        # ``creek.cli.author_llm_factory`` is the CLI twin of the factories
+        # ``build_server`` takes (#1254): the one seam that lets `creek author`
+        # be voiced hermetically. Installed for every run because a CLI
+        # invocation carries no injection channel of its own; every other
+        # command ignores it.
+        with mock.patch.object(creek_cli, "author_llm_factory", _author_llm_double):
+            result = self._runner.invoke(
+                app,
+                [*command.split(), *(part.format(**slots) for part in argv)],
+                input=stdin,
+            )
         # A surface that dies at a client boundary raises rather than printing,
         # and the exemption staleness probes need to see that reason too.
         detail = "" if result.exception is None else f"\n{result.exception!r}"
@@ -784,7 +800,8 @@ class Bench:
 
         The LLM factories ``build_server`` accepts are the production seam for
         provider injection, so a recording double proves the wire without a
-        key. ``creek.author`` has no such seam, which is why it is exempt.
+        key — including ``author_llm_factory``, added by #1254 so the wire past
+        the Writing Desk stopped being an exemption and became an assertion.
 
         Args:
             tool: Registered tool name.
@@ -803,6 +820,7 @@ class Bench:
             draft_llm_factory=lambda _tier: lambda _prompt: _LLM_CANARY,
             compile_llm_factory=lambda _tier: lambda _prompt: _LLM_CANARY,
             reflect_llm_factory=lambda: lambda _tier: lambda _prompt: _REFLECT_CANARY,
+            author_llm_factory=_author_llm_double,
         )
         args = {
             key: value.format(**slots) if isinstance(value, str) else value
@@ -822,6 +840,90 @@ _LLM_CANARY: Final = f"LLM-DOUBLE-SPOKE. {CANARY}"
 _REFLECT_CANARY: Final = json.dumps(
     {"notes": [{"quote": "I rest sometimes", "kind": "reframe", "note": "Yours."}]},
 )
+
+_AUTHOR_CANARY: Final = "AUTHOR-DOUBLE-SPOKE"
+"""Prefix the injected author voice double emits; it must reach the draft body.
+
+Proves the *injected client* was consulted rather than the desk's deterministic
+rendering — the half of #460/#649/#658 that no other gate could see.
+"""
+
+_SHOUTED_CLAIM: Final = "INGEST REWRITE"
+"""The seeded ``Ingest rewrite`` claim as the double shouts it back.
+
+The second half, and the reason :class:`_AuthorVoiceDouble` uppercases rather
+than echoing verbatim. Every corpus string the voice prompt carries — claim
+excerpts, fragment ids — the MCP envelope *also* reports in ``provenance`` and
+``claims``, whether or not a model ever ran; a verbatim needle would therefore
+be satisfied by a dead wire. Uppercased, the needle exists nowhere but on the
+far side of the client, so one assertion covers the whole path: corpus →
+evidence → prompt → injected client → body → rendered output.
+"""
+
+
+class _AuthorVoiceDouble:
+    """Provider double for the author desk's voice call.
+
+    Shouts back the prompt it was handed under :data:`_AUTHOR_CANARY`, so the
+    contract can read the corpus out of the far end of the wire instead of
+    trusting that a fixed reply means the evidence arrived.
+    """
+
+    is_cloud = False
+    """The double never leaves the process, so the cloud-consent gate is moot."""
+
+    @property
+    def model(self) -> str:
+        """Return the double's model identifier.
+
+        Returns:
+            A name no real backend answers to.
+        """
+        return "author-voice-double"
+
+    @property
+    def available(self) -> bool:
+        """Report the double as ready so the desk takes the live-voicing path.
+
+        Returns:
+            Always ``True``.
+        """
+        return True
+
+    def complete(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int | None = None,
+        system: str | None = None,
+    ) -> Completion:
+        """Return the voice prompt shouted back under the canary prefix.
+
+        Args:
+            prompt: The dynamic voice prompt carrying the assembled evidence.
+            max_tokens: Ignored; the double generates nothing to truncate.
+            system: The static prompt prefix, shouted with the rest.
+
+        Returns:
+            A :class:`Completion` whose text is the prefix plus the whole
+            prompt in upper case — see :data:`_SHOUTED_CLAIM` for why the case
+            change is load-bearing rather than decorative.
+        """
+        del max_tokens
+        spoken = f"{_AUTHOR_CANARY}\n\n{system or ''}\n\n{prompt}"
+        return Completion(text=spoken.upper())
+
+
+def _author_llm_double(_tier: PrivacyTier | None) -> AuthorLLMClient:
+    """Return the voice client both author surfaces are injected with.
+
+    Args:
+        _tier: The run's content tier, which the double does not route on.
+
+    Returns:
+        An :class:`AuthorLLMClient` wrapping :class:`_AuthorVoiceDouble`.
+    """
+    return AuthorLLMClient(_AuthorVoiceDouble())
 
 
 def _digest_tree(root: Path) -> dict[str, str]:
@@ -874,6 +976,23 @@ def elevated_token(monkeypatch: pytest.MonkeyPatch) -> str:
 # ---------------------------------------------------------------------------
 
 _BARE = "an unseeded vault has no corpus, so the corpus-derived verdict must vanish"
+
+_AUTHOR_ARGV: Final[tuple[str, ...]] = (
+    "--vault",
+    "{vault}",
+    "--query",
+    "creek and stone",
+    "--include-tier",
+    "all",
+)
+"""Arguments both ``author`` runs share; the ceiling matches the MCP twin's.
+
+``--include-tier all`` is not decoration: the seeded corpus is deliberately
+left unclassified, and under the default ``open`` ceiling the desk gathers no
+evidence at all, so the prompt would carry nothing for the double to shout
+back. The MCP entry admits the same corpus through ``_ALL``; the two surfaces
+must be asked the same question or the comparison between them is worthless.
+"""
 
 CLI_CONTRACT: Final[Mapping[str, Surface]] = {
     "init": Surface(
@@ -988,6 +1107,30 @@ CLI_CONTRACT: Final[Mapping[str, Surface]] = {
             prints=("Idea seeds",),
         ),
         contrast=Contrast(why="no vault at all means no seed table", seeded=False),
+    ),
+    "author": Surface(
+        shape=Shape.REPORTS,
+        why=(
+            "#460/#649/#658: `creek author` printed 'No LLM provider available — "
+            "rendering the deterministic stub', exited 0 and wrote nothing; "
+            "#1027 could only exempt it, because until #1254 the command built "
+            "its voice client internally and no test could reach past the desk"
+        ),
+        derived_from=(
+            "creek.cli:author_llm_factory",
+            "creek.author.voice:VoiceAgent",
+        ),
+        argv=_AUTHOR_ARGV,
+        effect=Effect(prints=(_AUTHOR_CANARY, _SHOUTED_CLAIM)),
+        contrast=Contrast(
+            why=(
+                "--dry-run plans and counts evidence without voicing, so neither "
+                "the injected client's words nor the corpus text it would have "
+                "been handed may reach a body"
+            ),
+            argv=(*_AUTHOR_ARGV, "--dry-run"),
+            seeded=True,
+        ),
     ),
     "save": Surface(
         shape=Shape.WRITES,
@@ -1401,6 +1544,28 @@ MCP_CONTRACT: Final[Mapping[str, Surface]] = {
             ),
         ),
     ),
+    "creek.author": Surface(
+        shape=Shape.REPORTS,
+        why=(
+            "#460: the verb answered `status: ok` carrying a deterministically "
+            "stubbed body, indistinguishable from a live one, until #1254 gave "
+            "`build_server` the author factory its three siblings already had"
+        ),
+        derived_from=(
+            "creek_mcp.server:build_server",
+            "creek.author.conductor:run_author",
+        ),
+        kwargs={"query": "creek and stone", **_ALL},
+        effect=Effect(prints=(_AUTHOR_CANARY, _SHOUTED_CLAIM)),
+        contrast=Contrast(
+            why=(
+                "a dry run returns the plan and evidence *counts*; a voiced body "
+                "must be absent from it"
+            ),
+            kwargs={"query": "creek and stone", "dry_run": True, **_ALL},
+            seeded=True,
+        ),
+    ),
     "creek.save": Surface(
         shape=Shape.WRITES,
         why="#580: the save target routing table is where artefacts get orphaned",
@@ -1554,16 +1719,6 @@ EXEMPTIONS: Final[Mapping[str, Exemption]] = {
         argv=("--vault", "{vault}", "--no-llm"),
         blocker="LLM provider unavailable; cannot generate draft",
     ),
-    "author": Exemption(
-        reason=(
-            "#460/#649/#658: neither `creek author` nor `creek.author` accepts an "
-            "LLM factory, so with no provider the desk renders a deterministic "
-            "stub and exits 0 — the exact signature of the bug. Proving the wire "
-            "needs an injection seam that does not exist yet."
-        ),
-        argv=("--vault", "{vault}", "--query", "creek and stone"),
-        blocker="rendering the deterministic stub",
-    ),
     "compile": Exemption(
         reason=(
             "#1024: `creek compile` builds its provider internally; with none "
@@ -1597,14 +1752,6 @@ EXEMPTIONS: Final[Mapping[str, Exemption]] = {
             "schema here would give this module a second copy to drift."
         ),
         delegate="tests/test_mcp_write_tools.py:creek.compile",
-    ),
-    "creek.author": Exemption(
-        reason=(
-            "#460: the MCP author verb constructs AuthorLLMClient internally; "
-            "`build_server` exposes draft/compile/reflect factories but no author "
-            "factory, so the wire past the desk cannot be observed hermetically."
-        ),
-        seam="creek_mcp.server:build_server:author_llm_factory",
     ),
 }
 


### PR DESCRIPTION
Closes #1254. Refs #1027, #1024.

`creek author` and `creek.author` exited 0 / `status: ok`, printed *"No LLM provider available — rendering the deterministic stub"*, and produced nothing. #460/#649/#658's signature, still live — and **untestable**, because neither surface could take an injected provider. #1027's contract could only *exempt* it.

## Two exemptions deleted, not weakened

These were `EXEMPTIONS` entries, not xfails — worth stating plainly because the issue's framing invites the confusion:

- `EXEMPTIONS["author"]` — `blocker="rendering the deterministic stub"`
- `EXEMPTIONS["creek.author"]` — `seam="creek_mcp.server:build_server:author_llm_factory"`

**The staleness detectors fought back exactly as designed.** Once the seam existed, `test_seam_exemption_is_stale_once_the_injection_point_exists` would have failed on the seam entry and `test_exempt_surface_still_reports_its_blocker` on the blocker entry. Removal was the only honest move — which is the ratchet working rather than an inconvenience.

## A correction to the brief I was given

I was told to *"add the CLI equivalent, matching how the CLI already injects for draft/compile."* **The CLI injects for neither.** `creek/cli.py` has no `draft_llm_factory` and no `compile_llm_factory`; both commands build their providers internally. The contract table says so itself — `EXEMPTIONS['draft']` reads *"Adding the CLI seam is #1040's unfinished half"*, and `EXEMPTIONS['compile']`'s probe is `seam="creek.cli:compile_llm_factory"`, an attribute **that does not exist**.

So there was no precedent to mirror. I followed the shape the contract's own seam vocabulary already anticipates (`"module:name"`) and added a module attribute `creek.cli:author_llm_factory` — the exact naming pattern `EXEMPTIONS['compile']` is waiting for, so the next seam has a precedent that this one lacked. A Typer command cannot take a Python callable through argv, so a parameter was never an option.

## The acceptance criterion could not mean what it says

*"A stub factory produces an observable artefact"* cannot mean a file on either surface: **`creek author` writes nothing even with a live provider** — it prints the body, there is no save step — and the MCP verb returns the body in its envelope. Adding a write would be rewriting the desk, explicitly out of scope.

Both entries are therefore `Shape.REPORTS` with a mandatory `Contrast`, which the harness enforces: the stub's output must appear in one world and vanish in another. That is a real effect assertion, just not a filesystem one.

Stale line ref: the issue cites the internal client construction at `cli.py:4964`; that line is the lazy import inside `author()`. The construction is at ~5003.

## One finding worth a follow-up rather than a fix here

Under the default `open` ceiling, `creek author` gathers **no evidence at all** from an unclassified corpus — `provenance=0`, `(NO GROUNDED EVIDENCE)` — while the MCP twin at `privacy_tier_ceiling=all` gathers seven claims. Both entries now use `all` so the two surfaces are asked the same question.

Whether an unclassified corpus should be invisible to `creek author` at the default ceiling is a separate behavioural question, outside this issue's scope. Filed separately.

Gate: **12/12**. Zero suppressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EaHDtyDuNrpGtzUGMJT7Fw
