### PR TITLE
feat(mcp): rotate consumer tokens through an overlapping window, not a cutover

### DIFF
--- a/creek-tools/creek_mcp/httpapi/auth.py
+++ b/creek-tools/creek_mcp/httpapi/auth.py
@@ -65,6 +65,14 @@ def build_verifier(
 ) -> ConsumerTokenVerifier:
     """Return the verifier for the configured consumers, or refuse to build one.
 
+    A consumer may hold an ordered set of currently-valid tokens (#895), so a
+    ``/v1`` deployment rotates a secret through the same environment variable
+    and the same parser the MCP surface uses — there is nothing adapter-local
+    to keep in step. The map's *values* are token sequences rather than single
+    tokens, which changes nothing here: the truthiness check below asks
+    whether any consumer is configured at all, and an empty map is still the
+    only way to answer "no".
+
     Args:
         environ: Environment mapping to read, or ``None`` for
             :data:`os.environ`. Tests always pass one explicitly, so no test
@@ -77,11 +85,13 @@ def build_verifier(
     Raises:
         ValueError: When no consumer tokens are configured, naming the setting
             the operator must set; or, propagated unchanged from
-            :func:`creek_mcp.remote_auth.load_consumer_tokens`, when a
-            configured token is below the shared length floor. That second
-            message names the consumer, the observed and required lengths and
-            the rotation recipe — and never the token value, because a startup
-            error lands in logs, terminals and process supervisors.
+            :func:`creek_mcp.remote_auth.load_consumer_tokens`, when the
+            configuration cannot be read unambiguously — a token below the
+            shared length floor (#838), a consumer named twice, or one token
+            value configured for two consumers (#895). Those messages name the
+            consumers, the observed and required lengths and the rotation
+            recipe — and never a token value, because a startup error lands in
+            logs, terminals and process supervisors.
     """
     tokens = load_consumer_tokens(environ)
     if not tokens:

--- a/creek-tools/creek_mcp/httpapi/cli.py
+++ b/creek-tools/creek_mcp/httpapi/cli.py
@@ -20,6 +20,14 @@ Startup is fail-closed three times over, all before a socket exists:
 * **No cleartext bearer on a routable network.** A non-loopback bind without
   TLS exits naming the flags that fix it.
 
