### PR TITLE
fix(crawdad): route bot-capture through the allowlist, bot filter and tier gate (#1052)

### DIFF
--- a/crawdad/CLAUDE.md
+++ b/crawdad/CLAUDE.md
@@ -108,6 +108,15 @@ Four gates, each must pass before the next:
   - `allowed_channel_ids` — channels the bot will respond in.
   - `max_loop_rounds` — optional FEAT-036 override for the agent-loop
     round cap (default `MAX_LOOP_ROUNDS = 5`, bounded `[1, 50]`).
+  - `capture_enabled` — bot-capture toggle (#687), default `False`.
+    Opt-in per deployment; see [§5.2](#52-bot-capture-boundary).
+  - `capture_subpath` — vault-relative dir the capture writer appends
+    to, default `discord-capture`. Must stay inside the vault (same
+    absolute/`..` validation as `attachments.staging_subpath`).
+  - `attachments.channel_privacy_tiers` — per-channel declared ceiling
+    (`open` / `personal` / `intimate` / `all`), validated at
+    config-parse time. See [§5.2](#52-bot-capture-boundary) for how
+    bot-capture reads it.
 
 Both allowlists must be non-empty — an empty list is a configuration
 error, not "open to everyone".
@@ -125,6 +134,63 @@ it means:
 - Do *not* feed user-controlled content into `crawdad.yaml`.
 - Multi-user / shared deployments are out of scope for v1.0; revisit
   this assumption before broadening access.
+
+See also [§5.2 Bot-capture boundary](#52-bot-capture-boundary) for the
+narrower trust boundary bot-capture applies on top of this one.
+
+### 5.2 Bot-capture boundary
+
+Bot-capture (#687) writes messages to `<vault>/<capture_subpath>/` for
+later Tier-A ingest. A message is captured only when **both** hold:
+
+1. It passes `_passes_allowlist` — the same gate the command path
+   uses: not the bot's own message, not `author.bot`, and both
+   `allowed_user_ids` and `allowed_channel_ids` admit it. **The
+   capture boundary is the command boundary** (#1052) — before this
+   fix, capture ran ahead of the allowlist gate and logged strangers,
+   other bots, and channels the operator never allowlisted.
+2. The channel's declared privacy tier (`_channel_tier`, reading
+   `attachments.channel_privacy_tiers`) is in `CAPTURE_ADMITTED_TIERS`
+   = `{"open", "personal"}`:
+
+   | Declared tier | Captured? |
+   |---|---|
+   | `open` | yes (narrower than needed once landed) |
+   | `personal` | yes (exact match) |
+   | unset (no `channel_privacy_tiers` entry) | yes — `_channel_tier` falls back to `personal` |
+   | `intimate` | **no** |
+   | `all` | **no** — admits intimate content by definition |
+
+   A capture record carries no tier field, and the creek-tools side
+   that stages the capture dir drops channel metadata, so a captured
+   message lands downstream as `unclassified`, which ranks *with*
+   `personal` (`creek_mcp/tier_ceiling.py`, #961). Writing an
+   `intimate` channel into capture would be a silent privacy
+   de-escalation — capture must not carry content whose ceiling it
+   cannot represent.
+
+The tier gate is **capture-scoped only**. `channel_privacy_tiers` has
+never gated whether the bot *replies* in a channel and still does not
+— an `intimate` channel still gets `/crawdad` and free-text replies;
+it is just never written to the capture log.
+
+The gate (`_capture_allowed`) is evaluated *inside*
+`CrawDadClient._capture_message`'s `try`, so a gate that raises (a
+malformed message, an attribute that errors) fails closed to "not
+captured" while the command path keeps running unaffected — capture
+is best-effort and must never take a command turn down with it.
+
+**Standing constraint for future work:** `MessageCapture.backfill` has
+no production caller today. If it is ever wired in (#1057), it MUST
+evaluate `_capture_allowed` **per message inside the history loop**,
+not once per channel — a channel's history contains messages from
+non-allowlisted users and other bots that a channel-level check would
+wave through.
+
+`CAPTURE_ADMITTED_TIERS` may only widen once #1262 lands: carrying the
+tier end-to-end from the capture record through staging into fragment
+frontmatter, so an `intimate` channel can be captured faithfully
+instead of refused outright.
 
 ## 6. MCP subprocess resilience
 

--- a/crawdad/README.md
+++ b/crawdad/README.md
@@ -18,7 +18,9 @@ CrawDad v1.0 ships:
 - Voice-skill activation per session from `<vault>/creek-skills/`.
 - The six `/crawdad` slash commands (FEAT-016): `reflect`, `checkin`,
   `surface`, `draft`, `save`, `workflow`.
-- A user + channel allowlist; non-allowlisted callers get no response.
+- A user + channel allowlist; non-allowlisted callers get no response
+  — and, as of #1052, no bot-capture record either (see
+  [Bot capture](#bot-capture) below).
 - A graceful "creek-tools is unreachable" reply when the MCP
   subprocess dies.
 
@@ -69,8 +71,34 @@ allowed_channel_ids:
 | `attachments` | no | see source | Per-attachment limits, allow/deny lists, channel privacy tiers (FEAT-027/035). |
 | `consent` | no | see source | Conversational consent tokens + TTL (FEAT-034). |
 | `max_loop_rounds` | no | `5` | FEAT-036 agent-loop round cap, bounded `[1, 50]`. Raise when a single user turn legitimately needs more router/dispatcher passes (multi-source ingest, large re-classification asks, long workflow chains); the upper bound prevents pathological runaway loops. |
+| `capture_enabled` | no | `False` | Bot-capture toggle (#687) — see [Bot capture](#bot-capture) below. |
+| `capture_subpath` | no | `discord-capture` | Vault-relative dir bot-capture writes into. Must stay inside the vault. |
 
 Secrets are **never** in `crawdad.yaml` — they come only from the environment.
+
+### Bot capture
+
+Bot-capture logs the channels CrawDad is in to `<vault>/<capture_subpath>/`
+for later ingest — it is off by default (`capture_enabled: false`). When on,
+the bot captures **only messages it would also respond to**: the same
+user + channel allowlists as the command path, never another bot or
+webhook, and never its own replies.
+
+It also **never** captures a channel declared `intimate` or `all` in
+`attachments.channel_privacy_tiers` — those channels still get normal
+`/crawdad` and free-text replies, they are just never logged to the
+vault, because a captured message currently can't carry its channel's
+privacy tier with it. #1262 tracks carrying that tier end-to-end so
+`intimate` channels can be captured faithfully instead of refused.
+
+**Upgrading from a pre-#1052 build.** If you ran with
+`capture_enabled: true` before this fix, `<vault>/discord-capture/`
+may already hold records from non-allowlisted users, other bots, or
+an `intimate` channel — the old capture path bypassed all three
+gates. These records are still ingestible today. #1264 tracks the
+fix; until then the manual mitigation is deleting the offending
+channel subdirectories under `discord-capture/` before running
+`creek sync`.
 
 ### LLM provider selection
 

--- a/crawdad/crawdad/bot.py
+++ b/crawdad/crawdad/bot.py
@@ -29,6 +29,7 @@ from crawdad.attachments import (
     format_attachment_summary,
     process_attachments,
 )
+from crawdad.config import CAPTURE_ADMITTED_TIERS, DEFAULT_CHANNEL_TIER
 from crawdad.consent import (
     PendingBatch,
     PendingBatchStore,
@@ -270,10 +271,48 @@ def _passes_allowlist(
     Returns ``True`` when the caller should keep processing the
     message, ``False`` when the message should be silently dropped
     (per FEAT-013 §non-allowlisted callers get no response).
+
+    Two callers share this gate: :func:`handle_message` (the command
+    path) and :func:`_capture_allowed` (bot-capture, #1052), so
+    "silently dropped" now means no reply *and* no capture record.
     """
     if message.author.id == bot_user_id or message.author.bot:
         return False
     return config.is_allowed(user_id=message.author.id, channel_id=message.channel.id)
+
+
+def _capture_allowed(
+    message: _MessageLike,
+    *,
+    config: CrawDadConfig,
+    bot_user_id: int,
+) -> bool:
+    """Whether *message* may be written to the bot-capture log (#1052).
+
+    The capture boundary is the command boundary **plus** a tier gate.
+    Reusing :func:`_passes_allowlist` is the point: capture used to run
+    ahead of it and so logged messages the bot would never answer —
+    strangers, other bots, and channels the operator never allowlisted.
+    Anything the command path refuses, capture refuses for the same
+    reason.
+
+    The extra condition is the channel's privacy tier, which the command
+    path deliberately does not consult (the bot still *talks* in an
+    ``intimate`` channel): a capture record carries no tier of its own,
+    so only tiers in :data:`~crawdad.config.CAPTURE_ADMITTED_TIERS` may
+    be written. :func:`_channel_tier` fails closed to ``personal`` for a
+    channel with no override, so an operator who never wrote a
+    ``channel_privacy_tiers`` block keeps capture.
+
+    Fail-closed contract: this returns ``True`` only when every gate
+    affirmatively passes. Callers must treat a raised exception as a
+    refusal — see :meth:`CrawDadClient._capture_message`, which
+    evaluates this inside its ``try``.
+    """
+    if not _passes_allowlist(message, config=config, bot_user_id=bot_user_id):
+        return False
+    tier = _channel_tier(channel_id=message.channel.id, config=config)
+    return tier in CAPTURE_ADMITTED_TIERS
 
 
 def _empty_skills() -> VoiceSkillStack:
@@ -710,12 +749,15 @@ def _format_scan_section(body: str) -> str:
 def _channel_tier(*, channel_id: int, config: CrawDadConfig) -> str:
     """Return the privacy tier ceiling for *channel_id*.
 
-    Falls back to ``personal`` when the channel is absent from
+    Falls back to :data:`~crawdad.config.DEFAULT_CHANNEL_TIER`
+    (``personal``) when the channel is absent from
     :attr:`AttachmentConfig.channel_privacy_tiers` — ingest writes
     default to personal per FEAT-011, so a missing entry never
     silently relaxes the ceiling.
     """
-    return config.attachments.channel_privacy_tiers.get(channel_id, "personal")
+    return config.attachments.channel_privacy_tiers.get(
+        channel_id, DEFAULT_CHANNEL_TIER
+    )
 
 
 def _resolve_skills(
@@ -865,7 +907,7 @@ class CrawDadClient(discord.Client):
         if self.user is None:
             _LOGGER.debug("on_message before client ready; dropping event")
             return
-        await self._capture_message(message)
+        await self._capture_message(message, bot_user_id=self.user.id)
         await handle_message(
             cast("_MessageLike", message),
             config=self._config,
@@ -882,21 +924,36 @@ class CrawDadClient(discord.Client):
             workflow_runner=self._workflow_runner,
         )
 
-    async def _capture_message(self, message: discord.Message) -> None:
+    async def _capture_message(
+        self, message: discord.Message, *, bot_user_id: int
+    ) -> None:
         """Append the message to the bot-capture log, never disturbing commands.
 
-        No-op when capture is disabled. The bot's own messages are skipped (it
-        would only re-capture its own replies). A capture write failure is logged
-        and swallowed — capture is best-effort and must never break the command
-        path (#687).
+        No-op when capture is disabled, and no-op unless :func:`_capture_allowed`
+        admits the message — capture answers to the command path's own gate
+        (self-suppression, the ``author.bot`` filter, both allowlists) plus the
+        channel-tier gate, so it can no longer log what the bot would refuse to
+        answer or record a channel whose ceiling the capture file cannot carry
+        (#1052).
+
+        The gate is evaluated *inside* the ``try`` on purpose: a gate that raises
+        (a malformed message, a Discord object that errors on attribute access)
+        must fail closed to "not captured" and still leave the command path
+        running. A capture write failure is likewise logged and swallowed —
+        capture is best-effort and must never break the command path (#687).
         """
         if self._message_capture is None:
             return
-        if self.user is not None and message.author.id == self.user.id:
-            return
         try:
+            if not _capture_allowed(
+                cast("_MessageLike", message),
+                config=self._config,
+                bot_user_id=bot_user_id,
+            ):
+                return
             await self._message_capture.on_message(message)
         except Exception:
-            # Best-effort capture: any failure (bad message shape, disk error)
-            # is logged and swallowed so it can never break the command path.
+            # Best-effort capture: any failure (bad message shape, disk error,
+            # or a gate that raised) is logged and swallowed so it can never
+            # break the command path — and a raising gate never admits.
             _LOGGER.exception("bot-capture failed; continuing command path")

--- a/crawdad/crawdad/config.py
+++ b/crawdad/crawdad/config.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Self
+from typing import Final, Self
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -192,6 +192,56 @@ MAX_LOOP_ROUNDS: int = 5
 CREEK_SKILLS_DIRNAME: str = "creek-skills"
 DEFAULT_REGISTER: str = "confessional"
 
+# The privacy tier vocabulary a channel override may name. Mirrored from
+# :class:`creek_mcp.tier_ceiling.TierCeiling` without importing it — crawdad
+# has no Python dependency on creek-tools. Enforced at config-parse time by
+# :meth:`AttachmentConfig._validate_channel_tiers`.
+_VALID_CHANNEL_TIERS: Final[frozenset[str]] = frozenset(
+    {"open", "personal", "intimate", "all"}
+)
+
+# The only channel tiers whose messages bot-capture may write to the vault
+# (#1052).
+#
+# A capture record carries no tier field (``capture.py::_record_for``), and the
+# creek-tools side that reads the capture dir
+# (``stage_capture_as_data_package``) drops channel metadata, so a captured
+# message lands downstream as ``unclassified`` — which ranks WITH ``personal``
+# (``creek_mcp/tier_ceiling.py``, #961). Capture may therefore carry only
+# content whose ceiling the record can represent: ``open`` (narrower than
+# ``personal`` once landed) and ``personal`` (exact). ``intimate`` must be
+# refused, and so must ``all``, which admits intimate content by definition.
+#
+# Written out explicitly rather than derived as
+# ``_VALID_CHANNEL_TIERS - {"intimate", "all"}``: a subtraction would silently
+# auto-admit any tier added to the vocabulary later, when the safe default for
+# an unreviewed tier is refusal.
+#
+# The value coincides with ``workflows.WORKFLOW_ADMITTED_CEILINGS`` but is
+# deliberately NOT derived from it, and neither is canonical for the other:
+# that set draws its line at the cloud composer, this one at what a capture
+# record can represent. The reasoning above stands on its own if the workflow
+# set ever changes.
+#
+# Membership (``in``), never a rank comparison: ``crawdad.loop`` owns the
+# single tier-ordering table and a second one must not exist. The values stay
+# plain ``str`` rather than ``intents.PrivacyTierCeiling`` members because
+# ``channel_privacy_tiers`` is a ``dict[int, str]`` of operator-written YAML
+# and this module deliberately owns the tier vocabulary without importing
+# ``crawdad.intents``. (A ``StrEnum`` member would in fact match a plain string
+# here — ``str.__hash__`` precedes ``Enum.__hash__`` in the MRO — so this is a
+# layering choice, not a correctness workaround.)
+CAPTURE_ADMITTED_TIERS: Final[frozenset[str]] = frozenset({"open", "personal"})
+
+# The ceiling assumed for a channel with no ``channel_privacy_tiers`` entry.
+# Ingest writes are personal by default per FEAT-011, so a missing entry never
+# silently relaxes the ceiling. Named rather than inlined because
+# :func:`crawdad.bot._channel_tier` and :data:`CAPTURE_ADMITTED_TIERS` jointly
+# decide whether an operator who never wrote a ``channel_privacy_tiers`` block
+# keeps bot-capture: that promise holds only while this value is a member of
+# that set, which ``test_default_channel_tier_is_capture_admitted`` pins.
+DEFAULT_CHANNEL_TIER: Final[str] = "personal"
+
 
 class AttachmentConfig(BaseModel):
     """Per-attachment limits and staging-path config (FEAT-027).
@@ -294,16 +344,15 @@ class AttachmentConfig(BaseModel):
         downstream, but a bogus override in ``crawdad.yaml`` would
         surface as a confusing MCP error at runtime instead of a clear
         config error at startup. Restrict the value set to the four
-        ``TierCeiling`` values (mirrored from
-        :class:`creek_mcp.tier_ceiling.TierCeiling` without importing it
-        — crawdad has no Python dependency on creek-tools).
+        ``TierCeiling`` values (:data:`_VALID_CHANNEL_TIERS`, mirrored
+        from :class:`creek_mcp.tier_ceiling.TierCeiling` without
+        importing it — crawdad has no Python dependency on creek-tools).
         """
-        allowed: frozenset[str] = frozenset({"open", "personal", "intimate", "all"})
         for channel_id, tier in value.items():
-            if tier not in allowed:
+            if tier not in _VALID_CHANNEL_TIERS:
                 msg = (
                     f"channel_privacy_tiers[{channel_id}] = {tier!r} is not a valid "
-                    f"tier ceiling; expected one of {sorted(allowed)}."
+                    f"tier ceiling; expected one of {sorted(_VALID_CHANNEL_TIERS)}."
                 )
                 raise ValueError(msg)
         return value

--- a/crawdad/tests/test_bot_capture.py
+++ b/crawdad/tests/test_bot_capture.py
@@ -1,9 +1,21 @@
-"""Bot-capture wiring on ``CrawDadClient.on_message`` (#687).
+"""Bot-capture wiring and its trust boundary (#687, #1052).
 
-Proves capture runs alongside — and never disturbs — the command path: a
-non-self message is captured *and* forwarded to ``handle_message``; the bot's
-own messages are skipped; a capture write failure is swallowed so commands still
-run; and the CLI builds the writer only when capture is enabled.
+Two concerns live here.
+
+The #687 half proves capture runs alongside — and never disturbs — the command
+path: a non-self message is captured *and* forwarded to ``handle_message``; the
+bot's own messages are skipped; a capture write failure is swallowed so commands
+still run; and the CLI builds the writer only when capture is enabled.
+
+The #1052 half pins the *boundary*. Capture used to run before
+``handle_message``, so it bypassed both allowlists, the ``author.bot`` filter,
+and ``channel_privacy_tiers`` entirely — a non-allowlisted user in a
+non-allowlisted ``intimate`` channel still landed in
+``<vault>/discord-capture/``, untiered, which reads downstream as
+``unclassified`` and therefore ranks with ``personal``. That is a privacy
+DE-escalation. Capture must now clear the same gate the command path clears
+*plus* a tier gate: only ``open`` and ``personal`` channels are admitted,
+because a capture record carries no tier of its own.
 """
 
 from __future__ import annotations
@@ -16,24 +28,63 @@ from typing import TYPE_CHECKING
 import pytest
 
 from crawdad import cli
-from crawdad.bot import CrawDadClient
+from crawdad.bot import CrawDadClient, _stub_reply
 from crawdad.capture import MessageCapture
-from crawdad.config import CrawDadConfig
+from crawdad.config import AttachmentConfig, CrawDadConfig
 
 if TYPE_CHECKING:
     from crawdad.capture import _MessageLike
+
+# Five distinct ids so no assertion can pass by collision. The pre-#1052
+# fixture set ``allowed_channel_ids=[999]`` while the fake channel defaulted to
+# ``id=1`` and ``999`` was also the bot's own user id — an arrangement in which
+# "the allowlisted channel was captured" could never actually be observed.
+_ALLOWED_USER_ID = 111
+_OTHER_USER_ID = 112
+_ALLOWED_CHANNEL_ID = 555
+_OTHER_CHANNEL_ID = 556
+_BOT_USER_ID = 999
+
+_CAPTURE_DIRNAME = "discord-capture"
+_CAPTURED_JSONL = Path(_CAPTURE_DIRNAME) / "general" / "2026-06-26.jsonl"
 
 
 @dataclass
 class _FakeUser:
     id: int
     name: str = "someone"
+    bot: bool = False
+
+
+class _ExplodingAuthor:
+    """An author whose ``bot`` flag raises when the capture gate reads it.
+
+    Used to prove the gate is evaluated *inside* ``_capture_message``'s
+    ``try/except`` — a gate that blows up must refuse the capture, not take
+    the command path down with it.
+    """
+
+    def __init__(self, user_id: int) -> None:
+        """Record the author id; ``name`` mirrors the plain fake user."""
+        self.id = user_id
+        self.name = "Ada"
+
+    @property
+    def bot(self) -> bool:
+        """Raise instead of answering, simulating a gate-time failure."""
+        msg = "author.bot lookup exploded"
+        raise RuntimeError(msg)
 
 
 @dataclass
 class _FakeChannel:
     name: str
-    id: int = 1
+    id: int = _ALLOWED_CHANNEL_ID
+    sent: list[str] = field(default_factory=list)
+
+    async def send(self, content: str) -> None:
+        """Record a reply so tests can observe the command path answering."""
+        self.sent.append(content)
 
 
 @dataclass
@@ -41,12 +92,9 @@ class _FakeMessage:
     id: int
     content: str
     created_at: datetime
-    author: _FakeUser
+    author: _FakeUser | _ExplodingAuthor
     channel: _FakeChannel
     attachments: list[object] = field(default_factory=list)
-
-
-_BOT_USER_ID = 999
 
 
 class _ReadyClient(CrawDadClient):
@@ -58,32 +106,68 @@ class _ReadyClient(CrawDadClient):
         return _FakeUser(id=_BOT_USER_ID)
 
 
-def _config(tmp_path: Path, *, capture_enabled: bool = False) -> CrawDadConfig:
-    """A minimal valid bot config rooted at *tmp_path*."""
+def _config(
+    tmp_path: Path,
+    *,
+    capture_enabled: bool = False,
+    channel_tiers: dict[int, str] | None = None,
+) -> CrawDadConfig:
+    """A minimal valid bot config rooted at *tmp_path*.
+
+    *channel_tiers* populates ``attachments.channel_privacy_tiers`` so a test
+    can declare a channel ``intimate`` / ``all`` and watch capture refuse it.
+    """
     return CrawDadConfig(
         discord_bot_token="t",
         vault_path=tmp_path,
-        allowed_user_ids=[111],
-        allowed_channel_ids=[999],
+        allowed_user_ids=[_ALLOWED_USER_ID],
+        allowed_channel_ids=[_ALLOWED_CHANNEL_ID],
         capture_enabled=capture_enabled,
+        attachments=AttachmentConfig(channel_privacy_tiers=channel_tiers or {}),
     )
 
 
-def _message(*, msg_id: int, author_id: int) -> _FakeMessage:
-    """A fake discord message carrying both capture + author fields."""
+def _message(
+    *,
+    msg_id: int,
+    author_id: int,
+    channel_id: int = _ALLOWED_CHANNEL_ID,
+    author_bot: bool = False,
+) -> _FakeMessage:
+    """A fake discord message carrying both capture + author fields.
+
+    *channel_id* defaults to the allowlisted channel so a test only has to
+    name it when the channel is the variable under test.
+    """
     return _FakeMessage(
         id=msg_id,
         content="a thoughtful note worth keeping in the vault",
         created_at=datetime.fromisoformat("2026-06-26T10:00:00").replace(tzinfo=UTC),
-        author=_FakeUser(id=author_id, name="Ada"),
-        channel=_FakeChannel(name="general"),
+        author=_FakeUser(id=author_id, name="Ada", bot=author_bot),
+        channel=_FakeChannel(name="general", id=channel_id),
     )
 
 
-def _client(tmp_path: Path, capture: MessageCapture | None) -> _ReadyClient:
+def _exploding_message(*, msg_id: int) -> _FakeMessage:
+    """A message whose author raises the moment the gate inspects ``bot``."""
+    return _FakeMessage(
+        id=msg_id,
+        content="a thoughtful note worth keeping in the vault",
+        created_at=datetime.fromisoformat("2026-06-26T10:00:00").replace(tzinfo=UTC),
+        author=_ExplodingAuthor(_ALLOWED_USER_ID),
+        channel=_FakeChannel(name="general", id=_ALLOWED_CHANNEL_ID),
+    )
+
+
+def _client(
+    tmp_path: Path,
+    capture: MessageCapture | None,
+    *,
+    channel_tiers: dict[int, str] | None = None,
+) -> _ReadyClient:
     """Construct a ready test client wired with *capture*."""
     return _ReadyClient(
-        config=_config(tmp_path),
+        config=_config(tmp_path, channel_tiers=channel_tiers),
         session_state=None,
         message_capture=capture,
     )
@@ -92,21 +176,31 @@ def _client(tmp_path: Path, capture: MessageCapture | None) -> _ReadyClient:
 async def test_captures_and_forwards_to_command_path(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A non-self message is captured AND forwarded to handle_message."""
+    """A non-self message is captured AND forwarded to handle_message.
+
+    Not a #1052 RED test — it is the #687 test repaired. It previously sent an
+    allowlisted user into a *non*-allowlisted channel, so its "the message was
+    captured" assertion documented the bypass rather than the feature. Pointing
+    it at ``_ALLOWED_CHANNEL_ID`` makes the assertion mean what it claims, and
+    it must stay green through the fix (the fix is strictly narrowing).
+    """
     handled: list[int] = []
 
     async def _fake_handle(message: _MessageLike, **_kwargs: object) -> None:
         handled.append(message.id)
 
     monkeypatch.setattr("crawdad.bot.handle_message", _fake_handle)
-    capture = MessageCapture(capture_dir=tmp_path / "discord-capture")
+    capture = MessageCapture(capture_dir=tmp_path / _CAPTURE_DIRNAME)
     client = _client(tmp_path, capture)
 
-    await client.on_message(_message(msg_id=100, author_id=111))
+    message = _message(
+        msg_id=100, author_id=_ALLOWED_USER_ID, channel_id=_ALLOWED_CHANNEL_ID
+    )
+
+    await client.on_message(message)
 
     assert handled == [100]  # command path still fires
-    captured = tmp_path / "discord-capture" / "general" / "2026-06-26.jsonl"
-    assert captured.is_file()  # and the message was captured
+    assert (tmp_path / _CAPTURED_JSONL).is_file()  # and the message was captured
 
 
 async def test_skips_the_bots_own_messages(
@@ -114,12 +208,12 @@ async def test_skips_the_bots_own_messages(
 ) -> None:
     """The bot does not capture its own replies."""
     monkeypatch.setattr("crawdad.bot.handle_message", _noop_handle)
-    capture = MessageCapture(capture_dir=tmp_path / "discord-capture")
+    capture = MessageCapture(capture_dir=tmp_path / _CAPTURE_DIRNAME)
     client = _client(tmp_path, capture)
 
     await client.on_message(_message(msg_id=200, author_id=_BOT_USER_ID))
 
-    assert not (tmp_path / "discord-capture").exists()
+    assert not (tmp_path / _CAPTURE_DIRNAME).exists()
 
 
 async def test_no_capture_configured_is_inert(
@@ -134,10 +228,10 @@ async def test_no_capture_configured_is_inert(
     monkeypatch.setattr("crawdad.bot.handle_message", _fake_handle)
     client = _client(tmp_path, capture=None)
 
-    await client.on_message(_message(msg_id=300, author_id=111))
+    await client.on_message(_message(msg_id=300, author_id=_ALLOWED_USER_ID))
 
     assert handled == [300]
-    assert not (tmp_path / "discord-capture").exists()
+    assert not (tmp_path / _CAPTURE_DIRNAME).exists()
 
 
 async def test_capture_failure_does_not_break_commands(
@@ -157,7 +251,7 @@ async def test_capture_failure_does_not_break_commands(
 
     client = _client(tmp_path, _BrokenCapture(capture_dir=tmp_path / "cap"))
 
-    await client.on_message(_message(msg_id=400, author_id=111))
+    await client.on_message(_message(msg_id=400, author_id=_ALLOWED_USER_ID))
 
     assert handled == [400]  # command path survived the capture failure
 
@@ -179,7 +273,7 @@ async def test_non_oserror_capture_failure_is_swallowed(
 
     client = _client(tmp_path, _BrokenCapture(capture_dir=tmp_path / "cap"))
 
-    await client.on_message(_message(msg_id=401, author_id=111))
+    await client.on_message(_message(msg_id=401, author_id=_ALLOWED_USER_ID))
 
     assert handled == [401]  # the broadened catch kept the command path alive
 
@@ -201,7 +295,7 @@ async def test_on_message_before_ready_drops_event(
         message_capture=MessageCapture(capture_dir=tmp_path / "cap"),
     )
 
-    await client.on_message(_message(msg_id=500, author_id=111))
+    await client.on_message(_message(msg_id=500, author_id=_ALLOWED_USER_ID))
 
     assert handled == []  # dropped before ready
     assert not (tmp_path / "cap").exists()
@@ -209,6 +303,271 @@ async def test_on_message_before_ready_drops_event(
 
 async def _noop_handle(message: _MessageLike, **_kwargs: object) -> None:
     """A handle_message stand-in that does nothing."""
+
+
+# ---------------------------------------------------------------------------
+# #1052 — capture must clear the command path's gate, plus a tier gate
+# ---------------------------------------------------------------------------
+
+
+async def test_non_allowlisted_channel_is_not_captured(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An allowlisted user speaking in an un-allowlisted channel is not captured.
+
+    ``config.is_allowed`` refuses the command path here; capture must refuse
+    for the same reason. Anything else means every channel the bot is merely
+    *present* in gets logged into the vault.
+    """
+    monkeypatch.setattr("crawdad.bot.handle_message", _noop_handle)
+    capture = MessageCapture(capture_dir=tmp_path / _CAPTURE_DIRNAME)
+    client = _client(tmp_path, capture)
+
+    message = _message(
+        msg_id=600, author_id=_ALLOWED_USER_ID, channel_id=_OTHER_CHANNEL_ID
+    )
+
+    await client.on_message(message)
+
+    assert not (tmp_path / _CAPTURE_DIRNAME).exists()
+
+
+async def test_non_allowlisted_user_is_not_captured(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stranger in an allowlisted channel is not captured.
+
+    The user allowlist is the bot's only consent record. A person who never
+    agreed to be logged must not be written into someone else's vault.
+    """
+    monkeypatch.setattr("crawdad.bot.handle_message", _noop_handle)
+    capture = MessageCapture(capture_dir=tmp_path / _CAPTURE_DIRNAME)
+    client = _client(tmp_path, capture)
+
+    message = _message(
+        msg_id=601, author_id=_OTHER_USER_ID, channel_id=_ALLOWED_CHANNEL_ID
+    )
+
+    await client.on_message(message)
+
+    assert not (tmp_path / _CAPTURE_DIRNAME).exists()
+
+
+async def test_other_bots_messages_are_not_captured(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Another bot / webhook is refused on the ``author.bot`` flag alone.
+
+    Distinct from ``test_skips_the_bots_own_messages``: this author is *not*
+    CrawDad (the self-id check passes it through) and satisfies BOTH
+    allowlists, so the only gate left that can refuse it is ``author.bot``.
+    Machine chatter is not the operator's thinking and must not be ingested
+    as if it were.
+    """
+    monkeypatch.setattr("crawdad.bot.handle_message", _noop_handle)
+    capture = MessageCapture(capture_dir=tmp_path / _CAPTURE_DIRNAME)
+    client = _client(tmp_path, capture)
+
+    message = _message(
+        msg_id=602,
+        author_id=_ALLOWED_USER_ID,
+        channel_id=_ALLOWED_CHANNEL_ID,
+        author_bot=True,
+    )
+
+    await client.on_message(message)
+
+    assert not (tmp_path / _CAPTURE_DIRNAME).exists()
+
+
+async def test_intimate_channel_is_not_captured(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A channel the operator declared ``intimate`` is never captured.
+
+    This asserts the bypass is closed under the NARROWEST ceiling, not merely
+    under the default one. Every other gate passes — allowlisted user,
+    allowlisted channel, human author, not the bot itself — so only the tier
+    gate can refuse. A capture record carries no tier field, so an intimate
+    message written into ``discord-capture/`` arrives downstream as
+    ``unclassified``, which ranks with ``personal`` (#961): a silent privacy
+    de-escalation of the operator's most sensitive channel. Refusal is the
+    only safe answer until the capture record can carry its ceiling.
+    """
+    monkeypatch.setattr("crawdad.bot.handle_message", _noop_handle)
+    capture = MessageCapture(capture_dir=tmp_path / _CAPTURE_DIRNAME)
+    tiers = {_ALLOWED_CHANNEL_ID: "intimate"}
+    client = _client(tmp_path, capture, channel_tiers=tiers)
+    message = _message(
+        msg_id=603, author_id=_ALLOWED_USER_ID, channel_id=_ALLOWED_CHANNEL_ID
+    )
+
+    await client.on_message(message)
+
+    assert not (tmp_path / _CAPTURE_DIRNAME).exists()
+
+
+async def test_all_tier_channel_is_not_captured(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A channel declared ``all`` is refused too — ``all`` admits intimate.
+
+    ``all`` is the widest ceiling in the vocabulary, which by definition
+    includes intimate content. Treating it as admissible would reopen the
+    exact hole ``intimate`` closes.
+    """
+    monkeypatch.setattr("crawdad.bot.handle_message", _noop_handle)
+    capture = MessageCapture(capture_dir=tmp_path / _CAPTURE_DIRNAME)
+    tiers = {_ALLOWED_CHANNEL_ID: "all"}
+    client = _client(tmp_path, capture, channel_tiers=tiers)
+    message = _message(
+        msg_id=604, author_id=_ALLOWED_USER_ID, channel_id=_ALLOWED_CHANNEL_ID
+    )
+
+    await client.on_message(message)
+
+    assert not (tmp_path / _CAPTURE_DIRNAME).exists()
+
+
+@pytest.mark.parametrize(
+    ("tier", "msg_id"),
+    [("open", 605), ("personal", 606), (None, 607)],
+)
+async def test_admitted_tier_channels_are_captured(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tier: str | None,
+    msg_id: int,
+) -> None:
+    """``open`` / ``personal`` / unset channels keep being captured.
+
+    LOAD-BEARING OVER-NARROWING GUARD — do not delete. The five refusal tests
+    above are all satisfied by a "fix" that simply refuses everything, which
+    would silently kill the whole #687 capture feature; none of them fails in
+    that case. Only three tests do: this one,
+    ``test_captures_and_forwards_to_command_path`` and
+    ``test_end_to_end_allowlisted_channel_captures_and_replies`` — so none of
+    the three is redundant with the others. This one is the only one that
+    covers the tier axis. The unset case matters most: ``_channel_tier``
+    defaults a missing channel to ``DEFAULT_CHANNEL_TIER`` (``personal``), so
+    an operator who never wrote a ``channel_privacy_tiers`` block must not
+    lose capture.
+    """
+    monkeypatch.setattr("crawdad.bot.handle_message", _noop_handle)
+    capture = MessageCapture(capture_dir=tmp_path / _CAPTURE_DIRNAME)
+    tiers = None if tier is None else {_ALLOWED_CHANNEL_ID: tier}
+    client = _client(tmp_path, capture, channel_tiers=tiers)
+    message = _message(
+        msg_id=msg_id, author_id=_ALLOWED_USER_ID, channel_id=_ALLOWED_CHANNEL_ID
+    )
+
+    await client.on_message(message)
+
+    captured = tmp_path / _CAPTURED_JSONL
+    assert captured.is_file()
+    assert f'"id": "{msg_id}"' in captured.read_text(encoding="utf-8")
+
+
+async def test_gate_failure_refuses_capture_and_keeps_commands_alive(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A gate that raises refuses the capture without breaking commands.
+
+    Pins that the gate is evaluated INSIDE ``_capture_message``'s existing
+    ``try/except Exception``. Two properties at once: fail-closed (an
+    exception must never be read as "admitted"), and best-effort (the #687
+    contract that capture can never take the command path down).
+    """
+    handled: list[int] = []
+
+    async def _fake_handle(message: _MessageLike, **_kwargs: object) -> None:
+        handled.append(message.id)
+
+    monkeypatch.setattr("crawdad.bot.handle_message", _fake_handle)
+    capture = MessageCapture(capture_dir=tmp_path / _CAPTURE_DIRNAME)
+    client = _client(tmp_path, capture)
+
+    await client.on_message(_exploding_message(msg_id=608))
+
+    assert not (tmp_path / _CAPTURE_DIRNAME).exists()  # failed closed
+    assert handled == [608]  # command path untouched
+
+
+class TestEndToEndCaptureBoundary:
+    """Capture and the command path answer to ONE boundary (#1052).
+
+    These deliberately do not monkeypatch ``crawdad.bot.handle_message``: the
+    real handler runs, so the allowlist decision under test is the same object
+    the production command path consults. With ``router`` / ``composer`` /
+    ``mcp_client`` all ``None`` and no pending batches, an admitted message
+    gets ``_stub_reply()`` on ``message.channel.send`` — an observable proxy
+    for "the command path ran".
+    """
+
+    async def test_end_to_end_allowlisted_channel_captures_and_replies(
+        self, tmp_path: Path
+    ) -> None:
+        """The sanctioned path: the bot answers AND the message is captured."""
+        capture = MessageCapture(capture_dir=tmp_path / _CAPTURE_DIRNAME)
+        client = _client(tmp_path, capture)
+        message = _message(
+            msg_id=700,
+            author_id=_ALLOWED_USER_ID,
+            channel_id=_ALLOWED_CHANNEL_ID,
+        )
+
+        await client.on_message(message)
+
+        assert message.channel.sent == [_stub_reply()]
+        assert (tmp_path / _CAPTURED_JSONL).is_file()
+
+    async def test_end_to_end_non_allowlisted_channel_is_silent_and_uncaptured(
+        self, tmp_path: Path
+    ) -> None:
+        """Outside the allowlist the bot is fully inert: no reply, no record.
+
+        FEAT-013 promises non-allowlisted callers get no response. Capture
+        made that promise a half-truth — silent to the user, loud to the
+        vault.
+        """
+        capture = MessageCapture(capture_dir=tmp_path / _CAPTURE_DIRNAME)
+        client = _client(tmp_path, capture)
+        message = _message(
+            msg_id=701,
+            author_id=_ALLOWED_USER_ID,
+            channel_id=_OTHER_CHANNEL_ID,
+        )
+
+        await client.on_message(message)
+
+        assert message.channel.sent == []
+        assert not (tmp_path / _CAPTURE_DIRNAME).exists()
+
+    async def test_end_to_end_intimate_channel_replies_but_does_not_capture(
+        self, tmp_path: Path
+    ) -> None:
+        """The discriminating case: commands still answer, capture refuses.
+
+        The tier gate is capture-scoped. ``channel_privacy_tiers`` has never
+        gated whether the bot will *talk* to you in a channel, and this fix
+        must not start: an operator who marks their journal channel
+        ``intimate`` still expects ``/crawdad`` and free text to work there.
+        This test fails if the new gate is bolted onto ``_passes_allowlist``
+        (or into ``handle_message``) instead of onto the capture path.
+        """
+        capture = MessageCapture(capture_dir=tmp_path / _CAPTURE_DIRNAME)
+        tiers = {_ALLOWED_CHANNEL_ID: "intimate"}
+        client = _client(tmp_path, capture, channel_tiers=tiers)
+        message = _message(
+            msg_id=702,
+            author_id=_ALLOWED_USER_ID,
+            channel_id=_ALLOWED_CHANNEL_ID,
+        )
+
+        await client.on_message(message)
+
+        assert message.channel.sent == [_stub_reply()]  # commands unaffected
+        assert not (tmp_path / _CAPTURE_DIRNAME).exists()  # capture refused
 
 
 class TestBuildMessageCapture:

--- a/crawdad/tests/test_config.py
+++ b/crawdad/tests/test_config.py
@@ -168,6 +168,74 @@ def test_attachment_config_accepts_all_four_tier_values() -> None:
     assert config.channel_privacy_tiers[2] == "personal"
 
 
+def test_capture_admitted_tiers_excludes_intimate_and_all() -> None:
+    """#1052: only ``open`` and ``personal`` channels may be bot-captured.
+
+    A capture record has no tier field, so a captured message arrives
+    downstream as ``unclassified``, which ranks with ``personal``
+    (``creek_mcp.tier_ceiling``, #961). Capturing an ``intimate`` channel
+    would therefore be a silent privacy de-escalation, and ``all`` admits
+    intimate content by definition. The equality (not a membership check) is
+    deliberate: adding a tier to this set must be an explicit, reviewed edit.
+    """
+    from crawdad.config import CAPTURE_ADMITTED_TIERS
+
+    assert frozenset({"open", "personal"}) == CAPTURE_ADMITTED_TIERS
+
+
+def test_capture_admitted_tiers_is_a_strict_subset_of_valid_tiers() -> None:
+    """#1052: the admitted set is a strict subset of the tier vocabulary.
+
+    Pins the escalate-only invariant against the two ways it can rot:
+    someone widening admission to the whole vocabulary, and a fifth tier
+    being added later and silently inheriting capture admission. A new tier
+    must fail this test until a human decides its admission explicitly.
+
+    The round-trip through ``AttachmentConfig`` keeps the constant honest —
+    it must be the same vocabulary the config validator enforces, not a
+    decorative duplicate that drifts.
+    """
+    from crawdad.config import (
+        _VALID_CHANNEL_TIERS,
+        CAPTURE_ADMITTED_TIERS,
+        AttachmentConfig,
+    )
+
+    assert CAPTURE_ADMITTED_TIERS < _VALID_CHANNEL_TIERS
+    assert (
+        frozenset({"intimate", "all"}) == _VALID_CHANNEL_TIERS - CAPTURE_ADMITTED_TIERS
+    )
+    for tier in sorted(_VALID_CHANNEL_TIERS):
+        parsed = AttachmentConfig(channel_privacy_tiers={1: tier})
+        assert parsed.channel_privacy_tiers[1] == tier
+
+
+def test_default_channel_tier_is_capture_admitted() -> None:
+    """#1052: a channel with no declared tier keeps bot-capture.
+
+    ``_channel_tier`` falls back to ``DEFAULT_CHANNEL_TIER`` for a channel the
+    operator never listed in ``channel_privacy_tiers``, and ``_capture_allowed``
+    then tests that value for membership in ``CAPTURE_ADMITTED_TIERS``. So the
+    #687 capture feature keeps working for the common "no tier block at all"
+    deployment *only* while these two constants agree. They are declared
+    independently, so pin the link here rather than leaving it to coincidence:
+    dropping ``personal`` from the admitted set would otherwise silently
+    disable capture for every un-tiered channel.
+
+    ``DEFAULT_CHANNEL_TIER`` must also be a real tier, not a typo — an
+    unrecognised fallback would fail closed and look identical to an
+    intentional refusal.
+    """
+    from crawdad.config import (
+        _VALID_CHANNEL_TIERS,
+        CAPTURE_ADMITTED_TIERS,
+        DEFAULT_CHANNEL_TIER,
+    )
+
+    assert DEFAULT_CHANNEL_TIER in _VALID_CHANNEL_TIERS
+    assert DEFAULT_CHANNEL_TIER in CAPTURE_ADMITTED_TIERS
+
+
 def test_load_config_parses_attachment_overrides(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- **Bot-capture now answers to the same boundary as the command path.** It ran ahead of `handle_message`, so it never reached `_passes_allowlist` and filtered on nothing but the bot's own user id — messages from users and channels the operator never allowlisted, plus other bots' and webhooks' output, were written into `<vault>/discord-capture/` and flowed into Tier-A ingest as human conversation. `_capture_allowed` now requires `_passes_allowlist` to pass first.
- **`channel_privacy_tiers` is applied to capture, fail-closed.** A capture record carries no tier field and `stage_capture_as_data_package` drops channel metadata, so a captured message lands downstream as `unclassified` — which ranks *with* `personal` (#961). Capturing a channel the operator declared `intimate` was a silent privacy de-escalation. Capture is now admitted only for tiers in `CAPTURE_ADMITTED_TIERS` (`{"open", "personal"}`); `intimate` and `all` are refused, because capture must not carry content whose ceiling it cannot represent.
- **The semantics are documented** in `crawdad/CLAUDE.md` §5 / new §5.2 and `crawdad/README.md`, per the issue's first acceptance criterion. This is option (a) of the issue's decision — the allowlist is documented as *the* scoping boundary, so exempting capture from it was never a decision anyone made.

## Design notes

**Strictly narrowing at every ceiling.** Across the 5×5 tier × actor matrix, **17 cells narrow, 8 are unchanged, 0 widen**. The new predicate is the old one conjoined with two more conditions, so widening is structurally impossible. The one admitted-but-inexact cell still escalates: an `open` channel's message lands as `unclassified` (rank 1) rather than `open` (rank 0) — more restrictive, not less.

**Allow-list, not deny-list.** `CAPTURE_ADMITTED_TIERS` is written out explicitly rather than derived as `_VALID_CHANNEL_TIERS - {"intimate", "all"}`. A subtraction would auto-admit any fifth tier added to the vocabulary later; the safe default for an unreviewed tier is refusal. `test_capture_admitted_tiers_is_a_strict_subset_of_valid_tiers` fails the moment a tier is added without an explicit admission decision.

**Membership, never a rank comparison** — `crawdad.loop` owns the single tier-ordering table and a second one must not exist (the rule `workflows.py` already states). As a bonus this fails closed on a value that never passed config validation, where a rank comparison would not.

**The gate is inside `_capture_message`'s existing `try`.** A gate that raises (a malformed message, an attribute that errors) therefore fails closed to "not captured" while the command path keeps running — fail-closed by construction rather than by convention. Pinned by `test_gate_failure_refuses_capture_and_keeps_commands_alive`.

**The tier gate is capture-scoped only.** `channel_privacy_tiers` has never gated whether the bot *replies* in a channel and still does not — an operator's `intimate` journal channel still gets `/crawdad` and free-text replies, it is just never written to the capture log. `test_end_to_end_intimate_channel_replies_but_does_not_capture` fails if that scope ever creeps into `handle_message`.

**`capture.py` is deliberately untouched.** Persisting a tier on the record would change the capture file format (out of scope per the issue) and be inert anyway, because the creek-tools ingest side that drops it is also out of scope — worse, an inert field would make the ceiling *look* honoured while the fragment still landed `unclassified`. #1262 tracks carrying the tier end-to-end, after which `CAPTURE_ADMITTED_TIERS` may widen.

## Known residual risk (please read before merging)

**This fix stops future bad writes; it does not remediate what a pre-fix build already wrote.** An operator who ran with `capture_enabled: true` may have non-allowlisted, other-bot, and `intimate` records already on disk under `<vault>/discord-capture/`, and those remain ingestible — `stage_capture_as_data_package` iterates every channel dir unconditionally. Blast radius is bounded by `capture_enabled` defaulting to `False`. Filed as **#1264** (audit/purge helper) and documented in `crawdad/README.md` under "Upgrading from a pre-#1052 build"; the manual mitigation today is deleting the offending channel subdirectories before running `creek sync`.

## Test plan

**Gate 1 — RED proven before any implementation landed.** Ran the new tests against unmodified `crawdad/crawdad/`: **10 failed, 46 passed**, each for the right reason (a JSONL file that should not exist; `ImportError` on the not-yet-added constants) — not a fixture or typo failure. New coverage:

- non-allowlisted channel → not captured
- non-allowlisted user → not captured
- another bot's message → not captured (both allowlists satisfied, so only the `bot` flag can refuse)
- **`intimate` channel → not captured** — the narrowest ceiling, with every other gate passing
- **`all` channel → not captured**
- a gate that raises → not captured *and* the command path still runs
- `open` / `personal` / unset channels → **still captured** (parametrised over-narrowing guard: an over-broad "refuse everything" fix passes all five refusal tests and fails only here)
- three e2e-shaped tests through the real `CrawDadClient.on_message` **without** monkeypatching `handle_message`, so capture and the command path are proven to consult the same object
- two config invariant pins on `CAPTURE_ADMITTED_TIERS`, plus one linking `DEFAULT_CHANNEL_TIER` to it

Also repairs the #687 fixture that **encoded the bug**: it set `allowed_channel_ids=[999]` while `_FakeChannel` defaulted to `id=1`, and `999` doubled as the bot's own user id — so "the allowlisted channel was captured" could never actually be observed. Verified against `git show HEAD:` that no pre-existing assertion was deleted or loosened; all 11 survive, one strengthened.

**Gate 2 — the CrawDad gate, run the way CI's "CrawDad Quality" job runs it** (`working-directory: crawdad`):

```
cd crawdad && ./scripts/check-all.sh
```

→ **7/7 checks pass** (lint, format, type check, security, docstrings, complexity, tests) · **598 passed, 3 deselected** · coverage **94.62%** (threshold 90). Lint, format and mypy independently re-verified with `--no-cache`.

Note `creek-tools/scripts/check-all.sh` does **not** cover `crawdad/`, and this change touches no creek-tools code, so the crawdad gate is the applicable one.

**Gate 2.5** — `security-specialist` returned `SECURITY VERDICT: CLEAN` (no blockers) after enumerating every path to the writer and walking the full tier × actor matrix; `code-review-orchestrator` returned `CLEAN` (no blockers). Both flagged non-blocking comment-precision items, which are fixed in this branch — including one factually wrong claim about `StrEnum` hashing that I disproved empirically before rewriting the comment.

## Follow-ups filed

- **#1264** (P1) — audit/purge helper for pre-#1052 capture data still on disk.
- **#1262** (P2) — carry the declared tier end-to-end (capture record → staging → fragment frontmatter) so `intimate` channels can be captured faithfully instead of refused.
- **#1265** (P2) — `_channel_tier` does not resolve a Discord thread to its parent channel, so a parent's `intimate` ceiling is not applied inside its threads. Pre-existing; also affects the shipped attachment-staging and safety-scan paths.
- **#1057** — commented with the decision and a standing constraint: when `MessageCapture.backfill` is wired in, it must evaluate `_capture_allowed` **per message inside the history loop**, not once per channel, or it re-opens this entire bypass at history scale.

Closes #1052
