### PR TITLE
fix(mcp): bound the elevated-purge brute force with a non-blocking attempt budget

### DIFF
--- a/creek-tools/creek_mcp/attempt_policy.py
+++ b/creek-tools/creek_mcp/attempt_policy.py
@@ -1,0 +1,168 @@
+"""Failed-attempt budget for the elevated-authorization gate (#914).
+
+The defect this closes: ``creek_mcp.auth.is_elevated`` compared the
+caller's token against ``CREEK_MCP_ELEVATED_TOKEN`` in constant time, but
+it compared it *as often as it was asked to*. Constant-time comparison
+stops an attacker learning the secret one byte at a time; it does nothing
+about guessing it whole, at machine speed, against a surface that answers
+in microseconds. A partially-trusted caller who could reach the MCP
+boundary could therefore brute-force the token that authorizes
+irreversible ``creek.purge.*`` vault destruction.
+
+:class:`AttemptBudget` puts a price on failure: after
+:data:`MAX_FAILED_ATTEMPTS` consecutive denials the gate stops evaluating
+tokens at all for :data:`LOCKOUT_SECONDS`.
+
+**The lockout is non-blocking.** Sleeping is the obvious way to rate
+limit and it is the wrong one here. The five purge tools are registered
+as *sync* functions (``creek_mcp/server.py:731``), and the MCP SDK
+invokes a sync tool function inline on the asyncio event loop
+(``mcp/server/fastmcp/utilities/func_metadata.py:96``). A blocking
+backoff in this module would therefore freeze the entire server — every
+tool, every consumer, both transports — for the duration, converting a
+rate-limit fix into a remotely-triggerable availability kill. There is no
+``sleep`` anywhere in this module, and there must never be one: a
+throttled caller is refused *immediately*, and pays in refusals rather
+than in held connections.
+
+Deliberately stdlib-only. :mod:`creek_mcp.auth` imports this module at
+import time, so a dependency pointing back — even at a single constant —
+would be an import cycle that surfaces as an ``ImportError`` in whichever
+module happened to load first.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+MAX_FAILED_ATTEMPTS: Final[int] = 5
+"""Consecutive denials that arm the lockout.
+
+Five *evaluated* guesses per lockout window, against the keyspace of a
+``secrets.token_urlsafe(32)`` secret — the 32-character floor
+``creek_mcp.token_policy.MIN_TOKEN_LEN`` enforces on any configured
+elevated token (#907). Five guesses per minute against that keyspace is
+not a search anyone completes; the pairing of the two policies is what
+makes the bound worth anything, which is why the floor is named here even
+though this module must not import it.
+"""
+
+LOCKOUT_SECONDS: Final[float] = 60.0
+"""How long the gate stays shut once the budget is spent.
+
+The self-heal guarantee: a lockout is a delay, never a ban. Sixty seconds
+after the last allowed failure the gate reopens with its full allowance
+restored, with no operator intervention, no restart, and no way for a
+hostile caller to hold it shut (see
+:meth:`AttemptBudget.attempt` — attempts made inside the window do not
+extend it). Bricking the only path an operator has to erase their own
+data would be a worse outcome than the brute-force channel #914 closes.
+"""
+
+# Monkeypatchable clock alias, mirroring `creek_mcp.remote_auth._now` so both
+# time-dependent auth surfaces are pinned the same way in tests. (Named rather
+# than cited by line: that module is under active change on another branch.)
+# Monotonic rather than `time.time` on purpose, and unlike that seam: wall-clock
+# time can be stepped by NTP or by an operator changing the system clock, and a
+# lockout a clock change can shorten is a lockout an attacker can shorten.
+_now = time.monotonic
+
+
+class AttemptBudget:
+    """A consecutive-failure allowance guarding one verification surface.
+
+    Verification is supplied to :meth:`attempt` as a callback rather than
+    performed by the caller, so an unthrottled check is not expressible at
+    the type level: there is no way to consult the secret except through
+    the budget that meters the consultation.
+
+    Instances are safe to share across threads. Every read-modify-write of
+    the counter happens under one lock, so N concurrent callers cannot each
+    observe "one attempt left" and each spend it — which would turn an
+    N-guess gate into an N-guesses-per-thread gate.
+    """
+
+    def __init__(self, *, max_failures: int, lockout_seconds: float) -> None:
+        """Configure a budget.
+
+        The policy is taken from these arguments and never re-read from
+        :data:`MAX_FAILED_ATTEMPTS` / :data:`LOCKOUT_SECONDS`, so an
+        instance means exactly what its construction site says it means.
+
+        Args:
+            max_failures: Consecutive failed attempts that arm the lockout.
+            lockout_seconds: How long the lockout lasts, in seconds, as
+                measured by the monotonic :data:`_now` clock.
+        """
+        self._max_failures = max_failures
+        self._lockout_seconds = lockout_seconds
+        self._lock = threading.Lock()
+        self._failures = 0
+        self._locked_until: float | None = None
+
+    def attempt(self, verify: Callable[[], bool]) -> bool:
+        """Consult *verify* if the budget allows it, and account for the answer.
+
+        The only entry point. While a lockout is armed *verify is not
+        called at all* — that is what makes the bound a bound, rather than
+        a throttle that still runs the comparison and discards the result.
+
+        Attempts made inside the window do not extend it. Without that
+        rule one hostile guess per second would keep the window
+        permanently re-armed and lock the legitimate operator out of their
+        own purge tools forever, with every individual refusal looking
+        correct.
+
+        *verify* must not block and must not perform I/O. The purge tools
+        are sync MCP tool functions invoked inline on the asyncio event
+        loop, so anything slow here stalls the whole server, not just this
+        request. For the same reason this method never sleeps, and the
+        internal lock is never held across a sleep or any I/O — it covers
+        only the counter arithmetic and the *verify* call itself.
+
+        Args:
+            verify: Performs the actual check, returning whether the
+                caller's credential is correct. Called at most once.
+
+        Returns:
+            ``True`` only when the budget was open *and* *verify* said yes.
+            A refusal inside the window is indistinguishable from an
+            ordinary rejection, so the lockout never becomes an oracle.
+        """
+        with self._lock:
+            now = _now()
+            if self._locked_until is not None:
+                if now < self._locked_until:
+                    return False
+                self._locked_until = None
+                self._failures = 0
+
+            if verify():
+                self._failures = 0
+                return True
+
+            self._failures += 1
+            if self._failures >= self._max_failures:
+                self._locked_until = now + self._lockout_seconds
+            return False
+
+    def reset(self) -> None:
+        """Clear the failure count and any armed lockout.
+
+        The test-isolation hook: the budget guarding the elevated gate is
+        process-global, so failures accrued by one test would otherwise
+        leak into the next and make the suite order-dependent. The autouse
+        ``_reset_elevated_attempt_budget`` fixture in ``tests/conftest.py``
+        calls this before every test.
+
+        Not for production use. Clearing a live lockout on demand would
+        hand back precisely the unbounded guessing #914 took away.
+        """
+        with self._lock:
+            self._failures = 0
+            self._locked_until = None

--- a/creek-tools/creek_mcp/auth.py
+++ b/creek-tools/creek_mcp/auth.py
@@ -9,8 +9,10 @@ a timing-side-channel comparison would leak the token byte-by-byte to a
 hostile MCP client. ``hmac.compare_digest`` runs in constant time
 relative to the input length, so an attacker cannot probe the secret
 through repeated calls. The :mod:`creek_mcp.auth` test module asserts
-via an AST walk that ``is_elevated`` contains no ``==``/``!=`` on the
-hot path; the rule is mechanical, not stylistic.
+via an AST walk that **no** function in this module contains an
+``==``/``!=`` comparison; the rule is mechanical, not stylistic, and it
+covers the whole module rather than one function because #914 moved the
+comparison into a private helper.
 
 The configured token must also clear the shared 32-character floor in
 :data:`creek_mcp.token_policy.MIN_TOKEN_LEN` (#907) — a guessable secret
@@ -21,55 +23,142 @@ here because it is the only chokepoint that covers embedders calling
 entirely. Here the deny is **silent**: ``is_elevated`` returns ``False``
 rather than raising or explaining, so a possibly-hostile caller is handed
 no oracle about the server's configuration.
+
+Constant-time comparison closes the *learning* channel; #914 closes the
+*guessing* one. Every verification is metered by a process-global
+:class:`creek_mcp.attempt_policy.AttemptBudget`, so the token cannot be
+searched at machine speed against a surface that answers in microseconds.
 """
 
 from __future__ import annotations
 
 import hmac
 import os
+from typing import Final
 
+from creek_mcp.attempt_policy import (
+    LOCKOUT_SECONDS,
+    MAX_FAILED_ATTEMPTS,
+    AttemptBudget,
+)
 from creek_mcp.token_policy import meets_min_length
 
 ELEVATED_TOKEN_ENV = "CREEK_MCP_ELEVATED_TOKEN"
 """Env var the server reads at startup to learn the expected token."""
 
+_ELEVATED_BUDGET: Final[AttemptBudget] = AttemptBudget(
+    max_failures=MAX_FAILED_ATTEMPTS,
+    lockout_seconds=LOCKOUT_SECONDS,
+)
+"""The one failed-attempt budget guarding the elevated gate (#914).
 
-def is_elevated(provided_token: str | None) -> bool:
-    """Return ``True`` when *provided_token* matches the configured secret.
+Process-global on purpose. The budget is a bound on how fast the *server*
+will evaluate guesses, so it has to be shared by every caller, every
+consumer, and all five purge tools. A per-tool or per-request budget is
+not a bound at all: five tools times five guesses is a twenty-five-guess
+gate, and an attacker who rotates tools between guesses never trips any
+of them.
 
-    The gate fails closed three ways. An absent or empty
-    ``CREEK_MCP_ELEVATED_TOKEN`` denies every call, and a missing client
-    token cannot accidentally match an empty server token. A *configured*
-    token below :data:`creek_mcp.token_policy.MIN_TOKEN_LEN` characters
-    also denies every call (#907): a secret weak enough to guess is not
-    allowed to authorize vault destruction, even on an exact match. Only
-    a strong server token combined with a constant-time match against the
-    client value returns ``True``.
+Reset between tests by the autouse ``_reset_elevated_attempt_budget``
+fixture in ``tests/conftest.py``; nothing in production clears it.
+"""
 
-    Only the *server's* token is measured. The client-supplied value is
-    never length-checked: it is attacker-controlled, so measuring it
-    proves nothing and only risks another signal leaking back out.
 
-    The weak-configuration deny is silent — this function returns a
-    ``bool`` and never raises, both to avoid disclosing server
-    configuration to the caller and because
-    :func:`creek_mcp.tools.purge._gate` does not catch: an exception here
-    would escape into the FastMCP tool surface and skip the audit entry
-    every purge call is required to write.
+def _verify_match(provided_token: str | None) -> bool:
+    """Return whether *provided_token* is the configured elevated secret.
+
+    The unthrottled comparison, private and called from exactly one place:
+    :func:`is_elevated` hands it to :meth:`AttemptBudget.attempt`, which is
+    what meters it. Nothing else may call it, and a test asserts
+    structurally that exactly one function in this module reaches
+    :func:`hmac.compare_digest`.
+
+    Only the *server's* token is measured against the length floor. The
+    client-supplied value is never length-checked: it is
+    attacker-controlled, so measuring it proves nothing and only risks
+    another signal leaking back out.
+
+    A token that cannot be encoded to UTF-8 is denied rather than allowed
+    to raise. Lone surrogates survive ``json.loads``, so ``auth_token`` can
+    carry one straight off the wire, and ``os.environ`` decodes invalid
+    UTF-8 with ``surrogateescape``, so the server side can hold one too.
+    Letting :exc:`UnicodeEncodeError` escape would break this module's
+    never-raises contract three ways: :func:`creek_mcp.tools.purge._gate`
+    does not catch, so the exception would skip the audit entry every purge
+    call must write; the raise would be *state-dependent*, since inside a
+    lockout ``verify`` is never called and the identical input returns
+    ``False``, handing back an exact oracle for whether the budget is
+    armed; and it would cost the attacker no budget, because the failure
+    counter is never reached. An unencodable value also cannot be the
+    secret — a configured token that survived
+    :func:`creek_mcp.token_policy.require_min_length` at startup is a real
+    string — so denying is both safe and correct.
 
     Args:
         provided_token: The ``auth_token`` the caller presented, if any.
 
     Returns:
-        ``True`` only when a floor-clearing server token is configured
-        and the caller's token matches it exactly.
+        ``True`` only when a floor-clearing server token is configured and
+        the caller's token matches it exactly, in constant time.
     """
     expected = os.environ.get(ELEVATED_TOKEN_ENV, "")
     if not expected or not provided_token:
         return False
     if not meets_min_length(expected):
         return False
-    return hmac.compare_digest(
-        expected.encode("utf-8"),
-        provided_token.encode("utf-8"),
-    )
+    try:
+        expected_bytes = expected.encode("utf-8")
+        provided_bytes = provided_token.encode("utf-8")
+    except UnicodeEncodeError:
+        return False
+    return hmac.compare_digest(expected_bytes, provided_bytes)
+
+
+def is_elevated(provided_token: str | None) -> bool:
+    """Return ``True`` when *provided_token* matches the configured secret.
+
+    The gate fails closed four ways. An absent or empty
+    ``CREEK_MCP_ELEVATED_TOKEN`` denies every call, and a missing client
+    token cannot accidentally match an empty server token. A *configured*
+    token below :data:`creek_mcp.token_policy.MIN_TOKEN_LEN` characters
+    also denies every call (#907): a secret weak enough to guess is not
+    allowed to authorize vault destruction, even on an exact match. A
+    non-matching client token is denied by a constant-time comparison. And
+    fourth (#914), the process may be inside a lockout window — armed by
+    :data:`~creek_mcp.attempt_policy.MAX_FAILED_ATTEMPTS` consecutive
+    denials, lasting
+    :data:`~creek_mcp.attempt_policy.LOCKOUT_SECONDS` — in which case even
+    a correct token is refused and the comparison is not performed at all.
+
+    Every denial mode is counted identically, deliberately. Counting only
+    mismatches would make "purge disabled or misconfigured" behave
+    differently from "wrong token", and the difference is observable in
+    when the lockout arms — which hands back exactly the configuration
+    oracle #913 closed.
+
+    The residual, stated honestly: the counter lives in this process, so a
+    restart returns the full allowance. This **bounds** the brute force —
+    from unlimited guesses per second to
+    :data:`~creek_mcp.attempt_policy.MAX_FAILED_ATTEMPTS` per lockout
+    window — rather than closing it outright. Against the 32-character
+    ``secrets.token_urlsafe`` keyspace the floor guarantees, that bound is
+    the difference between a feasible search and an infeasible one.
+
+    The weak-configuration deny is silent — this function returns a
+    ``bool`` and never raises, both to avoid disclosing server
+    configuration to the caller and because
+    :func:`creek_mcp.tools.purge._gate` does not catch: an exception here
+    would escape into the FastMCP tool surface and skip the audit entry
+    every purge call is required to write. The throttled deny is silent
+    for the same reasons and for one more: a refusal that announced itself
+    as throttled would tell a hostile caller that the policy is armed, how
+    long it lasts, and how many guesses remain.
+
+    Args:
+        provided_token: The ``auth_token`` the caller presented, if any.
+
+    Returns:
+        ``True`` only when the budget is open, a floor-clearing server
+        token is configured, and the caller's token matches it exactly.
+    """
+    return _ELEVATED_BUDGET.attempt(lambda: _verify_match(provided_token))

--- a/creek-tools/docs/mcp.md
+++ b/creek-tools/docs/mcp.md
@@ -386,7 +386,11 @@ Operational rules:
   (FEAT-013+) is launched without `CREEK_MCP_ELEVATED_TOKEN`, and its
   MCP requests omit `auth_token`. Every purge call from CrawDad
   therefore returns `status="refused"` — there is no Discord command
-  surface that could accidentally destroy vault content.
+  surface that could accidentally destroy vault content. CrawDad is
+  also the canonical transport-authorised, elevated-denied consumer,
+  which makes it exactly the party the attempt-rate bound below
+  (#914) is aimed at: its refusals spend from the same process-global
+  budget as everyone else's.
 - **The developer's Claude Code can be configured with the token.**
   Generate one with high entropy — this is the same recipe the startup
   check prints if the configured token is too weak:
@@ -418,6 +422,52 @@ Operational rules:
   entry to `mcp.jsonl`, so a token-less probe leaves a trail. The
   `auth_token` value never enters the audit log — only the
   refusal-or-success outcome and the structured args summary.
+- **Failed attempts are rate-bounded (#914).** Constant-time
+  comparison stops an attacker learning the token byte-by-byte; it
+  does nothing to stop them guessing it whole, at machine speed.
+  After 5 consecutive denials (`MAX_FAILED_ATTEMPTS`) the gate stops
+  evaluating tokens at all for 60 seconds (`LOCKOUT_SECONDS`) —
+  during the window even a correct token is refused, and the
+  comparison is never performed. Every denial mode counts toward the
+  5, identically: unset token, empty token, a sub-32-char server
+  token (the #907 floor above), a missing client token, and a wrong
+  client token. Counting only mismatches would make "purge
+  disabled/misconfigured" behave differently from "wrong token" and
+  hand back the configuration oracle #907/#913 closed. The refusal
+  itself is deliberately indistinguishable whether or not it was
+  throttled — same `status`, same `tool`, same `reason`; there is no
+  `throttled` flag, no `retry_after`, no `attempts_remaining` — so
+  detect a lockout by the *rate* of refusals in `mcp.jsonl` (see
+  above), not by any field on one. The budget is process-global, not
+  per-consumer or per-tool: a per-identity budget would multiply an
+  attacker's guesses by the number of identities they hold, and a
+  per-tool budget would turn the five purge tools into a 25-guess
+  gate. Attempts made inside the window do not extend it, so an
+  individual lockout always ends 60 seconds after it was armed, and a
+  single successful call resets the counter to zero. The lockout
+  self-heals — the full allowance returns after 60 seconds with no
+  restart, env var, or file to touch, and there is deliberately no
+  way to clear a live lockout in production. Three residuals, stated
+  honestly. (1) The counter lives in the process, so restarting the
+  server also restores the allowance — this *bounds* the brute force
+  rather than closing it, and an attacker able to cycle the process
+  already has more than guessing power. (2) Five wrong tokens —
+  fat-fingered, or sent by one hostile transport-authorised consumer
+  such as CrawDad above — lock `creek.purge.*` process-wide for 60
+  seconds. (3) **A *sustained* attacker keeps re-arming the lockout,
+  and that is the honest cost of a process-global budget.** One guess
+  per second for an hour yields the attacker 285 evaluated guesses
+  (4.75/min, against a previously unbounded rate) but leaves the gate
+  shut to *everyone* for roughly 92% of that hour: each time the
+  window expires the attacker spends the fresh allowance in about
+  four seconds and arms the next one. So MCP purge is not merely
+  delayed for 60 seconds while an attack is running — it is largely
+  unavailable for the duration. That is accepted deliberately: the
+  alternative, keying the budget per consumer, multiplies the
+  attacker's guess rate by the number of identities they hold, and
+  rate-limiting the *secret* is the point. The operator's recovery
+  path is not to wait it out but to use `creek purge` on the CLI,
+  which calls `PurgeEngine` directly and never reaches this gate.
 - **`status` has three values, not two (#1246, contract `0.4`).**
   `refused` means the gate said no and nothing was touched. `ok` means
   the erasure is complete. `partial` means the operation ran to the end

--- a/creek-tools/tests/conftest.py
+++ b/creek-tools/tests/conftest.py
@@ -3,12 +3,14 @@
 Provides auto-use fixtures that:
 
 - mock the sentence-transformer model loading so tests never download
-  models or require GPU access, and
+  models or require GPU access,
 - pin the terminal width so Rich/Typer CLI output renders deterministically
   regardless of the ambient terminal or whether stdout is a TTY (GAP-013).
   The width is pinned in :func:`pytest_configure` as well as in the fixture,
   because a Rich console caches its width at construction and creek's console
-  is constructed at collection time -- see that hook's docstring (#1141).
+  is constructed at collection time -- see that hook's docstring (#1141), and
+- clear the process-global elevated-authorization failure budget so the
+  #914 purge lockout cannot leak from one test into the next.
 
 Also provides the opt-in :func:`short_write` fixture (issue #987), which
 simulates partial ``os.write`` returns so the vault/save writers can be
@@ -80,6 +82,38 @@ def _pin_terminal_width(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     monkeypatch.setenv("COLUMNS", _TEST_TERMINAL_COLUMNS)
     monkeypatch.setenv("LINES", _TEST_TERMINAL_LINES)
+
+
+@pytest.fixture(autouse=True)
+def _reset_elevated_attempt_budget() -> None:
+    """Clear the elevated-auth failed-attempt budget before every test (#914).
+
+    ``creek_mcp.auth._ELEVATED_BUDGET`` is module-level state, so failed
+    ``is_elevated`` calls accumulate across the whole process. Five of them
+    anywhere arm a lockout that every later test inherits, and *which* tests
+    those are depends on collection order: ``tests/test_mcp_auth.py`` and
+    ``tests/test_mcp_remote.py`` each spend deliberate failures, while
+    ``tests/test_wiring_contract.py`` and the purge happy paths then present a
+    correct token and expect it to work. Without this reset that combination
+    is an order-dependent flake rather than a defect in either test, and the
+    suite has to pass under ``-p no:randomly`` *and* under a shuffle.
+
+    ``tests/test_mcp_attempt_policy.py`` additionally hard-asserts that the
+    budget exists and is resettable, in
+    ``test_the_auth_module_owns_a_budget_the_conftest_hook_can_reset``, so a
+    rename cannot quietly turn this hook into a no-op from the other side.
+
+    The import is deferred into the body rather than hoisted to module scope
+    on purpose: anything imported while this file is *read* runs before
+    :func:`pytest_configure`, and that is exactly the window #1141 needs kept
+    clear of import-time Rich consoles.
+    """
+    from creek_mcp import auth
+
+    # Accessed directly, not via getattr: a missing budget must fail loudly
+    # here rather than let this fixture decay into a silent no-op and hand
+    # back the order-dependent flake it exists to prevent.
+    auth._ELEVATED_BUDGET.reset()
 
 
 def _make_mock_model(dims: int = _DIMS) -> MagicMock:

--- a/creek-tools/tests/elevated_attempt_support.py
+++ b/creek-tools/tests/elevated_attempt_support.py
@@ -1,0 +1,113 @@
+"""Hand-driven clock and verify-callback doubles for the #914 attempt budget.
+
+``creek_mcp.attempt_policy.AttemptBudget`` refuses a caller for
+``LOCKOUT_SECONDS`` after too many failures. Asserting that against a real
+clock would mean sleeping a minute per assertion, so every #914 test drives
+time by hand through :class:`FakeMonotonicClock`, pinned over the policy
+module's ``_now`` seam. Issue #914 forbids ``time.sleep`` in the production
+path; this module is what lets the *tests* obey the same rule.
+
+Deliberately imports nothing from :mod:`creek_mcp`. Three test modules import
+this one at module scope, and two of them (``tests/test_mcp_auth.py`` and
+``tests/test_mcp_purge.py``) must keep *collecting* while
+``creek_mcp.attempt_policy`` does not exist yet, so their behavioural tests
+fail on their own assertions rather than on an import-time
+``ModuleNotFoundError``.
+
+Named as a flat ``tests/*_support.py`` module to match
+``tests/v1_api_support.py`` and ``tests/adapter_parity.py``. It is not
+collected: ``python_files = ["test_*.py"]`` in ``pyproject.toml`` does not
+match it.
+"""
+
+from __future__ import annotations
+
+import threading
+
+
+class FakeMonotonicClock:
+    """A stand-in for :func:`time.monotonic` that only a test advances.
+
+    Monotonic semantics are the point of the seam it replaces: an NTP step
+    must not be able to shorten a lockout, so the production clock cannot be
+    wall-clock time and this double cannot offer a way to run backwards.
+
+    Attributes:
+        now: The instant the clock currently reports, in seconds. Assign to
+            it directly when a test needs an exact absolute instant (the
+            window boundary), or call :meth:`advance` for a relative step.
+    """
+
+    def __init__(self, start: float = 1000.0) -> None:
+        """Start the clock at *start*.
+
+        Args:
+            start: The first instant the clock reports, in seconds. The
+                default is a round, obviously synthetic value, so a real
+                timestamp leaking into a failure message is easy to spot.
+        """
+        self.now = start
+
+    def __call__(self) -> float:
+        """Report the current instant, as :func:`time.monotonic` would.
+
+        Returns:
+            The pinned instant, in seconds.
+        """
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        """Move the clock forward by *seconds*.
+
+        Args:
+            seconds: How far forward to move, in seconds.
+
+        Raises:
+            ValueError: If *seconds* is negative. A monotonic clock that
+                runs backwards is not a monotonic clock, and a test that
+                relied on one would be pinning behaviour the production
+                seam can never produce.
+        """
+        if seconds < 0:
+            msg = f"a monotonic clock cannot run backwards: {seconds!r}"
+            raise ValueError(msg)
+        self.now += seconds
+
+
+class VerifySpy:
+    """A verify callback that records whether the budget consulted it at all.
+
+    The budget's central security property is a negative one — while a
+    lockout is armed the supplied token is *not evaluated* — and no return
+    value can express that. A call count can.
+
+    The counter is guarded by its own lock so the spy stays exact when
+    several threads race the same budget; the budget's own lock would
+    already serialise the increments if it works, which is precisely the
+    thing under test and therefore not something to rely on here.
+
+    Attributes:
+        result: The fixed answer this spy gives the budget.
+        calls: How many times the budget invoked this callback.
+    """
+
+    def __init__(self, *, result: bool) -> None:
+        """Create a spy that always answers *result*.
+
+        Args:
+            result: What the callback reports: ``True`` for a token that
+                matches, ``False`` for one that does not.
+        """
+        self.result = result
+        self.calls = 0
+        self._lock = threading.Lock()
+
+    def __call__(self) -> bool:
+        """Record the consultation and answer.
+
+        Returns:
+            The fixed :attr:`result` this spy was built with.
+        """
+        with self._lock:
+            self.calls += 1
+        return self.result

--- a/creek-tools/tests/test_mcp_attempt_policy.py
+++ b/creek-tools/tests/test_mcp_attempt_policy.py
@@ -1,0 +1,624 @@
+"""Unit tests for the elevated-auth failed-attempt budget (#914).
+
+``CREEK_MCP_ELEVATED_TOKEN`` guards irreversible ``creek.purge.*`` calls.
+Before #914 a wrong guess cost an attacker nothing, so the token was
+brute-forceable at machine speed against a surface that answers in
+microseconds. :class:`creek_mcp.attempt_policy.AttemptBudget` puts a price on
+failure: after :data:`~creek_mcp.attempt_policy.MAX_FAILED_ATTEMPTS` wrong
+answers the gate stops evaluating tokens at all for
+:data:`~creek_mcp.attempt_policy.LOCKOUT_SECONDS`.
+
+Three properties get most of the attention here, because they are the three
+ways this defence goes wrong in practice.
+
+* The refusal must be **non-blocking**. Sleeping is the tempting way to rate
+  limit and it is the wrong one: it converts a free brute-force attempt into
+  a denial of service against the server the throttle was protecting. No test
+  in this file sleeps either -- the clock is a seam
+  (``creek_mcp.attempt_policy._now``) that the tests pin.
+* The window must **not be extended** by attempts made inside it. A budget
+  that re-arms on every throttled knock locks the legitimate operator out
+  permanently for as long as anyone keeps knocking, which is a worse outcome
+  than the channel #914 closes.
+* The token must **not be evaluated** while the window is armed. That is a
+  negative property, so it is asserted on a spy's call count rather than on
+  a return value.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import threading
+import time
+from typing import TYPE_CHECKING
+
+from creek_mcp import attempt_policy, auth
+from creek_mcp.attempt_policy import (
+    LOCKOUT_SECONDS,
+    MAX_FAILED_ATTEMPTS,
+    AttemptBudget,
+)
+from tests.elevated_attempt_support import FakeMonotonicClock, VerifySpy
+
+if TYPE_CHECKING:
+    import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fresh_budget() -> AttemptBudget:
+    """Build a budget configured exactly the way production configures it.
+
+    Returns:
+        An :class:`AttemptBudget` wired to the shipped constants, so a
+        behavioural assertion here is an assertion about the real policy.
+    """
+    return AttemptBudget(
+        max_failures=MAX_FAILED_ATTEMPTS,
+        lockout_seconds=LOCKOUT_SECONDS,
+    )
+
+
+def _pin_clock(monkeypatch: pytest.MonkeyPatch) -> FakeMonotonicClock:
+    """Replace the policy module's clock with one the test drives.
+
+    Args:
+        monkeypatch: Restores the real ``_now`` at teardown.
+
+    Returns:
+        The installed clock, already reporting its start instant.
+    """
+    clock = FakeMonotonicClock()
+    monkeypatch.setattr(attempt_policy, "_now", clock)
+    return clock
+
+
+def _arm_the_lockout(budget: AttemptBudget) -> VerifySpy:
+    """Spend the whole budget on wrong answers, leaving the window armed.
+
+    Args:
+        budget: The budget to exhaust.
+
+    Returns:
+        The spy that answered every one of those attempts, so a caller can
+        keep watching its call count across the window.
+    """
+    spy = VerifySpy(result=False)
+    for _ in range(MAX_FAILED_ATTEMPTS):
+        assert budget.attempt(spy) is False
+    assert spy.calls == MAX_FAILED_ATTEMPTS
+    return spy
+
+
+def _policy_source() -> str:
+    """Return the on-disk source of :mod:`creek_mcp.attempt_policy`.
+
+    Returns:
+        The module's text, for the structural invariants below.
+    """
+    return inspect.getsource(attempt_policy)
+
+
+def _callee_name(node: ast.Call) -> str | None:
+    """Resolve a call's callee to a bare symbol name.
+
+    Args:
+        node: The call node to inspect.
+
+    Returns:
+        ``func.id`` for a direct call (``sleep(x)``), ``func.attr`` for a
+        qualified one (``time.sleep(x)``), or ``None`` when the callee is a
+        dynamic expression no static reader can name.
+    """
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+# ---------------------------------------------------------------------------
+# The seam and the policy numbers
+# ---------------------------------------------------------------------------
+
+
+def test_the_clock_seam_defaults_to_the_real_monotonic_clock() -> None:
+    """Production must ship the real clock, not a pinned test double.
+
+    ``_now`` exists so tests can drive time; the hazard of that seam is that
+    it ships pinned or, subtler, pointing at :func:`time.time`. Wall-clock
+    time is wrong here specifically: an NTP step backwards would silently
+    extend a lockout and a step forwards would end one early, so the identity
+    of the default is part of the policy rather than an implementation
+    detail.
+    """
+    assert attempt_policy._now is time.monotonic
+
+
+def test_the_documented_constants_are_the_shipped_values() -> None:
+    """Five guesses, sixty seconds -- exactly the numbers #914 specifies.
+
+    Exact values rather than a range: these two constants *are* the policy,
+    and a silent drift to (say) fifty failures would leave every behavioural
+    test in this file green while widening the brute-force window tenfold.
+    """
+    assert MAX_FAILED_ATTEMPTS == 5
+    assert LOCKOUT_SECONDS == 60.0
+
+
+def test_the_budget_honours_its_arguments_not_the_module_constants(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``max_failures`` is a constructor argument, not a re-read of the constant.
+
+    A class that ignored its own arguments and consulted
+    :data:`MAX_FAILED_ATTEMPTS` directly would pass every other test in this
+    file, because every other test configures it with exactly that value.
+    Two failures out of a budget of two must be enough here.
+    """
+    _pin_clock(monkeypatch)
+    budget = AttemptBudget(max_failures=2, lockout_seconds=5.0)
+    wrong = VerifySpy(result=False)
+
+    assert budget.attempt(wrong) is False
+    assert budget.attempt(wrong) is False
+
+    correct = VerifySpy(result=True)
+    assert budget.attempt(correct) is False
+    assert correct.calls == 0
+
+
+# ---------------------------------------------------------------------------
+# Where the lockout begins
+# ---------------------------------------------------------------------------
+
+
+def test_one_failure_short_of_the_limit_still_evaluates_the_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The budget spends every attempt it promised before it shuts.
+
+    An off-by-one that locked at ``max_failures - 1`` would cost the operator
+    a guess they were told they had, and would do it invisibly -- the refusal
+    payload is identical either way.
+    """
+    _pin_clock(monkeypatch)
+    budget = _fresh_budget()
+    wrong = VerifySpy(result=False)
+
+    for _ in range(MAX_FAILED_ATTEMPTS - 1):
+        assert budget.attempt(wrong) is False
+
+    assert wrong.calls == MAX_FAILED_ATTEMPTS - 1
+    correct = VerifySpy(result=True)
+    assert budget.attempt(correct) is True
+    assert correct.calls == 1
+
+
+def test_the_last_allowed_failure_arms_the_lockout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The window opens on failure number ``MAX_FAILED_ATTEMPTS``, not later.
+
+    Asserted on the *correct* token, which is the strongest form: if a
+    matching token is refused, a mismatched one provably was not evaluated
+    either.
+    """
+    _pin_clock(monkeypatch)
+    budget = _fresh_budget()
+    _arm_the_lockout(budget)
+
+    correct = VerifySpy(result=True)
+    assert budget.attempt(correct) is False
+    assert correct.calls == 0
+
+
+def test_a_locked_budget_never_evaluates_the_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No comparison happens inside the window -- the guess costs nothing to refuse.
+
+    This is the assertion that makes the bound a bound. A throttle that still
+    ran the comparison and merely discarded the answer would leave the timing
+    side channel wide open and would let a caller keep probing at full speed;
+    only the call count can tell the two apart.
+    """
+    _pin_clock(monkeypatch)
+    budget = _fresh_budget()
+    wrong = _arm_the_lockout(budget)
+
+    for _ in range(20):
+        assert budget.attempt(wrong) is False
+
+    assert wrong.calls == MAX_FAILED_ATTEMPTS
+
+
+def test_a_success_zeroes_the_failure_counter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The bound is on *consecutive* failures, so an honest typo never accrues.
+
+    Without the reset the budget is a lifetime allowance: four typos today
+    plus four next week lock the operator out mid-session with no failed
+    attack anywhere in the sequence.
+    """
+    _pin_clock(monkeypatch)
+    budget = _fresh_budget()
+    wrong = VerifySpy(result=False)
+    correct = VerifySpy(result=True)
+
+    for _ in range(MAX_FAILED_ATTEMPTS - 1):
+        assert budget.attempt(wrong) is False
+    assert budget.attempt(correct) is True
+
+    for _ in range(MAX_FAILED_ATTEMPTS - 1):
+        assert budget.attempt(wrong) is False
+
+    assert wrong.calls == 2 * (MAX_FAILED_ATTEMPTS - 1)
+    assert budget.attempt(correct) is True
+    assert correct.calls == 2
+
+
+# ---------------------------------------------------------------------------
+# The shape of the window
+# ---------------------------------------------------------------------------
+
+
+def test_attempts_made_inside_the_window_do_not_extend_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Knocking during a lockout must not restart it (the permanent-lockout bug).
+
+    The failure mode is quiet and total: if a throttled attempt re-arms the
+    window, anyone who can reach the MCP surface -- including a buggy client
+    on a retry loop -- can keep the operator locked out of their own purge
+    tools forever, and every individual refusal looks correct. The window is
+    armed at t=1000, knocked on once per simulated second for its whole
+    length, and must still open at t=1000+``LOCKOUT_SECONDS``.
+    """
+    clock = _pin_clock(monkeypatch)
+    budget = _fresh_budget()
+    armed_at = clock.now
+    wrong = _arm_the_lockout(budget)
+
+    for second in range(1, int(LOCKOUT_SECONDS)):
+        clock.now = armed_at + second
+        assert budget.attempt(wrong) is False
+
+    assert wrong.calls == MAX_FAILED_ATTEMPTS
+    clock.now = armed_at + LOCKOUT_SECONDS
+    correct = VerifySpy(result=True)
+    assert budget.attempt(correct) is True
+    assert correct.calls == 1
+
+
+def test_the_window_closes_exactly_at_lockout_seconds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both edges of the window, so its length cannot drift unnoticed.
+
+    A hair before the deadline the gate is still shut; at the deadline it is
+    open. Pinning only the "still shut" side would let the window grow without
+    bound, and pinning only the "open again" side would let it shrink to
+    nothing.
+    """
+    clock = _pin_clock(monkeypatch)
+    budget = _fresh_budget()
+    armed_at = clock.now
+    _arm_the_lockout(budget)
+
+    clock.now = armed_at + LOCKOUT_SECONDS - 1.0
+    still_shut = VerifySpy(result=True)
+    assert budget.attempt(still_shut) is False
+    assert still_shut.calls == 0
+
+    clock.now = armed_at + LOCKOUT_SECONDS
+    reopened = VerifySpy(result=True)
+    assert budget.attempt(reopened) is True
+    assert reopened.calls == 1
+
+
+def test_the_budget_is_whole_again_after_the_window_expires(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Expiry restores the full allowance, not a single probationary attempt.
+
+    If the counter were left at its high-water mark, the first failure after
+    the window would re-lock immediately and the gate would be effectively
+    permanently shut for anyone who ever mistyped it once.
+    """
+    clock = _pin_clock(monkeypatch)
+    budget = _fresh_budget()
+    armed_at = clock.now
+    _arm_the_lockout(budget)
+
+    clock.advance(LOCKOUT_SECONDS)
+    assert clock.now == armed_at + LOCKOUT_SECONDS
+
+    second_round = VerifySpy(result=False)
+    for _ in range(MAX_FAILED_ATTEMPTS - 1):
+        assert budget.attempt(second_round) is False
+    assert second_round.calls == MAX_FAILED_ATTEMPTS - 1
+
+    correct = VerifySpy(result=True)
+    assert budget.attempt(correct) is True
+    assert correct.calls == 1
+
+
+def test_a_sustained_attacker_is_held_to_the_documented_guess_rate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An hour of hammering buys 285 evaluated guesses, not 3600 (#914).
+
+    The per-window allowance only matters because it composes into a *rate*,
+    and the rate is the number an attacker actually plans against: they do
+    not get five guesses, they get five guesses per window for as long as
+    they care to keep knocking. Driven at one wrong guess per simulated
+    second for an hour, the yield is 285 evaluated guesses -- 4.75 a minute,
+    against a rate that was previously bounded only by the network. The
+    shape is a consequence of the no-extension rule two tests above: each
+    time a window expires the attacker spends the fresh allowance in four
+    seconds and immediately arms the next one.
+
+    The accepted cost, stated plainly. That same re-arming keeps
+    ``creek.purge.*`` shut to *everyone*, the operator included, for 59 of
+    every 64 seconds -- 3,315 of the hour's 3,600 seconds, about 92% of the
+    attack. (Five seconds of each cycle are open, not four: the fifth guess
+    is evaluated and *then* arms the window, so the arming second is an open
+    one. ``docs/mcp.md`` quotes the same 92%.) Under sustained attack MCP
+    purge is not merely delayed by a
+    minute; it is largely unavailable, and this test is the record that the
+    trade was made deliberately. It is the right trade: keying the budget
+    per consumer instead would multiply the attacker's guess rate by the
+    number of identities they hold, and it is the *secret* that needs rate
+    limiting. The operator's recovery path is not to wait the attacker out
+    but to run ``creek purge`` on the CLI, which drives
+    :class:`creek.purge.engine.PurgeEngine` directly and never reaches this
+    gate.
+
+    The upper bound is the regression this test exists to catch. Delete the
+    re-arm -- lock once, then never again -- and every assertion about a
+    single window still passes, while the attacker collects 3,541 guesses
+    out of this same hour: an unbounded gate wearing a throttle's clothes.
+    """
+    clock = _pin_clock(monkeypatch)
+    budget = _fresh_budget()
+    wrong = VerifySpy(result=False)
+    started_at = clock.now
+    attack_seconds = 3600
+
+    for second in range(attack_seconds):
+        clock.now = started_at + second
+        assert budget.attempt(wrong) is False
+
+    # One cycle is the time it takes to spend the whole allowance at 1 Hz
+    # (MAX_FAILED_ATTEMPTS - 1 seconds, the first guess costing none) plus the
+    # window that spending it arms. The hour's tail is long enough to hold one
+    # more whole allowance, which is what the +1 counts.
+    cycle_seconds = MAX_FAILED_ATTEMPTS - 1 + int(LOCKOUT_SECONDS)
+    whole_cycles, tail_seconds = divmod(attack_seconds, cycle_seconds)
+    assert tail_seconds >= MAX_FAILED_ATTEMPTS
+    expected_evaluations = (whole_cycles + 1) * MAX_FAILED_ATTEMPTS
+
+    seconds_per_minute = 60
+    documented_guesses_per_minute = 4.75
+    assert wrong.calls == expected_evaluations
+    assert (
+        wrong.calls * seconds_per_minute / attack_seconds
+        == documented_guesses_per_minute
+    )
+
+    # An order of magnitude above the documented rate: far clear of 285, and
+    # nowhere near the 3,541 a gate that locks only once would have handed
+    # over. The bound is deliberately loose so it fails for one reason only.
+    unbounded_alarm = attack_seconds // 10
+    assert wrong.calls < unbounded_alarm, (
+        "the lockout must re-arm on every window; a gate that locks once is "
+        "unbounded for the rest of the attack"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Total behaviour: never raises, and reset() really resets
+# ---------------------------------------------------------------------------
+
+
+def test_attempt_returns_a_bool_in_every_state_and_never_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every state answers with a plain ``bool``; none of them raises.
+
+    ``creek_mcp.tools.purge._gate`` does not catch, so anything raised out of
+    the budget escapes into the FastMCP tool surface and skips the audit entry
+    every purge call is required to write. The lockout adds a whole new family
+    of states to get that wrong in, so the walk covers all of them: fresh,
+    part-spent, just-armed, deep inside the window, at the boundary, and after
+    expiry.
+    """
+    clock = _pin_clock(monkeypatch)
+    budget = _fresh_budget()
+    armed_at = clock.now
+    wrong = VerifySpy(result=False)
+    correct = VerifySpy(result=True)
+
+    observed: list[bool] = []
+    for _ in range(MAX_FAILED_ATTEMPTS - 1):
+        observed.append(budget.attempt(wrong))
+    observed.append(budget.attempt(wrong))
+    observed.append(budget.attempt(correct))
+    clock.now = armed_at + LOCKOUT_SECONDS / 2
+    observed.append(budget.attempt(wrong))
+    clock.now = armed_at + LOCKOUT_SECONDS - 1.0
+    observed.append(budget.attempt(correct))
+    clock.now = armed_at + LOCKOUT_SECONDS
+    observed.append(budget.attempt(correct))
+
+    assert observed == [False] * (MAX_FAILED_ATTEMPTS + 3) + [True]
+    assert all(type(value) is bool for value in observed)
+
+
+def test_reset_clears_an_armed_lockout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``reset`` reopens the gate without waiting out the window.
+
+    This is the hook ``tests/conftest.py`` uses for isolation, so its whole
+    value is that it works *immediately* -- a reset that only cleared the
+    counter would leave the next test inheriting the window.
+    """
+    _pin_clock(monkeypatch)
+    budget = _fresh_budget()
+    _arm_the_lockout(budget)
+
+    budget.reset()
+
+    correct = VerifySpy(result=True)
+    assert budget.attempt(correct) is True
+    assert correct.calls == 1
+
+
+def test_reset_clears_the_failure_counter_too(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``reset`` restores the full allowance, not just the open gate.
+
+    Distinguishable from the test above only by what happens *next*: if the
+    counter survived the reset, the very first failure afterwards would push
+    it back over the limit and re-arm the window.
+    """
+    _pin_clock(monkeypatch)
+    budget = _fresh_budget()
+    _arm_the_lockout(budget)
+
+    budget.reset()
+
+    wrong = VerifySpy(result=False)
+    for _ in range(MAX_FAILED_ATTEMPTS - 1):
+        assert budget.attempt(wrong) is False
+    assert wrong.calls == MAX_FAILED_ATTEMPTS - 1
+
+    correct = VerifySpy(result=True)
+    assert budget.attempt(correct) is True
+
+
+# ---------------------------------------------------------------------------
+# Structural invariants: no sleeping, no import cycle, and a budget in auth
+# ---------------------------------------------------------------------------
+
+
+def test_a_throttled_refusal_never_sleeps() -> None:
+    """The gate refuses immediately; it does not stall the caller.
+
+    Sleeping is the obvious way to rate limit and the wrong one here. The MCP
+    server would hold the request open, so an attacker who could previously
+    fail a guess for free could instead pin a worker for a minute per guess --
+    trading a brute-force channel for a denial of service. The absence of a
+    call is only expressible structurally, so it is asserted on the AST, and
+    the ``from time import sleep as ...`` escape route is closed alongside it.
+    """
+    tree = ast.parse(_policy_source())
+
+    slept = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and _callee_name(node) == "sleep"
+    ]
+    assert slept == [], "attempt_policy must refuse without blocking the caller"
+
+    aliased = [
+        alias.asname or alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module == "time"
+        for alias in node.names
+        if alias.name == "sleep"
+    ]
+    assert aliased == [], f"time.sleep must not be imported under any name: {aliased}"
+
+
+def test_the_policy_module_depends_on_nothing_in_creek() -> None:
+    """The budget is stdlib-only, so nothing can import-cycle through it.
+
+    :mod:`creek_mcp.auth` imports this module at import time. If the
+    dependency ever pointed back -- even at a constant -- the cycle would
+    surface as an ``ImportError`` in whichever of the two happened to load
+    first, a failure that depends on collection order rather than on code and
+    that a green suite can hide for a long time.
+    """
+    tree = ast.parse(_policy_source())
+    imported: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imported.append("." * node.level + (node.module or ""))
+
+    first_party = [name for name in imported if name.startswith((".", "creek"))]
+    assert first_party == [], f"attempt_policy must stay stdlib-only: {first_party}"
+
+
+def test_the_auth_module_owns_a_budget_the_conftest_hook_can_reset() -> None:
+    """``tests/conftest.py``'s autouse reset must have something real to reset.
+
+    That fixture looks ``_ELEVATED_BUDGET`` up tolerantly, because it has to
+    survive the RED window in which the attribute does not exist yet.
+    Tolerance nothing checks decays into a silent no-op, and a silent no-op
+    there means process-global auth state leaks between tests and the suite
+    becomes order-dependent -- the exact failure the fixture exists to
+    prevent. This assertion is what keeps the tolerance honest.
+    """
+    assert isinstance(auth._ELEVATED_BUDGET, AttemptBudget)
+
+
+# ---------------------------------------------------------------------------
+# Concurrency: the budget is process-global state under a lock
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_attempts_cannot_overspend_the_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Racing callers still get ``MAX_FAILED_ATTEMPTS`` evaluations between them.
+
+    The budget is process-global state that every MCP request reads and
+    writes. An unsynchronised read-modify-write of the counter would let N
+    concurrent callers each observe "four failures so far" and each spend a
+    fifth, turning a five-guess gate into a five-guesses-per-thread gate --
+    the brute-force channel #914 closes, reopened under another name.
+
+    Honest about what this proves: a passing run is not a proof, because
+    interleaving is the scheduler's business and a serialised run passes
+    trivially. A *failing* run is proof of a real defect, and the barrier
+    maximises the overlap that makes the difference detectable. The join
+    timeout doubles as the non-blocking assertion -- ``attempt`` must never
+    park a caller.
+    """
+    _pin_clock(monkeypatch)
+    budget = _fresh_budget()
+    wrong = VerifySpy(result=False)
+    thread_count = 8
+    attempts_each = 3
+    barrier = threading.Barrier(thread_count)
+    outcomes: list[bool] = []
+    outcomes_lock = threading.Lock()
+
+    def _hammer() -> None:
+        """Line up with the other threads, then spend attempts flat out."""
+        barrier.wait()
+        mine = [budget.attempt(wrong) for _ in range(attempts_each)]
+        with outcomes_lock:
+            outcomes.extend(mine)
+
+    workers = [threading.Thread(target=_hammer) for _ in range(thread_count)]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=10.0)
+
+    assert not any(worker.is_alive() for worker in workers), (
+        "attempt() must refuse without blocking; a live thread means it parked"
+    )
+    assert outcomes == [False] * (thread_count * attempts_each)
+    assert wrong.calls == MAX_FAILED_ATTEMPTS

--- a/creek-tools/tests/test_mcp_auth.py
+++ b/creek-tools/tests/test_mcp_auth.py
@@ -6,6 +6,14 @@ environment variable at server startup; callers present a matching
 token via the ``auth_token`` tool argument. The comparison MUST use
 :func:`hmac.compare_digest` so a hostile client cannot infer the token
 byte-by-byte via timing.
+
+Constant-time comparison alone only stops the attacker *learning* the token
+one byte at a time; it does nothing about guessing it whole, at machine
+speed, over a surface that answers in microseconds. #914 adds the missing
+half — a failed-attempt budget in :mod:`creek_mcp.attempt_policy` that
+``is_elevated`` routes every verification through — so this module also pins
+where the comparison is allowed to live, and that the throttle is inherited
+rather than reimplemented.
 """
 
 from __future__ import annotations
@@ -14,15 +22,30 @@ import ast
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import pytest
+
 from creek_mcp import auth
+from tests.elevated_attempt_support import FakeMonotonicClock
 
 if TYPE_CHECKING:
-    import pytest
+    from collections.abc import Iterator
+    from types import ModuleType
 
 
 # 40 chars — clears the 32-char floor (#907). Low-entropy test literal,
 # not a real credential.
 _STRONG_TOKEN = "elevated-test-token-" + "a" * 20
+
+# 39 chars — clears the floor and matches nothing. Test literal, not a real
+# credential.
+_WRONG_TOKEN = "wrong-elevated-token-" + "z" * 18
+
+# 31 chars — one under the floor. Test literal, not a real credential.
+_WEAK_TOKEN = "weak-elevated-" + "a" * 17
+
+# 36 chars of unpaired surrogates — clears the floor by length but cannot be
+# encoded to UTF-8 (#914). Test literal, not a real credential.
+_SURROGATE_TOKEN = "\ud800" * 36
 
 
 def test_is_elevated_returns_false_when_env_unset(
@@ -122,26 +145,421 @@ def test_is_elevated_accepts_exact_boundary_token(
     assert auth.is_elevated(boundary_token) is True
 
 
+# ---------------------------------------------------------------------------
+# Static invariants over the gate's source
+# ---------------------------------------------------------------------------
+
+
+def _auth_tree() -> ast.Module:
+    """Parse ``creek_mcp/auth.py`` from disk.
+
+    Returns:
+        The module's AST, read from the file rather than from
+        :func:`inspect.getsource` so the assertion is about what ships.
+    """
+    return ast.parse(Path(auth.__file__).read_text(encoding="utf-8"))
+
+
+def _functions(tree: ast.AST) -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
+    """Return every function definition in *tree*, nested ones included.
+
+    Args:
+        tree: The parsed module (or any subtree) to scan.
+
+    Returns:
+        Each ``def`` and ``async def``. Coroutines are included so a future
+        ``async def`` cannot slip past a guard that only knew about
+        :class:`ast.FunctionDef`.
+    """
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)
+    ]
+
+
+def _own_nodes(node: ast.AST) -> Iterator[ast.AST]:
+    """Yield the nodes belonging to *node* itself, not to a nested ``def``.
+
+    Lambdas *are* descended into — a lambda body is code the enclosing
+    function runs, and ``is_elevated`` is expected to hand one to the attempt
+    budget — while ``def``/``async def`` bodies are not, so a helper defined
+    inside another function is attributed to itself alone and never
+    double-counted against its parent.
+
+    Args:
+        node: The subtree root to walk.
+
+    Yields:
+        Every descendant that is part of *node*'s own code.
+    """
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        yield child
+        yield from _own_nodes(child)
+
+
+def _calls_attribute(function: ast.AST, attribute: str) -> bool:
+    """Return whether *function*'s own body calls ``<something>.<attribute>``.
+
+    Args:
+        function: The function node to inspect.
+        attribute: The attribute name of the callee, e.g. ``compare_digest``.
+
+    Returns:
+        ``True`` when at least one such call site is in the function's own
+        code.
+    """
+    return any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == attribute
+        for node in _own_nodes(function)
+    )
+
+
+def _reads_name(function: ast.AST, name: str) -> bool:
+    """Return whether *function*'s own body mentions the bare symbol *name*.
+
+    Args:
+        function: The function node to inspect.
+        name: The symbol to look for, e.g. ``ELEVATED_TOKEN_ENV``.
+
+    Returns:
+        ``True`` when the symbol is loaded (or stored) anywhere in the
+        function's own code.
+    """
+    return any(
+        isinstance(node, ast.Name) and node.id == name for node in _own_nodes(function)
+    )
+
+
+def _dotted_module_name(path: Path, package_root: Path) -> str:
+    """Return the dotted import path of *path* inside the ``creek_mcp`` package.
+
+    Args:
+        path: A ``.py`` file somewhere under *package_root*.
+        package_root: The ``creek_mcp`` package directory.
+
+    Returns:
+        e.g. ``creek_mcp.tools.purge``; a package's ``__init__.py`` maps to
+        the package itself.
+    """
+    parts = list(path.relative_to(package_root.parent).with_suffix("").parts)
+    if parts[-1] == "__init__":
+        parts.pop()
+    return ".".join(parts)
+
+
+def _elevated_env_readers() -> set[tuple[str, str]]:
+    """Return every ``(module, function)`` in ``creek_mcp`` naming the env constant.
+
+    Returns:
+        One entry per function whose own code mentions
+        :data:`creek_mcp.auth.ELEVATED_TOKEN_ENV`. Module-scope statements
+        (the definition itself, and ``server.py``'s import of it) are not
+        functions and so are not reported.
+    """
+    package_root = Path(auth.__file__).parent
+    readers: set[tuple[str, str]] = set()
+    for source_file in sorted(package_root.rglob("*.py")):
+        tree = ast.parse(source_file.read_text(encoding="utf-8"))
+        module = _dotted_module_name(source_file, package_root)
+        readers.update(
+            (module, function.name)
+            for function in _functions(tree)
+            if _reads_name(function, "ELEVATED_TOKEN_ENV")
+        )
+    return readers
+
+
+_ELEVATED_ENV_ALLOWED_MODULES = frozenset({"creek_mcp.auth"})
+"""Modules whose functions may read ``CREEK_MCP_ELEVATED_TOKEN`` freely.
+
+Module-wide rather than function-wide on purpose: :mod:`creek_mcp.auth` owns
+the throttled gate, and its internals must stay free to move between private
+helpers without a rename turning the ratchet below red.
+"""
+
+_ELEVATED_ENV_ALLOWLIST = frozenset(
+    {("creek_mcp.server", "_require_strong_elevated_token")},
+)
+"""The one function outside :mod:`creek_mcp.auth` allowed to read the env var.
+
+It reads the configured value at startup to refuse a weak one (#907) and
+never compares it against anything a caller supplied, so it is not a
+guessing surface and needs no attempt budget.
+"""
+
+
 def test_auth_module_source_uses_compare_digest_not_equality() -> None:
     """Static check: ``auth.py`` must not compare token strings with ``==``.
 
     ADAPT-004 / FEAT-012: elevated-auth comparisons MUST be constant
     time. Walking the AST is more robust than a textual search — it
     won't false-positive on string literals like ``"=="`` in docstrings.
+
+    The walk covers **every** function in the module rather than only
+    ``is_elevated`` (#914). The throttle moves the comparison out of
+    ``is_elevated`` and into a helper the attempt budget calls; a guard
+    scoped to that one name would have gone quietly vacuous the moment the
+    body moved — which is exactly the edit during which a hand-rolled ``==``
+    is easiest to introduce.
     """
-    source = Path(auth.__file__).read_text(encoding="utf-8")
-    tree = ast.parse(source)
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.FunctionDef):
-            continue
-        if node.name != "is_elevated":
-            continue
-        for sub in ast.walk(node):
-            if isinstance(sub, ast.Compare):
-                for op in sub.ops:
-                    if isinstance(op, ast.Eq | ast.NotEq):
-                        msg = (
-                            "is_elevated must not use ==/!= on tokens; "
-                            "use hmac.compare_digest"
-                        )
-                        raise AssertionError(msg)
+    for function in _functions(_auth_tree()):
+        for node in _own_nodes(function):
+            if not isinstance(node, ast.Compare):
+                continue
+            for op in node.ops:
+                if isinstance(op, ast.Eq | ast.NotEq):
+                    msg = (
+                        f"{function.name} must not use ==/!= on tokens; "
+                        "use hmac.compare_digest"
+                    )
+                    raise AssertionError(msg)
+
+
+def test_elevated_compare_is_unreachable_outside_the_attempt_budget() -> None:
+    """Exactly one function may evaluate the token, and it is not ``is_elevated``.
+
+    The #914 throttle is a bound on guessing only if the comparison is
+    unreachable except through :meth:`AttemptBudget.attempt`. That is a
+    structural claim — no behavioural test can see a second, unthrottled path
+    that no caller happens to take *yet* — so it is asserted structurally:
+    one function in ``auth.py`` calls ``hmac.compare_digest``, ``is_elevated``
+    is not that function, and ``is_elevated`` delegates through a call to
+    ``.attempt``.
+
+    Asserted by count and location rather than by the private helper's name,
+    so renaming it is not a spurious red.
+    """
+    functions = _functions(_auth_tree())
+
+    comparing = sorted(
+        f.name for f in functions if _calls_attribute(f, "compare_digest")
+    )
+    assert len(comparing) == 1, (
+        f"exactly one function may compare the elevated token; found {comparing}"
+    )
+    assert "is_elevated" not in comparing, (
+        "is_elevated must delegate the comparison, never perform it — an "
+        "in-place compare is an unthrottled guessing surface (#914)"
+    )
+
+    gates = [f for f in functions if f.name == "is_elevated"]
+    assert len(gates) == 1, "auth.py must define exactly one is_elevated"
+    assert _calls_attribute(gates[0], "attempt"), (
+        "is_elevated must route every verification through the attempt budget"
+    )
+
+
+def test_only_the_gate_and_the_startup_check_read_the_elevated_env() -> None:
+    """No second, unthrottled reader of ``CREEK_MCP_ELEVATED_TOKEN`` (#914).
+
+    Honest framing: **this passes at HEAD.** It is a ratchet, not a red test.
+    The throttle lives inside :func:`creek_mcp.auth.is_elevated`, so it bounds
+    only the guessing that goes through that function; a second call site that
+    read the env var and compared it itself would be an unthrottled oracle
+    with nothing to notice it. Two locations are sanctioned — the gate's own
+    module, and the startup strength check, which never compares the value to
+    caller input.
+
+    The allowlist is also asserted to be *live*, so a rename on the server
+    side forces a deliberate review here instead of quietly leaving a stale
+    entry that exempts nothing.
+    """
+    readers = _elevated_env_readers()
+
+    assert readers >= _ELEVATED_ENV_ALLOWLIST, (
+        "the allowlist has gone stale — these no longer exist: "
+        f"{sorted(_ELEVATED_ENV_ALLOWLIST - readers)}"
+    )
+    offenders = {
+        (module, function)
+        for module, function in readers
+        if module not in _ELEVATED_ENV_ALLOWED_MODULES
+        and (module, function) not in _ELEVATED_ENV_ALLOWLIST
+    }
+    assert offenders == set(), (
+        f"these read the elevated token outside the throttled gate: {sorted(offenders)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The failed-attempt budget, seen from the gate (#914)
+# ---------------------------------------------------------------------------
+
+
+def _attempt_policy() -> ModuleType:
+    """Import :mod:`creek_mcp.attempt_policy` at call time.
+
+    Deferred rather than imported at module scope so this file still
+    *collects* while the module does not exist yet: the behavioural throttle
+    tests below must fail on their own assertions during the RED window, and
+    a top-level ``ModuleNotFoundError`` would turn every test in the file —
+    including the eight that predate #914 — into a collection error.
+
+    Returns:
+        The attempt-policy module.
+    """
+    from creek_mcp import attempt_policy
+
+    return attempt_policy
+
+
+def _arm_the_elevated_lockout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Spend the whole failure budget, so the gate is locked on return.
+
+    Args:
+        monkeypatch: Used to configure a floor-clearing server token first,
+            so the failures are genuine mismatches rather than the #907
+            weak-configuration deny. The caller is free to reconfigure the
+            environment afterwards — the budget does not re-read it.
+    """
+    policy = _attempt_policy()
+    monkeypatch.setenv("CREEK_MCP_ELEVATED_TOKEN", _STRONG_TOKEN)
+    for _ in range(policy.MAX_FAILED_ATTEMPTS):
+        assert auth.is_elevated(_WRONG_TOKEN) is False
+
+
+def test_the_correct_token_is_refused_inside_the_lockout_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Five wrong guesses shut the gate — even against the right token (#914).
+
+    Stated on the *authorized* caller because that is the strongest form of
+    the bound: if a valid token is refused inside the window, an invalid one
+    provably was never evaluated either.
+
+    The count is the literal ``5`` rather than
+    ``attempt_policy.MAX_FAILED_ATTEMPTS`` on purpose. During the RED window
+    that name does not exist, and reaching for it would make this test die on
+    a ``ModuleNotFoundError`` instead of on the assertion that describes the
+    defect. ``test_the_gate_reopens_after_the_lockout_window_expires`` below
+    is what ties the behaviour back to the named constants.
+    """
+    monkeypatch.setenv("CREEK_MCP_ELEVATED_TOKEN", _STRONG_TOKEN)
+    for _ in range(5):
+        assert auth.is_elevated(_WRONG_TOKEN) is False
+
+    assert auth.is_elevated(_STRONG_TOKEN) is False
+
+
+def test_one_failure_short_of_the_limit_leaves_the_gate_open(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The operator gets every guess the policy promises, then locks.
+
+    An off-by-one that shut the gate at ``MAX_FAILED_ATTEMPTS - 1`` would be
+    invisible from the outside — the refusal payload is byte-identical either
+    way — and would cost the operator a guess on a surface where the next
+    thing they can do is wait a minute.
+    """
+    policy = _attempt_policy()
+    monkeypatch.setenv("CREEK_MCP_ELEVATED_TOKEN", _STRONG_TOKEN)
+
+    for _ in range(policy.MAX_FAILED_ATTEMPTS - 1):
+        assert auth.is_elevated(_WRONG_TOKEN) is False
+
+    assert auth.is_elevated(_STRONG_TOKEN) is True
+
+
+def test_the_gate_reopens_after_the_lockout_window_expires(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The lockout is a delay of exactly ``LOCKOUT_SECONDS``, not a ban.
+
+    Bricking the operator's own gate would be a worse outcome than the
+    brute-force channel #914 closes, so the reopen is asserted rather than
+    assumed — and both edges of the window are pinned, so its length cannot
+    drift in either direction.
+
+    This is also what proves the two named constants are the ones actually in
+    force: the gate locks after ``MAX_FAILED_ATTEMPTS`` failures and reopens
+    ``LOCKOUT_SECONDS`` later. Time is driven by hand through the module's
+    ``_now`` seam, so the test costs microseconds and cannot be made to pass
+    by sleeping.
+    """
+    policy = _attempt_policy()
+    clock = FakeMonotonicClock()
+    monkeypatch.setattr(policy, "_now", clock)
+    monkeypatch.setenv("CREEK_MCP_ELEVATED_TOKEN", _STRONG_TOKEN)
+    armed_at = clock.now
+
+    for _ in range(policy.MAX_FAILED_ATTEMPTS):
+        assert auth.is_elevated(_WRONG_TOKEN) is False
+    assert auth.is_elevated(_STRONG_TOKEN) is False
+
+    clock.now = armed_at + policy.LOCKOUT_SECONDS - 1.0
+    assert auth.is_elevated(_STRONG_TOKEN) is False
+
+    clock.now = armed_at + policy.LOCKOUT_SECONDS
+    assert auth.is_elevated(_STRONG_TOKEN) is True
+
+
+_NEVER_RAISES_CASES = [
+    pytest.param(None, _STRONG_TOKEN, id="env-unset"),
+    pytest.param("", _STRONG_TOKEN, id="env-empty"),
+    pytest.param("", None, id="env-empty-and-no-client-token"),
+    pytest.param(_WEAK_TOKEN, _WEAK_TOKEN, id="env-weak-exact-match"),
+    pytest.param(_STRONG_TOKEN, _WRONG_TOKEN, id="wrong-client-token"),
+    pytest.param(_STRONG_TOKEN, None, id="no-client-token"),
+    pytest.param(_STRONG_TOKEN, _SURROGATE_TOKEN, id="unencodable-client-token"),
+]
+"""Every way the gate is expected to say no, as ``(configured, provided)``.
+
+The ``unencodable`` row is the #914 regression case. A lone surrogate
+survives ``json.loads``, so it reaches ``auth_token`` straight off the
+wire, and ``str.encode`` then raises :exc:`UnicodeEncodeError`. A raise
+here is not cosmetic: :func:`creek_mcp.tools.purge._gate` does not catch,
+so the exception escapes into the FastMCP tool surface and skips the audit
+entry every purge call must write — an unaudited probe of a destructive
+tool. Worse, once the budget exists the raise becomes *state-dependent*:
+inside a lockout ``verify`` is never called, so the identical input returns
+a clean ``False``. That difference is an exact, free oracle for whether the
+global budget is armed, and it costs the attacker nothing because the
+failure counter is never reached.
+
+Only the caller's token is exercised here. The server side can hold a
+surrogate too — ``os.environ`` decodes invalid UTF-8 with
+``surrogateescape`` — but ``monkeypatch.setenv`` cannot install one (the
+raise lands in ``os.putenv``, not in the code under test), so a row for it
+would be testing the harness. The fix guards both encodes regardless.
+"""
+
+
+@pytest.mark.parametrize(
+    "inside_window",
+    [pytest.param(False, id="unthrottled"), pytest.param(True, id="locked-out")],
+)
+@pytest.mark.parametrize(("configured", "provided"), _NEVER_RAISES_CASES)
+def test_is_elevated_never_raises_and_stays_closed_in_every_state(
+    monkeypatch: pytest.MonkeyPatch,
+    configured: str | None,
+    provided: str | None,
+    inside_window: bool,
+) -> None:
+    """The gate answers ``False`` rather than raising, throttled or not (#914).
+
+    :func:`creek_mcp.tools.purge._gate` does not catch, so anything raised
+    here escapes into the FastMCP tool surface and skips the audit entry every
+    purge call is required to write — a hostile caller could then probe the
+    gate and leave no trail. The lockout adds a whole new family of states to
+    get that wrong in, so each failing configuration is exercised twice: once
+    with the budget untouched, and once from inside an armed window.
+
+    Args:
+        monkeypatch: Sets the server-side token for each case.
+        configured: ``CREEK_MCP_ELEVATED_TOKEN``, or ``None`` to unset it.
+        provided: The caller's ``auth_token``.
+        inside_window: Whether to arm the lockout before the call.
+    """
+    if inside_window:
+        _arm_the_elevated_lockout(monkeypatch)
+    if configured is None:
+        monkeypatch.delenv("CREEK_MCP_ELEVATED_TOKEN", raising=False)
+    else:
+        monkeypatch.setenv("CREEK_MCP_ELEVATED_TOKEN", configured)
+
+    assert auth.is_elevated(provided) is False

--- a/creek-tools/tests/test_mcp_purge.py
+++ b/creek-tools/tests/test_mcp_purge.py
@@ -6,6 +6,11 @@ elevated-authorization gate (:mod:`creek_mcp.auth`). A call without the
 a partial purge — and the ``creek.purge.vault`` tool additionally
 requires a ``confirm_vault_path`` matching the absolute path of the
 target vault, mirroring the CLI's interactive guard.
+
+The final section covers #914: the gate is also *rate limited*. Five wrong
+tokens shut it for a minute, the bound is shared across all five tools rather
+than reimplemented per tool, and the throttled refusal is byte-identical to
+an ordinary one so the lockout never becomes an oracle.
 """
 
 from __future__ import annotations
@@ -21,21 +26,27 @@ from creek.purge.audit import PurgeAuditEntry, PurgeAuditLog
 from creek.purge.engine import PurgeResult
 from creek_mcp.audit import MCP_AUDIT_RELPATH
 from creek_mcp.tools.purge import (
+    _REFUSAL_NO_TOKEN,
     purge_classifications_tool,
     purge_daterange_tool,
     purge_fragment_tool,
     purge_source_tool,
     purge_vault_tool,
 )
+from tests.elevated_attempt_support import FakeMonotonicClock
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
     from pathlib import Path
 
 
 # 41 chars — clears the 32-char floor (#907). Low-entropy test literal,
 # not a real credential.
 ELEVATED_TOKEN = "test-elevated-secret-" + "a" * 20
+
+# 41 chars — clears the #907 floor and matches nothing. Test literal, not a
+# real credential.
+WRONG_TOKEN = "wrong-elevated-secret-" + "b" * 19
 
 
 @pytest.fixture
@@ -640,3 +651,360 @@ def test_the_previously_dropped_counters_reach_the_caller(vault: Path) -> None:
         "voice_body_undecodable",
     ):
         assert field in payload, f"{field} never reaches the MCP caller"
+
+
+# ---------------------------------------------------------------------------
+# The gate is not brute-forceable (#914)
+# ---------------------------------------------------------------------------
+
+
+def test_correct_token_is_refused_after_five_failed_attempts(vault: Path) -> None:
+    """Five wrong guesses lock the gate — the CORRECT token is then refused (#914).
+
+    The bound is proved on the *authorized* caller, which is the strongest
+    form: if a valid token is refused inside the window, an invalid one is
+    provably never evaluated.
+    """
+    for _ in range(5):  # literal, not MAX_FAILED_ATTEMPTS: at HEAD that name
+        purge_fragment_tool(  # does not exist and the test would die on an
+            vault_path=vault,  # AttributeError instead of on the assertion
+            fragment_id="frag-001",
+            auth_token=WRONG_TOKEN,
+            consumer="claude-code",
+        )
+
+    result = purge_fragment_tool(
+        vault_path=vault,
+        fragment_id="frag-001",
+        auth_token=ELEVATED_TOKEN,
+        consumer="claude-code",
+    )
+
+    assert result == {
+        "status": "refused",
+        "tool": "creek.purge.fragment",
+        "reason": _REFUSAL_NO_TOKEN,
+    }
+    assert (vault / "01-Fragments" / "Notes" / "frag-001.md").exists()
+
+
+def _fail_the_gate(vault_path: Path, times: int) -> None:
+    """Spend *times* wrong-token attempts against ``creek.purge.fragment``.
+
+    Args:
+        vault_path: The seeded vault; every attempt audits against it and
+            none of them touches a file.
+        times: How many wrong guesses to make.
+    """
+    for _ in range(times):
+        purge_fragment_tool(
+            vault_path=vault_path,
+            fragment_id="frag-001",
+            auth_token=WRONG_TOKEN,
+            consumer="claude-code",
+        )
+
+
+def test_a_throttled_refusal_is_byte_identical_to_an_ordinary_one(
+    vault: Path,
+) -> None:
+    """The lockout must leave no trace in the payload (#913, #914).
+
+    A ``retry_after`` / ``throttled`` / ``attempts_remaining`` key would be a
+    configuration oracle handed out for free: it tells a hostile caller that
+    the policy is armed, how long it lasts, and how many guesses remain — and
+    #913 closed exactly that class of leak. The key set is asserted whole, so
+    a helpful new field cannot be added without this test noticing.
+
+    Honest scope: the equality already holds at HEAD, where nothing
+    short-circuits and both payloads are the same ordinary refusal. This is a
+    ratchet on the implementation that follows, not a red test.
+    """
+    ordinary = purge_fragment_tool(
+        vault_path=vault,
+        fragment_id="frag-001",
+        auth_token=WRONG_TOKEN,
+        consumer="claude-code",
+    )
+    _fail_the_gate(vault, 4)  # ordinary + 4 == the whole budget
+
+    throttled = purge_fragment_tool(
+        vault_path=vault,
+        fragment_id="frag-001",
+        auth_token=WRONG_TOKEN,
+        consumer="claude-code",
+    )
+
+    assert throttled == ordinary
+    assert set(throttled) == {"status", "tool", "reason"}
+    assert throttled["reason"] == _REFUSAL_NO_TOKEN
+
+
+def test_a_locked_gate_cannot_be_told_apart_from_a_wrong_token(
+    vault: Path,
+) -> None:
+    """Inside the window, right and wrong tokens produce the same bytes (#914).
+
+    This is the sharper half of the byte-identity property. If a throttled
+    refusal of the *correct* token differed in any way from a refusal of a
+    wrong one, the lockout would have become an oracle that confirms a guess
+    — which is worth more to an attacker than the guesses the throttle took
+    away.
+    """
+    _fail_the_gate(vault, 5)
+
+    with_a_wrong_token = purge_fragment_tool(
+        vault_path=vault,
+        fragment_id="frag-001",
+        auth_token=WRONG_TOKEN,
+        consumer="claude-code",
+    )
+    with_the_right_token = purge_fragment_tool(
+        vault_path=vault,
+        fragment_id="frag-001",
+        auth_token=ELEVATED_TOKEN,
+        consumer="claude-code",
+    )
+
+    assert with_the_right_token == with_a_wrong_token
+    assert with_the_right_token["status"] == "refused"
+    assert (vault / "01-Fragments" / "Notes" / "frag-001.md").exists()
+
+
+def test_every_throttled_attempt_is_still_audited(vault: Path) -> None:
+    """Refusing faster must not mean refusing silently (#914).
+
+    ``mcp.jsonl`` is the only record that a brute-force attempt happened at
+    all, so the short-circuit that skips the token comparison must not also
+    skip the audit append. A throttle that hides the attack it is defending
+    against is worse than no throttle — the operator would see a quiet log
+    and a gate that mysteriously refuses them.
+
+    Honest scope: six attempts already produce six entries at HEAD, where
+    nothing short-circuits. This is what keeps that true once something does.
+    """
+    _fail_the_gate(vault, 6)
+
+    entries = _audit_entries(vault)
+    assert len(entries) == 6
+    assert [entry["tool"] for entry in entries] == ["creek.purge.fragment"] * 6
+    for entry in entries:
+        summary = entry["args_summary"]
+        assert isinstance(summary, dict)
+        assert "auth_token" not in summary
+
+
+def test_a_successful_purge_hands_the_whole_budget_back(vault: Path) -> None:
+    """Authorizing resets the counter, so honest typos never accumulate (#914).
+
+    Without the reset the budget is a lifetime allowance rather than a
+    consecutive-failure bound: four typos in this session plus four in the
+    next lock the operator out with no failed *attack* anywhere in the
+    sequence. Both successes are real — ``status == "ok"`` straight from the
+    engine — and ``dry_run`` is what leaves the fragment on disk so the
+    second round has something to purge.
+    """
+    for _ in range(2):
+        _fail_the_gate(vault, 4)
+        served = purge_fragment_tool(
+            vault_path=vault,
+            fragment_id="frag-001",
+            auth_token=ELEVATED_TOKEN,
+            consumer="claude-code",
+            dry_run=True,
+        )
+        assert served["status"] == "ok"
+        assert served["dry_run"] is True
+
+    assert (vault / "01-Fragments" / "Notes" / "frag-001.md").exists()
+
+
+def test_the_purge_gate_reopens_after_the_lockout_expires(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A locked-out operator gets their own tools back, on the clock (#914).
+
+    The failure this pins is worse than the one #914 fixes: a throttle that
+    never lifts bricks the only path the operator has to erase their own
+    data, and every individual refusal along the way looks correct. Time is
+    driven by hand through the policy module's ``_now`` seam, so the
+    assertion is exact and the test costs microseconds rather than a minute.
+
+    The import is deferred on purpose: during the RED window
+    ``creek_mcp.attempt_policy`` does not exist, and a module-level import
+    would turn every test in this file into a collection error instead of
+    letting the ones above fail on their own assertions.
+    """
+    from creek_mcp import attempt_policy
+
+    clock = FakeMonotonicClock()
+    monkeypatch.setattr(attempt_policy, "_now", clock)
+    armed_at = clock.now
+
+    _fail_the_gate(vault, attempt_policy.MAX_FAILED_ATTEMPTS)
+    locked = purge_fragment_tool(
+        vault_path=vault,
+        fragment_id="frag-001",
+        auth_token=ELEVATED_TOKEN,
+        consumer="claude-code",
+        dry_run=True,
+    )
+    assert locked["status"] == "refused"
+
+    clock.now = armed_at + attempt_policy.LOCKOUT_SECONDS
+    served = purge_fragment_tool(
+        vault_path=vault,
+        fragment_id="frag-001",
+        auth_token=ELEVATED_TOKEN,
+        consumer="claude-code",
+    )
+
+    assert served["status"] == "ok"
+    assert served["fragments_affected"] == 1
+    assert not (vault / "01-Fragments" / "Notes" / "frag-001.md").exists()
+
+
+def _attempt_fragment(vault_path: Path, token: str | None) -> dict[str, object]:
+    """Invoke ``creek.purge.fragment`` with *token*, previewing only.
+
+    Args:
+        vault_path: The seeded vault.
+        token: The ``auth_token`` to present.
+
+    Returns:
+        The tool's structured response.
+    """
+    return purge_fragment_tool(
+        vault_path=vault_path,
+        fragment_id="frag-001",
+        auth_token=token,
+        dry_run=True,
+    )
+
+
+def _attempt_source(vault_path: Path, token: str | None) -> dict[str, object]:
+    """Invoke ``creek.purge.source`` with *token*, previewing only.
+
+    Args:
+        vault_path: The seeded vault.
+        token: The ``auth_token`` to present.
+
+    Returns:
+        The tool's structured response.
+    """
+    return purge_source_tool(
+        vault_path=vault_path,
+        source_type="journal",
+        auth_token=token,
+        dry_run=True,
+    )
+
+
+def _attempt_classifications(vault_path: Path, token: str | None) -> dict[str, object]:
+    """Invoke ``creek.purge.classifications`` with *token*, previewing only.
+
+    Args:
+        vault_path: The seeded vault.
+        token: The ``auth_token`` to present.
+
+    Returns:
+        The tool's structured response.
+    """
+    return purge_classifications_tool(
+        vault_path=vault_path,
+        auth_token=token,
+        dry_run=True,
+    )
+
+
+def _attempt_daterange(vault_path: Path, token: str | None) -> dict[str, object]:
+    """Invoke ``creek.purge.daterange`` with *token*, previewing only.
+
+    Args:
+        vault_path: The seeded vault.
+        token: The ``auth_token`` to present.
+
+    Returns:
+        The tool's structured response.
+    """
+    return purge_daterange_tool(
+        vault_path=vault_path,
+        start="2026-05-01",
+        end="2026-05-02",
+        auth_token=token,
+        dry_run=True,
+    )
+
+
+def _attempt_vault(vault_path: Path, token: str | None) -> dict[str, object]:
+    """Invoke ``creek.purge.vault`` with *token* and a matching confirmation.
+
+    Args:
+        vault_path: The seeded vault, echoed back as ``confirm_vault_path``
+            so the tool's second factor is satisfied and the elevated gate
+            is the only thing left that can refuse.
+        token: The ``auth_token`` to present.
+
+    Returns:
+        The tool's structured response.
+    """
+    return purge_vault_tool(
+        vault_path=vault_path,
+        confirm_vault_path=str(vault_path),
+        auth_token=token,
+        dry_run=True,
+    )
+
+
+@pytest.mark.parametrize(
+    ("tool", "attempt"),
+    [
+        pytest.param("creek.purge.fragment", _attempt_fragment, id="fragment"),
+        pytest.param("creek.purge.source", _attempt_source, id="source"),
+        pytest.param(
+            "creek.purge.classifications",
+            _attempt_classifications,
+            id="classifications",
+        ),
+        pytest.param("creek.purge.daterange", _attempt_daterange, id="daterange"),
+        pytest.param("creek.purge.vault", _attempt_vault, id="vault"),
+    ],
+)
+def test_every_purge_tool_inherits_the_shared_lockout(
+    vault: Path,
+    tool: str,
+    attempt: Callable[[Path, str | None], dict[str, object]],
+) -> None:
+    """One budget guards all five tools — not five budgets of five guesses.
+
+    The window is armed entirely through ``creek.purge.classifications`` and
+    then checked on a *different* tool, so a per-tool counter fails here: five
+    tools times five guesses is a twenty-five-guess gate, and an attacker who
+    rotates tools between guesses never trips any of them. The
+    ``classifications`` parameter is the same-tool control.
+
+    Every invocation runs with ``dry_run=True``. The assertion is about the
+    gate, and a test that had to destroy the vault to learn the gate opened
+    could not then check that it stays shut.
+
+    Args:
+        vault: The seeded vault.
+        tool: The wire name the refusal must carry.
+        attempt: Invokes the tool under test with a given token.
+    """
+    for _ in range(5):  # literal: MAX_FAILED_ATTEMPTS does not exist at HEAD
+        purge_classifications_tool(
+            vault_path=vault,
+            auth_token=WRONG_TOKEN,
+            consumer="claude-code",
+            dry_run=True,
+        )
+
+    result = attempt(vault, ELEVATED_TOKEN)
+
+    assert result["status"] == "refused"
+    assert result["tool"] == tool
+    assert result["reason"] == _REFUSAL_NO_TOKEN
+    assert set(result) == {"status", "tool", "reason"}
+    assert (vault / "01-Fragments" / "Notes" / "frag-001.md").exists()


### PR DESCRIPTION
## Summary

- **Bounds the elevated-token brute force.** `is_elevated` compared the caller's token in constant time but compared it *as often as it was asked to*. `hmac.compare_digest` stops an attacker learning the secret byte-by-byte; nothing stopped them guessing it whole, at machine speed, against a surface that answers in microseconds. A new stdlib-only `creek_mcp/attempt_policy.py` meters every verification: after `MAX_FAILED_ATTEMPTS = 5` consecutive denials the gate stops evaluating tokens at all for `LOCKOUT_SECONDS = 60.0`.
- **`creek_mcp/tools/purge.py` is a deliberate zero-byte diff.** `is_elevated` keeps its exact signature and delegates to the budget; the old comparison moved verbatim into a private `_verify_match`. Because the gate's caller is untouched, a throttled refusal is byte-identical to any other — same `status`, `tool`, `reason`, no `retry_after`/`throttled`/`attempts_remaining`. No `CONTRACT_VERSION` bump: nothing moved on the wire.
- **Fixes a latent raise found during review.** A lone surrogate (which survives `json.loads`, so it arrives straight off the wire) made `.encode("utf-8")` throw `UnicodeEncodeError`. `purge._gate` does not catch, so the exception escaped into the tool surface and **skipped the mandatory audit entry**. Worse, once the budget existed the raise became *state-dependent* — inside a lockout `verify` is never called, so the same input returned a clean `False` — an exact, free oracle for whether the budget was armed, costing the attacker no budget. Now fails closed.

## Design decisions the issue asked for

**In-process vs. persisted: in-process, stdlib-only**, matching the #913 precedent that kept `token_policy.py` dependency-free. Persisted state was rejected because it adds a write path and a file-permission surface to an auth module. Stated plainly: this **bounds** the brute force, it does not close it. An attacker who can cycle the process resets the counter — which already requires powers strictly greater than guessing the token.

**Keying: process-global.** The *secret* is process-global, so one guess consumes one guess from the single shared keyspace regardless of who made it; per-identity keying would multiply an attacker's budget by the number of identities they hold, and a per-tool budget would make the five purge tools a 25-guess gate. (Note for the record: `consumer` is **not** caller-declarable — it is `_effective_consumer(...)`, the verified remote bearer's `client_id` when remote, else the build-time env default. `_purge_fragment` has no `consumer` parameter.)

**No `sleep`, anywhere in production.** The five purge tools are registered *sync* (`server.py:730-731`) and the MCP SDK invokes sync tool functions inline on the asyncio event loop (`mcp/server/fastmcp/utilities/func_metadata.py:94-96`). A blocking backoff would freeze the entire server — every tool, every consumer, both transports — turning a rate-limit fix into a remotely-triggerable availability kill. The lockout returns immediately; `test_a_throttled_refusal_never_sleeps` pins this structurally, including the aliased-import escape route.

**Threat model, not overstated.** Reaching a purge call already requires either the local stdio client or a valid ≥32-char consumer bearer (`main` refuses the network transport without `CREEK_MCP_CONSUMER_TOKENS`). The realistic brute-forcer is a *partially trusted* party — canonically CrawDad, which is deliberately given transport access and deliberately denied the elevated token. This is a real residual, not an open-internet attack.

**Availability cost, measured and accepted.** Under a sustained 1 Hz attack the attacker gets **285 evaluated guesses per hour (4.75/min**, previously bounded only by the network**)**, but the gate is shut to *everyone* for **~92%** of that hour: each expiring window is re-spent in five seconds and re-arms. So MCP purge is not merely delayed 60 seconds while an attack runs — it is largely unavailable. Accepted deliberately; the operator's recovery path is `creek purge` on the CLI, which drives `PurgeEngine` directly and never reaches this gate. All three numbers were measured against the built code, and `test_a_sustained_attacker_is_held_to_the_documented_guess_rate` pins them.

**Audit behaviour is unchanged and tested:** every attempt, throttled or not, still writes exactly one `mcp.jsonl` entry. The throttle is what bounds log growth. The throttle is deliberately invisible in the audit log, so operators detect it by the *rate* of refusals, not by a flag.

**Timing:** the throttled path returns before `compare_digest` and is observably faster. It leaks only the global lockout state, never token material, and is buried under the per-call `mcp.jsonl` append. It does not widen the pre-existing "misconfigured vs. armed" micro-oracle in `_verify_match`, which is out of scope here.

## Test plan

- **TDD, RED proved first.** Before any production edit: 18 failures, 8 behavioral. The lead test failed on its assertion, not on a missing symbol — `assert {'affected_fr...'} == {'reason': ...}`, `{'status': 'ok'} != {'status': 'refused'}`, and the fragment had been deleted. `test_every_purge_tool_inherits_the_shared_lockout` failed `'ok' == 'refused'` on all five tools.
- **Mutation-tested the re-arm**: disabling it makes the sustained-attack test go red (3541 evaluated guesses vs. 285), so that test has a real trip-wire rather than asserting a shape.
- **Adversarial hand-check** of the state machine: 5 wrong → 600 s of 1 Hz hammering inside the window → `verify` never invoked; window boundary exact at 59.999 s (refused) / 60.0 s (served); full allowance restored after heal, not one probationary attempt.
- **The surrogate regression case was RED first** (`UnicodeEncodeError`), then green.
- **Gate 2**: `./scripts/check-all.sh` → **12/12, exit 0**. 8664 passed, 94.35% branch coverage; `attempt_policy.py` 95.74%, `auth.py` 100%; per-file gate passes with **no new waiver**. Ruff lint + format re-verified with `--no-cache`.
- **Order-independence**: the MCP suites pass under several module permutations (553 and 570 passed). An autouse `_reset_elevated_attempt_budget` fixture clears the process-global budget between tests — without it this change would be green locally and flaky in CI.
- **No bypasses**: zero `# noqa` / `# type: ignore` / `# pylint: disable` / `skip` in the diff, no threshold edits, no coverage waiver, no test deleted. The one pre-existing AST guard that changed was *widened* from `is_elevated` to every function in `auth.py` — strictly stronger, since moving the comparison into a helper would otherwise have made it vacuous.
- **Scope**: `remote_auth.py` untouched (live sibling lane), `token_policy.py` untouched (`MIN_TOKEN_LEN` still 32), `contract.py` / `api/models.py` untouched, `crawdad/` untouched, no dependency or lockfile change.

## Note for the reviewer

This branch is based on `bc83b7b` and `main` has moved since; `remote_auth.py` in particular has been rewritten on `main` by a sibling lane. No file in this diff overlaps it, but the base is behind — worth a sync before merge.

Refs #907
Closes #914