+Having cleared those, startup **announces on stderr** any consumer holding
+more than one currently-valid token, so an open rotation window (#895) is
+visible rather than permanent. It goes to stderr because stdout here carries
+the ``--print-openapi`` document consumers pipe into client generators; the
+decision, and the notice itself, are
+:func:`creek_mcp.remote_auth.announce_rotation_window`'s, shared with the MCP
+adapter so it cannot hold on one entry point and lapse on the other.
+
 **The default port is deliberately not 8000.** That is both Adepthood's own
 backend port and :data:`creek_mcp.server.DEFAULT_MCP_NETWORK_PORT`, and the two
 Creek adapters are expected to run side by side on one host; identical defaults
@@ -46,6 +54,7 @@ from creek_mcp.api.openapi import build_openapi
 from creek_mcp.httpapi import SERVER_NAME
 from creek_mcp.httpapi.app import create_app
 from creek_mcp.httpapi.auth import build_verifier
+from creek_mcp.remote_auth import announce_rotation_window
 from creek_mcp.transport_posture import require_transport_confidentiality
 
 if TYPE_CHECKING:
@@ -162,8 +171,10 @@ def _verifier_or_exit(parser: argparse.ArgumentParser) -> ConsumerTokenVerifier:
     try:
         verifier = build_verifier()
     except ValueError as exc:
-        # Covers both "nothing configured" and "a configured token is below the
-        # shared length floor". Neither message ever carries a token value, and
+        # Covers "nothing configured", "a configured token is below the shared
+        # length floor" (#838), and the two ambiguous registries #895 refuses:
+        # a consumer named twice, and one token value configured for two
+        # consumers. No such message ever carries a token value, and
         # ``parser.error`` exits non-zero rather than returning.
         parser.error(str(exc))
     return verifier
@@ -231,7 +242,11 @@ def serve(app: Starlette, args: argparse.Namespace) -> None:  # pragma: no cover
 
 
 def main(argv: list[str] | None = None) -> None:
-    """Parse arguments, refuse an unsafe configuration, then serve.
+    """Parse arguments, refuse an unsafe configuration, announce, then serve.
+
+    The announcement is the one non-refusal in the sequence: any open rotation
+    window (#895) is reported on stderr before the socket exists, so it is
+    visible in the same startup output as the refusals above it.
 
     Args:
         argv: Command-line arguments, or ``None`` to read :data:`sys.argv`.
@@ -245,4 +260,12 @@ def main(argv: list[str] | None = None) -> None:
     _apply_config(parser, args)
     verifier = _verifier_or_exit(parser)
     require_transport_confidentiality(parser, args)
+    # After every refusal, never before one: a process about to exit 2 has
+    # nothing to announce, and announcing above the posture gate printed a
+    # rotation notice for a server that then refused to serve — while the MCP
+    # adapter announced below its own gate. Two adapters, one moment. A window
+    # has to be closed again, and an operator who cannot see one is open will
+    # not close it (#895). On stderr: stdout on this entry point carries the
+    # ``--print-openapi`` document, which consumers pipe into code generators.
+    announce_rotation_window(verifier)
     serve(create_app(verifier=verifier), args)

--- a/creek-tools/creek_mcp/remote_auth.py
+++ b/creek-tools/creek_mcp/remote_auth.py
@@ -3,8 +3,8 @@
 When ``creek-tools-mcp`` is served over the network (streamable-http), every
 request must present a bearer token that maps to a known **consumer identity** —
 there is no anonymous access. Tokens are configured in the environment only
-(never in code or the config file), one per remote consumer, mirroring the
-existing ``CREEK_MCP_ELEVATED_TOKEN`` fail-closed / constant-time precedent.
+(never in code or the config file), mirroring the existing
+``CREEK_MCP_ELEVATED_TOKEN`` fail-closed / constant-time precedent.
 
 The SDK's :class:`~mcp.server.auth.provider.TokenVerifier` hook does the rest:
 when a :class:`ConsumerTokenVerifier` is wired into ``FastMCP``, the SDK installs
@@ -13,16 +13,39 @@ scope) and exposes the authenticated identity per-call via ``get_access_token()`
 — which the server uses to stamp the consumer on the audit log and to apply the
 remote tier-ceiling cap.
 
+A consumer holds an **ordered set of currently-valid tokens** (#895), spelled as
+a comma-separated list inside its own ``consumer=`` segment
+(``adepthood=<old>,<new>``). Every token in the set authenticates as that one
+consumer, so a secret is rotated by widening the set, letting the consumer
+redeploy, and then narrowing it again: no cutover, and no window left open by
+accident, because startup announces every consumer holding more than one token
+(:meth:`ConsumerTokenVerifier.rotation_notice`, emitted by
+:func:`announce_rotation_window`). The step-by-step runbook lives in the
+network-transport section of ``docs/mcp.md``.
+
+Two configurations are refused rather than resolved. A consumer named twice is
+an error, because both readings rewrite the operator's intent — overwriting
+discards a credential they believe is live, accumulating invents a rotation
+window they never asked for — and the comma form says the supported thing
+plainly. One token value configured for more than one consumer is an error
+because :meth:`ConsumerTokenVerifier.verify_token` attributes a match to the
+last consumer it scans, so a shared value would audit calls under the wrong
+name.
+
 Verified tokens carry a **finite lifetime** (#837): ``verify_token`` stamps
 ``expires_at`` at ``now + TTL`` (default 3600s) rather than issuing a
 never-expiring credential. ``CREEK_MCP_TOKEN_TTL_SECONDS`` overrides the TTL;
 a non-integer or non-positive value falls back to the default rather than
-failing open with ``expires_at=None``.
+failing open with ``expires_at=None``. That expiry bounds an individually
+captured :class:`AccessToken` object; it does not revoke the *configured*
+secret, which is what the rotation window above is for.
 
 Configured tokens must clear a **minimum-length floor** (#838): a token in
 ``CREEK_MCP_CONSUMER_TOKENS`` shorter than 32 characters is refused at load
-time so a guessable secret never guards the wire. Generate compliant tokens
-with ``python -c "import secrets; print(secrets.token_urlsafe(32))"``.
+time so a guessable secret never guards the wire. The floor applies to every
+token in a consumer's set and not only the first, because a rotation is exactly
+when a fresh secret gets typed in. Generate compliant tokens with
+``python -c "import secrets; print(secrets.token_urlsafe(32))"``.
 
 Stdio (local CrawDad / Claude Code) is unaffected: no verifier is wired, so
 ``get_access_token()`` is ``None`` and calls run as before.
@@ -32,8 +55,9 @@ from __future__ import annotations
 
 import hmac
 import os
+import sys
 import time
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING, Final, NoReturn
 
 from mcp.server.auth.provider import AccessToken, TokenVerifier
 from mcp.server.auth.settings import AuthSettings
@@ -41,10 +65,14 @@ from mcp.server.auth.settings import AuthSettings
 from creek_mcp.token_policy import require_min_length
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Mapping, Sequence
 
 CONSUMER_TOKENS_ENV: Final[str] = "CREEK_MCP_CONSUMER_TOKENS"
-"""Env var holding ``consumer=token`` pairs, ``;``-separated (tokens never in code)."""
+"""Env var holding ``consumer=token`` entries (tokens never in code).
+
+``;`` separates one consumer from the next; ``,`` inside a single entry lists
+the several tokens that consumer may currently present (#895).
+"""
 
 REMOTE_SCOPE: Final[str] = "creek:remote"
 """The scope every remote consumer token is granted (and the server requires)."""
@@ -54,6 +82,18 @@ TOKEN_TTL_ENV: Final[str] = "CREEK_MCP_TOKEN_TTL_SECONDS"
 
 _REMOTE_TOKEN_TTL_SECONDS: Final[int] = 3600
 """Default lifetime of a verified bearer's ``AccessToken`` (one hour)."""
+
+_CONSUMER_SEPARATOR: Final[str] = ";"
+"""Separates one consumer's entry from the next in :data:`CONSUMER_TOKENS_ENV`."""
+
+_TOKEN_SEPARATOR: Final[str] = ","
+"""Separates the tokens within one consumer's entry (#895)."""
+
+_NAME_VALUE_SEPARATOR: Final[str] = "="
+"""Separates a consumer's name from its token set."""
+
+_SETTLED_TOKEN_COUNT: Final[int] = 1
+"""How many tokens a consumer holds when it is *not* mid-rotation."""
 
 # Monkeypatchable clock alias: tests pin `_now` to a fixed instant so the
 # expires_at arithmetic is exact; production keeps wall-clock time.
@@ -86,99 +126,347 @@ def _token_ttl_seconds() -> int:
     return ttl if ttl > 0 else _REMOTE_TOKEN_TTL_SECONDS
 
 
-def _validated_token(name: str, token: str) -> str:
-    """Return *token* if it clears the shared length floor, else raise (#838).
+def _validated_tokens(consumer: str, tokens: Sequence[str]) -> tuple[str, ...]:
+    """Return *tokens* if every one clears the shared length floor, else raise (#838).
 
     Delegates to :func:`creek_mcp.token_policy.require_min_length`, which the
     elevated-token gate shares (#907), so both surfaces enforce one number
-    with one wording. The error names the consumer and the observed/required
-    lengths and gives the rotation recipe — it never echoes the token itself.
+    with one wording. The floor is applied per token rather than to the set:
+    a rotation window is exactly where a *new* secret gets typed in, so a
+    check that only saw the incumbent would hold on the token nobody is about
+    to start using. The error names the consumer and the observed/required
+    lengths and gives the rotation recipe — it never echoes a token.
 
     Args:
-        name: The consumer the token belongs to (already stripped).
-        token: The configured token (already stripped, non-empty).
+        consumer: The consumer the tokens belong to (already stripped).
+        tokens: That consumer's configured tokens (already stripped, non-empty).
 
     Returns:
-        The token, unchanged, when it meets the minimum length.
+        The tokens, unchanged and in order, when every one meets the minimum.
 
     Raises:
-        ValueError: If the token is shorter than
+        ValueError: If any token is shorter than
             :data:`creek_mcp.token_policy.MIN_TOKEN_LEN`.
     """
-    return require_min_length(f"consumer {name!r} token", token)
+    subject = f"consumer {consumer!r} token"
+    return tuple(require_min_length(subject, token) for token in tokens)
+
+
+def _token_segments(value: str) -> tuple[str, ...]:
+    """Split one consumer's configured value into its non-empty tokens.
+
+    Whitespace around a comma is operator formatting and never token material,
+    and an empty segment (a doubled or trailing comma) is dropped *here* —
+    before the length floor runs — so a stray comma is a typo the parser
+    absorbs rather than a zero-character token it reports back at the operator.
+
+    Args:
+        value: The right-hand side of one ``consumer=`` entry.
+
+    Returns:
+        The configured tokens, stripped, in configured order; empty when the
+        entry configures no token at all.
+    """
+    stripped = (segment.strip() for segment in value.split(_TOKEN_SEPARATOR))
+    return tuple(segment for segment in stripped if segment)
+
+
+def _parsed_entry(entry: str) -> tuple[str, tuple[str, ...]] | None:
+    """Return the ``(consumer, tokens)`` one env entry configures, or ``None``.
+
+    ``None`` is the "nothing configured here" answer, and it is deliberately
+    silent: a blank entry, a ``name=`` with no token, an ``=orphan`` with no
+    name, and the comma spelling of the same thing (``name=,,``) are all
+    operator formatting rather than errors — the single-token parser skipped
+    them without comment before #895, and the comma form must reach the same
+    verdict rather than registering a consumer the verifier then refuses.
+
+    Args:
+        entry: One ``;``-delimited entry of :data:`CONSUMER_TOKENS_ENV`.
+
+    Returns:
+        The consumer name and its ordered token set, or ``None`` when the
+        entry names no consumer or configures no token.
+    """
+    name, _, value = entry.partition(_NAME_VALUE_SEPARATOR)
+    consumer = name.strip()
+    tokens = _token_segments(value)
+    if not consumer or not tokens:
+        return None
+    return consumer, tokens
+
+
+def _refuse_repeated_consumer(consumer: str) -> NoReturn:
+    """Refuse a consumer name configured more than once (#895).
+
+    Before #895 the second entry silently overwrote the first, throwing away a
+    credential the operator believed was live. Now that a consumer can
+    legitimately hold several tokens, accumulating instead would be just as
+    wrong: it would invent a rotation window nobody asked for. Both readings
+    rewrite the intent, so the parser names the supported spelling and stops.
+
+    Args:
+        consumer: The repeated consumer name.
+
+    Raises:
+        ValueError: Always. The message names the consumer and the comma form,
+            and never a token value.
+    """
+    msg = (
+        f"consumer {consumer!r} is configured more than once in "
+        f"{CONSUMER_TOKENS_ENV}; name each consumer once and give it a "
+        "comma-separated set of currently-valid tokens instead "
+        f"({consumer}=<current>,<replacement>)"
+    )
+    raise ValueError(msg)
+
+
+def _refuse_shared_token(first: str, second: str) -> NoReturn:
+    """Refuse a token value configured in more than one place (#895).
+
+    One rule for two shapes — the same value twice inside one consumer's set,
+    and the same value across two consumers — because they have one
+    consequence: :meth:`ConsumerTokenVerifier.verify_token` scans every
+    configured token without breaking and keeps the *last* match, so a shared
+    value resolves to whichever site the scan saw last. Every audit line and
+    access line that call produced would then name the wrong consumer. Within
+    one set it is additionally a rotation that rotated nothing.
+
+    Args:
+        first: The consumer the value was first seen under.
+        second: The consumer it was seen under again (possibly *first*).
+
+    Raises:
+        ValueError: Always. The message names both consumers and never the
+            value they share.
+    """
+    msg = (
+        "the same token value is configured twice — once for "
+        f"{first!r} and once for {second!r}; every configured token value must "
+        "be unique, because a match is attributed to the last consumer scanned "
+        "and a shared value would audit the call under the wrong identity"
+    )
+    raise ValueError(msg)
+
+
+def _token_set(consumer: str, configured: Sequence[str]) -> tuple[str, ...]:
+    """Return *configured* as a tuple, refusing the two shapes that cannot work.
+
+    Args:
+        consumer: The consumer the tokens belong to.
+        configured: The value the caller mapped that consumer to.
+
+    Returns:
+        The tokens as a tuple, in configured order.
+
+    Raises:
+        TypeError: If *configured* is a bare :class:`str`. ``str`` is itself a
+            ``Sequence[str]``, so the annotation alone cannot catch one, and
+            the value would be read as a single-character token per letter —
+            each of which ``hmac.compare_digest`` accepts, degrading one
+            43-character secret into an alphabet of valid credentials.
+        ValueError: If *configured* is empty. A named consumer holding no
+            token can never authenticate, which reads to an operator as an
+            auth outage rather than as the typo it is.
+    """
+    if isinstance(configured, str):
+        msg = (
+            f"consumer {consumer!r} is configured with a bare string; pass a "
+            "sequence of tokens (a 1-tuple for a settled consumer), because a "
+            "bare string is itself a sequence of its own characters and would "
+            "be read as one single-character token per letter"
+        )
+        raise TypeError(msg)
+    # Materialise before testing emptiness, not after: an empty *iterable*
+    # that is not a Sequence (a generator, a spent iterator) is truthy, so the
+    # order matters. Reversed, such a value would slip past this refusal and
+    # land as an empty tuple — the consumer would authenticate nobody, which
+    # reads to an operator as an auth outage rather than the typo it is, and
+    # the loud error promised below would never fire.
+    resolved = tuple(configured)
+    if not resolved:
+        msg = (
+            f"consumer {consumer!r} is configured with an empty token set, so "
+            "it can never authenticate; give it at least one token, or remove "
+            "the consumer"
+        )
+        raise ValueError(msg)
+    return resolved
+
+
+def _require_globally_unique(tokens: Mapping[str, tuple[str, ...]]) -> None:
+    """Refuse any token value that appears more than once in *tokens*.
+
+    Args:
+        tokens: The normalised ``{consumer: (token, ...)}`` configuration.
+
+    Raises:
+        ValueError: Via :func:`_refuse_shared_token`, on the first repeat —
+            same-consumer and cross-consumer alike, since they are one rule.
+    """
+    owner: dict[str, str] = {}
+    for consumer, configured in tokens.items():
+        for token in configured:
+            previous = owner.get(token)
+            if previous is not None:
+                _refuse_shared_token(previous, consumer)
+            owner[token] = consumer
+
+
+def _normalized_token_sets(
+    tokens: Mapping[str, Sequence[str]],
+) -> dict[str, tuple[str, ...]]:
+    """Return *tokens* as a validated ``{consumer: (token, ...)}`` mapping.
+
+    The one normalisation both entry points share — the environment parser
+    (:func:`load_consumer_tokens`) and the direct constructor
+    (:class:`ConsumerTokenVerifier`). Callers that never see the environment
+    build verifiers from literal maps (``tests/v1_api_support.py``, the wire
+    tests), so the constructor is the narrowest ceiling these invariants can
+    sit under; stating them once is what stops the two paths from disagreeing
+    about what a valid configuration is.
+
+    The #838 length floor is deliberately *not* enforced here. It is a
+    load-time rule about what an operator may put in the environment, and the
+    in-process callers above legitimately construct short literals.
+
+    Args:
+        tokens: A ``{consumer: sequence-of-tokens}`` mapping.
+
+    Returns:
+        The same mapping with every value a tuple.
+
+    Raises:
+        TypeError: If any value is a bare :class:`str`.
+        ValueError: If a named consumer holds no tokens, or if one token value
+            is configured more than once.
+    """
+    normalized = {
+        consumer: _token_set(consumer, configured)
+        for consumer, configured in tokens.items()
+    }
+    _require_globally_unique(normalized)
+    return normalized
 
 
 def load_consumer_tokens(
     environ: Mapping[str, str] | None = None,
-) -> dict[str, str]:
-    """Parse ``CREEK_MCP_CONSUMER_TOKENS`` into a ``{consumer: token}`` map.
+) -> dict[str, tuple[str, ...]]:
+    """Parse ``CREEK_MCP_CONSUMER_TOKENS`` into a ``{consumer: tokens}`` map.
 
-    Format: ``adepthood=<token>;other=<token>``. Blank entries and entries
-    without a token are skipped. Returns an empty dict when unset — the caller
-    treats "no tokens configured" as "network mode not permitted" (no anonymous
-    access). A *present* token shorter than
-    :data:`creek_mcp.token_policy.MIN_TOKEN_LEN` characters
-    is refused outright (#838); generate compliant tokens with
-    ``python -c "import secrets; print(secrets.token_urlsafe(32))"``.
+    Format: ``adepthood=<token>,<token>;other=<token>``. The ``;`` separates
+    consumers; the ``,`` lists the tokens one consumer may currently present
+    (#895), so ``adepthood=<old>,<new>`` is an open rotation window and
+    ``adepthood=<new>`` has closed it. A single-token configuration is
+    unchanged on the wire and lands as a one-element tuple, so an operator who
+    has never rotated anything parses exactly as before.
+
+    Blank entries, entries with no name, and entries with no token — including
+    the comma spelling ``name=,,`` — are skipped. Returns an empty dict when
+    unset: the caller treats "no tokens configured" as "network mode not
+    permitted" (no anonymous access).
 
     Args:
         environ: Environment mapping (defaults to :data:`os.environ`).
 
     Returns:
-        A ``{consumer: token}`` mapping.
+        A ``{consumer: (token, ...)}`` mapping, tokens in configured order.
 
     Raises:
         ValueError: If a configured token is shorter than
-            :data:`creek_mcp.token_policy.MIN_TOKEN_LEN` characters. The
-            message names the consumer and lengths but never the token value.
+            :data:`creek_mcp.token_policy.MIN_TOKEN_LEN` characters (#838), if
+            a consumer is named more than once, or if one token value is
+            configured more than once. Every message names the configuration
+            at fault — consumers, lengths, the rotation recipe — and never a
+            token value, because a startup error lands in logs, terminals and
+            process supervisors.
     """
     raw = (environ if environ is not None else os.environ).get(CONSUMER_TOKENS_ENV, "")
-    tokens: dict[str, str] = {}
-    for entry in raw.split(";"):
-        name, sep, token = entry.strip().partition("=")
-        if sep and name.strip() and token.strip():
-            tokens[name.strip()] = _validated_token(name.strip(), token.strip())
-    return tokens
+    parsed: dict[str, tuple[str, ...]] = {}
+    for entry in raw.split(_CONSUMER_SEPARATOR):
+        item = _parsed_entry(entry)
+        if item is None:
+            continue
+        consumer, tokens = item
+        if consumer in parsed:
+            _refuse_repeated_consumer(consumer)
+        parsed[consumer] = _validated_tokens(consumer, tokens)
+    return _normalized_token_sets(parsed)
 
 
 class ConsumerTokenVerifier(TokenVerifier):
-    """Verifies a bearer token against the configured per-consumer token map.
+    """Verifies a bearer token against the configured per-consumer token sets.
 
     Comparison is constant-time (``hmac.compare_digest``) against every known
-    token so a match leaks no timing signal about which consumer (or whether a
-    prefix) matched. A verified token yields an :class:`AccessToken` whose
-    ``client_id`` is the consumer name and whose scope is :data:`REMOTE_SCOPE`.
+    token so a match leaks no timing signal about which consumer — or which
+    token of that consumer's set — matched. A verified token yields an
+    :class:`AccessToken` whose ``client_id`` is the consumer name and whose
+    scope is :data:`REMOTE_SCOPE`.
+
+    A consumer maps to a **sequence** of tokens and never to a bare ``str``.
+    The signature is not ``str | Sequence[str]``, because that union is
+    unsound: ``str`` already *is* a ``Sequence[str]``, so the union collapses
+    and a type checker would wave a bare secret through. :func:`_token_set`
+    is the runtime half of the same guard.
     """
 
-    def __init__(self, tokens: Mapping[str, str]) -> None:
-        """Store the ``{consumer: token}`` map to verify against."""
-        self._tokens = dict(tokens)
+    def __init__(self, tokens: Mapping[str, Sequence[str]]) -> None:
+        """Store the ``{consumer: tokens}`` map to verify against.
+
+        Args:
+            tokens: The configured consumers and their ordered token sets. An
+                empty mapping is legal and refuses every bearer: "no consumers
+                configured" is the callers' *network denied* posture, which is
+                a different statement from "this consumer has no tokens".
+
+        Raises:
+            TypeError: If a consumer's value is a bare :class:`str`.
+            ValueError: If a named consumer holds no tokens, or if one token
+                value is configured more than once.
+        """
+        self._tokens = _normalized_token_sets(tokens)
 
     async def verify_token(self, token: str) -> AccessToken | None:
         """Return the consumer's :class:`AccessToken` for a valid token, else ``None``.
 
-        Iterates the whole map with constant-time compares (never a dict lookup)
-        so verification time does not depend on which token was supplied. The
-        operands are compared as **UTF-8 bytes**, not ``str``: ``compare_digest``
-        raises ``TypeError`` on a non-ASCII ``str`` but compares cleanly on
-        ``bytes``, so a non-ASCII bearer is *rejected* (returns ``None``) rather
-        than crashing verification (#776).
+        Iterates every configured token of every consumer with constant-time
+        compares (never a dict lookup) and **never breaks early**, not even
+        when the first token matches: an early exit would make verification
+        time depend on where in the configuration the presented token sits,
+        which is a positional oracle over the token set. The operands are
+        compared as **UTF-8 bytes**, not ``str``: ``compare_digest`` raises
+        ``TypeError`` on a non-ASCII ``str`` but compares cleanly on ``bytes``,
+        so a non-ASCII bearer is *rejected* (returns ``None``) rather than
+        crashing verification (#776).
+
+        Every token in a consumer's set resolves to that same consumer, so an
+        open rotation window does not change the caller's identity for its
+        duration — a window that did would rewrite every audit line written
+        while it was open (#895).
 
         The returned token expires ``_token_ttl_seconds()`` from now — never
         ``expires_at=None`` — bounding how long any individually captured
         :class:`AccessToken` (e.g. one logged or cached outside this call)
-        stays valid (#837). This does not rate-limit or expire the underlying
-        shared secret itself: the SDK's bearer middleware calls
-        ``verify_token`` fresh on every request, so a consumer that keeps
-        presenting the same ``CREEK_MCP_CONSUMER_TOKENS`` value is
-        re-verified and re-issued a fresh token indefinitely — only
-        rotating the configured secret revokes access.
+        stays valid (#837). That expiry does not revoke the underlying shared
+        secret: the SDK's bearer middleware calls ``verify_token`` fresh on
+        every request, so a consumer that keeps presenting a configured value
+        is re-verified indefinitely. What revokes it is dropping it from
+        :data:`CONSUMER_TOKENS_ENV` and restarting — the closing half of the
+        rotation runbook in the network-transport section of ``docs/mcp.md``.
+
+        Args:
+            token: The bearer token presented on the request.
+
+        Returns:
+            The matching consumer's access token, or ``None`` when no
+            configured token matches.
         """
         supplied = token.encode("utf-8")
         matched: str | None = None
-        for consumer, known in self._tokens.items():
-            if hmac.compare_digest(supplied, known.encode("utf-8")):
-                matched = consumer
+        for consumer, known_tokens in self._tokens.items():
+            for known in known_tokens:
+                if hmac.compare_digest(supplied, known.encode("utf-8")):
+                    matched = consumer
         if matched is None:
             return None
         return AccessToken(
@@ -187,6 +475,63 @@ class ConsumerTokenVerifier(TokenVerifier):
             scopes=[REMOTE_SCOPE],
             expires_at=int(_now()) + _token_ttl_seconds(),
         )
+
+    def rotation_notice(self) -> str | None:
+        """Return the operator notice for any open rotation window, else ``None``.
+
+        A window is a consumer holding more than one currently-valid token.
+        The steady state is silent on purpose: a notice printed on every start
+        is a notice operators stop reading, at which point the one that
+        matters — "you left a window open three months ago" — goes unread too.
+        A consumer holding exactly one token is therefore not named.
+
+        The message is built from consumer **names and counts only**, so it
+        cannot echo a secret by construction. It is printed at startup, which
+        means it lands in logs, terminals and process supervisors: the same
+        audience, and the same reason, as the #838 refusal message.
+
+        Returns:
+            A message naming every consumer mid-rotation and how many tokens
+            it holds, or ``None`` when no consumer holds more than one.
+        """
+        windows = [
+            (consumer, len(configured))
+            for consumer, configured in self._tokens.items()
+            if len(configured) > _SETTLED_TOKEN_COUNT
+        ]
+        if not windows:
+            return None
+        held = "; ".join(
+            f"{consumer} holds {count} tokens" for consumer, count in windows
+        )
+        return (
+            f"{CONSUMER_TOKENS_ENV}: rotation window open — {held}. "
+            "Each of those tokens authenticates as its consumer for as long as "
+            "it stays configured; drop the retired secret and restart once the "
+            "consumer has redeployed."
+        )
+
+
+def announce_rotation_window(verifier: ConsumerTokenVerifier) -> None:
+    """Print *verifier*'s rotation notice to stderr, when it has one (#895).
+
+    **stderr, never stdout**, on both entry points that call this, for two
+    independent reasons: ``creek-tools-mcp``'s stdio transport owns stdout for
+    JSON-RPC framing, and ``creek-tools-api --print-openapi`` writes a
+    machine-readable document there that consumers pipe into client
+    generators. A notice on stdout would corrupt the first and break every
+    pipe consuming the second — for exactly the operators who are mid-rotation
+    and least able to afford a second broken thing.
+
+    Shared by the two adapters rather than written twice, so that stream
+    decision cannot hold on one entry point and lapse on the other.
+
+    Args:
+        verifier: The verifier the adapter is about to serve behind.
+    """
+    notice = verifier.rotation_notice()
+    if notice is not None:
+        print(notice, file=sys.stderr)
 
 
 def remote_auth_settings() -> AuthSettings:

--- a/creek-tools/creek_mcp/server.py
+++ b/creek-tools/creek_mcp/server.py
@@ -36,6 +36,7 @@ from creek_mcp.policy import (
 from creek_mcp.remote_auth import (
     CONSUMER_TOKENS_ENV,
     ConsumerTokenVerifier,
+    announce_rotation_window,
     load_consumer_tokens,
     remote_auth_settings,
 )
@@ -955,9 +956,15 @@ def main(argv: list[str] | None = None) -> None:
     Startup is fail-closed four times over. On *every* transport it refuses
     an elevated token below the minimum-strength floor (#907). The network
     branch additionally refuses to start without per-consumer tokens (no
-    anonymous access), refuses a configured consumer token below the same
-    floor (#838), and refuses a non-loopback bind unless TLS is configured
-    (no cleartext bearer tokens, #837).
+    anonymous access), refuses a consumer-token configuration the parser
+    cannot read unambiguously — a token below the same floor (#838), a
+    consumer named twice, a token value shared by two consumers (#895) — and
+    refuses a non-loopback bind unless TLS is configured (no cleartext bearer
+    tokens, #837).
+
+    Having started, the network branch *announces* on stderr any consumer
+    holding more than one currently-valid token, so an open rotation window
+    is visible rather than permanent (#895).
 
     Args:
         argv: Optional list of command-line arguments. When ``None``
@@ -978,8 +985,11 @@ def main(argv: list[str] | None = None) -> None:
         try:
             tokens = load_consumer_tokens()
         except ValueError as exc:
-            # A configured token is below the minimum-strength floor (#838):
-            # exit with the rotation recipe rather than serve a weak secret.
+            # An unreadable consumer-token configuration: a token below the
+            # minimum-strength floor (#838), a consumer named twice, or one
+            # token value configured for two consumers (#895). Exit naming the
+            # setting to fix rather than serve a weak or ambiguous registry;
+            # no such message ever carries a token value.
             parser.error(str(exc))
         if not tokens:
             # No anonymous access: refuse to expose the vault without per-consumer
@@ -989,7 +999,12 @@ def main(argv: list[str] | None = None) -> None:
                 "(consumer=token pairs); refusing to serve without authentication"
             )
         _require_transport_confidentiality(parser, args)
-        server = build_server(token_verifier=ConsumerTokenVerifier(tokens))
+        verifier = ConsumerTokenVerifier(tokens)
+        # A rotation window has to be closed again, and an operator who cannot
+        # see one is open will not close it (#895). On stderr: stdout on this
+        # entry point belongs to the stdio transport's JSON-RPC framing.
+        announce_rotation_window(verifier)
+        server = build_server(token_verifier=verifier)
         server.settings.host = args.host
         server.settings.port = args.port
         _serve_network(server, args)

--- a/creek-tools/docs/api.md
+++ b/creek-tools/docs/api.md
@@ -94,7 +94,7 @@ lock-step, which is what this epic exists to prevent.
 
 | Variable | Meaning |
 |---|---|
-| `CREEK_MCP_CONSUMER_TOKENS` | `consumer=token` pairs, `;`-separated. Required — there is no anonymous access. |
+| `CREEK_MCP_CONSUMER_TOKENS` | `consumer=token` entries, `;`-separated; a consumer's value may itself be a `,`-separated set of currently-valid tokens (`adepthood=<old>,<new>`) while rotating a secret (#895). Required — there is no anonymous access. |
 | `CREEK_MCP_TOKEN_TTL_SECONDS` | Lifetime stamped on a verified token (default 3600). |
 | `CREEK_CONFIG` | Path to `creek_config.yaml` (also settable with `--config`). |
 
@@ -111,11 +111,25 @@ Generate and rotate:
 python -c "import secrets; print(secrets.token_urlsafe(32))"
 ```
 
-**Rotation is the only logout.** `CREEK_MCP_TOKEN_TTL_SECONDS` bounds how long
-an individually captured `AccessToken` object stays valid; it does **not** revoke
-the underlying shared secret, because the bearer is re-verified and re-issued on
-every request. To revoke a consumer, remove or replace its entry in
-`CREEK_MCP_CONSUMER_TOKENS` and restart.
+**Revocation and rotation are different operations, and both end in a
+restart.** `CREEK_MCP_TOKEN_TTL_SECONDS` bounds how long an individually
+captured `AccessToken` object stays valid; it does **not** revoke the
+underlying shared secret, because the bearer is re-verified and re-issued on
+every request.
+
+- **Revocation** is immediate and hard: remove a consumer's entry (or a
+  single token from its `,`-separated set) from `CREEK_MCP_CONSUMER_TOKENS`
+  and restart. The credential stops working the moment the restarted process
+  is serving — there is no overlap and no grace period.
+- **Rotation** replaces a secret without downtime by holding two
+  currently-valid tokens for one consumer at once (`adepthood=<old>,<new>`)
+  while the consumer redeploys onto the new one, then dropping the old one.
+  It still costs two restarts, but the consumer is never locked out
+  mid-swap. Follow the numbered runbook in
+  [`docs/mcp.md`](mcp.md#rotating-a-consumers-secret-no-downtime); see also
+  [ADR-0009](architecture/ADR/0009-mcp-consumer-token-rotation.md) for why
+  the credential is still a static, long-lived secret rather than something
+  short-lived.
 
 ### The authenticated consumer *is* the audit identity
 

--- a/creek-tools/docs/architecture/ADR/0009-mcp-consumer-token-rotation.md
+++ b/creek-tools/docs/architecture/ADR/0009-mcp-consumer-token-rotation.md
@@ -1,0 +1,165 @@
+# ADR-0009: MCP consumer token rotation — overlapping static tokens, not short-lived credentials
+
+- **Status**: Accepted
+- **Date**: 2026-08-09
+- **Driving issue**: #895 (P1, security). Builds on #759 (per-consumer bearer
+  auth for the network transport), #837 (verified-token TTL), #838 / #907
+  (shared 32-char entropy floor).
+
+## Context
+
+`CREEK_MCP_CONSUMER_TOKENS` maps each remote consumer (Adepthood, in
+practice) to one static bearer secret. Rotating that secret was a hard
+cutover: swap the value, restart, and every instance of the consumer still
+holding the old token loses access until it redeploys with the new one.
+There was no way to widen the credential and then narrow it — only replace.
+
+The #837 TTL stamped on a verified `AccessToken` does not help here. It
+bounds how long one *captured* token object stays valid after
+`verify_token` issues it; it says nothing about the *configured* secret,
+which the SDK's bearer middleware re-checks against `verify_token` fresh on
+every request. A consumer that keeps presenting the same configured value is
+re-verified indefinitely. Confusing the two — reading the TTL as a rotation
+mechanism — is exactly the gap #895 exists to close.
+
+A fix had to satisfy three things at once: it could not require the
+Adepthood client to change what it puts on the wire (a coordinated
+cross-repo change is out of scope for a P1 fix landing in this repo), it
+could not weaken the existing entropy floor (#838) or the constant-time,
+never-short-circuiting comparison the verifier already does, and it had to
+make an operator's rotation *safe by construction* rather than merely
+possible if done carefully.
+
+## Decision
+
+A consumer maps to an **ordered set of currently-valid tokens**, not a
+single token. The wire format for `CREEK_MCP_CONSUMER_TOKENS` gains one new
+separator: a `,`-separated list inside one consumer's entry —
+`adepthood=<old>,<new>` — names every token that currently authenticates as
+that consumer. A single-token entry is unchanged and is the steady state; an
+operator who never rotates anything sees no difference.
+
+Rotation is then: widen the set (add the new token alongside the old),
+restart, let the consumer redeploy onto the new token, narrow the set back
+to one (drop the old token), restart again. No cutover moment exists —
+both tokens work throughout the window — and the window closes by an
+explicit, later action rather than by an initial swap. The
+`docs/mcp.md` network-transport section carries the numbered, copy-pasteable
+version of these steps as the operational contract this decision commits to;
+an ADR that only describes the shape of a runbook without publishing it
+would not actually fix the operational hazard #895 reports.
+
+Two configurations that this widened grammar makes *possible* are refused at
+load time rather than silently resolved, because both previously had a
+silent-but-wrong behaviour and now have an available syntax for what the
+operator actually means:
+
+- **A consumer named twice** (`adepthood=a;adepthood=b`) used to have the
+  second entry silently overwrite the first — discarding a credential the
+  operator believed was live. Now that a consumer can legitimately hold
+  several tokens, the alternative reading (accumulate both entries) is
+  exactly as wrong: it invents a rotation window nobody asked for. Both
+  readings rewrite intent, so this is refused and the error names the
+  supported comma spelling.
+- **One token value configured for more than one consumer** — across two
+  consumers, or twice within one consumer's set — is refused because
+  `ConsumerTokenVerifier.verify_token` scans every configured token without
+  breaking early (a deliberate anti-timing-oracle property) and keeps the
+  *last* match. A shared value would therefore audit a call under whichever
+  consumer the scan happens to visit last, which is a wrong identity on the
+  audit log, not just a redundant configuration.
+
+Startup announces, on stderr, the name and token count of every consumer
+holding more than one token — never a value — so an open rotation window is
+visible in logs, terminals, and process supervisors rather than a fact only
+the environment variable itself remembers. The 32-character floor from #838
+applies to every token in a set, not only the first, because a rotation is
+exactly the moment a fresh secret is typed in.
+
+## Rejected
+
+- **Short-lived derived credentials.** Instead of a static secret, mint a
+  time-boxed, HMAC-signed credential from the configured secret (as OAuth
+  bearer/refresh pairs or signed capability tokens do), so a leaked
+  credential expires on its own. This is the more thorough fix and is not
+  dismissed on its merits — it is **deferred**, because it changes what the
+  Adepthood client puts on the wire: today's client sends the configured
+  secret verbatim as a bearer token, and a derived-credential scheme would
+  require it to first exchange that secret for a short-lived one (a token
+  endpoint, a refresh flow, or equivalent). That is a coordinated
+  client-contract change across two repositories, which cannot ride inside a
+  P1 security fix landing unilaterally in `creek-tools`. This ADR is the
+  record of why it was set aside rather than silently forgotten: the
+  short-lived-credential path is real future work, scoped as a coordinated
+  change with the Adepthood client, and is tracked as **#1267** (P2,
+  `follow-up` / `scan:security`) rather than folded into #895.
+- **Per-token expiry timestamps in the env grammar** (for example
+  `adepthood=<token>@<unix-ts>`). This would let a rotation window close
+  itself without a second restart, which is attractive on its face. It was
+  rejected because it adds a **clock-dependent refusal path**: a token
+  parsed as "expired" on a host with a skewed clock, or restored from a
+  stale backup of the env file, silently drops a consumer's access with no
+  local signal beyond a 401 the operator has to go debug — trading a
+  visible, operator-driven revocation step for an invisible, clock-driven
+  one. The chosen design keeps every expiry decision an explicit, restart-
+  gated operator action instead.
+- **An ADR that accepts the status quo.** Recording "this is a known
+  limitation, no change" was on the table only in the sense that doing
+  nothing is always an option. It is rejected outright: #895 is a P1
+  security item because the previous design had no non-disruptive rotation
+  path at all, and a decision record that ratifies the absence of a fix is
+  not a decision, it is a non-fix wearing a decision's format.
+
+## Consequences
+
+- **Positive**: a consumer's secret can be rotated with no downtime and no
+  window where the consumer is locked out; a repeated consumer name and a
+  shared token value — both previously silent misconfigurations — are now
+  load-time errors; the 32-character floor and the constant-time,
+  non-short-circuiting comparison are preserved unchanged for every token in
+  a set, not weakened to accommodate the set.
+- **Negative, stated plainly**:
+  - The credentials are still **static, long-lived secrets** copied into an
+    environment variable. This decision does not make them short-lived,
+    does not add signing or scoping beyond what existed, and does not
+    change the trust model of the network transport.
+  - **Revocation still requires an env edit and a restart.** Nothing here
+    adds revocation-without-restart; a consumer's access cannot be pulled
+    instantly without stopping the process that serves it.
+  - **The rotation window is operator-bounded, not system-bounded.** Widening
+    a token set is the only automatic part; narrowing it back to one is a
+    manual pair of steps (steps 5–6 of the runbook — step 5 edits the
+    environment variable, and **step 6, the second restart, is what actually
+    revokes the retired secret**) that nothing enforces. An operator
+    who runs the widening restart and never runs the narrowing one has
+    **permanently** widened the consumer's valid-credential set — the old
+    token keeps authenticating indefinitely. The startup rotation notice is
+    the only pressure against that outcome; it is a reminder, not a
+    guardrail, and an operator who stops reading startup logs loses it.
+  - **Global token-value uniqueness is now mandatory.** An operator who was
+    (knowingly or not) relying on one value covering two consumer names —
+    or two entries for one consumer, where the second silently won — must
+    now give each consumer its own distinct token(s); the old configuration
+    fails closed at startup rather than serving with a surprising identity
+    mapping.
+  - **A repeated consumer name is now a hard startup error** where it was
+    previously accepted and silently resolved (by overwrite). Any deployment
+    script that regenerated `CREEK_MCP_CONSUMER_TOKENS` by naive
+    concatenation, relying on the last write winning, now fails fast instead
+    of quietly keeping only its last entry.
+
+## Revisit when
+
+- The Adepthood client contract is renegotiated for another reason (a new
+  auth scheme, a token-exchange endpoint, a move off bearer-in-env
+  entirely). At that point, re-open **#1267** — the deferred
+  short-lived-derived-credential option above — rather than adding it as an
+  unplanned addendum to a static scheme.
+- An operator incident traces back to a rotation window left open past its
+  intended lifetime — the deferred risk this ADR names explicitly under
+  "Negative" above — which would argue for the window to be system-enforced
+  (a maximum-age refusal, for example) rather than only operator-remembered.
+- A regulatory or product requirement demands revocation-without-restart.
+  That is a materially different transport/verification design (likely
+  requiring the derived-credential path above) and would be its own ADR, not
+  an amendment to this one.

