### PR TITLE
fix(crawdad): enforce the FEAT-027 redaction-scan gate at the dispatch boundary

### DIFF
--- a/crawdad/CLAUDE.md
+++ b/crawdad/CLAUDE.md
@@ -192,6 +192,60 @@ tier end-to-end from the capture record through staging into fragment
 frontmatter, so an `intimate` channel can be captured faithfully
 instead of refused outright.
 
+### 5.3 Redaction-scan gate (FEAT-027, #1054)
+
+**Policy: record the batch, refuse at dispatch.** An attachment turn
+whose `creek.redact.scan` could not run still stages the files and
+still records a `PendingBatch` — so the user can see what landed and
+`cancel` it — but that batch can never be dispatched to `creek.ingest`.
+
+Rejected alternatives: *withholding the consent prompt* (relies on the
+user never typing `ingest` unprompted — prompt suppression is not
+enforcement), and *a distinct opt-in token* (a documented override is
+a fail-open path, and this is the one gate standing between unscanned
+content and the vault).
+
+**Mechanism.** `PendingBatch.scanned` is a **required field with no
+default**, placed ahead of the defaulted fields. There is deliberately
+no permissive default and no `ConsentConfig` knob: either would let a
+construction site — or an operator — silently reopen the hole.
+`_run_safety_scan` returns a `_ScanOutcome(scanned, text)` rather than
+a bare string, so the caller reads a status instead of string-matching
+the reply text against `_MCP_UNAVAILABLE_REPLY` (shared with the ingest
+and state paths). All four failure modes — no MCP client, the tool
+unadvertised, `MCPUnavailableError`, and any other exception — yield
+`scanned=False`.
+
+Enforcement is **one branch in `_dispatch_ingest_for_batch`**, the sole
+convergence point of the consent flow. Both `_apply_consent_reply` and
+`_apply_disambiguation_reply` reach ingest through it, so one guard
+closes the `ingest` route, the `ingest` → type-question → type-word
+route, and any future caller. Do not add a second guard at a caller: two
+gates drift, one cannot. `with_resolved_types` / `with_state` /
+`with_ingested` are all `dataclasses.replace` copies, so `scanned`
+survives every transition and cannot be laundered.
+
+**Explicit non-goal.** The gate enforces *"the scan could not run"* —
+**not** *"the scan found nothing"*. `creek_mcp/tools/redact.py` computes
+`status = "empty" if not scanned.matches else "ok"`, so there is no
+failing status to read: a scan that runs and reports secrets still
+clears the gate. User-facing copy must claim only what is enforced —
+`_SCAN_BLOCKED_REPLY` says "I couldn't run the redaction scan", never
+"these files are clean". Substituting a new false claim for the old one
+would miss the point of the fix.
+
+Related, explicitly **not** covered here: #1087 (`scan_batch` follows
+symlinks out of the scan root — a scan that *runs* but under-reports,
+and this gate marks such a batch `scanned=True`). #1088
+(`attachments.staging_subpath` outside the scan's canonical scope) *is*
+a fifth way the scan fails to run; this design absorbs it with one more
+`_ScanOutcome(scanned=False, …)` arm, so sequence it next rather than
+touching `_run_safety_scan` twice.
+
+**Revisit predicate:** when `creek.redact.scan` gains a failing status
+for non-empty findings, revisit whether `scanned` should become a
+three-state outcome and whether findings should block ingest.
+
 ## 6. MCP subprocess resilience
 
 The bot does **not** exit on MCP subprocess failure. The pattern is:

--- a/crawdad/crawdad/bot.py
+++ b/crawdad/crawdad/bot.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol, cast
 
 import discord
@@ -83,10 +84,34 @@ _REDACT_TOOL_MISSING_REPLY = (
 # via the per-channel :class:`PendingBatchStore` threaded through this
 # module. The CLI escape hatch in the prompt below is preserved for
 # users who prefer the deterministic terminal path.
+#
+# #1054: this prompt is now sent ONLY when the redaction scan actually
+# ran. When it could not, the turn closes with _SCAN_BLOCKED_REPLY
+# instead, and ``PendingBatch.scanned=False`` makes the refusal stick
+# at the dispatch boundary — so the bot can no longer tell the user to
+# "run `creek redact --scan` before ingesting" and offer `ingest` in
+# the very next message.
 _INGEST_CONSENT_PROMPT = (
     "I did **not** ingest anything. Reply with `ingest` (or run "
     "`creek ingest --type <type> --input <staging path>`) to proceed. "
     "Reply `cancel` to drop the batch."
+)
+
+# #1054: the refusal for a batch whose redaction scan never ran. ONE
+# constant deliberately serves TWO call sites — the close of an
+# unscanned attachment turn (:func:`_handle_attachments`) and the
+# refusal at the dispatch boundary
+# (:func:`_dispatch_ingest_for_batch`) — so the two messages are
+# literally the same string and cannot drift into contradicting each
+# other the way _REDACT_TOOL_MISSING_REPLY and _INGEST_CONSENT_PROMPT
+# did. The wording claims only the invariant actually enforced ("could
+# not scan"); it must NOT be reworded to imply a successful scan blocks
+# findings, because ``creek.redact.scan`` returns a permissive status
+# even when it finds secrets. See crawdad/CLAUDE.md §5.3.
+_SCAN_BLOCKED_REPLY = (
+    "I couldn't run the redaction scan on these files, so I won't ingest "
+    "them. Run `creek redact --scan <staging path>` from the terminal to "
+    "check them yourself, or reply `cancel` to drop the batch."
 )
 
 _ALREADY_STAGED_REPLY = (
@@ -322,6 +347,25 @@ def _empty_skills() -> VoiceSkillStack:
     return VoiceSkillStack(skills=())
 
 
+@dataclass(frozen=True, slots=True)
+class _ScanOutcome:
+    """What :func:`_run_safety_scan` did, and what to tell the user (#1054).
+
+    Attributes:
+        scanned: ``True`` only when ``creek.redact.scan`` actually
+            executed and returned a body. ``False`` for every failure
+            mode, and it is the value recorded on
+            :attr:`crawdad.consent.PendingBatch.scanned`. Deliberately
+            narrow: ``True`` says the scan *ran*, not that it came back
+            clean — the tool reports findings with a permissive status.
+        text: Discord-safe section to show the user — the formatted scan
+            report on success, a soft error otherwise.
+    """
+
+    scanned: bool
+    text: str
+
+
 async def _handle_attachments(
     *,
     message: _MessageLike,
@@ -343,15 +387,21 @@ async def _handle_attachments(
        hash already on disk), reply "already staged" and stop — no
        redundant scan or ingest.
     3. Otherwise invoke ``creek.redact.scan`` on the staging directory
-       via MCP. If MCP is unreachable or the tool is not advertised,
-       fall back to a clear soft error rather than silently ingesting.
+       via MCP. If MCP is unreachable, the tool is not advertised, there
+       is no MCP client, or the call raises, the returned
+       :class:`_ScanOutcome` carries ``scanned=False`` and a soft error.
     4. Record the staged batch on the per-channel
-       :class:`PendingBatchStore` (FEAT-034) so a follow-up
-       ``ingest`` / ``yes`` / ``proceed`` message in the same channel
-       dispatches ``creek.ingest`` for the batch.
-    5. Reply with the combined download summary, the scan report, and a
-       consent prompt. The bot **never** auto-ingests; the user must
-       respond explicitly.
+       :class:`PendingBatchStore` (FEAT-034) **including** that
+       ``scanned`` flag, so a follow-up ``ingest`` / ``yes`` /
+       ``proceed`` message dispatches ``creek.ingest`` only for a batch
+       that was actually scanned. An unscanned batch is still recorded —
+       it stays inspectable and cancel-able — but
+       :func:`_dispatch_ingest_for_batch` refuses it (#1054).
+    5. Reply with the combined download summary and scan section, then
+       close with the consent prompt when the scan ran or
+       :data:`_SCAN_BLOCKED_REPLY` when it did not. The bot **never**
+       auto-ingests; the user must respond explicitly, and for an
+       unscanned batch even an explicit ``ingest`` is refused.
     """
     channel_id = message.channel.id
     processed = await process_attachments(
@@ -375,7 +425,7 @@ async def _handle_attachments(
         )
         return
 
-    scan_section = await _run_safety_scan(
+    outcome = await _run_safety_scan(
         processed=processed,
         config=config,
         mcp_client=mcp_client,
@@ -394,17 +444,21 @@ async def _handle_attachments(
                 processed=processed,
                 channel_id=channel_id,
                 config=config,
+                scanned=outcome.scanned,
             )
 
     # Send the summary + scan section first (may be truncated for long
-    # scan bodies) and then the consent prompt as a separate message.
-    # The consent string is short and well under the Discord cap; sending
+    # scan bodies) and then the closing message as a separate message.
+    # The closing string is short and well under the Discord cap; sending
     # it on its own guarantees the "I did **not** ingest anything" trust
-    # signal can never be silently dropped by truncation of the scan
-    # section, even for a multi-file batch with many findings.
-    body = "\n\n".join((summary, scan_section))
+    # signal — or, for an unscanned batch, the refusal — can never be
+    # silently dropped by truncation of the scan section, even for a
+    # multi-file batch with many findings.
+    body = "\n\n".join((summary, outcome.text))
     await message.channel.send(_truncate_for_discord(body))
-    await message.channel.send(_INGEST_CONSENT_PROMPT)
+    await message.channel.send(
+        _INGEST_CONSENT_PROMPT if outcome.scanned else _SCAN_BLOCKED_REPLY
+    )
 
 
 def _record_pending_batch(
@@ -413,11 +467,21 @@ def _record_pending_batch(
     processed: ProcessedAttachments,
     channel_id: int,
     config: CrawDadConfig,
+    scanned: bool,
 ) -> None:
     """Record *processed* on the pending-batch store, superseding prior state.
 
     Skipped (no-op) when the store wasn't wired (test paths that don't
     exercise the consent flow) or when no files landed on disk.
+
+    Args:
+        pending_batches: Store to record on; ``None`` is a no-op.
+        processed: Result of the attachment download/staging pass.
+        channel_id: Discord channel the batch belongs to.
+        config: Bot config, consulted for the channel's tier ceiling.
+        scanned: :attr:`_ScanOutcome.scanned` from this turn's safety
+            pass, persisted on the batch so the dispatch boundary can
+            refuse a batch that was never scanned (#1054).
     """
     if pending_batches is None or not processed.accepted:
         return
@@ -437,6 +501,7 @@ def _record_pending_batch(
         accepted_files=files,
         privacy_tier_ceiling=_channel_tier(channel_id=channel_id, config=config),
         now=pending_batches.now(),
+        scanned=scanned,
     )
     pending_batches.record(batch)
 
@@ -522,7 +587,14 @@ async def _apply_consent_reply(
     * ``"ingested"``: re-consent is a clear no-op.
     * unresolved types: transition to ``"awaiting_type"`` and ask
       which type to apply to the unresolved subset.
-    * everything resolved: dispatch ingest immediately.
+    * everything resolved: hand off to
+      :func:`_dispatch_ingest_for_batch`, which refuses the batch
+      outright if its redaction scan never ran (#1054).
+
+    Note the ordering: an unscanned batch with an unresolved file type
+    still gets the type question on this turn and the refusal on the
+    next. One wasted turn, zero ``creek.ingest`` calls — the gate lives
+    at the shared callee so it cannot be bypassed by either route.
     """
     if batch.state == "ingested":
         await message.channel.send(_ALREADY_INGESTED_REPLY)
@@ -559,6 +631,11 @@ async def _apply_disambiguation_reply(
     type word landing while the batch is still ``"awaiting_consent"``
     or already ``"ingested"`` falls through to the regular agent loop
     so the user is never trapped inside the consent state machine.
+
+    ``with_resolved_types`` is a :func:`dataclasses.replace` copy, so
+    :attr:`PendingBatch.scanned` survives disambiguation unchanged and
+    this route cannot launder an unscanned batch past the gate in
+    :func:`_dispatch_ingest_for_batch` (#1054).
     """
     if batch.state != "awaiting_type":
         return False
@@ -584,16 +661,31 @@ async def _dispatch_ingest_for_batch(
     pending_batches: PendingBatchStore,
     config: CrawDadConfig,
 ) -> None:
-    """Invoke ``creek.ingest`` for every file in *batch* and reply.
+    """Refuse unscanned batches; otherwise invoke ``creek.ingest`` and reply.
 
-    The batch is mutated in the store to track ingested hashes (so a
-    follow-up consent in the same channel reports "already ingested")
-    and to transition state to ``"ingested"`` only once every file in
-    the batch has landed. A partial failure (mid-batch
+    **The redaction-scan gate lives here** (#1054). A batch whose
+    ``creek.redact.scan`` never ran (:attr:`PendingBatch.scanned` is
+    ``False``) is refused before any tool call. This function is the
+    single convergence point of the consent flow — both
+    :func:`_apply_consent_reply` and :func:`_apply_disambiguation_reply`
+    reach ingest through it — so guarding the callee rather than the two
+    callers closes the ``ingest`` route, the
+    ``ingest`` → type-question → type-word route, and any future third
+    caller with one branch that cannot drift out of sync. The gate
+    enforces "the scan could not run", **not** "the scan found nothing";
+    see crawdad/CLAUDE.md §5.3.
+
+    Otherwise the batch is mutated in the store to track ingested hashes
+    (so a follow-up consent in the same channel reports "already
+    ingested") and to transition state to ``"ingested"`` only once every
+    file in the batch has landed. A partial failure (mid-batch
     :class:`MCPUnavailableError`) leaves the batch in
     ``"awaiting_consent"`` so the user can retry; the already-landed
     files are then skipped on the retry via their content hashes.
     """
+    if not batch.scanned:
+        await message.channel.send(_SCAN_BLOCKED_REPLY)
+        return
     if mcp_client is None or _INGEST_TOOL not in known_tools:
         await message.channel.send(_INGEST_TOOL_MISSING_REPLY)
         return
@@ -684,17 +776,24 @@ async def _run_safety_scan(
     mcp_client: MCPClient | None,
     known_tools: tuple[str, ...],
     channel_id: int,
-) -> str:
-    """Invoke ``creek.redact.scan`` on the staging dir, return Discord-safe text.
+) -> _ScanOutcome:
+    """Invoke ``creek.redact.scan`` on the staging dir; report what happened.
 
-    Returns a soft-error message instead of raising when MCP is
-    unavailable, the tool is not advertised, or any other unexpected
-    exception occurs during the call. The user always gets the
-    download summary and a clear next step — the bot never goes silent
-    on attachment turns.
+    Returns an :class:`_ScanOutcome` rather than a bare string so the
+    caller can branch on whether the scan *ran* without string-sniffing
+    the reply text. That distinction matters: the soft-error strings are
+    shared with the ingest path (:func:`_run_ingest_dispatch`) and the
+    state path (:func:`render_mcp_unavailable_reply`), so comparing
+    against them would be a latent bug.
+
+    All four ways the scan can fail to run — no MCP client, the tool
+    unadvertised, :class:`MCPUnavailableError`, and any other unexpected
+    exception — return ``scanned=False`` with a Discord-safe soft error.
+    The bot never raises out of an attachment turn and never goes
+    silent; it just refuses to ingest afterwards (#1054).
     """
     if mcp_client is None or _REDACT_SCAN_TOOL not in known_tools:
-        return _REDACT_TOOL_MISSING_REPLY
+        return _ScanOutcome(scanned=False, text=_REDACT_TOOL_MISSING_REPLY)
 
     try:
         rel_staging = processed.staging_dir.relative_to(config.vault_path)
@@ -714,16 +813,16 @@ async def _run_safety_scan(
             )
     except MCPUnavailableError as exc:
         _LOGGER.warning("creek.redact.scan failed: %s", exc)
-        return _MCP_UNAVAILABLE_REPLY
+        return _ScanOutcome(scanned=False, text=_MCP_UNAVAILABLE_REPLY)
     except Exception:
         # Any other failure (timeout, protocol error, bad JSON, etc.)
         # must not bubble up — the bot would go silent on the user's
         # attachment turn. Log a full traceback for the operator and
         # surface the same soft error.
         _LOGGER.exception("unexpected error during creek.redact.scan call")
-        return _MCP_UNAVAILABLE_REPLY
+        return _ScanOutcome(scanned=False, text=_MCP_UNAVAILABLE_REPLY)
 
-    return _format_scan_section(body)
+    return _ScanOutcome(scanned=True, text=_format_scan_section(body))
 
 
 def _format_scan_section(body: str) -> str:

--- a/crawdad/crawdad/consent.py
+++ b/crawdad/crawdad/consent.py
@@ -109,6 +109,16 @@ class PendingBatch:
             MCP server can enforce the policy at its boundary.
         created_at: Monotonic timestamp the batch was recorded at;
             consumed by :meth:`is_expired`.
+        scanned: Whether ``creek.redact.scan`` actually ran for this
+            batch (FEAT-027, #1054). ``False`` means the scan could not
+            run — MCP unreachable, the tool unadvertised, no MCP client
+            at all, or an unexpected error — and the batch must never be
+            dispatched to ``creek.ingest``. Enforced by the single guard
+            in :func:`crawdad.bot._dispatch_ingest_for_batch`. Required
+            with **no default** so no construction site can silently
+            inherit a permissive value. Note the narrow claim: ``True``
+            means the scan ran, *not* that it came back clean — see
+            crawdad/CLAUDE.md §5.3.
         state: Lifecycle stage (``"awaiting_consent"`` →
             ``"awaiting_type"`` → ``"ingested"``). Abandonment removes
             the batch entirely instead of transitioning the state.
@@ -122,6 +132,11 @@ class PendingBatch:
     files: tuple[PendingFile, ...]
     privacy_tier_ceiling: str
     created_at: float
+    # Placement is load-bearing: ``scanned`` has no default, so it must
+    # precede every defaulted field or the class raises
+    # ``TypeError: non-default argument follows default argument`` at
+    # import time.
+    scanned: bool
     state: BatchState = "awaiting_consent"
     ingested_hashes: frozenset[str] = field(default_factory=frozenset)
 
@@ -352,12 +367,24 @@ def build_pending_batch(
     accepted_files: tuple[PendingFile, ...],
     privacy_tier_ceiling: str,
     now: float,
+    scanned: bool,
 ) -> PendingBatch:
     """Construct a fresh :class:`PendingBatch` in the ``awaiting_consent`` state.
 
     Thin factory so the bot handler doesn't have to remember the
     initial state — the only valid starting point for a freshly staged
     batch is ``awaiting_consent``.
+
+    Args:
+        channel_id: Discord channel the batch belongs to.
+        staging_dir: Per-message staging directory under the vault.
+        accepted_files: Staged attachments awaiting consent.
+        privacy_tier_ceiling: Channel ceiling forwarded to every
+            ``creek.ingest`` call.
+        now: Timestamp to stamp the batch with.
+        scanned: Whether ``creek.redact.scan`` actually ran. Required —
+            see :attr:`PendingBatch.scanned`; a caller that cannot say
+            must pass ``False``.
     """
     return PendingBatch(
         channel_id=channel_id,
@@ -365,4 +392,5 @@ def build_pending_batch(
         files=accepted_files,
         privacy_tier_ceiling=privacy_tier_ceiling,
         created_at=now,
+        scanned=scanned,
     )

--- a/crawdad/tests/test_bot.py
+++ b/crawdad/tests/test_bot.py
@@ -8,7 +8,11 @@ from typing import Any
 
 import pytest
 
-from crawdad.bot import handle_message, render_state_unavailable_reply
+from crawdad.bot import (
+    _SCAN_BLOCKED_REPLY,
+    handle_message,
+    render_state_unavailable_reply,
+)
 from crawdad.config import CrawDadConfig
 from crawdad.consent import PendingBatchStore
 from crawdad.mcp_client import MCPUnavailableError
@@ -1025,12 +1029,18 @@ async def test_attachment_path_replies_when_redact_tool_missing(
         known_tools=("creek.state.read",),  # no creek.redact.scan here
     )
 
-    # Two messages: body (with missing-tool soft error) + consent prompt.
+    # Two messages: body (with missing-tool soft error) + the #1054
+    # refusal. This test used to assert the *consent prompt* here — the
+    # bot told the user to scan first and then offered `ingest` in the
+    # very next message. Exact equality, plus an explicit negative,
+    # because a substring check for "ingest" is vacuous against the new
+    # copy ("I won't ingest them").
     assert len(channel.sent) == 2
-    body, consent = channel.sent
+    body, closing = channel.sent
     assert "creek.redact.scan" in body
     assert "Run `creek redact --scan" in body
-    assert "ingest" in consent.lower()
+    assert closing == _SCAN_BLOCKED_REPLY
+    assert "Reply with `ingest`" not in closing
 
 
 async def test_attachment_path_uses_soft_reply_when_mcp_dies_during_scan(
@@ -1059,11 +1069,13 @@ async def test_attachment_path_uses_soft_reply_when_mcp_dies_during_scan(
         mcp_client=_StubMCPClient(session),  # type: ignore[arg-type]
         known_tools=("creek.redact.scan",),
     )
-    # Two messages: body (with unreachable soft error) + consent prompt.
+    # Two messages: body (with unreachable soft error) + the #1054
+    # refusal, not the consent prompt — the scan never ran.
     assert len(channel.sent) == 2
-    body, consent = channel.sent
+    body, closing = channel.sent
     assert "unreachable" in body.lower()
-    assert "ingest" in consent.lower()
+    assert closing == _SCAN_BLOCKED_REPLY
+    assert "Reply with `ingest`" not in closing
 
 
 async def test_attachment_path_short_circuits_when_all_already_present(
@@ -1346,11 +1358,13 @@ async def test_run_safety_scan_swallows_unexpected_exceptions(
         known_tools=("creek.redact.scan",),
     )
 
-    # Two messages: body (soft "unreachable" error) + consent prompt.
+    # Two messages: body (soft "unreachable" error) + the #1054 refusal,
+    # not the consent prompt — the scan raised, so it never ran.
     assert len(channel.sent) == 2
-    body, consent = channel.sent
+    body, closing = channel.sent
     assert "unreachable" in body.lower()
-    assert "ingest" in consent.lower()
+    assert closing == _SCAN_BLOCKED_REPLY
+    assert "Reply with `ingest`" not in closing
 
 
 async def test_run_safety_scan_extracts_report_markdown_from_dict_response(
@@ -2383,6 +2397,7 @@ async def test_consent_dispatch_with_staged_path_outside_vault(
         accepted_files=(pf,),
         privacy_tier_ceiling="personal",
         now=store.now(),
+        scanned=True,  # this batch dispatches, so the #1054 gate must pass
     )
     store.record(batch)
 
@@ -2621,3 +2636,320 @@ async def test_already_present_batch_does_not_record_pending_state(
 
     assert store.get(999) is None
     assert any("already staged" in s.lower() for s in channel.sent)
+
+
+# ---------------------------------------------------------------------------
+# FEAT-027 — the redaction-scan gate is enforced, not advisory (#1054)
+# ---------------------------------------------------------------------------
+
+
+def _open_ceiling_config(tmp_path: Path) -> CrawDadConfig:
+    """Return a config whose channel 999 declares the narrowest tier ceiling.
+
+    ``open`` is the most restrictive :class:`TierCeiling` value, so the
+    gate tests below prove the refusal holds under the strictest channel
+    policy rather than only under the default ``personal``.
+    """
+    from crawdad.config import AttachmentConfig
+
+    return CrawDadConfig(
+        discord_bot_token="t",
+        vault_path=tmp_path,
+        allowed_user_ids=[111],
+        allowed_channel_ids=[999],
+        attachments=AttachmentConfig(channel_privacy_tiers={999: "open"}),
+    )
+
+
+async def _stage_with_client(
+    *,
+    config: CrawDadConfig,
+    session_state: SessionState,
+    channel: _FakeChannel,
+    pending_batches: PendingBatchStore,
+    mcp_client: Any,
+    known_tools: tuple[str, ...],
+    filename: str = "note.md",
+    message_id: int = 100,
+) -> None:
+    """Drive one attachment turn with an explicit MCP client / tool list.
+
+    ``_stage_attachment`` always injects a healthy scan session; the gate
+    tests need the failing sessions (and ``mcp_client=None``) instead.
+    """
+    message: Any = _FakeMessage(
+        author=_FakeAuthor(id=111),
+        channel=channel,
+        content="",
+        id=message_id,
+        attachments=[_FakeAttachment(filename=filename, size=4, payload=b"safe")],
+    )
+    await handle_message(
+        message,
+        config=config,
+        session_state=session_state,
+        bot_user_id=42,
+        mcp_client=mcp_client,
+        known_tools=known_tools,
+        pending_batches=pending_batches,
+    )
+
+
+async def _reply_and_record_ingests(
+    *,
+    config: CrawDadConfig,
+    session_state: SessionState,
+    channel: _FakeChannel,
+    pending_batches: PendingBatchStore,
+    content: str,
+) -> list[dict[str, Any]]:
+    """Send *content* as a follow-up; return every MCP tool call it made."""
+    calls: list[dict[str, Any]] = []
+
+    class _RecordingSession:
+        async def call_tool(
+            self, name: str, arguments: dict[str, Any] | None = None
+        ) -> str:
+            calls.append({"name": name, "args": arguments or {}})
+            return "ok"
+
+    followup: Any = _FakeMessage(
+        author=_FakeAuthor(id=111),
+        channel=channel,
+        content=content,
+    )
+    await handle_message(
+        followup,
+        config=config,
+        session_state=session_state,
+        bot_user_id=42,
+        mcp_client=_StubMCPClient(_RecordingSession()),
+        known_tools=("creek.ingest",),
+        pending_batches=pending_batches,
+    )
+    return calls
+
+
+def _assert_refused(
+    *, channel: _FakeChannel, store: PendingBatchStore, calls: list[dict[str, Any]]
+) -> None:
+    """Assert the batch was refused: no dispatch, no state change, clear reply."""
+    assert calls == []
+    batch = store.get(999)
+    assert batch is not None
+    assert batch.scanned is False
+    assert batch.state != "ingested"
+    # Exact equality, not a substring: "ingest" appears inside the
+    # refusal copy, so a substring probe would pass against the old
+    # consent prompt too.
+    assert channel.sent == [_SCAN_BLOCKED_REPLY]
+    assert "Reply with `ingest`" not in channel.sent[0]
+
+
+async def test_unscanned_batch_cannot_reach_creek_ingest_under_open_ceiling(
+    session_state: SessionState, tmp_path: Path
+) -> None:
+    """#1054: `creek.redact.scan` unadvertised → an `ingest` reply dispatches nothing.
+
+    This is the issue's Signal-1 runtime proof. Before the fix the same
+    turn produced a full ``creek.ingest`` call for never-scanned content
+    at the narrowest declared ceiling.
+    """
+    config = _open_ceiling_config(tmp_path)
+    channel = _FakeChannel(id=999, sent=[])
+    store = _make_store()
+    await _stage_with_client(
+        config=config,
+        session_state=session_state,
+        channel=channel,
+        pending_batches=store,
+        mcp_client=_StubMCPClient(_StubSession()),
+        known_tools=("creek.ingest",),  # creek.redact.scan UNADVERTISED
+    )
+    channel.sent.clear()
+
+    calls = await _reply_and_record_ingests(
+        config=config,
+        session_state=session_state,
+        channel=channel,
+        pending_batches=store,
+        content="ingest",
+    )
+    _assert_refused(channel=channel, store=store, calls=calls)
+
+
+async def test_unscanned_batch_after_mcp_death_cannot_reach_creek_ingest(
+    session_state: SessionState, tmp_path: Path
+) -> None:
+    """#1054: MCP dies mid-scan → the recorded batch is refused at dispatch."""
+    config = _open_ceiling_config(tmp_path)
+    channel = _FakeChannel(id=999, sent=[])
+    store = _make_store()
+    session = _StubSession(
+        errors={"creek.redact.scan": MCPUnavailableError("subprocess died")}
+    )
+    await _stage_with_client(
+        config=config,
+        session_state=session_state,
+        channel=channel,
+        pending_batches=store,
+        mcp_client=_StubMCPClient(session),
+        known_tools=("creek.redact.scan",),
+    )
+    channel.sent.clear()
+
+    calls = await _reply_and_record_ingests(
+        config=config,
+        session_state=session_state,
+        channel=channel,
+        pending_batches=store,
+        content="ingest",
+    )
+    _assert_refused(channel=channel, store=store, calls=calls)
+
+
+async def test_unscanned_batch_after_unexpected_error_cannot_reach_creek_ingest(
+    session_state: SessionState, tmp_path: Path
+) -> None:
+    """#1054: a non-MCP exception during the scan is also fail-closed."""
+    config = _open_ceiling_config(tmp_path)
+    channel = _FakeChannel(id=999, sent=[])
+    store = _make_store()
+
+    class _BrokenSession:
+        async def call_tool(
+            self, _name: str, _args: dict[str, Any] | None = None
+        ) -> str:
+            raise TimeoutError("upstream timed out")
+
+    await _stage_with_client(
+        config=config,
+        session_state=session_state,
+        channel=channel,
+        pending_batches=store,
+        mcp_client=_StubMCPClient(_BrokenSession()),
+        known_tools=("creek.redact.scan",),
+    )
+    channel.sent.clear()
+
+    calls = await _reply_and_record_ingests(
+        config=config,
+        session_state=session_state,
+        channel=channel,
+        pending_batches=store,
+        content="ingest",
+    )
+    _assert_refused(channel=channel, store=store, calls=calls)
+
+
+async def test_unscanned_batch_with_no_mcp_client_cannot_reach_creek_ingest(
+    session_state: SessionState, tmp_path: Path
+) -> None:
+    """#1054: the degraded session (``mcp_client is None``) is fail-closed too."""
+    config = _open_ceiling_config(tmp_path)
+    channel = _FakeChannel(id=999, sent=[])
+    store = _make_store()
+    await _stage_with_client(
+        config=config,
+        session_state=session_state,
+        channel=channel,
+        pending_batches=store,
+        mcp_client=None,
+        known_tools=("creek.redact.scan",),
+    )
+    channel.sent.clear()
+
+    calls = await _reply_and_record_ingests(
+        config=config,
+        session_state=session_state,
+        channel=channel,
+        pending_batches=store,
+        content="ingest",
+    )
+    _assert_refused(channel=channel, store=store, calls=calls)
+
+
+async def test_unscanned_batch_cannot_ingest_via_type_disambiguation_route(
+    session_state: SessionState, tmp_path: Path
+) -> None:
+    """#1054: `ingest` → type question → type word must not launder the gate.
+
+    The issue body names only ``_apply_consent_reply``; this pins the
+    second dispatch entry point at ``_apply_disambiguation_reply``.
+    """
+    from crawdad.config import AttachmentConfig
+
+    config = CrawDadConfig(
+        discord_bot_token="t",
+        vault_path=tmp_path,
+        allowed_user_ids=[111],
+        allowed_channel_ids=[999],
+        # Empty allow list permits ``.xyz`` so ``inferred_type`` is None.
+        attachments=AttachmentConfig(
+            allowed_extensions=frozenset(), channel_privacy_tiers={999: "open"}
+        ),
+    )
+    channel = _FakeChannel(id=999, sent=[])
+    store = _make_store()
+    await _stage_with_client(
+        config=config,
+        session_state=session_state,
+        channel=channel,
+        pending_batches=store,
+        mcp_client=_StubMCPClient(_StubSession()),
+        known_tools=("creek.ingest",),  # creek.redact.scan UNADVERTISED
+        filename="weird.xyz",
+    )
+    channel.sent.clear()
+
+    # Turn 1: `ingest` → the bot asks which type (no dispatch yet).
+    first = await _reply_and_record_ingests(
+        config=config,
+        session_state=session_state,
+        channel=channel,
+        pending_batches=store,
+        content="ingest",
+    )
+    assert first == []
+    channel.sent.clear()
+
+    # Turn 2: the type word — this is the route the issue body missed.
+    second = await _reply_and_record_ingests(
+        config=config,
+        session_state=session_state,
+        channel=channel,
+        pending_batches=store,
+        content="document",
+    )
+    _assert_refused(channel=channel, store=store, calls=second)
+
+
+async def test_scanned_batch_still_ingests_after_the_gate_lands(
+    config: CrawDadConfig, session_state: SessionState
+) -> None:
+    """#1054 must not brick the happy path: a scanned batch still ingests."""
+    channel = _FakeChannel(id=999, sent=[])
+    store = _make_store()
+    await _stage_attachment(
+        config=config,
+        session_state=session_state,
+        channel=channel,
+        attachment=_FakeAttachment(filename="note.md", size=4, payload=b"safe"),
+        pending_batches=store,
+    )
+    staged = store.get(999)
+    assert staged is not None
+    assert staged.scanned is True
+    channel.sent.clear()
+
+    calls = await _reply_and_record_ingests(
+        config=config,
+        session_state=session_state,
+        channel=channel,
+        pending_batches=store,
+        content="ingest",
+    )
+    assert [c["name"] for c in calls] == ["creek.ingest"]
+    final = store.get(999)
+    assert final is not None
+    assert final.state == "ingested"

--- a/crawdad/tests/test_consent.py
+++ b/crawdad/tests/test_consent.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -43,14 +44,23 @@ def _batch(
     created_at: float = 0.0,
     state: BatchState = "awaiting_consent",
     ingested_hashes: frozenset[str] = frozenset(),
+    scanned: bool = True,
 ) -> PendingBatch:
-    """Return a :class:`PendingBatch` with sensible test defaults."""
+    """Return a :class:`PendingBatch` with sensible test defaults.
+
+    ``scanned`` defaults to ``True`` *here only* — these unit tests
+    predate the #1054 gate and exercise unrelated behaviour, so the
+    helper preserves their original meaning (a normally-scanned batch).
+    The production dataclass has no default; see
+    ``test_pending_batch_requires_an_explicit_scanned_flag``.
+    """
     return PendingBatch(
         channel_id=channel_id,
         staging_dir=Path("/tmp/stage"),
         files=files or (_file(),),
         privacy_tier_ceiling="personal",
         created_at=created_at,
+        scanned=scanned,
         state=state,
         ingested_hashes=ingested_hashes,
     )
@@ -151,6 +161,7 @@ def test_all_ingested_false_for_empty_batch() -> None:
         files=(),
         privacy_tier_ceiling="personal",
         created_at=0.0,
+        scanned=True,
     )
 
     assert batch.all_ingested is False
@@ -396,6 +407,7 @@ def test_build_pending_batch_starts_in_awaiting_consent_state() -> None:
         accepted_files=files,
         privacy_tier_ceiling="intimate",
         now=99.0,
+        scanned=True,
     )
 
     assert batch.channel_id == 42
@@ -403,5 +415,61 @@ def test_build_pending_batch_starts_in_awaiting_consent_state() -> None:
     assert batch.files == files
     assert batch.privacy_tier_ceiling == "intimate"
     assert batch.created_at == 99.0
+    assert batch.scanned is True
     assert batch.state == "awaiting_consent"
     assert batch.ingested_hashes == frozenset()
+
+
+def test_build_pending_batch_threads_a_false_scanned_flag() -> None:
+    """#1054: the factory records a failed safety pass verbatim."""
+    batch = build_pending_batch(
+        channel_id=42,
+        staging_dir=Path("/vault/inbound/42/100"),
+        accepted_files=(_file(),),
+        privacy_tier_ceiling="open",
+        now=1.0,
+        scanned=False,
+    )
+
+    assert batch.scanned is False
+    # Still recorded and cancel-able — option (b) in crawdad/CLAUDE.md §5.3.
+    assert batch.state == "awaiting_consent"
+
+
+def test_pending_batch_requires_an_explicit_scanned_flag() -> None:
+    """#1054: ``scanned`` has no default, so nothing can inherit a permissive one.
+
+    A default of ``True`` would be a fail-open gate; a default of
+    ``False`` would silently mislabel real batches. Requiring it means
+    every construction site — present and future — has to state which
+    it is.
+    """
+    # Splatted so the omission is a *runtime* fact to assert on rather
+    # than a mypy error that would need suppressing to express.
+    without_scanned: dict[str, Any] = {
+        "channel_id": 1,
+        "staging_dir": Path("/tmp"),
+        "files": (),
+        "privacy_tier_ceiling": "personal",
+        "created_at": 0.0,
+    }
+
+    with pytest.raises(TypeError, match="scanned"):
+        PendingBatch(**without_scanned)
+
+
+def test_scanned_flag_survives_resolution_and_state_transitions() -> None:
+    """#1054: no copy helper can launder ``scanned=False`` into ``True``.
+
+    ``with_resolved_types`` is the type-disambiguation route's copy step
+    and ``with_state`` is the lifecycle's — both are
+    :func:`dataclasses.replace` calls, and this pins that they stay so.
+    """
+    batch = _batch(
+        files=(_file(filename="weird.xyz", inferred_type=None),), scanned=False
+    )
+
+    resolved = batch.with_resolved_types("document")
+    assert resolved.scanned is False
+    assert resolved.with_state("awaiting_type").scanned is False
+    assert resolved.with_ingested(frozenset({"abc"})).scanned is False


### PR DESCRIPTION
## Summary

FEAT-027's redaction-scan gate was **advisory**. When `creek.redact.scan` could
not run, the bot still recorded a `PendingBatch`, still sent the "Reply with
`ingest`" consent prompt, and a one-word `ingest` reply dispatched a full
`creek.ingest` of never-scanned content. Its own two consecutive messages
contradicted each other: *"Run `creek redact --scan` … before ingesting"*
immediately followed by *"Reply with `ingest` … to proceed."*

This makes the gate **enforced**, strictly in the more-restrictive direction.

**Policy — option (b) from Task 1, recorded in `crawdad/CLAUDE.md` §5.3:** still
record the batch (it stays inspectable and `cancel`-able) but refuse it at the
dispatch boundary.

**Mechanism**

- `PendingBatch.scanned` — a **required `bool` with no default**, placed ahead of
  the defaulted fields. Placement is load-bearing (a trailing required field is a
  `TypeError` at import). No permissive default and no `ConsentConfig` knob:
  either would let a construction site — or an operator — silently reopen the
  hole. Survives `with_resolved_types` / `with_state` / `with_ingested`, which
  are all `dataclasses.replace` copies.
- `_run_safety_scan` now returns a frozen `_ScanOutcome(scanned, text)` instead of
  a bare `str`, so the caller reads a status rather than string-matching
  `_MCP_UNAVAILABLE_REPLY` — a string shared with the ingest path
  (`_run_ingest_dispatch`) and the state path (`render_mcp_unavailable_reply`).
  All **four** failure modes yield `scanned=False`: no MCP client, tool
  unadvertised, `MCPUnavailableError`, and the bare `except Exception` arm.
- **One guard**, the first statement of `_dispatch_ingest_for_batch` — the sole
  convergence point of the consent flow.
- One new `_SCAN_BLOCKED_REPLY` constant serving **both** the unscanned
  attachment-turn close and the dispatch refusal, so the two messages are
  literally the same string and cannot drift apart.
- Docstrings corrected on `_handle_attachments` (steps 3–5 — the issue's headline
  complaint), `_run_safety_scan`, `_dispatch_ingest_for_batch`,
  `_apply_consent_reply`, `_apply_disambiguation_reply`, the FEAT-034 comment
  block, and `PendingBatch`.

### Two deviations from the AC's letter, both deliberate

1. **AC 3 asks that `_apply_consent_reply` "refuse to reach
   `_dispatch_ingest_for_batch`"; this guards the shared callee instead.** The
   issue names that one site because it missed the *second* dispatch entry point
   at `_apply_disambiguation_reply` — `ingest` → type question → `markdown`
   ingests through a different caller. `_dispatch_ingest_for_batch` has exactly
   two callers, so one branch satisfies both AC bullets, plus any future third
   caller, and cannot drift out of sync the way two gates would.
   *UX consequence:* an unscanned batch with an unresolved file type gets the
   type question first and the refusal on the type word — one wasted turn, still
   zero `creek.ingest` calls. A second guard to save that turn is a follow-up
   nit, not part of this fix.
2. **The new copy claims only the invariant actually enforced.** The gate means
   *"I couldn't run the redaction scan"* — **not** *"these files are clean"*.
   `creek_mcp/tools/redact.py` computes
   `status = "empty" if not scanned.matches else "ok"`, so a scan that *runs* and
   reports secrets still returns a permissive status and still clears the gate.
   Making the gate enforce on findings is a separate, larger decision; it is
   named as an explicit non-goal in §5.3 with a revisit predicate. Swapping the
   old false claim for a new one would have failed AC 3 just as badly.

Related, explicitly **not** covered: #1087 (`scan_batch` follows symlinks out of
the scan root — a scan that *runs* but under-reports; this gate marks such a
batch `scanned=True`). **#1088** *is* a fifth way the scan fails to run and this
design absorbs it with one more `_ScanOutcome(scanned=False, …)` arm — sequence
it next rather than touching `_run_safety_scan` twice.

## Test plan

**RED proof, before any source changed.** All five gate tests failed on the
behavioural assertion `assert calls == []` — not on a missing symbol — each with
a real dispatch recorded:

```
E  AssertionError: assert [{'name': 'cr...ng': 'open'}}] == []
E    Left contains one more item: {'name': 'creek.ingest', 'args':
E      {'source_type': 'document', 'input_path': '…/weird.xyz',
E       'privacy_tier_ceiling': 'open'}}
```

That is the issue's own Signal-1 runtime proof, reproduced at the **narrowest**
declared ceiling (`open` is the most restrictive `TierCeiling`) rather than the
default `personal`.

**Guard proven load-bearing.** With only the two guard lines commented out:
exactly the 5 gate tests go red and the other 61 in `test_bot.py` — including
every `_stage_attachment`-seeded happy-path consent test — stay green. Restored
and re-verified.

New coverage:

- All four scan-failure modes reach zero dispatch: tool unadvertised,
  `MCPUnavailableError` mid-scan, generic exception mid-scan, `mcp_client is
  None`.
- The type-disambiguation route (`ingest` → type question → `document`) also
  reaches zero dispatch.
- Happy-path regression: a scanned batch still records `scanned is True` and
  still ingests.
- `consent.py` units: the factory threads `scanned=False`; `PendingBatch` raises
  `TypeError` when `scanned` is omitted (proving the no-default tripwire is
  real); `scanned=False` survives `with_resolved_types` / `with_state` /
  `with_ingested`.

The three tests that *pinned the hole* now assert the new behaviour by **exact
equality** to `_SCAN_BLOCKED_REPLY` plus an explicit
`assert "Reply with \`ingest\`" not in closing`. A substring probe for `"ingest"`
would be **vacuous** — the word appears inside the refusal copy ("I won't ingest
them"), so the old assertions would have passed against either string.

**Gate 2 — CrawDad's own toolchain** (separate venv, script and CI job from
creek-tools):

```
cd crawdad && ./scripts/check-all.sh     # exit 0
659 passed · branch coverage 94.60% (≥90)
xenon --max-absolute B --max-modules B --max-average A   # clean
mypy --strict · ruff lint+format (verified --no-cache) · bandit · pip-audit
```

No `# noqa`, no `# type: ignore`, no `@pytest.mark.skip`, no `--no-verify`, no
threshold touched. (The new tests also omit the `# type: ignore[arg-type]`
comment the surrounding file carries on its stub-client call sites — the gate
runs `mypy crawdad`, never `tests/`, so those 78 legacy comments are inert and
this change declines to add more.)

Closes #1054
