### PR TITLE
fix(compile): rank ancestry so an admitted child cannot leak its parent's title

### DIFF
--- a/creek-tools/creek/classify/privacy_filter.py
+++ b/creek-tools/creek/classify/privacy_filter.py
@@ -32,6 +32,12 @@ an explicit ``unclassified`` only in the raw frontmatter — is ``INTIMATE``),
 :func:`max_source_tier` (the reduction over the tiers a call would carry,
 ``INTIMATE`` when empty).
 
+:func:`build_ancestor_index` / :class:`AncestorIndex` / :func:`ancestry_tiers`
+(#931) are the ancestry-aware sibling of :func:`source_tiers`, for the one
+caller — ``creek.compile`` — whose prompt renders a fragment's *ancestors*
+alongside the fragment itself. They exist as a separate survey rather than as a
+widening of :func:`source_tiers` on purpose; see that function's docstring.
+
 :func:`raw_privacy_tier` and :func:`within_ceiling` (#968) are the
 raw-frontmatter siblings of that pair, for generation flows that never build a
 :class:`~creek.models.Fragment` at all. They live here, and not in a new
@@ -73,7 +79,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypeGuard
+from typing import TYPE_CHECKING, Any, Final, TypeGuard
 
 from creek.audit import AuditLog
 from creek.models import PrivacyTier
@@ -513,6 +519,20 @@ def source_tiers(vault_path: Path, fragment_ids: Iterable[str]) -> list[PrivacyT
     naming a thousand ids still pays one walk of the corpus rather than a
     thousand.
 
+    **This survey is deliberately ancestry-blind, and #931 kept it that
+    way.** It reports the tiers of the ids a call *names* and nothing else.
+    Its callers — ``creek.draft``, ``creek.journal``, ``creek.upload`` —
+    hand the LLM the named fragments' own content and render no
+    ``structural_path`` breadcrumb, so an ancestor's title never reaches
+    their prompts and ranking ancestry there would refuse calls that leak
+    nothing. ``creek.compile`` is the one caller whose prompt *does* render
+    ancestry, and it uses :func:`ancestry_tiers` instead. The two are two
+    functions rather than one flag because they answer two different
+    questions; ``tests/test_privacy_filter.py``'s
+    ``test_source_tiers_stays_ancestry_blind`` pins the difference so a
+    future de-duplication has to argue with a test rather than with a
+    comment.
+
     The walk deliberately goes through that shared loader — the same one
     ``creek.compile.engine._load_fragments_for_compile`` uses — so the set
     of files this survey inspects and the set the compile engine would
@@ -571,6 +591,294 @@ def source_tiers(vault_path: Path, fragment_ids: Iterable[str]) -> list[PrivacyT
         )
         if fragment.id in requested
     ]
+
+
+@dataclass(frozen=True)
+class _Chain:
+    """One node's resolved ancestry contribution, memoised during a survey.
+
+    Attributes:
+        tiers: The tiers of the node and every ancestor above it, plus any
+            fail-closed ``INTIMATE`` the walk had to add. Reduced by the
+            caller; multiplicity and order carry no meaning.
+        depth: How many strict ancestors the walk actually reached above the
+            node. Compared against the persisted breadcrumb's length by
+            :meth:`AncestorIndex._own_tiers` (rule (e)). A walk truncated by
+            a cycle or a missing parent reports ``0``, which can only
+            *add* an ``INTIMATE`` to a chain that already carries one.
+    """
+
+    tiers: tuple[PrivacyTier, ...]
+    depth: int
+
+
+_ROOT_CHAIN: Final[_Chain] = _Chain(tiers=(), depth=0)
+"""Nothing above a clean root: no tiers, no ancestors."""
+
+_CYCLE_CHAIN: Final[_Chain] = _Chain(tiers=(PrivacyTier.INTIMATE,), depth=0)
+"""A chain the walk could not finish — a cycle, or a parent that does not resolve.
+
+Rules (c) and (d) share one value because they must be indistinguishable:
+both mean "this ancestry cannot be surveyed", and a caller that could tell
+them apart would learn something about the vault's shape from a refusal.
+"""
+
+
+@dataclass(frozen=True)
+class _AncestorEntry:
+    """One node of the ancestry graph, as :class:`AncestorIndex` ranks it.
+
+    Attributes:
+        parent_id: The node's link up the hierarchy, or ``None`` at a root.
+        tier: The node's tier, read through :func:`fragment_tier` so a
+            *missing* ``privacy_tier`` key fails closed to ``INTIMATE``.
+        has_structural_path: Whether the node carries a persisted
+            ``structural_path``. Recorded because a breadcrumb is a
+            ``list[str]`` with no id binding, so its *length* is the only
+            handle on how much ancestry the prompt will render: any excess
+            over the ancestry this index can walk is ancestry it cannot
+            rank. See :meth:`AncestorIndex.chain_tiers` rule (e).
+    """
+
+    parent_id: str | None
+    tier: PrivacyTier
+    breadcrumb_len: int
+
+
+@dataclass(frozen=True)
+class AncestorIndex:
+    """Whole-corpus ``parent_id`` graph, keyed by fragment id, with tiers attached.
+
+    Built once per call by :func:`build_ancestor_index` from records the
+    caller has *already* walked, so ranking ancestry costs no extra pass
+    over ``01-Fragments``. :func:`ancestry_tiers` is the walk-it-for-me
+    entry point for callers that have no walk of their own.
+
+    Attributes:
+        entries: One :class:`_AncestorEntry` per fragment the index covers.
+            A fragment absent from this mapping is one
+            :func:`creek.vault.reader.try_load_fragment` skipped —
+            unreadable, non-``fragment``-typed, or schema-invalid — and is
+            therefore unrankable rather than open.
+    """
+
+    entries: Mapping[str, _AncestorEntry]
+
+    def chain_tiers(self, fragment_ids: Iterable[str]) -> list[PrivacyTier]:
+        """Return every tier the ancestry of *fragment_ids* would carry.
+
+        The rules, each of which is a test in
+        ``tests/test_privacy_filter.py``:
+
+        (a) A requested id that resolves contributes its own tier and the
+            tier of every strict ancestor reached by walking ``parent_id``.
+        (b) A requested id that does **not** resolve contributes nothing.
+            This is the one rule here that is not fail-closed, and it is
+            load-bearing: ``creek.compile``'s ``ValueError("Fragment(s) not
+            found in vault: ...")`` must still reach a caller with a typo'd
+            id rather than collapsing into the content-free above-ceiling
+            refusal. Nothing absent from the vault can be rendered into a
+            prompt, so admitting it costs no privacy.
+        (c) A ``parent_id`` that does not resolve contributes ``INTIMATE``.
+            Its tier is unknowable while the child's breadcrumb still names
+            it — the same posture :func:`fragment_tier` takes to a missing
+            ``privacy_tier`` key.
+        (d) A ``parent_id`` cycle is truncated by a per-leaf visited set and
+            contributes ``INTIMATE``: a chain that cannot be fully surveyed
+            fails closed.
+        (e) **Breadcrumb deeper than the ancestry we could walk contributes
+            ``INTIMATE``.** The survey ranks fragment *ids* up ``parent_id``;
+            the prompt renders *strings* out of ``structural_path``. Nothing
+            in the data binds the two, so the only sound check is the count:
+            ``creek.atomize.split._build_children`` appends at most one
+            heading per level, so ``len(structural_path)`` can never exceed
+            the number of strict ancestors. When it does — a root carrying a
+            breadcrumb, or a fragment re-parented onto a shallower parent
+            while keeping a deeper breadcrumb — the excess entries name
+            ancestors this index cannot reach, and unrankable ancestry fails
+            closed. The depth-0 case (``parent_id is None`` with a non-empty
+            breadcrumb) is the one an unmodified pipeline could plausibly
+            produce; the general rule costs nothing extra and stops the
+            invariant resting on a writer-side promise no code asserts.
+        (f) **Uniform probe cost.** Every resolved requested id is ranked
+            before the caller can read a decision: no short-circuit on the
+            first offender, no lazy per-parent vault lookup. That is what
+            keeps ``creek_mcp.tools.compile._ABOVE_CEILING_REASON`` from
+            leaking *where* the offending ancestor sits through timing, and
+            it is the same property :func:`source_tiers` documents for its
+            own loop. Making this lazy re-opens that channel.
+        (g) Chain results are memoised for the duration of the call, so a
+            wide batch sharing a deep ancestry stays cheap *and* uniform.
+        (h) A fragment id claimed by **more than one file** contributes
+            ``INTIMATE`` (applied in :func:`build_ancestor_index`). Ids are
+            content-hashed, so a collision is anomalous — but the index is a
+            mapping and a mapping is last-wins, which would let a later
+            ``privacy_tier: open`` shadow file hide an earlier ``intimate``
+            one. :func:`source_tiers` yields one tier per *file* and so had
+            no such hole; failing closed here keeps this survey at least as
+            restrictive as the one it replaces at the compile gate.
+
+        Args:
+            fragment_ids: The ids the caller named. Duplicates collapse.
+
+        Returns:
+            The tiers to reduce over, as an unordered bag. Unlike
+            :func:`source_tiers` this is **not** one entry per requested id
+            — a chain contributes as many tiers as it has surveyable nodes,
+            plus a fail-closed ``INTIMATE`` for anything it cannot survey.
+            Both callers reduce it (``max_source_tier`` /
+            ``any(not write_tier_allowed(...))``), so multiplicity and order
+            carry no meaning and neither is promised.
+        """
+        memo: dict[str, _Chain] = {}
+        tiers: list[PrivacyTier] = []
+        for fragment_id in dict.fromkeys(fragment_ids):
+            if fragment_id in self.entries:
+                tiers.extend(self._chain_from(fragment_id, memo).tiers)
+        return tiers
+
+    def _chain_from(self, leaf_id: str, memo: dict[str, _Chain]) -> _Chain:
+        """Return the chain contribution of *leaf_id*, filling *memo*.
+
+        Folds the un-memoised nodes from the root-most downwards, so each
+        node's ``depth`` (its count of successfully-walked strict ancestors)
+        is one more than its parent's and rule (e) can compare it against
+        the persisted breadcrumb's length.
+        """
+        path, tail = self._ascend(leaf_id, memo)
+        tiers, depth = tail.tiers, tail.depth
+        for node_id in reversed(path):
+            tiers = (*self._own_tiers(node_id, depth), *tiers)
+            memo[node_id] = _Chain(tiers=tiers, depth=depth)
+            depth += 1
+        return _Chain(tiers=tiers, depth=depth)
+
+    def _ascend(
+        self,
+        leaf_id: str,
+        memo: dict[str, _Chain],
+    ) -> tuple[list[str], _Chain]:
+        """Walk up from *leaf_id*, returning the un-memoised nodes and the tail.
+
+        The tail is the already-known contribution of everything above the
+        last node in the returned path: a memo hit, or the fail-closed
+        ``(INTIMATE,)`` of rule (c) / rule (d), or empty at a clean root. Its
+        ``depth`` is how many strict ancestors that last node has. A
+        truncated walk reports ``0`` — an undercount, which can only add a
+        further ``INTIMATE`` to a chain that already carries one.
+        """
+        path: list[str] = []
+        visited: set[str] = set()
+        current: str | None = leaf_id
+        while current is not None:
+            known = memo.get(current)
+            if known is not None:
+                return path, _Chain(tiers=known.tiers, depth=known.depth + 1)
+            if current in visited:
+                return path, _CYCLE_CHAIN
+            entry = self.entries.get(current)
+            if entry is None:
+                return path, _CYCLE_CHAIN
+            visited.add(current)
+            path.append(current)
+            current = entry.parent_id
+        return path, _ROOT_CHAIN
+
+    def _own_tiers(self, node_id: str, depth: int) -> tuple[PrivacyTier, ...]:
+        """Return *node_id*'s own contribution, applying rule (e) at *depth*."""
+        entry = self.entries[node_id]
+        if entry.breadcrumb_len > depth:
+            return (entry.tier, PrivacyTier.INTIMATE)
+        return (entry.tier,)
+
+
+def build_ancestor_index(
+    records: Iterable[tuple[Fragment, dict[str, object]]],
+) -> AncestorIndex:
+    """Build an :class:`AncestorIndex` from already-walked vault records.
+
+    Pure: takes the ``(fragment, raw)`` pairs a caller has in hand rather
+    than a vault path, so ``creek.compile.engine._load_fragments_for_compile``
+    — which already walks the whole of ``01-Fragments`` — pays no second
+    pass. At the 35k-fragment bar a second rglob-plus-parse of the corpus
+    doubles the pre-LLM wall clock, which is why the index is threaded out
+    of the existing walk instead of being fetched beside it;
+    ``tests/test_compile.py``'s
+    ``test_compile_to_vault_walks_the_vault_exactly_once`` pins that.
+
+    **Duplicate ids fail closed** (rule (h)). A mapping keyed on
+    ``fragment.id`` is last-wins, and :func:`source_tiers` — which this
+    replaces at the compile gate — is not: it yields one tier per *file*, so
+    two files claiming one id contributed both tiers and the more sensitive
+    one won the reduction. Preserving that is not optional, because a shadow
+    file carrying an above-ceiling ancestor's id with ``privacy_tier: open``
+    and a later sort position would otherwise downgrade the real ancestor
+    while the child's breadcrumb still rendered its heading. Ids are
+    content-hashed (``creek.ingest.base.generate_fragment_id``), so a
+    collision is anomalous by construction and ``INTIMATE`` is the honest
+    answer: nobody can say which file the chain belongs to.
+
+    Args:
+        records: ``(fragment, raw_frontmatter)`` pairs for **every** fragment
+            in the corpus, not just the ones a call names — an ancestor the
+            caller never named is precisely what this index exists to find.
+
+    Returns:
+        The index, with each entry's tier read through :func:`fragment_tier`
+        so a missing ``privacy_tier`` key fails closed to ``INTIMATE``.
+    """
+    entries: dict[str, _AncestorEntry] = {}
+    for fragment, raw in records:
+        collides = fragment.id in entries
+        entries[fragment.id] = _AncestorEntry(
+            parent_id=fragment.parent_id,
+            tier=PrivacyTier.INTIMATE if collides else fragment_tier(fragment, raw),
+            breadcrumb_len=len(fragment.structural_path),
+        )
+    return AncestorIndex(entries=entries)
+
+
+def ancestry_tiers(vault_path: Path, fragment_ids: Iterable[str]) -> list[PrivacyTier]:
+    """Return the tiers of *fragment_ids* **and their ancestors**, in one vault walk.
+
+    The ancestry-aware sibling of :func:`source_tiers` (#931), and the entry
+    point for callers that have no corpus walk of their own —
+    ``creek_mcp.tools.compile._survey_sources`` is the only one.
+
+    It exists because ``creek.compile``'s prompt renders an admitted
+    fragment's ancestry: :func:`creek.hierarchy.structural_path_context`
+    returns the persisted ``structural_path`` — ancestor headings the
+    splitter accumulated — and ``_build_prompt`` emits it after
+    ``structural_path:``. #848's gate ranks only the ids a caller *names*, so
+    an ``open`` child of an ``intimate`` parent was admitted at
+    ``ceiling=open`` and carried its parent's heading to a cloud-routed
+    provider. Ranking the ancestry closes that channel without redacting the
+    breadcrumb, which is unredactable anyway: the persisted entries are bare
+    strings with no owning-fragment id.
+
+    Uses the same shared loader as :func:`source_tiers` and
+    ``creek.compile.engine._load_fragments_for_compile``, for the same
+    reason: a file one side sees and the other does not is the bug class
+    these surveys exist to prevent. The walk is a single non-short-circuiting
+    pass and the ranking that follows it is exhaustive, so probe cost stays
+    uniform by construction — see :meth:`AncestorIndex.chain_tiers` rule (f).
+
+    Args:
+        vault_path: Vault root; fragments are read from ``01-Fragments``.
+        fragment_ids: The ids the caller named. Duplicates collapse; an id
+            that does not resolve contributes nothing, exactly as in
+            :func:`source_tiers`, so a caller's not-found path is untouched.
+
+    Returns:
+        The tiers to reduce over. See :meth:`AncestorIndex.chain_tiers` for
+        why this is a bag rather than one entry per requested id.
+    """
+    return build_ancestor_index(
+        (fragment, raw)
+        for _path, fragment, _body, raw in iter_vault_fragments(
+            vault_path / "01-Fragments",
+        )
+    ).chain_tiers(fragment_ids)
 
 
 def record_privacy_override(

--- a/creek-tools/creek/classify/privacy_filter.py
+++ b/creek-tools/creek/classify/privacy_filter.py
@@ -632,12 +632,13 @@ class _AncestorEntry:
         parent_id: The node's link up the hierarchy, or ``None`` at a root.
         tier: The node's tier, read through :func:`fragment_tier` so a
             *missing* ``privacy_tier`` key fails closed to ``INTIMATE``.
-        has_structural_path: Whether the node carries a persisted
-            ``structural_path``. Recorded because a breadcrumb is a
-            ``list[str]`` with no id binding, so its *length* is the only
-            handle on how much ancestry the prompt will render: any excess
-            over the ancestry this index can walk is ancestry it cannot
-            rank. See :meth:`AncestorIndex.chain_tiers` rule (e).
+        breadcrumb_len: How many entries the node's persisted
+            ``structural_path`` carries. Recorded as a *length*, not a
+            presence flag, because a breadcrumb is a ``list[str]`` with no id
+            binding: the count is the only handle on how much ancestry the
+            prompt will render, and any excess over the ancestry this index
+            can walk is ancestry it cannot rank. See
+            :meth:`AncestorIndex.chain_tiers` rule (e).
     """
 
     parent_id: str | None

--- a/creek-tools/creek/compile/engine.py
+++ b/creek-tools/creek/compile/engine.py
@@ -31,7 +31,12 @@ import frontmatter
 
 from creek.audit import AuditLog
 from creek.care.guardrail import CARE_POLICY
-from creek.classify.privacy_filter import fragment_tier, max_source_tier
+from creek.classify.privacy_filter import (
+    AncestorIndex,
+    build_ancestor_index,
+    fragment_tier,
+    max_source_tier,
+)
 from creek.compile.provenance import ProvenanceEntry, merge_provenance
 from creek.hierarchy import (
     LevelPolicy,
@@ -268,6 +273,7 @@ def _payload_to_paradox_entries(
 
 def _routing_tier_for(
     loaded: list[tuple[Fragment, str, dict[str, object]]],
+    ancestry: list[PrivacyTier],
 ) -> PrivacyTier:
     """Return the tier this compile's LLM call must be keyed with.
 
@@ -280,10 +286,40 @@ def _routing_tier_for(
     ``by_id`` lookup spanning *all* pairs to
     :func:`creek.hierarchy.structural_path_context`, which walks
     ``parent_id`` and emits the dropped parents' **titles** as the
-    surviving child's ``structural_path:`` breadcrumb
-    (``creek/hierarchy.py:115-124``). Reducing over the policy-selected
-    subset would therefore under-route: an intimate parent's title would
-    egress on a call keyed by its open child.
+    surviving child's ``structural_path:`` breadcrumb. Reducing over the
+    policy-selected subset would therefore under-route: an intimate
+    parent's title would egress on a call keyed by its open child.
+
+    **The *ancestry* term closes the other half of the same channel
+    (#931).** The walk above only reaches ancestors the caller *named*, so
+    it never saw the branch that fires when they did not:
+    ``structural_path_context`` prefers the leaf's own **persisted**
+    ``structural_path``, a list of ancestor headings the splitter baked in
+    at ingest, and that branch needs no ancestor fragment in memory at all.
+    Name one ``open`` child of an ``intimate`` document and pre-#931 the
+    call routed ``OPEN`` — a cloud client built with ``structural_path:
+    <the intimate document's heading>`` sitting in the prompt. Folding
+    :meth:`creek.classify.privacy_filter.AncestorIndex.chain_tiers` into the
+    reduction escalates the routing tier instead of redacting the
+    breadcrumb: the ``creek compile`` operator owns the vault, so the
+    orienting value of the ancestry is theirs to keep — it just may not
+    leave the machine. (The MCP wrapper makes the opposite and equally
+    correct choice for *its* caller, refusing the whole call; see
+    ``creek_mcp.tools.compile``.)
+
+    **Two accepted costs of ranking by walking ``parent_id``.** First it
+    *over-covers*: it ranks the root document, whose title the persisted
+    breadcrumb never carries (the splitter appends only headings). An
+    intimate root therefore forces its descendants' compiles local even
+    though the prompt shows only section headings — accepted, because the
+    fallback branch of ``structural_path_context`` *does* render the root's
+    title, and the two branches must be gated the same way. Second, an
+    ancestry link that cannot be surveyed — dangling (``creek
+    ingest``'s resplit unlinks a merged parent), cyclic, or a breadcrumb
+    deeper than the walk can reach — ranks ``INTIMATE``, so a whole subtree
+    becomes uncompilable at cloud tiers and the operator sees only
+    ``IntimateRoutingError``. That is the right privacy answer and a poor
+    diagnostic; ``creek lint`` surfacing those states is #1277.
 
     Sensitivity is read fragment-by-fragment through
     :func:`creek.classify.privacy_filter.fragment_tier`, which is why the
@@ -296,15 +332,22 @@ def _routing_tier_for(
     Args:
         loaded: Every ``(fragment, body, raw)`` triple the compile loaded,
             pre-policy and in requested order.
+        ancestry: The tiers of the requested fragments' ancestors, from
+            :meth:`creek.classify.privacy_filter.AncestorIndex.chain_tiers`.
+            Empty when nothing requested resolved — which cannot narrow the
+            result, because the reduction below then has nothing to reduce
+            and fails closed anyway.
 
     Returns:
-        The most sensitive tier among *loaded*, or
-        :attr:`~creek.models.PrivacyTier.INTIMATE` when *loaded* is empty
+        The most sensitive tier among *loaded* and *ancestry*, or
+        :attr:`~creek.models.PrivacyTier.INTIMATE` when both are empty
         — an empty compile carries no evidence about what it would send,
         and :func:`creek.classify.privacy_filter.max_source_tier` owns
         that fail-closed default so every caller of it agrees.
     """
-    return max_source_tier(fragment_tier(f, raw) for f, _body, raw in loaded)
+    return max_source_tier(
+        [*(fragment_tier(f, raw) for f, _body, raw in loaded), *ancestry],
+    )
 
 
 def compile_to_vault(
@@ -365,8 +408,8 @@ def compile_to_vault(
             credential — propagates untouched for the same reason: the
             engine takes no view on how a client is built.
     """
-    pairs_with_raw = _load_fragments_for_compile(vault_path, fragment_ids)
-    tier = _routing_tier_for(pairs_with_raw)
+    pairs_with_raw, ancestors = _load_fragments_for_compile(vault_path, fragment_ids)
+    tier = _routing_tier_for(pairs_with_raw, ancestors.chain_tiers(fragment_ids))
     llm = llm_factory(tier)
     target_path = _resolve_target_path(vault_path, target_kind, target_id)
     existing = _load_existing_provenance(target_path)
@@ -567,7 +610,7 @@ def _render_body(title: str, claims: list[dict[str, object]]) -> str:
 def _load_fragments_for_compile(
     vault_path: Path,
     fragment_ids: list[str],
-) -> list[tuple[Fragment, str, dict[str, object]]]:
+) -> tuple[list[tuple[Fragment, str, dict[str, object]]], AncestorIndex]:
     """Load the requested fragments from the vault and preserve order.
 
     Keeps the ``raw`` frontmatter :func:`creek.vault.reader.iter_vault_fragments`
@@ -582,29 +625,44 @@ def _load_fragments_for_compile(
     that duplication is pre-existing and unresolved (#847). The two must
     keep agreeing; nothing but review currently makes them.
 
+    It also returns the whole-corpus
+    :class:`~creek.classify.privacy_filter.AncestorIndex` (#931), built from
+    the records of *this* walk rather than fetched by a second one. The
+    ancestors the prompt's ``structural_path:`` breadcrumb renders are
+    usually not among the requested ids, so ranking them needs the corpus —
+    but at the 35k-fragment bar a second ``rglob``-plus-parse pass doubles
+    the pre-LLM wall clock, and a privacy fix has no business shipping that
+    regression. ``tests/test_compile.py``'s
+    ``test_compile_to_vault_walks_the_vault_exactly_once`` pins the single
+    walk so a future lane cannot quietly reintroduce the second one.
+
     Args:
         vault_path: Vault root; fragments are read from ``01-Fragments``.
         fragment_ids: The ids to load, in the order the caller wants them.
 
     Returns:
-        One ``(fragment, body, raw)`` triple per requested id, in
-        requested order.
+        A ``(triples, ancestor_index)`` pair: one ``(fragment, body, raw)``
+        triple per requested id in requested order, and the ancestry index
+        spanning every fragment in the corpus.
 
     Raises:
         ValueError: If any requested id has no matching fragment.
     """
     requested = fragment_ids.copy()
-    by_id: dict[str, tuple[Fragment, str, dict[str, object]]] = {}
-    for _path, fragment, body, raw in iter_vault_fragments(
-        vault_path / "01-Fragments",
-    ):
-        if fragment.id in requested:
-            by_id[fragment.id] = (fragment, body, raw)
+    records = iter_vault_fragments(vault_path / "01-Fragments")
+    by_id: dict[str, tuple[Fragment, str, dict[str, object]]] = {
+        fragment.id: (fragment, body, raw)
+        for _path, fragment, body, raw in records
+        if fragment.id in requested
+    }
+    ancestors = build_ancestor_index(
+        (fragment, raw) for _path, fragment, _body, raw in records
+    )
     missing = [fid for fid in requested if fid not in by_id]
     if missing:
         msg = f"Fragment(s) not found in vault: {', '.join(missing)}"
         raise ValueError(msg)
-    return [by_id[fid] for fid in requested]
+    return [by_id[fid] for fid in requested], ancestors
 
 
 def _resolve_target_path(

--- a/creek-tools/creek/hierarchy.py
+++ b/creek-tools/creek/hierarchy.py
@@ -102,6 +102,19 @@ def structural_path_context(
     field is empty because the writer that produced this fragment
     pre-dated FEAT-020.
 
+    **Tier contract: this function ranks nothing.** Both branches return
+    strings derived from *ancestors*, and the persisted branch does so
+    without the ancestor fragments being present at all — which is how an
+    above-ceiling parent's heading reached the compile prompt through an
+    admitted child (#931). Rendering the breadcrumb is therefore only safe
+    where the ancestry has already been *ranked*:
+    :func:`creek.classify.privacy_filter.ancestry_tiers` (and its pure
+    sibling :func:`~creek.classify.privacy_filter.build_ancestor_index`) is
+    the survey that does it. ``creek.compile.engine`` is the only production
+    caller, pinned by
+    ``tests/test_hierarchy.py::test_structural_path_context_has_exactly_one_production_caller``;
+    a second renderer must add its tier gate first.
+
     Args:
         leaf: The fragment whose ancestry to render.
         by_id: Mapping of fragment ID → :class:`Fragment` for every
@@ -109,15 +122,28 @@ def structural_path_context(
             the first missing parent rather than raising.
 
     Returns:
-        Breadcrumb from root to immediate parent, in display order.
-        Empty when *leaf* has no ancestry to surface.
+        Breadcrumb from root to immediate parent, in display order, with
+        each ancestor appearing at most once. Empty when *leaf* has no
+        ancestry to surface.
     """
     if leaf.structural_path:
         return leaf.structural_path.copy()
     path: list[str] = []
+    # A ``parent_id`` cycle inside ``by_id`` (a↔b, or a self-parent) used to
+    # spin forever: the loop's only exit was a parent *missing* from the
+    # mapping, and in a cycle every parent is present. Seeded with the leaf
+    # so a fragment never appears in its own breadcrumb. Kept deliberately
+    # in step with the vault-backed walk in
+    # ``creek.classify.privacy_filter.AncestorIndex._ascend`` (#931) —
+    # two ancestry walks with different cycle semantics is the
+    # two-readers-can-disagree drift that module's docstring exists to stop.
+    visited: set[str] = {leaf.id}
     current = leaf
-    while current.parent_id is not None and current.parent_id in by_id:
-        parent = by_id[current.parent_id]
+    while current.parent_id is not None and current.parent_id not in visited:
+        parent = by_id.get(current.parent_id)
+        if parent is None:
+            break
+        visited.add(parent.id)
         path.append(parent.title or parent.id)
         current = parent
     path.reverse()

--- a/creek-tools/creek_mcp/read_gate.py
+++ b/creek-tools/creek_mcp/read_gate.py
@@ -254,7 +254,12 @@ TOOL_POSTURES: dict[str, ToolPosture] = {
             "Source fragment_ids name fragments the caller did not supply; "
             "_survey_sources ranks every one of them with write_tier_allowed "
             "and compile_tool refuses the whole call on its above_ceiling flag, "
-            "before the LLM or the compiled-page write (#848)."
+            "before the LLM or the compiled-page write (#848). Their "
+            "ancestors are ranked too (#931): the prompt renders an admitted "
+            "fragment's persisted structural_path, which carries ancestor "
+            "headings the caller may never have named, so ancestry_tiers "
+            "walks parent_id and an above-ceiling ancestor refuses the whole "
+            "call with the same content-free reason."
         ),
         gate_module="creek_mcp.tools.compile",
         gate_symbol="_survey_sources",

--- a/creek-tools/creek_mcp/tools/compile.py
+++ b/creek-tools/creek_mcp/tools/compile.py
@@ -9,9 +9,16 @@ of them was asserted in this docstring and implemented nowhere):
   any state-affecting step.** Compile's variant of the FEAT-011 write-side
   rule gates the classified tiers of the fragments being rolled up
   rather than the tier of the page being created: a caller cannot
-  compile a page out of fragments they *named* and could not read.
-  (Only the named ids are checked — an admitted fragment's own
-  ``structural_path`` ancestry is not, which is a tracked follow-up.)
+  compile a page out of fragments they could not read — nor out of a
+  fragment whose *ancestry* they could not read. Since #931 the survey
+  ranks the named ids **and** every ancestor reached by walking
+  ``parent_id``, because the prompt renders an admitted fragment's
+  persisted ``structural_path`` (ancestor headings the splitter baked in
+  at ingest) whether or not the caller named the ancestor. An
+  above-ceiling ancestor refuses the whole call, with the same
+  content-free :data:`_ABOVE_CEILING_REASON` and the same audit row as a
+  named-id violation — a distinguishable refusal would be a fresh oracle
+  saying "the offender is above you in the tree".
   The check runs
   ahead of any LLM client being built, any page being written, and any
   paradox being logged — the three places the source ids would
@@ -59,7 +66,7 @@ from __future__ import annotations
 import hashlib
 from typing import TYPE_CHECKING, Any, Final, NamedTuple, Protocol, cast
 
-from creek.classify.privacy_filter import source_tiers
+from creek.classify.privacy_filter import ancestry_tiers
 from creek.compile.engine import TARGET_KINDS, compile_to_vault
 from creek_mcp.audit import MCPAuditLog
 from creek_mcp.tier_ceiling import (
@@ -84,6 +91,21 @@ TOOL_NAME = "creek.compile"
 # group testing *exact*, so a caller could binary-search a batch knowing
 # precisely how many above-ceiling ids each half holds.
 #
+# SINCE #931 THE BOOL ANSWERS A WIDER PROPOSITION: not "a named id is above
+# your ceiling" but "a named id *or any of its transitive ancestors* is above
+# your ceiling". Re-analysed and accepted as no worse than the residual below,
+# and in one respect better:
+#
+# - It is one bit per ancestry chain, and it does not localise the offender.
+#   Ids are derivable *downward* only (``generate_child_fragment_id`` hashes
+#   ``f"{parent_id}:{level}:{index}"``), so a caller cannot enumerate upward
+#   from an admitted child to name the ancestor the bit refers to.
+# - It is strictly less than what the bug leaked, which was the ancestor's
+#   literal heading text into a compiled page the caller then reads.
+# - It *degrades* the group-testing oracle below: subset resubmission can no
+#   longer isolate a named id's own tier, because an above-ceiling ancestor
+#   contaminates every subset containing any of its descendants.
+#
 # ACCEPTED RESIDUAL RISK: a bare boolean is still a group-testing oracle — a
 # caller who resubmits subsets of a batch identifies every above-ceiling id in
 # O(k log n) calls. Two things that argument must NOT lean on:
@@ -102,7 +124,12 @@ TOOL_NAME = "creek.compile"
 #   uniform *by construction* rather than resting on an accident of iteration
 #   order. The reasoning moved rather than being dropped because the property
 #   is now shared: switching that one function to a lazy loader would re-open
-#   the timing channel here and in ``creek.draft`` at the same time.
+#   the timing channel here and in ``creek.draft`` at the same time. Compile
+#   now calls the ancestry-aware ``ancestry_tiers`` (#931), which preserves
+#   the property in both halves: one non-short-circuiting walk, then an
+#   exhaustive ranking of every resolved id's whole chain before any
+#   decision is read (``AncestorIndex.chain_tiers`` rule (f)). A lazy
+#   per-parent lookup would re-open the channel this constant guards.
 #
 # Accepted because the real control is the audit trail, not id entropy: every
 # True probe appends a ``creek.compile`` entry distinguishable from a success
@@ -217,9 +244,21 @@ def _survey_sources(
             call argument and no longer depends on the operator's model config.
         ceiling: The caller's declared ceiling.
 
+    Since #931 the survey is :func:`creek.classify.privacy_filter.ancestry_tiers`
+    rather than its ancestry-blind sibling ``source_tiers``, so "requested
+    fragment" below means the named ids **and** their ancestors. Compile is
+    the only tool that needs the wider survey: its prompt renders an
+    admitted fragment's persisted ``structural_path``, which is a list of
+    ancestor headings, so #848's named-ids-only gate admitted an ``open``
+    child of an ``intimate`` parent and shipped the parent's heading to the
+    provider. ``draft`` / ``journal`` / ``upload`` render no breadcrumb and
+    keep the narrower survey deliberately.
+
     Returns:
         A :class:`_SourceGate` whose ``above_ceiling`` is ``True`` when at
-        least one requested fragment is above *ceiling*.
+        least one requested fragment — or one of its ancestors — is above
+        *ceiling*. The two are deliberately indistinguishable in the result
+        and everywhere downstream of it.
 
         The refusal decision is deliberately a bare bool: the offending ids
         never leave this function; see :data:`_ABOVE_CEILING_REASON` for why.
@@ -234,8 +273,10 @@ def _survey_sources(
         reaches this wrapper at all, so there is nothing here to leak.
     """
     # One shared survey (#958) so ``creek.compile`` and ``creek.draft`` can
-    # never read the same file's tier two different ways.
-    tiers = source_tiers(vault_path, fragment_ids)
+    # never read the same file's tier two different ways. Compile takes the
+    # ancestry-aware variant (#931) because compile — alone among the survey's
+    # callers — renders an admitted fragment's ancestors into its prompt.
+    tiers = ancestry_tiers(vault_path, fragment_ids)
     return _SourceGate(
         above_ceiling=any(not write_tier_allowed(tier, ceiling) for tier in tiers),
     )

--- a/creek-tools/tests/test_compile.py
+++ b/creek-tools/tests/test_compile.py
@@ -46,6 +46,7 @@ from creek.models import (
     PrivacyTier,
     SourcePlatform,
 )
+from creek.vault.reader import iter_vault_fragments
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -1750,7 +1751,19 @@ def test_compile_to_vault_routes_on_a_parent_the_level_policy_dropped(
     :func:`creek.hierarchy.structural_path_context`, which walks
     ``parent_id`` through the pre-policy lookup whenever the persisted
     ``structural_path`` is empty. The intimate parent's title therefore
-    egresses on a call whose only surviving source is ``open``.
+    reaches the prompt on a call whose only surviving source is ``open``.
+
+    **#931 did not change this row, and assertion (ii) deliberately still
+    asserts the title is present.** This test names *both* fragments, so
+    #848's named-id gate already covers it on the MCP side and assertion (i)
+    already covers it on the CLI side: the breadcrumb is safe here because
+    the call is keyed ``INTIMATE`` and therefore never reaches a cloud
+    provider — not because the breadcrumb was stripped. Retaining it is the
+    ``creek compile`` operator's due; they own the vault. What #931 fixed is
+    the case this test cannot see, where the caller names only the child and
+    the breadcrumb comes from the *persisted* field with no ancestor loaded
+    at all:
+    ``test_compile_to_vault_routes_intimate_on_a_persisted_ancestor_not_named``.
     """
     parent = Fragment(
         id="frag-parent",
@@ -1795,6 +1808,199 @@ def test_compile_to_vault_routes_on_a_parent_the_level_policy_dropped(
     assert "the open child body" in prompt
     # (ii) and yet its title egressed anyway, as the child's breadcrumb.
     assert f"structural_path: {_INTIMATE_TITLE}" in prompt
+
+
+def _write_ancestry_pair(
+    vault: Path,
+    *,
+    ancestor_tier: PrivacyTier,
+    child_tier: PrivacyTier = PrivacyTier.PERSONAL,
+) -> None:
+    """Write an ancestor/child pair whose link is a *persisted* breadcrumb (#931).
+
+    The child carries ``structural_path=[_INTIMATE_TITLE]``, so
+    :func:`creek.hierarchy.structural_path_context` returns the ancestor's
+    heading from its persisted-field branch — the branch that fires even
+    when the ancestor is absent from the prompt builder's ``by_id`` lookup,
+    which is exactly the case when the caller names only the child.
+
+    Args:
+        vault: Vault root.
+        ancestor_tier: Tier of ``frag-ancestor``.
+        child_tier: Tier of ``frag-child``.
+    """
+    ancestor = Fragment(
+        id="frag-ancestor",
+        title=_INTIMATE_TITLE,
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+        created=datetime(2026, 5, 1, 12, 0, tzinfo=UTC),
+        ingested=datetime(2026, 5, 1, 12, 0, tzinfo=UTC),
+        level="document",
+        child_ids=["frag-child"],
+        privacy_tier=ancestor_tier,
+    )
+    child = Fragment(
+        id="frag-child",
+        title="On grief",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+        created=datetime(2026, 5, 1, 12, 0, tzinfo=UTC),
+        ingested=datetime(2026, 5, 1, 12, 0, tzinfo=UTC),
+        level="paragraph",
+        parent_id="frag-ancestor",
+        structural_path=[_INTIMATE_TITLE],
+        privacy_tier=child_tier,
+    )
+    # The breadcrumb must come from the PERSISTED field, not the by_id walk:
+    # the caller never names the ancestor, so it is never in ``by_id``.
+    assert child.structural_path == [_INTIMATE_TITLE]
+    _write_fragment_to_vault(vault, ancestor, _INTIMATE_BODY)
+    _write_fragment_to_vault(vault, child, "the personal child body")
+
+
+def test_compile_to_vault_routes_intimate_on_a_persisted_ancestor_not_named(
+    vault: Path,
+) -> None:
+    """An unnamed intimate ancestor sets the CLI's routing tier (#931).
+
+    The ceiling-less ``creek compile`` CLI deliberately **keeps** the
+    breadcrumb — its operator is the vault owner, and the orienting value of
+    the ancestry is real — and escalates the *routing* tier instead, so the
+    ancestor's heading only ever reaches a model through
+    :class:`~creek.classify.llm.router.ModelRouter`'s ``Intimate``-never-cloud
+    chokepoint (#647/#962). The MCP wrapper makes the opposite (and equally
+    correct) choice for its caller: it refuses the whole call.
+
+    Distinct from
+    ``test_compile_to_vault_routes_on_a_parent_the_level_policy_dropped``,
+    which names *both* fragments and so is already covered by the pre-#931
+    reduction over loaded fragments. Here only the child is named, so the
+    ancestor is never loaded, never in ``by_id``, and contributed nothing to
+    the routing tier before this fix — while its heading egressed anyway.
+    """
+    _write_ancestry_pair(vault, ancestor_tier=PrivacyTier.INTIMATE)
+    factory = _TierRecordingFactory()
+
+    compile_to_vault(
+        fragment_ids=["frag-child"],
+        vault_path=vault,
+        target_kind="thread",
+        target_id="thread-anc",
+        target_title="Anc",
+        llm_factory=factory,
+    )
+
+    # (i) the unnamed ancestor set the routing tier.
+    assert factory.tiers == [PrivacyTier.INTIMATE]
+    # (ii) and the breadcrumb is deliberately retained, not redacted — which
+    # is precisely why (i) has to hold.
+    assert f"structural_path: {_INTIMATE_TITLE}" in factory.prompts[0]
+
+
+def test_compile_to_vault_keeps_open_routing_for_a_within_tier_ancestor(
+    vault: Path,
+) -> None:
+    """Ancestry ranking escalates only when the ancestry warrants it.
+
+    Anti-vacuity for #931: with the ancestor at ``open`` and the child at
+    ``open`` the call still routes ``OPEN``. Without this row the fix could
+    be "route every fragment with a parent as INTIMATE" and the escalation
+    test above would still pass.
+    """
+    _write_ancestry_pair(
+        vault,
+        ancestor_tier=PrivacyTier.OPEN,
+        child_tier=PrivacyTier.OPEN,
+    )
+    factory = _TierRecordingFactory()
+
+    compile_to_vault(
+        fragment_ids=["frag-child"],
+        vault_path=vault,
+        target_kind="thread",
+        target_id="thread-anc-open",
+        target_title="Anc Open",
+        llm_factory=factory,
+    )
+
+    assert factory.tiers == [PrivacyTier.OPEN]
+
+
+def test_compile_to_vault_refuses_an_unnamed_intimate_ancestor_with_no_local_backend(
+    vault: Path,
+) -> None:
+    """All-cloud config + an unnamed intimate ancestor raises instead of egressing.
+
+    The #931 sibling of
+    ``test_compile_to_vault_propagates_the_intimate_routing_refusal``: with
+    ``default`` also cloud there is nowhere local to redirect to, so the
+    escalated routing tier becomes a loud
+    :class:`~creek.classify.llm.router.IntimateRoutingError` rather than a
+    silent cloud call carrying the ancestor's heading.
+
+    **Anti-vacuity.** The assertion before the ``raises`` block pins that the
+    tier-less resolution on this same config is perfectly happy and hands
+    back the cloud provider, so the raise can only come from the tier the
+    engine derived. The trailing assertion pins that a refused compile leaves
+    no page behind — ``_resolve_target_path`` ``mkdir``s unconditionally, so
+    the gate has to win before it.
+    """
+    _write_ancestry_pair(vault, ancestor_tier=PrivacyTier.INTIMATE)
+    router = ModelRouter(
+        LLMRoutingConfig(
+            default=LLMConfig(provider="anthropic"),
+            generation=LLMConfig(provider="anthropic"),
+        ),
+    )
+    # ANTI-VACUITY: with no tier this config resolves happily, to the CLOUD.
+    assert router.resolve("generation").provider == "anthropic"
+
+    with pytest.raises(IntimateRoutingError, match="cannot route to cloud provider"):
+        compile_to_vault(
+            fragment_ids=["frag-child"],
+            vault_path=vault,
+            target_kind="thread",
+            target_id="thread-anc-refused",
+            target_title="Refused",
+            llm_factory=lambda tier: default_llm(router.resolve("generation", tier)),
+        )
+
+    assert not (vault / "02-Threads" / "Active" / "thread-anc-refused.md").exists()
+
+
+def test_compile_to_vault_walks_the_vault_exactly_once(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ranking ancestry must not cost a second corpus walk (#931).
+
+    ``iter_vault_fragments`` rglobs and parses every file under
+    ``01-Fragments`` into a list before returning; at the 35k-fragment bar a
+    second pass doubles the pre-LLM wall clock. The ancestor index is
+    therefore built from the records ``_load_fragments_for_compile`` already
+    walked, and this counter is what stops a future lane reintroducing the
+    convenient-but-quadratic ``ancestry_tiers(vault_path, ...)`` call here.
+    """
+    _write_ancestry_pair(vault, ancestor_tier=PrivacyTier.INTIMATE)
+    real = iter_vault_fragments
+    calls: list[Path] = []
+
+    def _counting(root: Path) -> list[tuple[Path, Fragment, str, dict[str, object]]]:
+        """Record the walked root and delegate to the real loader."""
+        calls.append(root)
+        return real(root)
+
+    monkeypatch.setattr("creek.compile.engine.iter_vault_fragments", _counting)
+
+    compile_to_vault(
+        fragment_ids=["frag-child"],
+        vault_path=vault,
+        target_kind="thread",
+        target_id="thread-walks",
+        target_title="Walks",
+        llm_factory=_TierRecordingFactory(),
+    )
+
+    assert calls == [vault / "01-Fragments"]
 
 
 def test_compile_to_vault_propagates_the_intimate_routing_refusal(

--- a/creek-tools/tests/test_hierarchy.py
+++ b/creek-tools/tests/test_hierarchy.py
@@ -17,6 +17,7 @@ deciding which structural levels they operate on. The helpers must:
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from pathlib import Path
 
 import pytest
 
@@ -198,6 +199,58 @@ class TestStructuralPathContext:
     def test_no_parent_returns_empty(self) -> None:
         """A root fragment has no breadcrumb."""
         assert structural_path_context(_frag("a"), {}) == []
+
+    def test_parent_id_cycle_terminates_without_repeating_an_ancestor(self) -> None:
+        """A mutual-parent cycle returns instead of looping forever (#931).
+
+        The walk terminated at HEAD only because ``by_id`` is finite *and*
+        every step moved to a strictly new key — a mutual-parent pair breaks
+        that accident and spins. Its sibling walk in
+        :func:`creek.classify.privacy_filter.AncestorIndex.chain_tiers` is
+        vault-backed and has no such accident to rely on, and shipping two
+        ancestry walks with different cycle semantics is exactly the
+        two-readers-can-disagree drift the privacy-filter module docstring
+        exists to prevent.
+        """
+        a = _frag("a", parent_id="b", title="A")
+        b = _frag("b", parent_id="a", title="B")
+        by_id = {"a": a, "b": b}
+
+        path = structural_path_context(a, by_id)
+
+        assert len(path) == len(set(path))
+        assert set(path) <= {"A", "B"}
+
+    def test_self_parent_terminates(self) -> None:
+        """The degenerate cycle — a fragment that is its own parent — terminates.
+
+        The breadcrumb is empty rather than ``["S"]``: a fragment is never
+        its own ancestor, so the visited set is seeded with the leaf.
+        """
+        s = _frag("s", parent_id="s", title="S")
+        assert structural_path_context(s, {"s": s}) == []
+
+
+def test_structural_path_context_has_exactly_one_production_caller() -> None:
+    """Only :mod:`creek.compile.engine` may render the breadcrumb (#931).
+
+    The ancestry channel is closed by *ranking* ancestors in
+    :func:`creek.classify.privacy_filter.ancestry_tiers`, which
+    ``creek.compile``'s two entry points consult. A second renderer
+    elsewhere in ``creek`` / ``creek_mcp`` would re-open the leak silently,
+    with no test failing — so the caller count is pinned rather than merely
+    noted. Adding a renderer means adding its tier gate first, then this
+    list.
+    """
+    project_root = Path(__file__).resolve().parents[1]
+    callers = {
+        path.relative_to(project_root).as_posix()
+        for pkg in ("creek", "creek_mcp")
+        for path in (project_root / pkg).rglob("*.py")
+        if "structural_path_context(" in path.read_text(encoding="utf-8")
+        and path.name != "hierarchy.py"
+    }
+    assert callers == {"creek/compile/engine.py"}
 
 
 class TestLevelPolicyType:

--- a/creek-tools/tests/test_mcp_write_tools.py
+++ b/creek-tools/tests/test_mcp_write_tools.py
@@ -86,9 +86,30 @@ def _write_fragment(
     body: str = "Body text.",
     privacy_tier: str = "open",
     title: str | None = None,
+    parent_id: str | None = None,
+    structural_path: list[str] | None = None,
+    child_ids: list[str] | None = None,
 ) -> None:
-    """Write a minimal fragment under ``01-Fragments/Notes`` for compile tests."""
-    metadata = {
+    """Write a minimal fragment under ``01-Fragments/Notes`` for compile tests.
+
+    The three hierarchy kwargs are emitted **only when supplied**, so every
+    pre-existing caller's frontmatter is byte-for-byte unchanged. They exist
+    for the #931 ancestry tests, which need a child whose persisted
+    ``structural_path`` carries an ancestor's heading while the ancestor
+    itself is never named in the request.
+
+    Args:
+        vault: Vault root; the file lands under ``01-Fragments/Notes``.
+        frag_id: Fragment id, also the filename stem.
+        body: Markdown body beneath the frontmatter.
+        privacy_tier: The ``privacy_tier`` frontmatter value.
+        title: Fragment title; defaults to ``"Title <frag_id>"``.
+        parent_id: Optional ``parent_id`` link up the hierarchy.
+        structural_path: Optional persisted breadcrumb, as
+            :func:`creek.atomize.split._build_children` writes it.
+        child_ids: Optional ``child_ids`` links down the hierarchy.
+    """
+    metadata: dict[str, object] = {
         "type": "fragment",
         "id": frag_id,
         "title": title or f"Title {frag_id}",
@@ -99,6 +120,12 @@ def _write_fragment(
         "privacy_tier": privacy_tier,
         "eddies": [],
     }
+    if parent_id is not None:
+        metadata["parent_id"] = parent_id
+    if structural_path is not None:
+        metadata["structural_path"] = structural_path
+    if child_ids is not None:
+        metadata["child_ids"] = child_ids
     target = vault / "01-Fragments" / "Notes" / f"{frag_id}.md"
     target.write_text(
         frontmatter.dumps(frontmatter.Post(content=body, **metadata)),
@@ -1660,6 +1687,272 @@ def test_compile_above_ceiling_wins_over_missing_id(vault: Path) -> None:
     assert result["reason"] == _ABOVE_CEILING_REASON
     assert "not found" not in result["reason"]
     assert factory.calls == 0
+
+
+# ---------------------------------------------------------------------------
+# compile — unnamed-ancestor ceiling leak (issue #931)
+# ---------------------------------------------------------------------------
+
+_ANCESTOR_HEADING = "Ritual with M."
+"""Heading of the above-ceiling ancestor, as the child's breadcrumb carries it.
+
+Deliberately the *heading* rather than a synthetic marker:
+:func:`creek.atomize.split._build_children` accumulates ancestor headings into
+each child's persisted ``structural_path``, and for an intermediate ancestor the
+heading *is* its title. That string is what
+:func:`creek.hierarchy.structural_path_context` returns and
+:func:`creek.compile.engine._build_prompt` renders after ``structural_path:``.
+"""
+
+
+def _seed_ancestry(vault: Path, *, ancestor_tier: str, child_tier: str) -> None:
+    """Write an ancestor/child pair linked both by id and by persisted breadcrumb.
+
+    The child alone is what the #931 tests name. Its ``structural_path``
+    carries :data:`_ANCESTOR_HEADING`, so the leak is reachable through the
+    *persisted* branch of :func:`creek.hierarchy.structural_path_context` —
+    the branch that needs no ancestor fragment in memory and is therefore the
+    one an MCP caller can reach.
+
+    Args:
+        vault: Vault root.
+        ancestor_tier: ``privacy_tier`` for ``frag-ancestor``.
+        child_tier: ``privacy_tier`` for ``frag-child``.
+    """
+    _write_fragment(
+        vault,
+        frag_id="frag-ancestor",
+        privacy_tier=ancestor_tier,
+        title=_ANCESTOR_HEADING,
+        child_ids=["frag-child"],
+    )
+    _write_fragment(
+        vault,
+        frag_id="frag-child",
+        privacy_tier=child_tier,
+        title="On grief",
+        parent_id="frag-ancestor",
+        structural_path=[_ANCESTOR_HEADING],
+    )
+
+
+def test_compile_refuses_an_unnamed_above_ceiling_ancestor_at_the_open_ceiling(
+    vault: Path,
+) -> None:
+    """An ``intimate`` ancestor refuses the call even though only its child is named.
+
+    Issue #931, the narrowest ceiling. #848 ranks the ids the caller
+    **names**; here the caller names one ``open`` child, so that gate admits
+    it — and the engine then renders the child's persisted
+    ``structural_path``, egressing the intimate ancestor's heading to a
+    cloud-routed provider. Ranking ancestry closes the channel.
+
+    ``factory.calls == 0`` is the load-bearing egress assertion; a
+    ``status == "refused"`` on its own would be a false green (see
+    :class:`_RecordingLLMFactory`). The refusal must also be
+    *indistinguishable* from a named-id refusal — a separate reason string
+    would be a fresh oracle telling the caller the offender is above them in
+    the tree — hence the verbatim :data:`_ABOVE_CEILING_REASON` comparison.
+    """
+    _seed_ancestry(vault, ancestor_tier="intimate", child_tier="open")
+    factory = _RecordingLLMFactory()
+
+    result = compile_tool(
+        vault_path=vault,
+        fragment_ids=["frag-child"],
+        target_kind="thread",
+        target_id="thread-anc",
+        target_title="Thread Anc",
+        llm_factory=factory,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+    assert result["status"] == "refused"
+    assert result["reason"] == _ABOVE_CEILING_REASON
+    assert factory.calls == 0
+
+
+def test_compile_ancestor_refusal_leaves_zero_state_and_one_clean_audit_row(
+    vault: Path,
+) -> None:
+    """The ancestor refusal is audited exactly like a named-id refusal (#931).
+
+    Same path, same payload shape, same absence of on-disk state: no
+    compiled page, no hash marker, no paradox log, no target directory. The
+    stub LLM returns a payload that *would* write all three, so each missing
+    artefact is evidence the engine never ran.
+
+    The audit row must not distinguish an ancestor violation from a named-id
+    one either — no extra field, no ancestor id, no tier — so the assertions
+    mirror ``test_compile_refusal_is_audited_without_ids_or_tiers`` exactly.
+    """
+    _seed_ancestry(vault, ancestor_tier="intimate", child_tier="open")
+    payload = json.dumps(
+        {
+            "claims": [
+                {"id": "c1", "text": "A claim.", "fragment_ids": ["frag-child"]}
+            ],
+            "paradoxes": [
+                {"description": "A tension.", "fragment_ids": ["frag-child"]}
+            ],
+        },
+    )
+
+    def _leaky_factory(tier: PrivacyTier) -> object:
+        """Return a stub LLM that would emit a page body and a paradox."""
+        return lambda _prompt: payload
+
+    result = compile_tool(
+        vault_path=vault,
+        fragment_ids=["frag-child"],
+        target_kind="eddy",
+        target_id="eddy-anc",
+        target_title="Eddy Anc",
+        llm_factory=_leaky_factory,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+    assert result["status"] == "refused"
+    assert result["reason"] == _ABOVE_CEILING_REASON
+    assert not (vault / "03-Eddies" / "eddy-anc.md").exists()
+    assert not (vault / PARADOX_LOG_RELPATH).exists()
+    assert not (vault / "00-Creek-Meta" / "audit" / "compile-eddy-anc.hash").exists()
+
+    entries = [e for e in _read_audit(vault) if e["tool"] == "creek.compile"]
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["args_summary"]["fragment_ids"] == {"count": 1}
+    assert "affected_fragment_ids" not in entry
+    assert "created_path" not in entry
+    assert "created_tier" not in entry
+    assert "target_title" not in entry["args_summary"]
+
+    raw = (vault / MCP_AUDIT_RELPATH).read_text(encoding="utf-8")
+    assert _ANCESTOR_HEADING not in raw
+    assert "frag-ancestor" not in raw
+    assert "intimate" not in raw
+    verify_mcp_audit_chain(vault)
+
+
+def test_compile_admits_a_within_ceiling_ancestor(vault: Path) -> None:
+    """Ancestry ranking narrows; it must not refuse everything (anti-vacuity).
+
+    Identical shape to the refusal above with the ancestor at ``open``: the
+    call is admitted, the engine runs, and the breadcrumb reaches the prompt
+    as designed. Without this row the #931 fix could be "refuse every
+    fragment that has a parent" and the refusal tests would still pass.
+    """
+    _seed_ancestry(vault, ancestor_tier="open", child_tier="open")
+    factory = _RecordingLLMFactory()
+
+    result = compile_tool(
+        vault_path=vault,
+        fragment_ids=["frag-child"],
+        target_kind="thread",
+        target_id="thread-ok",
+        target_title="Thread OK",
+        llm_factory=factory,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+    assert result["status"] == "ok"
+    assert factory.calls == 1
+
+
+def test_compile_refuses_a_dangling_ancestry_link(vault: Path) -> None:
+    """A ``parent_id`` that resolves to nothing fails closed (#931).
+
+    A missing, unreadable, non-``fragment``-typed or schema-invalid parent is
+    invisible to :func:`creek.vault.reader.try_load_fragment`, so its tier is
+    unknowable — and the child's breadcrumb still carries whatever that
+    ancestor was called. Matching :func:`creek.classify.privacy_filter.fragment_tier`'s
+    missing-key posture, an unsurveyable chain ranks ``INTIMATE``.
+    """
+    _write_fragment(
+        vault,
+        frag_id="frag-child",
+        privacy_tier="open",
+        title="On grief",
+        parent_id="frag-vanished",
+        structural_path=[_ANCESTOR_HEADING],
+    )
+    factory = _RecordingLLMFactory()
+
+    result = compile_tool(
+        vault_path=vault,
+        fragment_ids=["frag-child"],
+        target_kind="thread",
+        target_id="thread-dangle",
+        target_title="Thread Dangle",
+        llm_factory=factory,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+    assert result["status"] == "refused"
+    assert result["reason"] == _ABOVE_CEILING_REASON
+    assert factory.calls == 0
+
+
+def test_compile_refuses_an_orphan_breadcrumb(vault: Path) -> None:
+    """A breadcrumb with no ``parent_id`` to walk fails closed (#931).
+
+    The persisted ``structural_path`` is a ``list[str]`` with no id binding,
+    so a fragment carrying one while its ``parent_id`` is ``None`` —
+    re-parented, parent deleted, hand-edited — has ancestry that can be
+    *rendered* but not *ranked*. ``creek.atomize.split._build_children`` is
+    the only writer of the field and always sets ``parent_id`` in the same
+    ``model_copy``, so this state is anomalous by construction and ranks
+    ``INTIMATE`` rather than sailing through.
+    """
+    _write_fragment(
+        vault,
+        frag_id="frag-orphan",
+        privacy_tier="open",
+        title="On grief",
+        structural_path=[_ANCESTOR_HEADING],
+    )
+    factory = _RecordingLLMFactory()
+
+    result = compile_tool(
+        vault_path=vault,
+        fragment_ids=["frag-orphan"],
+        target_kind="thread",
+        target_id="thread-orphan",
+        target_title="Thread Orphan",
+        llm_factory=factory,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+    assert result["status"] == "refused"
+    assert result["reason"] == _ABOVE_CEILING_REASON
+    assert factory.calls == 0
+
+
+def test_compile_ancestry_gate_still_loses_to_a_missing_id(vault: Path) -> None:
+    """Ancestry ranking must not swallow the engine's not-found refusal (#931).
+
+    The ordering #848 established is unchanged: an id that resolves to
+    nothing contributes no tier to the survey, so a request naming only
+    within-ceiling fragments plus a typo still reaches the engine and the
+    caller still learns *which* id does not resolve.
+    """
+    _seed_ancestry(vault, ancestor_tier="open", child_tier="open")
+    factory = _RecordingLLMFactory()
+
+    result = compile_tool(
+        vault_path=vault,
+        fragment_ids=["frag-child", "frag-missing"],
+        target_kind="thread",
+        target_id="thread-x",
+        target_title="Thread X",
+        llm_factory=factory,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+    assert result["status"] == "refused"
+    assert "not found" in result["reason"]
+    assert "frag-missing" in result["reason"]
+    assert result["reason"] != _ABOVE_CEILING_REASON
 
 
 def test_compile_reports_unknown_target_kind_even_with_above_ceiling_sources(

--- a/creek-tools/tests/test_privacy_filter.py
+++ b/creek-tools/tests/test_privacy_filter.py
@@ -10,16 +10,21 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+import frontmatter
 import pytest
 
 from creek.audit import AuditLog
+from creek.classify import privacy_filter
 from creek.classify.privacy_filter import (
     PRIVACY_AUDIT_RELPATH,
     PrivacyTierOverride,
+    ancestry_tiers,
+    build_ancestor_index,
     filter_fragments_by_tier,
     override_elevates,
     parse_include_tier,
     record_privacy_override,
+    source_tiers,
     tier_within_override,
 )
 from creek.models import (
@@ -301,3 +306,305 @@ def test_tier_within_override(
 ) -> None:
     """The hard rank cutoff admits a tier iff it is at/below the override (#660)."""
     assert tier_within_override(tier, override) is expected
+
+
+# ---------------------------------------------------------------------------
+# Ancestry survey (issue #931)
+# ---------------------------------------------------------------------------
+
+
+def _node(
+    frag_id: str,
+    *,
+    tier: PrivacyTier = PrivacyTier.OPEN,
+    parent_id: str | None = None,
+    structural_path: list[str] | None = None,
+    omit_tier_key: bool = False,
+) -> tuple[Fragment, dict[str, object]]:
+    """Return the ``(fragment, raw)`` record shape the ancestry index consumes.
+
+    Args:
+        frag_id: Fragment id.
+        tier: The fragment's declared privacy tier.
+        parent_id: Optional link up the hierarchy.
+        structural_path: Optional persisted breadcrumb.
+        omit_tier_key: Drop ``privacy_tier`` from *raw* only, reproducing a
+            hand-edited or legacy file — the one case
+            :func:`creek.classify.privacy_filter.fragment_tier` distinguishes
+            from an explicit ``unclassified``.
+
+    Returns:
+        A ``(Fragment, raw_frontmatter)`` pair.
+    """
+    fragment = Fragment(
+        id=frag_id,
+        title=f"Title {frag_id}",
+        source=FragmentSource(
+            platform=SourcePlatform.JOURNAL,
+            author=Authorship.SELF,
+        ),
+        created=datetime(2026, 5, 1, tzinfo=UTC),
+        privacy_tier=tier,
+        parent_id=parent_id,
+        structural_path=structural_path or [],
+    )
+    raw: dict[str, object] = {"id": frag_id, "type": "fragment"}
+    if not omit_tier_key:
+        raw["privacy_tier"] = tier.value
+    return fragment, raw
+
+
+def test_chain_tiers_emits_the_leaf_and_every_strict_ancestor() -> None:
+    """Rule (a): a resolved id contributes its own tier and its whole chain."""
+    index = build_ancestor_index(
+        [
+            _node("root", tier=PrivacyTier.INTIMATE),
+            _node("mid", tier=PrivacyTier.PERSONAL, parent_id="root"),
+            _node("leaf", tier=PrivacyTier.OPEN, parent_id="mid"),
+        ],
+    )
+    assert set(index.chain_tiers(["leaf"])) == {
+        PrivacyTier.OPEN,
+        PrivacyTier.PERSONAL,
+        PrivacyTier.INTIMATE,
+    }
+
+
+def test_chain_tiers_ignores_an_id_that_does_not_resolve() -> None:
+    """Rule (b): an unresolved id contributes nothing, not ``INTIMATE``.
+
+    Load-bearing, and the one rule here that is *not* fail-closed. The
+    compile engine's ``ValueError("Fragment(s) not found in vault: ...")``
+    must still reach a caller with a typo'd id; if the survey failed closed
+    on unresolved ids, every typo would collapse into the content-free
+    above-ceiling refusal and a legitimate client's bug would be
+    undebuggable. Admission of the *rest* of the call is unaffected: nothing
+    that is not in the vault can be rendered into a prompt.
+    """
+    index = build_ancestor_index([_node("leaf", tier=PrivacyTier.OPEN)])
+    assert index.chain_tiers(["nope"]) == []
+    assert index.chain_tiers(["leaf", "nope"]) == [PrivacyTier.OPEN]
+
+
+def test_chain_tiers_fails_closed_on_an_unresolvable_parent() -> None:
+    """Rule (c): a ``parent_id`` the index cannot resolve ranks ``INTIMATE``.
+
+    A missing, unreadable, non-``fragment``-typed or schema-invalid parent is
+    invisible to :func:`creek.vault.reader.try_load_fragment`, so its tier is
+    unknowable while the child's breadcrumb still names it.
+    """
+    index = build_ancestor_index(
+        [_node("leaf", tier=PrivacyTier.OPEN, parent_id="vanished")],
+    )
+    assert PrivacyTier.INTIMATE in index.chain_tiers(["leaf"])
+
+
+def test_chain_tiers_terminates_and_fails_closed_on_a_cycle() -> None:
+    """Rule (d): a ``parent_id`` cycle ranks ``INTIMATE`` and does not hang.
+
+    A chain that cannot be fully surveyed fails closed. The mutual-parent
+    pair below is the minimal case; a self-parent is the degenerate one.
+    """
+    index = build_ancestor_index(
+        [
+            _node("a", tier=PrivacyTier.OPEN, parent_id="b"),
+            _node("b", tier=PrivacyTier.OPEN, parent_id="a"),
+        ],
+    )
+    assert PrivacyTier.INTIMATE in index.chain_tiers(["a"])
+
+    self_parent = build_ancestor_index(
+        [_node("s", tier=PrivacyTier.OPEN, parent_id="s")],
+    )
+    assert PrivacyTier.INTIMATE in self_parent.chain_tiers(["s"])
+
+
+def test_chain_tiers_fails_closed_on_an_orphan_breadcrumb() -> None:
+    """Rule (e): a persisted breadcrumb with no ``parent_id`` ranks ``INTIMATE``.
+
+    The breadcrumb is a ``list[str]`` with no id binding, so ancestry that
+    can be *rendered* but not *walked* is ancestry that cannot be ranked.
+    :func:`creek.atomize.split._build_children` is the only writer of the
+    field and always sets ``parent_id`` in the same ``model_copy``, so this
+    state is anomalous by construction.
+    """
+    index = build_ancestor_index(
+        [_node("orphan", tier=PrivacyTier.OPEN, structural_path=["Ritual with M."])],
+    )
+    assert PrivacyTier.INTIMATE in index.chain_tiers(["orphan"])
+
+
+def test_chain_tiers_fails_closed_on_a_breadcrumb_deeper_than_the_ancestry() -> None:
+    """Rule (e), the general case: more headings than walkable ancestors.
+
+    The survey ranks fragment *ids* up ``parent_id``; the prompt renders
+    *strings* out of ``structural_path``. Nothing in the data binds the two,
+    so a fragment re-parented onto a shallower ``open`` parent while keeping
+    its deeper breadcrumb would pass rules (c), (d) and the depth-0 orphan
+    case and still render headings from a chain nobody ranked. Comparing the
+    counts is the only sound check, and it costs nothing:
+    ``creek.atomize.split._build_children`` appends at most one heading per
+    level, so ``len(structural_path)`` can never legitimately exceed the
+    strict-ancestor count.
+    """
+    index = build_ancestor_index(
+        [
+            _node("root", tier=PrivacyTier.OPEN),
+            _node(
+                "leaf",
+                tier=PrivacyTier.OPEN,
+                parent_id="root",
+                structural_path=["Deep", "Deeper", "Ritual with M."],
+            ),
+        ],
+    )
+    assert PrivacyTier.INTIMATE in index.chain_tiers(["leaf"])
+
+
+def test_chain_tiers_admits_a_breadcrumb_matching_its_ancestry_depth() -> None:
+    """Anti-vacuity for the depth rule: a well-formed breadcrumb escalates nothing.
+
+    One heading, one strict ancestor — exactly what
+    ``creek.atomize.split._build_children`` produces for a titled section of
+    a document. If the depth check were off by one, every real split fragment
+    in the vault would become uncompilable at cloud tiers and the test above
+    would still pass.
+    """
+    index = build_ancestor_index(
+        [
+            _node("root", tier=PrivacyTier.OPEN),
+            _node(
+                "leaf",
+                tier=PrivacyTier.OPEN,
+                parent_id="root",
+                structural_path=["A section heading"],
+            ),
+        ],
+    )
+    assert index.chain_tiers(["leaf"]) == [PrivacyTier.OPEN, PrivacyTier.OPEN]
+
+
+def test_chain_tiers_fails_closed_on_a_duplicated_fragment_id() -> None:
+    """Rule (h): two files claiming one id are unrankable, so ``INTIMATE``.
+
+    The index is a mapping and a mapping is last-wins, while the
+    :func:`source_tiers` it replaces at the compile gate yields one tier per
+    *file* and so had no such hole. Without this rule a shadow file carrying
+    an above-ceiling ancestor's id with ``privacy_tier: open`` and a later
+    sort position would downgrade the real ancestor while the child's
+    breadcrumb still rendered its heading — the one way this change could be
+    *less* restrictive than what it replaced.
+    """
+    index = build_ancestor_index(
+        [
+            _node("frag-anc", tier=PrivacyTier.INTIMATE),
+            _node("frag-anc", tier=PrivacyTier.OPEN),
+            _node("leaf", tier=PrivacyTier.OPEN, parent_id="frag-anc"),
+        ],
+    )
+    assert PrivacyTier.INTIMATE in index.chain_tiers(["leaf"])
+    assert PrivacyTier.INTIMATE in index.chain_tiers(["frag-anc"])
+
+
+def test_chain_tiers_leaves_a_breadcrumbless_root_alone() -> None:
+    """Anti-vacuity for rule (e): no breadcrumb, no escalation.
+
+    Without this row the orphan rule could be "every root fragment is
+    intimate", which would refuse practically every compile at an ``open``
+    ceiling and still pass the test above.
+    """
+    index = build_ancestor_index([_node("root", tier=PrivacyTier.OPEN)])
+    assert index.chain_tiers(["root"]) == [PrivacyTier.OPEN]
+
+
+def test_chain_tiers_reads_a_missing_privacy_tier_key_as_intimate() -> None:
+    """Per-entry tiers come from ``fragment_tier``, so a missing key fails closed."""
+    index = build_ancestor_index(
+        [
+            _node("root", tier=PrivacyTier.UNCLASSIFIED, omit_tier_key=True),
+            _node("leaf", tier=PrivacyTier.OPEN, parent_id="root"),
+        ],
+    )
+    assert PrivacyTier.INTIMATE in index.chain_tiers(["leaf"])
+
+
+def test_chain_tiers_surveys_every_requested_id_before_answering() -> None:
+    """Rules (f)+(g): the whole batch is surveyed, and shared chains are cheap.
+
+    No short-circuit on the first offender: both leaves are ranked, so the
+    cost of a probe does not depend on *where* in the batch (or how far up a
+    chain) the above-ceiling ancestor sits. Sharing a memoised ancestor chain
+    is what keeps that uniformity affordable on a deep, wide request.
+    """
+    index = build_ancestor_index(
+        [
+            _node("root", tier=PrivacyTier.INTIMATE),
+            _node("l1", tier=PrivacyTier.OPEN, parent_id="root"),
+            _node("l2", tier=PrivacyTier.PERSONAL, parent_id="root"),
+        ],
+    )
+    tiers = set(index.chain_tiers(["l1", "l2"]))
+    assert tiers == {PrivacyTier.OPEN, PrivacyTier.PERSONAL, PrivacyTier.INTIMATE}
+    # Order of the request cannot change the answer.
+    assert set(index.chain_tiers(["l2", "l1"])) == tiers
+
+
+def test_ancestry_tiers_reads_the_vault_in_one_walk(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The MCP entry point surveys ancestry with a single ``01-Fragments`` pass.
+
+    ``iter_vault_fragments`` rglobs and parses every file under the root
+    before returning, so a second pass is a real 35k-vault regression rather
+    than a micro-optimisation.
+    """
+    root = tmp_path / "01-Fragments" / "Notes"
+    root.mkdir(parents=True)
+    for frag_id, tier, parent in (
+        ("frag-anc", PrivacyTier.INTIMATE, None),
+        ("frag-kid", PrivacyTier.OPEN, "frag-anc"),
+    ):
+        fragment, _raw = _node(frag_id, tier=tier, parent_id=parent)
+        post = frontmatter.Post(content="body", **fragment.model_dump(mode="json"))
+        (root / f"{frag_id}.md").write_text(frontmatter.dumps(post), encoding="utf-8")
+
+    real = privacy_filter.iter_vault_fragments
+    calls: list[Path] = []
+
+    def _counting(
+        walk_root: Path,
+    ) -> list[tuple[Path, Fragment, str, dict[str, object]]]:
+        """Record the walked root and delegate to the real loader."""
+        calls.append(walk_root)
+        return real(walk_root)
+
+    monkeypatch.setattr(privacy_filter, "iter_vault_fragments", _counting)
+
+    tiers = ancestry_tiers(tmp_path, ["frag-kid"])
+
+    assert calls == [tmp_path / "01-Fragments"]
+    assert PrivacyTier.INTIMATE in tiers
+
+
+def test_source_tiers_stays_ancestry_blind(tmp_path: Path) -> None:
+    """``source_tiers`` must NOT gain the ancestry term (#931).
+
+    ``draft`` / ``journal`` / ``upload`` reduce over it and render no
+    breadcrumb, so widening it would refuse calls that leak nothing — and
+    silently change three tools this issue never analysed. The two surveys
+    are deliberately two functions; this pins the difference so a future
+    "de-duplication" has to argue with a test.
+    """
+    root = tmp_path / "01-Fragments" / "Notes"
+    root.mkdir(parents=True)
+    for frag_id, tier, parent in (
+        ("frag-anc", PrivacyTier.INTIMATE, None),
+        ("frag-kid", PrivacyTier.OPEN, "frag-anc"),
+    ):
+        fragment, _raw = _node(frag_id, tier=tier, parent_id=parent)
+        post = frontmatter.Post(content="body", **fragment.model_dump(mode="json"))
+        (root / f"{frag_id}.md").write_text(frontmatter.dumps(post), encoding="utf-8")
+
+    assert source_tiers(tmp_path, ["frag-kid"]) == [PrivacyTier.OPEN]
+    assert PrivacyTier.INTIMATE in ancestry_tiers(tmp_path, ["frag-kid"])


### PR DESCRIPTION
## Summary

- **Closes the ancestry leak by ranking ancestors, not by redacting the breadcrumb.** `creek/hierarchy.py::structural_path_context` prefers a fragment's *persisted* `structural_path` — ancestor headings `creek.atomize.split._build_children` baked in at ingest — and `creek/compile/engine.py::_build_prompt` emits them after `structural_path:`. #848's gate ranks only the ids a caller **names**, so an `open` child of an `intimate` parent was admitted at `ceiling=open` and shipped its parent's heading to a cloud-routed provider. One new chokepoint in `creek/classify/privacy_filter.py` — `AncestorIndex` / `build_ancestor_index` / `ancestry_tiers` — now walks `parent_id` and reports the whole chain's tiers; both compile entry points reduce over it with the existing `max_source_tier` / `write_tier_allowed`. Neither call site contains any ancestry logic of its own.
- **The two callers get two different, deliberately asymmetric answers.** The MCP `compile_tool` **refuses the whole call** — its caller does not own the vault, and refusal is what #848 already means there. The ceiling-less `creek compile` CLI **keeps the breadcrumb and escalates its LLM routing tier** to the ancestor's, so the ancestry's real orienting value stays with the vault owner while the call is forced onto a local model — or raises `IntimateRoutingError` when there is no local backend. Redacting on the CLI side would silently degrade the operator who owns the content; routing-only on the MCP side would hand a summariser content the caller was never admitted to. If a reviewer cannot find that sentence, the fix is half-designed.
- **No new walk anywhere.** The index is built from the records `_load_fragments_for_compile` already walks, so the CLI stays at exactly one `01-Fragments` pass and the MCP stays at the two it already had. `tests/test_compile.py::test_compile_to_vault_walks_the_vault_exactly_once` pins it; at the 35k-fragment bar a second rglob-plus-parse would double the pre-LLM wall clock, and a privacy fix has no business shipping that regression.

### What the fix does *not* change

`_ABOVE_CEILING_REASON` is byte-identical, the audit payload is identical, `_SourceGate` keeps its single field, `_survey_sources` keeps its pinned gate symbol, and `CONTRACT_VERSION` stays at `0.4.0`. **An ancestor refusal is indistinguishable from a named-id refusal** in the response, the audit row and the probe cost — a distinct reason string would be a fresh oracle telling the caller "the offender is above you in the tree", which is strictly more than the bool #848 accepted. `chain_tiers` never short-circuits and never does a lazy per-parent lookup, so the uniform-probe-cost property that keeps the refusal from leaking position through timing survives (rule (f) in its docstring).

`source_tiers` was deliberately **not** widened. `draft` / `journal` / `upload` reduce over it and render no breadcrumb, so ancestry-ranking there would refuse calls that leak nothing and would silently change three tools this issue never analysed. `tests/test_privacy_filter.py::test_source_tiers_stays_ancestry_blind` pins the difference so a future de-duplication has to argue with a test.

### Two hardenings the pre-push security review earned

Both were found by the Gate 2.5 security pass, and both are strict narrowings:

- **Duplicate fragment ids were the one place this change was *less* restrictive than what it replaced.** `source_tiers` yields one tier per *file*, so two files claiming one id contributed both tiers and the more sensitive won. An index keyed on `fragment.id` is last-wins, which would have let a shadow file carrying an above-ceiling ancestor's id with `privacy_tier: open` and a later sort position downgrade the real ancestor while the child's breadcrumb still rendered its heading. Rule (h) now fails a colliding id closed to `INTIMATE`. Proved red: without it, `chain_tiers` returns `['open', 'open']` for exactly that shadow-file input.
- **Breadcrumb depth is now bound to the ancestry actually walked.** The survey ranks *ids*; the prompt renders *strings*, and nothing in the data binds the two. The original rule (e) caught only the depth-0 case (`parent_id is None` with a breadcrumb). It is now the general count check — `len(structural_path)` may never exceed the strict-ancestor count, which `creek.atomize.split._build_children` guarantees by appending at most one heading per level — so a fragment re-parented onto a shallower `open` parent while keeping a deeper breadcrumb also fails closed. No production writer can produce that state today; the point is that the fix no longer *rests* on that being true.

### Consequences worth stating plainly

1. **Walking `parent_id` over-covers.** It ranks the root document too, whose title the persisted breadcrumb never carries. A vault with `intimate` top-level documents will now route descendant compiles local, and refuse them at an `open` MCP ceiling. That is a strict narrowing, chosen over an entry-level attribution the data cannot support: persisted breadcrumb entries are bare strings with no owning-fragment id, so "strip the entries whose owning fragment is above the ceiling" (the issue's cheaper option) is not implementable as written — mapping entry to ancestor requires the same `parent_id` walk, and then still has to guess.
2. **A broken ancestry link makes a subtree uncompilable at cloud tiers**, with a refusal that names nothing. A dangling, cyclic or orphaned `parent_id` all fail closed to `INTIMATE` (rules (c), (d), (e)). That is the right privacy answer and a poor debugging experience, so `creek lint` surfacing those states is filed as **#1277**.
3. **`creek/hierarchy.py` gains a `visited` set**, kept in this PR rather than split out. The file genuinely hangs today on a `parent_id` cycle whose members are all in `by_id` — the loop's only exit was a *missing* parent, and in a cycle every parent is present; the new test hung the runner before the fix. It is the direct sibling of the walk this PR adds, and shipping two ancestry walks with different cycle semantics is exactly the two-readers-can-disagree drift `privacy_filter`'s module docstring exists to prevent. `structural_path_context`'s signature, return type and behaviour are otherwise untouched.

### Answering the issue's audit bullet

> Worth auditing whether the same ancestry channel exists in other tools that render `structural_path`.

It does not. `grep -rn structural_path creek/ creek_mcp/` gives exactly one production caller of `structural_path_context`: `creek/compile/engine.py`. No other tool renders a breadcrumb. That is now pinned by a test rather than noted in a comment, so a future second renderer cannot silently re-open the channel.

### Corrections to the issue body

The issue points at `creek/compile/hierarchy.py`, which does not exist — the function is `creek/hierarchy.py::structural_path_context`. It also describes the mechanism as "a list of parent titles", which aims the fix at the wrong branch: the `parent_id`-walk branch only fires when the parent is in `_build_prompt`'s `by_id`, i.e. when the caller *named* it, in which case #848 already refuses. The MCP-reachable channel is the **persisted-field** branch, which needs no ancestor fragment in memory at all. The pre-existing `tests/test_compile.py::test_compile_to_vault_routes_on_a_parent_the_level_policy_dropped` covers the already-safe branch; only its docstring changed here, and both of its assertions — including `assert f"structural_path: {_INTIMATE_TITLE}" in prompt` — survive verbatim, because that call names both fragments and this PR does not change its behaviour at all.

## Test plan

Gate 1, red first. Every new test was authored and run before any source edit, and the red was re-proved after the fix by restoring `creek/compile/engine.py` and `creek_mcp/tools/compile.py` to `git merge-base HEAD origin/main` (no `git stash` — one shared ref across four live worktrees). Six failures, each for the right reason:

- `test_compile_to_vault_routes_intimate_on_a_persisted_ancestor_not_named` — `assert ['personal'] == [PrivacyTier.INTIMATE]`: a **cloud** client built with `structural_path: Therapy session with Dana` in the prompt.
- `test_compile_to_vault_refuses_an_unnamed_intimate_ancestor_with_no_local_backend` — `RuntimeError: ANTHROPIC_API_KEY ... not set`, i.e. it reached the Anthropic client constructor instead of raising `IntimateRoutingError`.
- Four MCP rows (`..._at_the_open_ceiling`, `..._leaves_zero_state_and_one_clean_audit_row`, `..._a_dangling_ancestry_link`, `..._an_orphan_breadcrumb`) — `assert 'ok' == 'refused'`.
- `tests/test_hierarchy.py::test_parent_id_cycle_terminates_without_repeating_an_ancestor` did not fail, it **hung** the runner — the pre-fix walk spins forever on a mutual-parent pair.

New coverage:

- `tests/test_mcp_write_tools.py` — the narrowest-ceiling refusal with `factory.calls == 0` (status alone is a false green); zero on-disk state (no page, no `compile-<id>.hash`, no paradox log) with a stub LLM that *would* write all three; exactly one `creek.compile` audit row with `fragment_ids` collapsed to a count and `created_path` / `created_tier` / `affected_fragment_ids` / `target_title` absent, the ancestor's heading and id absent from the raw log, and `verify_mcp_audit_chain` intact; the dangling-parent and orphan-breadcrumb fail-closed rows; an **admit** row so the fix cannot be "refuse everything with a parent"; and a row proving the ancestry gate still loses to the engine's not-found `ValueError`.
- `tests/test_compile.py` — the CLI routing escalation (breadcrumb retained, tier `INTIMATE`), an `IntimateRoutingError` sibling with the same anti-vacuity assertion as the #962 original, an anti-vacuity `OPEN`-stays-`OPEN` row, and the one-walk counter.
- `tests/test_privacy_filter.py` — one test per `chain_tiers` rule (a) through (h), plus the ancestry-blindness pin on `source_tiers` and a single-walk pin on `ancestry_tiers`. The two hardening rules were separately proved red by reverting only their own branch: `['open', 'open']` in both cases. Their anti-vacuity siblings (`..._admits_a_breadcrumb_matching_its_ancestry_depth`, `..._leaves_a_breadcrumbless_root_alone`) stayed green throughout, so the depth check is not off by one — if it were, every real split fragment in the vault would become uncompilable at cloud tiers.
- `tests/test_hierarchy.py` — mutual-parent and self-parent cycle termination, and the one-production-caller pin on `structural_path_context`.

Gate 2, in a CI-equivalent env with all provider keys and `CREEK_*` consent vars stripped: `./scripts/check-all.sh` exits 0 — **12/12 checks passed**, 8679 unit tests, 94.37% branch coverage, per-file gate green on all 255 files, mypy strict, xenon, ruff lint + format with `--no-cache`, refurb, bandit, pip-audit. Plus `./scripts/test.sh --integration` (356 passed) and `./scripts/test.sh --e2e` (14 passed).

Test integrity: `git diff $(git merge-base HEAD origin/main)` removes **zero** assertions. The only deleted lines under `tests/` are one rewritten docstring sentence and the two-line `_write_fragment` helper signature it extends (new kwargs are emitted only when supplied, so no existing caller's frontmatter changes).

## Notes for the reviewer

- Same `Intimate`-never-cloud invariant as **#1152**, which is in flight on the crawdad side. Separate venv, separate `check-all.sh`, separate CI job — a green gate here says nothing about that lane and vice versa. Cross-referenced rather than restated.
- Touches `creek_mcp/read_gate.py` (rationale prose only; `gate_module` / `gate_symbol` unchanged), which **#1036** also touches. #1036's prompt-side canary is the natural regression harness for this leak; serialise the two lanes.
- `ancestry_tiers` is plausibly reusable by **#971** (`creek.skills.refresh` never threads `privacy_tier_ceiling`). Flagged, not coupled.
- Follow-ups filed: **#1277** (`creek lint` dangling/cyclic/orphaned `parent_id` — the diagnostic gap behind consequence 2 above), **#1278** (the pre-existing MCP gate-walk + engine-walk duplication), **#1282** (`CompiledPage` carries no `privacy_tier`; downstream safety currently rests on `raw_privacy_tier`'s missing-key default in another module).
- Gate 2.5 ran `code-review-orchestrator` (returned `CLEAN` across privacy monotonicity, oracle, probe cost, rule correctness, scale, layering, test integrity and anti-vacuity) and `security-specialist` (no blocker; its two actionable findings are the hardenings above, its two documentation findings are folded into the `_ABOVE_CEILING_REASON` comment and `_routing_tier_for`'s docstring, and its informational finding is #1282).
- Planning pass: this change was executed from an independent adversarial premise-and-design audit of #931 (which returned `partly` on the issue's own premise and produced the judged `hybrid` design implemented here), not from a `chief-architect` spawn.

Closes #931
Refs #848, #962, #647