--- a/creek-tools/docs/mcp.md
+++ b/creek-tools/docs/mcp.md
@@ -498,11 +498,16 @@ Adepthood backend, the server also serves an **authenticated
 streamable-http** transport:
 
 ```bash
-# Generate each consumer token as high-entropy hex, once, per consumer:
-#   python -c "import secrets; print(secrets.token_hex(32))"
-export CREEK_MCP_CONSUMER_TOKENS="adepthood=<secrets.token_hex(32)>;other=<token>"
+# Generate each consumer token as a high-entropy secret, once, per consumer:
+#   python -c "import secrets; print(secrets.token_urlsafe(32))"
+export CREEK_MCP_CONSUMER_TOKENS="adepthood=<token>;other=<token>"
 creek-tools-mcp --transport network --host 127.0.0.1 --port 8000
 ```
+
+A consumer mid-rotation lists more than one currently-valid token,
+comma-separated, inside its own entry — `adepthood=<current>,<incoming>` — see
+"Rotating a consumer's secret" below. A single-token entry, as above, is the
+steady state and parses exactly as it did before #895.
 
 ### TLS is enforced for non-loopback binds (#837)
 
@@ -528,14 +533,28 @@ that happens to resolve to `127.0.0.1`, e.g. via `/etc/hosts`) is treated as
 routable by design and requires TLS.
 
 - **No anonymous access.** Network mode refuses to start unless
-  `CREEK_MCP_CONSUMER_TOKENS` is set. It holds `consumer=token` pairs,
+  `CREEK_MCP_CONSUMER_TOKENS` is set. It holds `consumer=token` entries,
   `;`-separated; tokens live in the **environment only** (never in code or
   config), mirroring the `CREEK_MCP_ELEVATED_TOKEN` precedent. Generate each
-  token as high-entropy hex — `secrets.token_hex(32)` — so a token is never
+  token high-entropy — `secrets.token_urlsafe(32)` — so a token is never
   guessable; the constant-time comparison only matters against a strong secret.
   A configured token below 32 characters is refused at startup, the same
   floor `CREEK_MCP_ELEVATED_TOKEN` now enforces (#907) — both surfaces share
   one minimum defined once in `creek_mcp/token_policy.py`.
+- **A consumer may hold more than one currently-valid token (#895).** A
+  `,`-separated list inside one consumer's entry — `adepthood=<old>,<new>` —
+  names an *ordered set* of tokens that all currently authenticate as that
+  consumer. A single token, as in the example above, is the unrotated steady
+  state and parses exactly as it did before this change. The 32-character
+  floor applies to every token in the set, not just the first, because a
+  rotation is exactly when a fresh secret gets typed in. Two configurations
+  are refused at load time rather than silently resolved: naming the same
+  consumer twice (`adepthood=a;adepthood=b` — the second entry no longer
+  silently overwrites the first) and configuring the same token value more
+  than once, whether inside one consumer's set or across two consumers —
+  every token value must be **globally unique**, because a shared value would
+  be attributed to whichever consumer the verifier happens to scan last,
+  auditing the call under the wrong identity.
 - **Per-consumer identity.** Each request must present its bearer token
   (`Authorization: Bearer <token>`). The token maps to a consumer name that
   is stamped on every audit-log entry — so remote calls are attributable the
@@ -551,8 +570,14 @@ routable by design and requires TLS.
   same configured `CREEK_MCP_CONSUMER_TOKENS` secret is re-verified and
   granted a fresh `AccessToken`/`expires_at` on each call; the TTL bounds how
   long any *individually captured* `AccessToken` (e.g. one logged or cached
-  outside the server) would remain valid, not how often the underlying
-  shared secret must be rotated.
+  outside the server) would remain valid. It does **not** bound the
+  configured secret itself and it is not a rotation mechanism — a consumer
+  that keeps presenting a value from `CREEK_MCP_CONSUMER_TOKENS` is
+  re-verified indefinitely. Dropping a token from the set and restarting is
+  what revokes it; see "Rotating a consumer's secret" below, and
+  [ADR-0009](architecture/ADR/0009-mcp-consumer-token-rotation.md) for why
+  overlapping static tokens, rather than short-lived derived credentials, is
+  the shape of that runbook.
 - **A consumer token grants remote _write_ access, by design.** A valid
   `CREEK_MCP_CONSUMER_TOKENS` entry can reach every non-purge tool at or below
   the `personal` ceiling — including the **write** tools (`creek.journal`,
@@ -596,6 +621,54 @@ routable by design and requires TLS.
   audit log from the same `CallerIdentity`, and `_effective_consumer` in
   `creek_mcp/server.py` is now MCP's thin adapter over it, unchanged in
   behaviour.
+
+### Rotating a consumer's secret (no downtime)
+
+Rotation widens a consumer's token set so the old and new secrets both work,
+lets the consumer redeploy onto the new one, then narrows the set back to
+one. Two restarts bound the window, and **the window is not closed until the
+second restart runs** — until then the retired secret still authenticates as
+that consumer, exactly like the new one.
+
+1. Generate a fresh token for the consumer being rotated:
+   ```bash
+   python -c "import secrets; print(secrets.token_urlsafe(32))"
+   ```
+2. Add it alongside the consumer's current token in
+   `CREEK_MCP_CONSUMER_TOKENS`, comma-separated, current value first:
+   ```bash
+   export CREEK_MCP_CONSUMER_TOKENS="adepthood=<current>,<new>;other=<token>"
+   ```
+3. Restart **every** process that reads this variable — `creek-tools-mcp`,
+   `creek-tools-api`, or both, if the host runs the two adapters side by side.
+   They share one registry, so a process that was not restarted is still
+   serving the pre-edit set. Startup prints a
+   rotation notice to stderr naming `adepthood` and its token count — that
+   notice is the reminder that a window is open, not a one-time line to
+   dismiss. From this restart on, both `<current>` and `<new>` authenticate
+   as `adepthood`.
+4. Redeploy the consumer onto `<new>` and confirm *at the consumer* that it
+   is presenting the new token. (The audit log at
+   `<vault>/00-Creek-Meta/audit/mcp.jsonl` attributes every call to
+   `adepthood` regardless of which token authenticated it, so it cannot tell
+   you which one is in use — check the consumer's own configuration.)
+5. Remove `<current>` from `CREEK_MCP_CONSUMER_TOKENS`, leaving only `<new>`:
+   ```bash
+   export CREEK_MCP_CONSUMER_TOKENS="adepthood=<new>;other=<token>"
+   ```
+6. Restart again — every process you restarted in step 3, not just one of
+   them. **This step is not optional.** Until it runs, `<current>` still
+   authenticates as `adepthood` on any process still holding the widened set,
+   and the rotation notice keeps firing at that process's every startup as a
+   reminder. This second restart is the only thing that actually revokes the
+   retired secret — nothing else in this system does.
+
+Skipping step 6 does not fail loudly; it leaves a permanently widened
+credential set that keeps working indefinitely. The startup notice is the
+only pressure against that, so treat it as an open task, not a status line.
+See [ADR-0009](architecture/ADR/0009-mcp-consumer-token-rotation.md) for why
+this overlapping-token runbook, rather than short-lived derived credentials,
+is the shape of rotation today.
 
 The transport is a thin wrapper around the MCP SDK's `TokenVerifier` /
 streamable-http app; the tool registry, tier-ceiling rules, and hash-chained

--- a/creek-tools/tests/test_mcp_remote.py
+++ b/creek-tools/tests/test_mcp_remote.py
@@ -23,6 +23,16 @@ Security properties under test:
   shorter than 32 chars fails ``load_consumer_tokens`` (and the network
   transport, via ``parser.error``) with a rotation recipe that names the
   consumer and lengths but never echoes the token value.
+- **Rotation needs no cutover** (#895) — a consumer may hold an *ordered set* of
+  currently-valid tokens, so the old and the new secret both authenticate for as
+  long as the operator leaves the window open, and dropping the old one revokes
+  it on the very next request. The configuration is refused outright for a
+  repeated consumer name (previously a silent last-wins), for a token value
+  reused anywhere in the configuration, and for a bare ``str`` map value —
+  ``str`` is itself a ``Sequence[str]``, so one would otherwise be read as one
+  single-character token per letter, each of which ``compare_digest`` accepts.
+  ``rotation_notice()`` tells the operator which consumers are mid-rotation, by
+  name and count only, so it cannot echo a value by construction.
 
 No real/production token material is hardcoded — every token is a test literal.
 """
@@ -53,7 +63,7 @@ from creek_mcp.remote_auth import (
 from creek_mcp.server import build_server, main
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator, Mapping, Sequence
     from pathlib import Path
 
     from mcp.server.fastmcp import FastMCP
@@ -94,26 +104,71 @@ def _fake_token(consumer: str) -> AccessToken:
 _STRONG_TOKEN = "unit-test-strong-token-" + "a" * 20
 
 
+def _window_token(tag: str) -> str:
+    """Return a distinct, floor-clearing test token tagged with *tag* (#895).
+
+    The rotation-window tests need several tokens that differ from each other
+    and from :data:`_STRONG_TOKEN`, and all of which clear the 32-char floor so
+    a rotation test never trips the length gate by accident. Spelled as a
+    concatenation, matching the convention above, so a secret scanner reads a
+    constructed string rather than a credential.
+
+    Args:
+        tag: A short word distinguishing this token from its siblings.
+
+    Returns:
+        A constructed test string of at least 32 characters.
+    """
+    return f"unit-test-{tag}-token-" + "x" * 24
+
+
+# The rotation-window cast. Every one is a test literal, not a real credential.
+_OLD_TOKEN = _window_token("old")  # the secret being retired
+_NEW_TOKEN = _window_token("new")  # the secret replacing it
+_THIRD_TOKEN = _window_token("third")
+_FOURTH_TOKEN = _window_token("fourth")
+_FIFTH_TOKEN = _window_token("fifth")
+
+# 7 chars, well under the 32-char floor. Test literal, not a real credential.
+_WEAK_TOKEN = "hunter2"
+
+_ALL_TEST_TOKENS = (
+    _STRONG_TOKEN,
+    _OLD_TOKEN,
+    _NEW_TOKEN,
+    _THIRD_TOKEN,
+    _FOURTH_TOKEN,
+    _FIFTH_TOKEN,
+    _WEAK_TOKEN,
+)
+"""Every token literal a refusal message or a notice must never echo."""
+
+
 # --------------------------------------------------------------------------- #
 # load_consumer_tokens — parsing
 # --------------------------------------------------------------------------- #
 
 
 def test_load_consumer_tokens_parses_pairs() -> None:
-    """Well-formed ``consumer=token`` pairs parse into a map."""
+    """Well-formed ``consumer=token`` pairs parse into a map.
+
+    Today's single-token format is unchanged on the wire and now lands as a
+    one-element tuple (#895), so an operator who has never rotated anything
+    parses exactly as before.
+    """
     adepthood_token = "adepthood-strong-token-" + "a" * 20  # 43 chars, test literal
     crawdad_token = "crawdad-strong-token-" + "b" * 20  # 41 chars, test literal
     env = {CONSUMER_TOKENS_ENV: f"adepthood={adepthood_token};crawdad={crawdad_token}"}
     assert load_consumer_tokens(env) == {
-        "adepthood": adepthood_token,
-        "crawdad": crawdad_token,
+        "adepthood": (adepthood_token,),
+        "crawdad": (crawdad_token,),
     }
 
 
 def test_load_consumer_tokens_skips_blank_and_tokenless_entries() -> None:
     """Blank segments and ``name=`` entries with no token are dropped."""
     env = {CONSUMER_TOKENS_ENV: f" adepthood = {_STRONG_TOKEN} ; ; missing= ;=orphan"}
-    assert load_consumer_tokens(env) == {"adepthood": _STRONG_TOKEN}
+    assert load_consumer_tokens(env) == {"adepthood": (_STRONG_TOKEN,)}
 
 
 def test_load_consumer_tokens_rejects_sub_minimum_token() -> None:
@@ -132,25 +187,147 @@ def test_load_consumer_tokens_rejects_sub_minimum_token() -> None:
 def test_load_consumer_tokens_accepts_minimum_length_token() -> None:
     """A token at or above the 32-char minimum is accepted and returned intact."""
     env = {CONSUMER_TOKENS_ENV: f"adepthood={_STRONG_TOKEN}"}
-    assert load_consumer_tokens(env) == {"adepthood": _STRONG_TOKEN}
+    assert load_consumer_tokens(env) == {"adepthood": (_STRONG_TOKEN,)}
 
 
 def test_load_consumer_tokens_accepts_exact_boundary_token() -> None:
     """A token of exactly 32 chars sits on the floor and is accepted."""
     boundary_token = "a" * 32
     env = {CONSUMER_TOKENS_ENV: f"adepthood={boundary_token}"}
-    assert load_consumer_tokens(env) == {"adepthood": boundary_token}
+    assert load_consumer_tokens(env) == {"adepthood": (boundary_token,)}
 
 
 def test_load_consumer_tokens_skips_blanks_without_raising() -> None:
     """Blank and bare ``name=`` entries stay silently skipped, not length-checked."""
     env = {CONSUMER_TOKENS_ENV: f";;missing=;=orphan;adepthood={_STRONG_TOKEN}"}
-    assert load_consumer_tokens(env) == {"adepthood": _STRONG_TOKEN}
+    assert load_consumer_tokens(env) == {"adepthood": (_STRONG_TOKEN,)}
 
 
 def test_load_consumer_tokens_empty_when_unset() -> None:
     """An unset env var yields an empty map (caller treats as 'network denied')."""
     assert load_consumer_tokens({}) == {}
+
+
+# --------------------------------------------------------------------------- #
+# load_consumer_tokens — the rotation window (#895)
+#
+# One consumer, several currently-valid tokens, comma-separated inside its own
+# ``consumer=`` segment. The ``;`` separator still means "next consumer"; the
+# ``,`` separator means "another token this same consumer may present".
+# --------------------------------------------------------------------------- #
+
+
+def test_load_consumer_tokens_parses_an_ordered_token_set() -> None:
+    """``adepthood=old,new`` yields both tokens, in configured order.
+
+    Order is asserted with a tuple rather than a set: the configured order is
+    the operator's statement of which secret is the incumbent and which is the
+    replacement, and it is what a notice or a future report would read.
+    """
+    env = {CONSUMER_TOKENS_ENV: f"adepthood={_OLD_TOKEN},{_NEW_TOKEN}"}
+    assert load_consumer_tokens(env) == {"adepthood": (_OLD_TOKEN, _NEW_TOKEN)}
+
+
+def test_load_consumer_tokens_strips_whitespace_around_comma_segments() -> None:
+    """Whitespace around a comma is operator formatting, never token material.
+
+    The single-token form already strips, so a multi-token form that did not
+    would silently produce a token nobody can present.
+    """
+    env = {CONSUMER_TOKENS_ENV: f"adepthood= {_OLD_TOKEN} , {_NEW_TOKEN} "}
+    assert load_consumer_tokens(env) == {"adepthood": (_OLD_TOKEN, _NEW_TOKEN)}
+
+
+def test_load_consumer_tokens_drops_empty_comma_segments() -> None:
+    """A doubled or trailing comma leaves no empty token behind.
+
+    Dropping has to happen *before* the length floor runs, or a trailing comma
+    would be reported to the operator as a zero-character token.
+    """
+    env = {CONSUMER_TOKENS_ENV: f"adepthood={_OLD_TOKEN},,{_NEW_TOKEN},"}
+    assert load_consumer_tokens(env) == {"adepthood": (_OLD_TOKEN, _NEW_TOKEN)}
+
+
+def test_load_consumer_tokens_skips_a_consumer_whose_segments_are_all_empty() -> None:
+    """``missing=,,`` is the multi-token spelling of ``missing=``: skipped, not raised.
+
+    The single-token parser already skips ``name=`` silently; the comma form
+    must reach the same verdict rather than registering a consumer with no
+    tokens (which the verifier refuses outright).
+    """
+    env = {CONSUMER_TOKENS_ENV: f"missing=,,;adepthood={_STRONG_TOKEN}"}
+    assert load_consumer_tokens(env) == {"adepthood": (_STRONG_TOKEN,)}
+
+
+def test_load_consumer_tokens_applies_the_floor_to_every_token() -> None:
+    """The 32-char floor is per comma segment — one weak token in a set still raises.
+
+    A rotation is exactly when a fresh secret gets typed in, so the floor has to
+    hold on the *new* token and not only on whichever one happens to be first.
+    The message names the consumer, the observed and required lengths and the
+    rotation recipe, and echoes neither of the two configured values.
+    """
+    env = {CONSUMER_TOKENS_ENV: f"adepthood={_STRONG_TOKEN},{_WEAK_TOKEN}"}
+    with pytest.raises(ValueError, match="adepthood") as excinfo:
+        load_consumer_tokens(env)
+    message = str(excinfo.value)
+    assert "'adepthood'" in message  # consumer named via repr
+    assert "7" in message  # observed length of the rejected token
+    assert "32" in message  # the enforced minimum
+    assert "secrets.token_urlsafe(32)" in message  # the rotation recipe
+    assert _WEAK_TOKEN not in message  # NEVER echo the token value
+    assert _STRONG_TOKEN not in message  # nor the compliant one beside it
+
+
+def test_load_consumer_tokens_rejects_a_repeated_consumer_name() -> None:
+    """``adepthood=a;adepthood=b`` is a loud error, never a silent last-wins.
+
+    The pre-#895 parser wrote both entries into one dict key, so the first
+    token vanished without a word. Now that a consumer can legitimately hold
+    several tokens, either silent reading is indefensible: overwriting throws
+    away a credential the operator believes is live, and accumulating quietly
+    invents a rotation window they never asked for. The message names the
+    consumer and points at the comma form that expresses the intent properly.
+    """
+    env = {CONSUMER_TOKENS_ENV: f"adepthood={_OLD_TOKEN};adepthood={_NEW_TOKEN}"}
+    with pytest.raises(ValueError, match="adepthood") as excinfo:
+        load_consumer_tokens(env)
+    message = str(excinfo.value)
+    assert "adepthood" in message
+    assert "comma" in message.lower()  # the supported spelling is named
+    assert _OLD_TOKEN not in message  # NEVER echo the token value
+    assert _NEW_TOKEN not in message
+
+
+def test_load_consumer_tokens_rejects_a_value_shared_by_two_consumers() -> None:
+    """One secret configured for two consumers destroys attribution, so it is refused.
+
+    ``verify_token`` scans every consumer without breaking, so a shared value
+    resolves to whichever consumer the scan saw last — every audit line that
+    call produced would then name the wrong caller. The message names both
+    consumers and never the value they share.
+    """
+    env = {CONSUMER_TOKENS_ENV: f"adepthood={_OLD_TOKEN};crawdad={_OLD_TOKEN}"}
+    with pytest.raises(ValueError) as excinfo:
+        load_consumer_tokens(env)
+    message = str(excinfo.value)
+    assert "adepthood" in message
+    assert "crawdad" in message
+    assert _OLD_TOKEN not in message  # NEVER echo the token value
+
+
+def test_load_consumer_tokens_rejects_a_value_repeated_within_one_consumer() -> None:
+    """A duplicate inside one set is a rotation that rotated nothing.
+
+    Same rule and same message as the cross-consumer case: every configured
+    token value is globally unique, stated once so the two cannot drift.
+    """
+    env = {CONSUMER_TOKENS_ENV: f"adepthood={_OLD_TOKEN},{_OLD_TOKEN}"}
+    with pytest.raises(ValueError, match="adepthood") as excinfo:
+        load_consumer_tokens(env)
+    message = str(excinfo.value)
+    assert "adepthood" in message
+    assert _OLD_TOKEN not in message  # NEVER echo the token value
 
 
 # --------------------------------------------------------------------------- #
@@ -160,7 +337,7 @@ def test_load_consumer_tokens_empty_when_unset() -> None:
 
 def test_verify_token_returns_access_token_for_valid_bearer() -> None:
     """A known token resolves to its consumer's :class:`AccessToken`."""
-    verifier = ConsumerTokenVerifier({"adepthood": "secret123"})
+    verifier = ConsumerTokenVerifier({"adepthood": ("secret123",)})
     token = asyncio.run(verifier.verify_token("secret123"))
     assert token is not None
     assert token.client_id == "adepthood"
@@ -169,7 +346,7 @@ def test_verify_token_returns_access_token_for_valid_bearer() -> None:
 
 def test_verify_token_rejects_unknown_bearer() -> None:
     """An unknown token yields ``None`` (401 at the middleware)."""
-    verifier = ConsumerTokenVerifier({"adepthood": "secret123"})
+    verifier = ConsumerTokenVerifier({"adepthood": ("secret123",)})
     assert asyncio.run(verifier.verify_token("wrong")) is None
 
 
@@ -181,7 +358,7 @@ def test_verify_token_rejects_against_empty_map() -> None:
 
 def test_verify_token_rejects_non_ascii_bearer_cleanly() -> None:
     """A non-ASCII bearer is rejected (``None``), never a ``TypeError`` (#776)."""
-    verifier = ConsumerTokenVerifier({"adepthood": "secret123"})
+    verifier = ConsumerTokenVerifier({"adepthood": ("secret123",)})
     # hmac.compare_digest raises TypeError on a non-ASCII str; the byte-compare
     # must reject cleanly instead of crashing verification.
     assert asyncio.run(verifier.verify_token("nön-ascii-tökén")) is None
@@ -323,7 +500,7 @@ def test_streamable_http_rejects_unauthenticated_request(vault: Path) -> None:
     server = build_server(
         vault_path=vault,
         draft_llm_factory=lambda tier: lambda prompt: "ignored",
-        token_verifier=ConsumerTokenVerifier({"adepthood": "secret123"}),
+        token_verifier=ConsumerTokenVerifier({"adepthood": ("secret123",)}),
     )
     client = TestClient(server.streamable_http_app())
     path = server.settings.streamable_http_path
@@ -359,7 +536,7 @@ def _network_server(vault: Path, token: str) -> FastMCP:
     server = build_server(
         vault_path=vault,
         draft_llm_factory=lambda tier: lambda prompt: "ignored",
-        token_verifier=ConsumerTokenVerifier({"adepthood": token}),
+        token_verifier=ConsumerTokenVerifier({"adepthood": (token,)}),
     )
     server.settings.transport_security = TransportSecuritySettings(
         enable_dns_rebinding_protection=False
@@ -477,7 +654,7 @@ def _verified_token_at_fixed_now(monkeypatch: pytest.MonkeyPatch) -> AccessToken
     lands.
     """
     monkeypatch.setattr(remote_auth_mod, "_now", lambda: _FIXED_NOW)
-    verifier = ConsumerTokenVerifier({"adepthood": "secret123"})
+    verifier = ConsumerTokenVerifier({"adepthood": ("secret123",)})
     token = asyncio.run(verifier.verify_token("secret123"))
     assert token is not None
     return token
@@ -506,6 +683,318 @@ def test_token_ttl_invalid_env_falls_back_to_default(
     monkeypatch.setenv(_TOKEN_TTL_ENV, raw_ttl)
     token = _verified_token_at_fixed_now(monkeypatch)
     assert token.expires_at == 1_000_000 + _DEFAULT_TTL_SECONDS
+
+
+# --------------------------------------------------------------------------- #
+# ConsumerTokenVerifier — the rotation window (#895)
+#
+# The #837 TTL bounds a *captured* AccessToken object; it does nothing to the
+# wire credential, which the SDK's bearer middleware re-verifies fresh on every
+# request. Rotating that credential used to mean a hard cutover: swap the env
+# value, restart, and break every consumer still holding the old secret. A
+# consumer may now hold an ordered set of currently-valid tokens instead, so the
+# operator opens a window, lets consumers redeploy, and then closes it.
+#
+# The window is only a window if closing it works, so the revocation test below
+# is load-bearing: without it this feature is a permanent widening of the
+# credential surface wearing a rotation's clothes.
+# --------------------------------------------------------------------------- #
+
+
+def test_every_token_in_the_window_verifies_as_the_same_consumer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Old and new both authenticate, as one identity, each with a finite expiry.
+
+    Same ``client_id`` for both is the point: a window that changed the caller's
+    name for its duration would rewrite every audit line written while it was
+    open. ``expires_at`` is asserted exactly rather than as "not ``None``", so
+    the multi-token path cannot quietly issue the never-expiring token #837
+    removed.
+    """
+    monkeypatch.delenv(_TOKEN_TTL_ENV, raising=False)
+    monkeypatch.setattr(remote_auth_mod, "_now", lambda: _FIXED_NOW)
+    verifier = ConsumerTokenVerifier({"adepthood": (_OLD_TOKEN, _NEW_TOKEN)})
+    for presented in (_OLD_TOKEN, _NEW_TOKEN):
+        token = asyncio.run(verifier.verify_token(presented))
+        assert token is not None
+        assert token.client_id == "adepthood"
+        assert token.scopes == [REMOTE_SCOPE]
+        assert token.token == presented
+        assert token.expires_at == 1_000_000 + _DEFAULT_TTL_SECONDS
+
+
+def test_retiring_a_token_revokes_it_immediately(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dropping the old token from the set is what closes the window.
+
+    This is the assertion that makes the feature a *bounded* rotation rather
+    than a permanent widening of the credential surface: the retired secret
+    authenticates while it is configured and stops the moment it is not.
+    """
+    monkeypatch.setattr(remote_auth_mod, "_now", lambda: _FIXED_NOW)
+
+    during = ConsumerTokenVerifier({"adepthood": (_OLD_TOKEN, _NEW_TOKEN)})
+    assert asyncio.run(during.verify_token(_OLD_TOKEN)) is not None
+
+    after = ConsumerTokenVerifier({"adepthood": (_NEW_TOKEN,)})
+    assert asyncio.run(after.verify_token(_OLD_TOKEN)) is None
+    assert asyncio.run(after.verify_token(_NEW_TOKEN)) is not None
+
+
+def test_verifier_refuses_a_bare_string_token_value() -> None:
+    """A bare ``str`` map value is refused at runtime, not only by the type checker.
+
+    The signature is ``Mapping[str, Sequence[str]]`` and **not**
+    ``Mapping[str, str | Sequence[str]]``, because that union is unsound: ``str``
+    already *is* a ``Sequence[str]``, so the union collapses and mypy would wave
+    through ``{"adepthood": "secret123"}``. The runtime guard is the half that
+    protects a caller who never runs mypy — notably ``tests/v1_api_support.py``,
+    which builds verifiers from literal maps.
+    """
+    with pytest.raises(TypeError) as excinfo:
+        ConsumerTokenVerifier({"adepthood": _OLD_TOKEN})
+    message = str(excinfo.value)
+    assert "adepthood" in message  # the offending key is named
+    assert _OLD_TOKEN not in message  # NEVER echo the token value
+
+
+def test_a_single_character_of_a_configured_token_never_authenticates() -> None:
+    """The security complement of the guard above, observed rather than asserted.
+
+    Iterating a bare ``str`` value yields one single-character "token" per
+    letter, and ``compare_digest`` accepts each of them, so a 43-character
+    secret would degrade into an alphabet of valid credentials. Refusing the
+    bare string is the fix; this sweeps every distinct character of a correctly
+    configured token to show the consequence is really gone.
+    """
+    verifier = ConsumerTokenVerifier({"adepthood": (_OLD_TOKEN,)})
+    for character in sorted(set(_OLD_TOKEN)):
+        assert asyncio.run(verifier.verify_token(character)) is None
+
+
+def test_verifier_refuses_one_value_shared_by_two_consumers() -> None:
+    """Global token uniqueness is the *verifier's* rule, not only the parser's.
+
+    ``tests/v1_api_support.py`` and the wire tests in this module construct
+    verifiers directly from literal maps, never going through
+    ``load_consumer_tokens``, so the constructor is the narrowest ceiling this
+    invariant can sit under. Asserting it here rather than only at the parser
+    is what stops a direct caller from configuring an ambiguous identity.
+    """
+    with pytest.raises(ValueError) as excinfo:
+        ConsumerTokenVerifier({"adepthood": (_OLD_TOKEN,), "crawdad": (_OLD_TOKEN,)})
+    message = str(excinfo.value)
+    assert "adepthood" in message
+    assert "crawdad" in message
+    assert _OLD_TOKEN not in message  # NEVER echo the token value
+
+
+def test_verifier_refuses_an_empty_token_set_for_a_named_consumer() -> None:
+    """A named consumer holding no tokens authenticates nobody — say so, loudly.
+
+    Silently keeping the entry would leave a consumer in the configuration that
+    can never connect, which reads to an operator as an auth outage rather than
+    as the typo it is.
+    """
+    with pytest.raises(ValueError) as excinfo:
+        ConsumerTokenVerifier({"adepthood": ()})
+    assert "adepthood" in str(excinfo.value)
+
+
+def test_verifier_refuses_an_empty_iterable_that_is_not_a_sequence() -> None:
+    """The same refusal for an empty value that is *truthy* — pinning the ordering.
+
+    Not a second reading of the empty-tuple case above: ``()`` is falsy both
+    before and after materialisation, so it is refused under either ordering of
+    ``_token_set``'s emptiness check and cannot tell the two apart. An empty
+    iterable that is *not* a ``Sequence`` — a spent iterator, an exhausted
+    generator — is **truthy**, so it is only caught when the value is
+    materialised *before* it is tested. Under the reversed order it would slip
+    past the refusal and land as an empty tuple, leaving the named consumer
+    able to authenticate nobody: a silent auth outage in place of the loud
+    "can never authenticate" error. This pins that ordering, not the branch.
+    """
+    with pytest.raises(ValueError) as excinfo:
+        ConsumerTokenVerifier({"adepthood": iter(())})
+    assert "adepthood" in str(excinfo.value)
+
+
+def test_verifier_over_no_consumers_at_all_stays_legal() -> None:
+    """``ConsumerTokenVerifier({})`` is still constructible, and refuses everything.
+
+    "No consumers configured" is a different statement from "this consumer has
+    no tokens": the callers treat the empty map as *network mode denied* and
+    refuse to serve on it, so making the constructor raise would turn a handled
+    posture into a crash.
+    """
+    verifier = ConsumerTokenVerifier({})
+    assert verifier.rotation_notice() is None
+    assert asyncio.run(verifier.verify_token(_OLD_TOKEN)) is None
+
+
+def test_verify_token_compares_against_every_configured_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The scan never breaks early — not even when the very first token matches.
+
+    Newly load-bearing now the loop is nested consumer → tokens: a ``break`` on
+    either level would make verification time depend on *where* in the
+    configuration the presented token sits, which is a positional oracle over
+    the token set. Counted through ``remote_auth.hmac.compare_digest`` so the
+    property is measured rather than read off the source.
+
+    Args:
+        monkeypatch: Installs the counting wrapper over the real compare.
+    """
+    comparisons: list[tuple[bytes, bytes]] = []
+    real_compare = remote_auth_mod.hmac.compare_digest
+
+    def _counting(left: bytes, right: bytes) -> bool:
+        """Record the comparison, then delegate to the real constant-time one."""
+        comparisons.append((left, right))
+        return real_compare(left, right)
+
+    # Built before the patch, so only verification's own comparisons are counted.
+    verifier = ConsumerTokenVerifier(
+        {"adepthood": (_OLD_TOKEN, _NEW_TOKEN), "crawdad": (_THIRD_TOKEN,)}
+    )
+    monkeypatch.setattr(remote_auth_mod.hmac, "compare_digest", _counting)
+    token = asyncio.run(verifier.verify_token(_OLD_TOKEN))
+
+    assert token is not None
+    assert token.client_id == "adepthood"
+    # Three configured tokens across two consumers => three comparisons, even
+    # though the first one matched.
+    assert len(comparisons) == 3
+
+
+# --------------------------------------------------------------------------- #
+# rotation_notice — telling the operator a window is open, without a secret
+# --------------------------------------------------------------------------- #
+
+_NO_WINDOW_MAPS: list[dict[str, tuple[str, ...]]] = [
+    {},
+    {"adepthood": (_STRONG_TOKEN,)},
+    {"adepthood": (_STRONG_TOKEN,), "crawdad": (_OLD_TOKEN,)},
+]
+
+_NO_WINDOW_IDS = ["no-consumers", "one-consumer", "two-consumers"]
+
+
+@pytest.mark.parametrize("tokens", _NO_WINDOW_MAPS, ids=_NO_WINDOW_IDS)
+def test_rotation_notice_is_none_when_no_window_is_open(
+    tokens: Mapping[str, Sequence[str]],
+) -> None:
+    """One token per consumer is the steady state, and the steady state is silent.
+
+    A notice printed on every start is a notice operators stop reading, at which
+    point the one that matters — "you left a window open three months ago" —
+    goes unread too.
+
+    Args:
+        tokens: A configuration in which no consumer holds more than one token.
+    """
+    assert ConsumerTokenVerifier(tokens).rotation_notice() is None
+
+
+def test_rotation_notice_names_every_consumer_in_a_window() -> None:
+    """Each multi-token consumer is named with its count; settled ones are not.
+
+    Naming only the consumers mid-rotation is what makes the notice actionable:
+    it is a to-do list of windows still to close, not an inventory of the
+    configuration.
+    """
+    verifier = ConsumerTokenVerifier(
+        {
+            "adepthood": (_OLD_TOKEN, _NEW_TOKEN),
+            "crawdad": (_THIRD_TOKEN, _FOURTH_TOKEN, _FIFTH_TOKEN),
+            "settled": (_STRONG_TOKEN,),
+        }
+    )
+    notice = verifier.rotation_notice()
+    assert notice is not None
+    assert "adepthood" in notice
+    assert "2" in notice  # adepthood's token count
+    assert "crawdad" in notice
+    assert "3" in notice  # crawdad's token count
+    assert "settled" not in notice  # a single-token consumer is not in a window
+
+
+def test_rotation_notice_carries_no_token_value() -> None:
+    """The notice takes names and counts, so it cannot echo a secret by construction.
+
+    It is printed at startup, which means it lands in logs, terminals and
+    process supervisors — the same audience the #838 rejection message is
+    written for, and the same reason it must stay value-free.
+    """
+    verifier = ConsumerTokenVerifier(
+        {
+            "adepthood": (_OLD_TOKEN, _NEW_TOKEN),
+            "crawdad": (_THIRD_TOKEN, _FOURTH_TOKEN),
+        }
+    )
+    notice = verifier.rotation_notice()
+    assert notice is not None
+    for configured in _ALL_TEST_TOKENS:
+        assert configured not in notice
+
+
+# --------------------------------------------------------------------------- #
+# Cross-cutting: no refusal on ANY of the new paths ever echoes a token
+# --------------------------------------------------------------------------- #
+
+_RAISING_CONFIGURATIONS: list[Callable[[], object]] = [
+    lambda: load_consumer_tokens(
+        {CONSUMER_TOKENS_ENV: f"adepthood={_STRONG_TOKEN},{_WEAK_TOKEN}"}
+    ),
+    lambda: load_consumer_tokens(
+        {CONSUMER_TOKENS_ENV: f"adepthood={_OLD_TOKEN};adepthood={_NEW_TOKEN}"}
+    ),
+    lambda: load_consumer_tokens(
+        {CONSUMER_TOKENS_ENV: f"adepthood={_OLD_TOKEN};crawdad={_OLD_TOKEN}"}
+    ),
+    lambda: load_consumer_tokens(
+        {CONSUMER_TOKENS_ENV: f"adepthood={_OLD_TOKEN},{_OLD_TOKEN}"}
+    ),
+    lambda: ConsumerTokenVerifier({"adepthood": _OLD_TOKEN}),
+    lambda: ConsumerTokenVerifier({"adepthood": ()}),
+    lambda: ConsumerTokenVerifier(
+        {"adepthood": (_OLD_TOKEN,), "crawdad": (_OLD_TOKEN,)}
+    ),
+]
+
+_RAISING_IDS = [
+    "parser-weak-token-inside-a-set",
+    "parser-repeated-consumer-name",
+    "parser-value-shared-across-consumers",
+    "parser-value-repeated-within-one-set",
+    "verifier-bare-string-value",
+    "verifier-empty-token-set",
+    "verifier-value-shared-across-consumers",
+]
+
+
+@pytest.mark.parametrize("configure", _RAISING_CONFIGURATIONS, ids=_RAISING_IDS)
+def test_no_rejection_message_ever_echoes_a_token(
+    configure: Callable[[], object],
+) -> None:
+    """Every refusal on the #895 surface names configuration, never credentials.
+
+    Swept as one parametrize rather than left to each test's own assertion so a
+    path added later is a path that has to be added here too. Startup errors
+    land in logs, terminals and process supervisors, so a message that echoed
+    the value it rejected would publish the secret it exists to protect.
+
+    Args:
+        configure: A zero-argument call that must raise.
+    """
+    with pytest.raises((TypeError, ValueError)) as excinfo:
+        configure()
+    message = str(excinfo.value)
+    for configured in _ALL_TEST_TOKENS:
+        assert configured not in message, message
 
 
 # --------------------------------------------------------------------------- #

--- a/creek-tools/tests/test_mcp_server.py
+++ b/creek-tools/tests/test_mcp_server.py
@@ -7,6 +7,7 @@ import base64
 import json
 import os
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
 import frontmatter
@@ -14,7 +15,11 @@ import pytest
 
 from creek_mcp.auth import ELEVATED_TOKEN_ENV
 from creek_mcp.contract import CONTRACT_VERSION, ONTOLOGY_VERSION
-from creek_mcp.remote_auth import CONSUMER_TOKENS_ENV
+from creek_mcp.remote_auth import (
+    CONSUMER_TOKENS_ENV,
+    ConsumerTokenVerifier,
+    load_consumer_tokens,
+)
 from creek_mcp.server import SERVER_NAME, build_server
 
 if TYPE_CHECKING:
@@ -1216,3 +1221,114 @@ def test_main_treats_empty_elevated_token_as_unconfigured(
     server_module.main([])
 
     assert runs == ["stdio"]
+
+
+# --------------------------------------------------------------------------- #
+# Rotation-window startup notice (#895)
+#
+# A consumer may hold several currently-valid tokens so a secret can be rotated
+# without a hard cutover. That window has to be *closed* again, and an operator
+# who cannot see it is open will not close it — so network startup announces it.
+#
+# **On stderr, never stdout.** stdout on this entry point belongs to the stdio
+# transport's JSON-RPC framing, and the sibling ``creek-tools-api`` prints its
+# OpenAPI document there; an operator notice on stdout corrupts one and breaks
+# every pipe consuming the other.
+# --------------------------------------------------------------------------- #
+
+# 43 chars each. Low-entropy test literals, not real credentials.
+_ROTATION_TOKEN_A = "server-test-rotation-" + "c" * 22
+_ROTATION_TOKEN_B = "server-test-rotation-" + "d" * 22
+
+
+class _StubNetworkServer:
+    """Socket-free stand-in for the built network server.
+
+    ``main`` stamps ``settings.host``/``settings.port`` onto whatever
+    ``build_server`` returns, so the stub only has to carry those.
+    """
+
+    def __init__(self) -> None:
+        """Start with mutable settings and nothing bound."""
+        self.settings = SimpleNamespace(host=None, port=None)
+
+
+def _stub_network_startup(monkeypatch: pytest.MonkeyPatch) -> list[object]:
+    """Route the network branch away from sockets; return the served-server log.
+
+    Mirrors ``_stub_build_server`` in ``tests/test_mcp_remote.py``: a guard that
+    fails to fire then shows up as an unexpected entry in the log rather than as
+    a real bind that hangs the run.
+
+    Args:
+        monkeypatch: The active monkeypatch fixture.
+
+    Returns:
+        A list that records each server handed to ``_serve_network``.
+    """
+    from creek_mcp import server as server_module
+
+    served: list[object] = []
+    monkeypatch.setattr(
+        server_module, "build_server", lambda **_kwargs: _StubNetworkServer()
+    )
+    monkeypatch.setattr(
+        server_module, "_serve_network", lambda server, _args: served.append(server)
+    )
+    return served
+
+
+def test_network_startup_announces_an_open_rotation_window_on_stderr(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A consumer holding two tokens is announced — by name and count, on stderr.
+
+    The notice is compared against the verifier's own ``rotation_notice()`` for
+    the same configuration, so ``main`` is pinned to *emit the shared message*
+    rather than to a second wording that could drift from it.
+    """
+    from creek_mcp import server as server_module
+
+    raw = f"adepthood={_ROTATION_TOKEN_A},{_ROTATION_TOKEN_B}"
+    monkeypatch.delenv(ELEVATED_TOKEN_ENV, raising=False)
+    monkeypatch.setenv(CONSUMER_TOKENS_ENV, raw)
+    served = _stub_network_startup(monkeypatch)
+
+    server_module.main(["--transport", "network", "--host", "127.0.0.1"])
+
+    captured = capsys.readouterr()
+    assert len(served) == 1  # it announced and then served, not instead of serving
+    expected = ConsumerTokenVerifier(
+        load_consumer_tokens({CONSUMER_TOKENS_ENV: raw})
+    ).rotation_notice()
+    assert expected is not None
+    assert expected in captured.err
+    assert "adepthood" in captured.err  # the consumer mid-rotation is named
+    assert "2" in captured.err  # ...with its token count
+    assert _ROTATION_TOKEN_A not in captured.err  # NEVER echo a token value
+    assert _ROTATION_TOKEN_B not in captured.err
+    assert captured.out == ""  # stdout belongs to JSON-RPC, not to notices
+
+
+def test_network_startup_is_silent_when_no_rotation_window_is_open(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """One token per consumer is the steady state, and the steady state says nothing.
+
+    A notice on every start is a notice operators stop reading, at which point
+    the one that matters goes unread too.
+    """
+    from creek_mcp import server as server_module
+
+    monkeypatch.delenv(ELEVATED_TOKEN_ENV, raising=False)
+    monkeypatch.setenv(CONSUMER_TOKENS_ENV, f"adepthood={_STRONG_CONSUMER_TOKEN}")
+    served = _stub_network_startup(monkeypatch)
+
+    server_module.main(["--transport", "network", "--host", "127.0.0.1"])
+
+    captured = capsys.readouterr()
+    assert len(served) == 1
+    assert captured.err == ""
+    assert captured.out == ""

--- a/creek-tools/tests/test_v1_api_auth.py
+++ b/creek-tools/tests/test_v1_api_auth.py
@@ -120,6 +120,10 @@ _MALFORMED_IDS: Final[tuple[str, ...]] = (
     "two-tokens",
 )
 
+# 45 chars. The token that replaces ``STRONG_TOKEN`` during a rotation window
+# (#895). Test literal, not a real credential.
+_ROTATION_TOKEN: Final[str] = "unit-test-rotation-token-" + "d" * 20
+
 
 @pytest.fixture
 def vault(tmp_path: Path) -> Iterator[Path]:
@@ -435,3 +439,71 @@ def test_build_verifier_enforces_the_shared_length_floor(length: int) -> None:
     assert str(MIN_TOKEN_LEN) in message
     assert "secrets.token_urlsafe(32)" in message
     assert token not in message  # NEVER echo the token value
+
+
+# --------------------------------------------------------------------------- #
+# build_verifier — the rotation window reaches /v1 through the same env (#895)
+# --------------------------------------------------------------------------- #
+
+
+def test_build_verifier_opens_a_rotation_window_for_one_consumer(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Old and new both authenticate as one consumer, straight from the env.
+
+    Driven end-to-end through the adapter rather than against ``verify_token``
+    directly, because the point of the window is what a *consumer* experiences:
+    one still holding the retired secret keeps being served while it redeploys,
+    and it is served under its own name. A window that changed the caller's
+    identity for its duration would rewrite every access line it produced, so
+    the identity handed to :func:`creek_mcp.policy.admitted_ceiling` is what is
+    asserted.
+
+    Args:
+        vault: A seeded vault.
+        monkeypatch: Installs the admission spy.
+    """
+    built = build_verifier(
+        {CONSUMER_TOKENS_ENV: f"{CONSUMER}={STRONG_TOKEN},{_ROTATION_TOKEN}"}
+    )
+    calls = spy_admitted_ceiling(monkeypatch)
+    with client(vault_path=vault, verifier=built) as test_client:
+        for token in (STRONG_TOKEN, _ROTATION_TOKEN):
+            response = test_client.get(HEALTH_PATH, headers=headers(token=token))
+            assert response.status_code == 200
+    assert [call[0].consumer for call in calls] == [CONSUMER, CONSUMER]
+
+
+def test_closing_the_window_revokes_the_retired_token(vault: Path) -> None:
+    """Once the operator drops the old secret, presenting it is a ``401`` again.
+
+    The half of #895 that keeps it a rotation rather than a permanent widening:
+    without this, "both tokens work" is indistinguishable from "tokens are never
+    revoked".
+
+    Args:
+        vault: A seeded vault.
+    """
+    built = build_verifier({CONSUMER_TOKENS_ENV: f"{CONSUMER}={_ROTATION_TOKEN}"})
+    with client(vault_path=vault, verifier=built) as test_client:
+        retired = test_client.get(HEALTH_PATH, headers=headers(token=STRONG_TOKEN))
+        current = test_client.get(HEALTH_PATH, headers=headers(token=_ROTATION_TOKEN))
+    assert retired.status_code == _UNAUTHENTICATED_STATUS
+    assert current.status_code == 200
+
+
+def test_build_verifier_refuses_one_token_configured_for_two_consumers() -> None:
+    """A shared secret is refused before ``/v1`` has an identity to attribute to.
+
+    The verifier scans every consumer without breaking, so a value configured
+    twice resolves to whichever consumer the scan saw last — and ``/v1`` derives
+    the audited ``consumer`` from exactly that ``client_id``. Refusing at build
+    time is the only point at which the ambiguity is still visible.
+    """
+    shared = f"{CONSUMER}={STRONG_TOKEN};{OTHER_CONSUMER}={STRONG_TOKEN}"
+    with pytest.raises(ValueError) as excinfo:
+        build_verifier({CONSUMER_TOKENS_ENV: shared})
+    message = str(excinfo.value)
+    assert CONSUMER in message
+    assert OTHER_CONSUMER in message
+    assert STRONG_TOKEN not in message  # NEVER echo the token value

--- a/creek-tools/tests/test_v1_api_cli.py
+++ b/creek-tools/tests/test_v1_api_cli.py
@@ -34,6 +34,7 @@ import pytest
 from creek_mcp import server as server_mod
 from creek_mcp.api.openapi import build_openapi
 from creek_mcp.httpapi import cli as cli_mod
+from creek_mcp.httpapi.auth import build_verifier
 from creek_mcp.httpapi.cli import DEFAULT_API_PORT, main
 from creek_mcp.remote_auth import CONSUMER_TOKENS_ENV
 from creek_mcp.server import DEFAULT_MCP_NETWORK_PORT
@@ -116,6 +117,20 @@ def _valid_tokens() -> str:
         A single ``consumer=token`` pair clearing the length floor.
     """
     return f"{CONSUMER}={STRONG_TOKEN}"
+
+
+# 44 chars each. Low-entropy test literals, not real credentials.
+_ROTATION_TOKEN_A: Final[str] = "api-test-rotation-token-" + "e" * 20
+_ROTATION_TOKEN_B: Final[str] = "api-test-rotation-token-" + "f" * 20
+
+
+def _rotation_window() -> str:
+    """Return a ``CREEK_MCP_CONSUMER_TOKENS`` value with one consumer mid-rotation.
+
+    Returns:
+        A single consumer holding two currently-valid tokens (#895).
+    """
+    return f"{CONSUMER}={_ROTATION_TOKEN_A},{_ROTATION_TOKEN_B}"
 
 
 # --------------------------------------------------------------------------- #
@@ -423,6 +438,90 @@ def test_print_openapi_writes_nothing_to_stderr(
     _stub_serve(monkeypatch)
     main(["--print-openapi"])
     assert capsys.readouterr().err == ""
+
+
+# --------------------------------------------------------------------------- #
+# Rotation-window startup notice (#895)
+#
+# A window has to be closed again, and an operator who cannot see one is open
+# will not close it. The notice goes to **stderr**: stdout on this entry point
+# carries the ``--print-openapi`` document, which consumers pipe into code
+# generators, so an operator message there breaks every one of those pipes.
+# --------------------------------------------------------------------------- #
+
+
+def test_serving_a_rotation_window_announces_it_on_stderr(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The operator is told which consumers are mid-rotation, and on which stream.
+
+    Compared against the verifier's own ``rotation_notice()`` for the same
+    configuration, so the CLI is pinned to emitting the shared message rather
+    than a second wording free to drift from it.
+
+    Args:
+        monkeypatch: Configures a rotation window and stubs the serve loop.
+        capsys: Captures both streams.
+    """
+    _configure_tokens(monkeypatch, _rotation_window())
+    recorder = _stub_serve(monkeypatch)
+    main(["--host", "127.0.0.1"])
+    captured = capsys.readouterr()
+
+    assert len(recorder.calls) == 1  # it announced and served, not instead of serving
+    expected = build_verifier(
+        {CONSUMER_TOKENS_ENV: _rotation_window()}
+    ).rotation_notice()
+    assert expected is not None
+    assert expected in captured.err
+    assert CONSUMER in captured.err  # the consumer mid-rotation is named
+    assert "2" in captured.err  # ...with its token count
+    assert _ROTATION_TOKEN_A not in captured.err  # NEVER echo a token value
+    assert _ROTATION_TOKEN_B not in captured.err
+    assert captured.out == ""  # stdout is the contract's channel
+
+
+def test_serving_without_a_rotation_window_announces_nothing(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Steady state is silent, so the notice means something when it appears.
+
+    Args:
+        monkeypatch: Configures one token per consumer and stubs the serve loop.
+        capsys: Captures both streams.
+    """
+    _configure_tokens(monkeypatch, _valid_tokens())
+    recorder = _stub_serve(monkeypatch)
+    main(["--host", "127.0.0.1"])
+    captured = capsys.readouterr()
+
+    assert len(recorder.calls) == 1
+    assert captured.err == ""
+
+
+def test_print_openapi_stdout_stays_pure_json_during_a_rotation_window(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """An open window must not contaminate the machine-readable dump.
+
+    ``--print-openapi`` is what a consumer pipes into a client generator. A
+    notice printed to stdout would make the document unparseable exactly for
+    the operators who are mid-rotation — the ones least able to afford a second
+    broken thing.
+
+    Args:
+        monkeypatch: Configures a rotation window and stubs the serve loop.
+        capsys: Captures stdout.
+    """
+    _configure_tokens(monkeypatch, _rotation_window())
+    recorder = _stub_serve(monkeypatch)
+    main(["--print-openapi"])
+    out = capsys.readouterr().out
+
+    assert json.loads(out) == build_openapi()
+    assert _ROTATION_TOKEN_A not in out
+    assert _ROTATION_TOKEN_B not in out
+    assert recorder.calls == []
 
 
 # --------------------------------------------------------------------------- #

--- a/creek-tools/tests/v1_api_support.py
+++ b/creek-tools/tests/v1_api_support.py
@@ -35,6 +35,7 @@ from creek_mcp.httpapi.middleware import ceiling as ceiling_middleware
 from creek_mcp.remote_auth import ConsumerTokenVerifier
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
     from pathlib import Path
 
     import httpx
@@ -263,19 +264,28 @@ def snapshot(root: Path) -> list[str]:
 # --------------------------------------------------------------------------- #
 
 
-def verifier(tokens: dict[str, str] | None = None) -> ConsumerTokenVerifier:
+def verifier(
+    tokens: Mapping[str, Sequence[str]] | None = None,
+) -> ConsumerTokenVerifier:
     """Return a verifier over the suite's two consumers, or over *tokens*.
 
     Args:
-        tokens: An explicit ``{consumer: token}`` map, or ``None`` for the
-            two-consumer default.
+        tokens: An explicit ``{consumer: (token, ...)}`` map, or ``None`` for
+            the two-consumer default. The value is a **sequence** of tokens and
+            never a bare ``str``: since #895 a consumer may hold an ordered set
+            of currently-valid tokens so a rotation needs no cutover, and
+            :class:`~creek_mcp.remote_auth.ConsumerTokenVerifier` refuses a bare
+            string at runtime as well as in its signature — ``str`` is itself a
+            ``Sequence[str]``, so one would otherwise be read as one
+            single-character token per letter, each of which
+            ``hmac.compare_digest`` accepts.
 
     Returns:
         A :class:`creek_mcp.remote_auth.ConsumerTokenVerifier` — the *same*
         registry the MCP surface uses, never a second one.
     """
     if tokens is None:
-        tokens = {CONSUMER: STRONG_TOKEN, OTHER_CONSUMER: OTHER_TOKEN}
+        tokens = {CONSUMER: (STRONG_TOKEN,), OTHER_CONSUMER: (OTHER_TOKEN,)}
     return ConsumerTokenVerifier(tokens)
 
 


### PR DESCRIPTION
## Summary

- **A consumer may now hold an ordered set of currently-valid tokens**, comma-separated inside its own `CREEK_MCP_CONSUMER_TOKENS` entry (`adepthood=<old>,<new>`). Every token in the set authenticates as that one consumer, so a secret rotates by widening the set → letting the consumer redeploy → narrowing it again. No cutover moment, and no wire-format change: a single-token entry is the steady state and parses exactly as it did before.
- **Two silently-wrong configurations are now refused at load time.** A consumer named twice (`adepthood=a;adepthood=b`) used to have the second entry silently overwrite the first, discarding a credential the operator believed was live — and now that a consumer can legitimately hold several tokens, the other reading (accumulate) would invent a rotation window nobody asked for. One token value configured more than once (across consumers, or twice within one set) is refused because `verify_token` deliberately never breaks early and keeps the *last* match, so a shared value would audit the call under the wrong consumer. The #838 32-char floor now applies to **every** token in a set, not just the first — a rotation is exactly when a fresh secret gets typed in.
- **Startup announces an open rotation window on stderr** (names and token counts only, never a value), so a window is visible rather than permanent. A published, numbered rotation runbook in `docs/mcp.md` is part of the fix, not documentation of it; `ADR-0009` records why overlapping static tokens were chosen over short-lived derived credentials.

### One type-level hazard worth calling out

`ConsumerTokenVerifier` takes `Mapping[str, Sequence[str]]` and **not** `Mapping[str, str | Sequence[str]]`. That union is unsound rather than merely loose: `str` already *is* a `Sequence[str]`, so the union collapses and `{"adepthood": "<secret>"}` would type-check while being read as one single-character token per letter — each of which `hmac.compare_digest` accepts, degrading one 43-character secret into an alphabet of valid credentials. A runtime `isinstance` guard closes the same hole for callers mypy never sees, and a test sweeps every distinct character of a configured token asserting none authenticates.

### What this deliberately does *not* do

The credentials are still static, long-lived secrets in an environment variable, and revocation still means editing the variable and restarting. The rotation window is operator-bounded: an operator who never runs the closing restart has permanently widened the credential set, and the startup notice is the only pressure against that. All of this is stated plainly in ADR-0009's Consequences rather than papered over. Short-lived derived credentials are the more thorough fix and are **deferred, not dismissed** — they change what the Adepthood client puts on the wire, which is a coordinated cross-repo contract change that must not ride inside a P1 fix. Filed as #1267.

`CONTRACT_VERSION` and every wire shape are untouched.

## Test plan

TDD throughout — the failing tests were written first and **verified failing before the fix existed**: 55 failed / 174 passed, each for the right reason (`AttributeError: 'tuple' object has no attribute 'encode'` on the shape change, `DID NOT RAISE` on every new refusal, `no attribute 'rotation_notice'` on the notice). After the implementation: 251 passed on the same four files.

New coverage, by behavior:

- **Parsing** — ordered multi-token sets; whitespace around commas stripped; empty comma segments dropped *before* the floor runs (so `missing=,,` is skipped, not reported as a 0-char token); the floor applied per token; repeated consumer name refused; a duplicate value refused both across consumers and within one set.
- **Verifier, under the narrowest ceiling** — both tokens of a window resolve to the *same* `client_id` with an exact `expires_at` (never `None`); **retiring a token revokes it immediately**, which is what makes the window bounded rather than a permanent widening; a bare `str` value raises `TypeError` *and* no single character of it authenticates; uniqueness enforced by the constructor independently of the parser (`tests/v1_api_support.py` builds verifiers from literal maps, bypassing `load_consumer_tokens`); the no-early-break property pinned by counting `hmac.compare_digest` calls — 3 tokens across 2 consumers with a match on the *first* one, where an inner break would give 2 and an outer break 1.
- **Notice** — `None` in the steady state; names each consumer mid-rotation with its count; asserted to contain none of the configured token substrings; lands on stderr with stdout empty, and `--print-openapi` stdout stays pure parseable JSON while a window is open.
- **Cross-cutting** — one parametrized sweep over all seven raising paths asserting no message ever echoes a token value.

One further ordering invariant is pinned. `_token_set` materialises `tuple(configured)` *before* testing emptiness, because an empty iterable that is not a `Sequence` (a spent iterator) is **truthy** and would otherwise slip past the refusal and land as an empty token set — a named consumer that authenticates nobody, i.e. a silent auth outage instead of the loud error the docstring promises. Every pre-existing test passed a literal `()`, which is falsy under either ordering, so nothing distinguished the two. I proved the new pin by reverting the ordering in place: `test_verifier_refuses_an_empty_iterable_that_is_not_a_sequence` went `DID NOT RAISE ValueError` with the rest of the file still passing, then went green again on restore.

Existing tests were reshaped in **call shape only** (`{"c": tok}` → `{"c": (tok,)}`); every assertion body is unchanged. I diffed the result against `git show HEAD:` to confirm no assertion was weakened or deleted.

Gate 2, run in a CI-equivalent environment with all provider credentials and consent vars stripped:

```
cd creek-tools && ./scripts/check-all.sh
→ Passed: 12  Failed: 0
→ 8655 passed, 5 skipped; aggregate coverage 94.36%; creek_mcp/remote_auth.py 98.67%
→ per-file gate, mypy strict, ruff, xenon, bandit, pip-audit, interrogate (99%), pylint (9.65) all clean
```

Gate 2.5: `code-review-orchestrator` over the diff, plus an explicit `security-specialist` pass (mandatory for this surface). The security pass caught and fixed a real one the tests did not cover: both adapters read the same `CREEK_MCP_CONSUMER_TOKENS` and this repo expects them side by side on one host, so the runbook's restart steps now say restart **every** process reading the variable — a partial restart at the closing step leaves the retired secret authenticating on the un-restarted process while the runbook tells the operator it is revoked. It also moved `announce_rotation_window` below the TLS posture gate in `httpapi/cli.py`, which was announcing a rotation window on a startup that then exited 2 (and falsifying its own module docstring).

## Notes for the reviewer

- Two off-contract edges in `_token_set` were considered and consciously left: a non-`str` *element* (`bytes`, an int) passes the constructor and fails at `verify_token` as a per-request 500 rather than a load-time refusal. It is fail-closed, unreachable from any in-repo caller, and mypy strict makes it unrepresentable for every real one; an element-type check on the auth path seemed the worse trade. Say the word if you disagree.
- The blank-`client_id` hazard tracked in #1100 is unchanged here, but this PR creates the natural place to close it — `_normalized_token_sets` is now the single constructor-level chokepoint every verifier passes through. Noted on #1100 rather than folded in.

Closes #895
