### PR TITLE
fix(crawdad): refuse a staging root the redaction scan cannot reach

### DIFF
--- a/crawdad/CLAUDE.md
+++ b/crawdad/CLAUDE.md
@@ -111,8 +111,14 @@ Four gates, each must pass before the next:
   - `capture_enabled` — bot-capture toggle (#687), default `False`.
     Opt-in per deployment; see [§5.2](#52-bot-capture-boundary).
   - `capture_subpath` — vault-relative dir the capture writer appends
-    to, default `discord-capture`. Must stay inside the vault (same
-    absolute/`..` validation as `attachments.staging_subpath`).
+    to, default `discord-capture`. Must stay inside the vault — the same
+    absolute/`..` validation `attachments.staging_subpath` gets, but not
+    its canonical-root arm (#1088): nothing scans the capture dir.
+  - `attachments.staging_subpath` — vault-relative attachment staging
+    dir, default `00-Creek-Meta/Inbound`, and it must stay under that
+    root: it is the only subtree `creek.redact.scan` admits at a
+    channel's ceiling, so anywhere else the safety pass never runs
+    (#1088). See [§5.3](#53-redaction-scan-gate-feat-027-1054).
   - `attachments.channel_privacy_tiers` — per-channel declared ceiling
     (`open` / `personal` / `intimate` / `all`), validated at
     config-parse time. See [§5.2](#52-bot-capture-boundary) for how
@@ -236,11 +242,37 @@ would miss the point of the fix.
 
 Related, explicitly **not** covered here: #1087 (`scan_batch` follows
 symlinks out of the scan root — a scan that *runs* but under-reports,
-and this gate marks such a batch `scanned=True`). #1088
-(`attachments.staging_subpath` outside the scan's canonical scope) *is*
-a fifth way the scan fails to run; this design absorbs it with one more
-`_ScanOutcome(scanned=False, …)` arm, so sequence it next rather than
-touching `_run_safety_scan` twice.
+and this gate marks such a batch `scanned=True`).
+
+#1088 (`attachments.staging_subpath` outside the scan's canonical
+scope) was the fifth way the scan fails to run, and it has now landed
+in two layers. **Config gate:** `AttachmentConfig` refuses at
+config-parse time any `staging_subpath` outside
+`CANONICAL_STAGING_ROOT` (`00-Creek-Meta/Inbound`, mirrored from
+`creek_mcp/tools/redact.py`), with `validate_default=True` on the model
+so a drifted *default* is caught too. That check is lexical — the real
+confinement boundary is still creek-tools' `resolve_within_vault` plus
+its resolved `is_relative_to`. **Runtime arm:** `_run_safety_scan`
+gained the fifth `_ScanOutcome(scanned=False, …)` arm, for a response
+body that is a JSON object whose `status` is exactly `"refused"` —
+creek-tools' `refusal_response()` envelope. Every other body keeps
+`scanned=True`, deliberately: fail-open on unparseable, non-object, or
+status-less responses means the change can only ever *remove*
+admissions.
+
+This does **not** disturb the non-goal above. `ok` and `empty` both
+still clear the gate, so a scan that runs and reports secrets still
+ingests. Only `refused` — a scan that was *declined*, never a scan that
+found something — flips `scanned`, and the user-facing copy
+(`_SCAN_REFUSED_REPLY`) claims only that no scan ran.
+
+That copy is pinned by test, not just by review: `status="refused"`
+covers every refusal reason creek-tools has (out-of-scope root, but
+also `input_path not found`), so the fixed text hedges about the cause
+and `_scan_refusal_text` echoes creek-tools' own `reason` verbatim.
+`_assert_claims_no_cleanliness` asserts no delivered refusal message
+contains a cleanliness claim — if a future edit reintroduces one, a
+test goes red rather than a reviewer having to notice.
 
 **Revisit predicate:** when `creek.redact.scan` gains a failing status
 for non-empty findings, revisit whether `scanned` should become a

--- a/crawdad/README.md
+++ b/crawdad/README.md
@@ -68,7 +68,7 @@ allowed_channel_ids:
 | `mcp_server_command` | no | `[creek-tools-mcp]` | argv for the MCP subprocess. |
 | `allowed_user_ids` | yes | — | Discord user ids permitted to message the bot. |
 | `allowed_channel_ids` | yes | — | Channels the bot will respond in. |
-| `attachments` | no | see source | Per-attachment limits, allow/deny lists, channel privacy tiers (FEAT-027/035). |
+| `attachments` | no | see source | Per-attachment limits, allow/deny lists, channel privacy tiers (FEAT-027/035). `staging_subpath` must stay under `00-Creek-Meta/Inbound/`: `creek.redact.scan` is scoped to that subtree (#972), so anywhere else is ranked as intimate content and the safety pass never runs. A non-conforming value is refused at config-parse time (#1088). |
 | `consent` | no | see source | Conversational consent tokens + TTL (FEAT-034). |
 | `max_loop_rounds` | no | `5` | FEAT-036 agent-loop round cap, bounded `[1, 50]`. Raise when a single user turn legitimately needs more router/dispatcher passes (multi-source ingest, large re-classification asks, long workflow chains); the upper bound prevents pathological runaway loops. |
 | `capture_enabled` | no | `False` | Bot-capture toggle (#687) — see [Bot capture](#bot-capture) below. |

--- a/crawdad/crawdad/bot.py
+++ b/crawdad/crawdad/bot.py
@@ -72,6 +72,17 @@ _DISCORD_REPLY_LIMIT = 1900
 # no Python-level dependency on creek-tools beyond the MCP contract.
 _REDACT_SCAN_TOOL = "creek.redact.scan"
 
+# #1088: the ``status`` value creek-tools returns when it *declines* to
+# scan rather than scanning. Sourced from ``refusal_response()``
+# (``creek-tools/creek_mcp/tier_ceiling.py:264-281``), which returns
+# exactly ``{"status", "tool", "tier_ceiling", "reason"}``;
+# ``creek.redact.scan`` is registered ``-> dict[str, Any]``
+# (``creek-tools/creek_mcp/server.py:637``), so FastMCP JSON-serialises
+# that dict and :meth:`crawdad.mcp_client.MCPSession.call_tool` hands the
+# bot the JSON as a plain string. Mirrored, not imported, for the same
+# reason as :data:`_REDACT_SCAN_TOOL` above.
+_SCAN_REFUSED_STATUS = "refused"
+
 _REDACT_TOOL_MISSING_REPLY = (
     "I downloaded the file(s), but the `creek.redact.scan` tool isn't advertised "
     "by creek-tools yet. Run `creek redact --scan <staging path>` from the "
@@ -112,6 +123,32 @@ _SCAN_BLOCKED_REPLY = (
     "I couldn't run the redaction scan on these files, so I won't ingest "
     "them. Run `creek redact --scan <staging path>` from the terminal to "
     "check them yourself, or reply `cancel` to drop the batch."
+)
+
+# #1088: the scan section for a turn where ``creek.redact.scan`` answered
+# with a refusal envelope instead of a report. The copy claims ONLY the
+# invariant actually established — that no scan ran — and says nothing
+# about whether the files are clean, because a scan that *does* run
+# returns a permissive status even when it finds secrets (crawdad/CLAUDE.md
+# §5.3). Swapping one false reassurance for another would miss the point
+# of the fix.
+#
+# It also does not assert *which* refusal fired. ``status="refused"`` covers
+# every refusal reason creek-tools has — the out-of-scope staging root that
+# motivated #1088, but also ``input_path not found`` (redact.py:200-205) and
+# the off-vault-symlink case. Naming the staging root as the definite cause
+# would misdirect an operator debugging a different failure, so the fixed
+# copy hedges ("most common cause") and :func:`_scan_refusal_text` appends
+# creek-tools' own ``reason`` verbatim, which is authoritative for whichever
+# refusal actually fired. Register matches _REDACT_TOOL_MISSING_REPLY; the
+# turn still closes with the shared _SCAN_BLOCKED_REPLY.
+_SCAN_REFUSED_REPLY = (
+    "creek-tools **refused** the redaction scan, so no scan ran on these "
+    "files. The most common cause is a staging root outside "
+    "`00-Creek-Meta/Inbound/` — the only subtree `creek.redact.scan` will "
+    "read at this channel's privacy ceiling — so check "
+    "`attachments.staging_subpath` in `crawdad.yaml`. To check the files "
+    "yourself, run `creek redact --scan <staging path>` from the terminal."
 )
 
 _ALREADY_STAGED_REPLY = (
@@ -353,7 +390,8 @@ class _ScanOutcome:
 
     Attributes:
         scanned: ``True`` only when ``creek.redact.scan`` actually
-            executed and returned a body. ``False`` for every failure
+            executed and returned a report rather than a refusal
+            envelope (#1088). ``False`` for every failure
             mode, and it is the value recorded on
             :attr:`crawdad.consent.PendingBatch.scanned`. Deliberately
             narrow: ``True`` says the scan *ran*, not that it came back
@@ -388,7 +426,9 @@ async def _handle_attachments(
        redundant scan or ingest.
     3. Otherwise invoke ``creek.redact.scan`` on the staging directory
        via MCP. If MCP is unreachable, the tool is not advertised, there
-       is no MCP client, or the call raises, the returned
+       is no MCP client, the call raises, or creek-tools answers with a
+       ``status="refused"`` envelope because the staging root is outside
+       its canonical scope (#1088), the returned
        :class:`_ScanOutcome` carries ``scanned=False`` and a soft error.
     4. Record the staged batch on the per-channel
        :class:`PendingBatchStore` (FEAT-034) **including** that
@@ -786,11 +826,13 @@ async def _run_safety_scan(
     state path (:func:`render_mcp_unavailable_reply`), so comparing
     against them would be a latent bug.
 
-    All four ways the scan can fail to run — no MCP client, the tool
-    unadvertised, :class:`MCPUnavailableError`, and any other unexpected
-    exception — return ``scanned=False`` with a Discord-safe soft error.
-    The bot never raises out of an attachment turn and never goes
-    silent; it just refuses to ingest afterwards (#1054).
+    All five ways the scan can fail to run — no MCP client, the tool
+    unadvertised, :class:`MCPUnavailableError`, any other unexpected
+    exception, and (#1088) a call that returns creek-tools' refusal
+    envelope instead of a report — return ``scanned=False`` with a
+    Discord-safe soft error. The bot never raises out of an attachment
+    turn and never goes silent; it just refuses to ingest afterwards
+    (#1054).
     """
     if mcp_client is None or _REDACT_SCAN_TOOL not in known_tools:
         return _ScanOutcome(scanned=False, text=_REDACT_TOOL_MISSING_REPLY)
@@ -822,26 +864,87 @@ async def _run_safety_scan(
         _LOGGER.exception("unexpected error during creek.redact.scan call")
         return _ScanOutcome(scanned=False, text=_MCP_UNAVAILABLE_REPLY)
 
-    return _ScanOutcome(scanned=True, text=_format_scan_section(body))
+    parsed = _parse_scan_body(body)
+    refusal = _scan_refusal_text(parsed)
+    if refusal is not None:
+        # A refusal is a scan that was *declined*, not one that came back
+        # clean: the tool never read a byte, so the batch is unscanned.
+        _LOGGER.warning("creek.redact.scan refused the scan target: %s", body)
+        return _ScanOutcome(scanned=False, text=refusal)
+
+    return _ScanOutcome(
+        scanned=True, text=_format_scan_section(body=body, parsed=parsed)
+    )
 
 
-def _format_scan_section(body: str) -> str:
-    """Wrap the MCP scan tool's text response into a Discord-safe section.
+def _parse_scan_body(body: str) -> dict[str, Any] | None:
+    """Parse an MCP scan response into a JSON object, or ``None``.
+
+    Both readers of the body — the ``status="refused"`` check in
+    :func:`_run_safety_scan` and the ``report_markdown`` extraction in
+    :func:`_format_scan_section` — need the same parse, so it happens
+    exactly once here instead of twice behind two ``try``/``except``
+    blocks that could drift apart.
+
+    ``None`` means "nothing structured to read": plain text, malformed
+    JSON, and a well-formed JSON *array* or scalar all land there, and
+    every caller falls back to today's behaviour for them. That
+    fail-open default is deliberate — it keeps the #1088 change able only
+    to *remove* admissions, never to newly refuse a turn that works now.
+    """
+    try:
+        parsed = json.loads(body)
+    except json.JSONDecodeError:
+        return None
+    if isinstance(parsed, dict):
+        return parsed
+    return None
+
+
+def _scan_refusal_text(parsed: dict[str, Any] | None) -> str | None:
+    """Return the reply for a scan refusal, or ``None`` if not one (#1088).
+
+    Keyed on ``status`` being exactly :data:`_SCAN_REFUSED_STATUS`. Widening
+    that to "carries a status" or "is a JSON object" would refuse every
+    attachment turn and brick the feature, so the match stays exact.
+
+    Detection and rendering live together so there is exactly one place
+    that decides a body is a refusal — a separate predicate could drift
+    out of step with the copy that explains it.
+
+    creek-tools' own ``reason`` is appended verbatim when present.
+    :data:`_SCAN_REFUSED_REPLY` can only hedge about *why* the scan was
+    declined, because ``status="refused"`` covers several reasons; the
+    echoed ``reason`` is authoritative for the one that actually fired.
+    It discloses nothing new — an out-of-scope reason is a fixed string,
+    and a "not found" reason names a staging path the download summary
+    already showed the user in the same turn.
+    """
+    if parsed is None:
+        return None
+    # Annotated ``object`` rather than the value's ``Any``: the comparison
+    # then resolves through ``object.__eq__`` and is statically a ``bool``.
+    status: object = parsed.get("status")
+    if status != _SCAN_REFUSED_STATUS:
+        return None
+    reason = parsed.get("reason")
+    if isinstance(reason, str) and reason.strip():
+        return f"{_SCAN_REFUSED_REPLY}\n\ncreek-tools said: {reason.strip()}"
+    return _SCAN_REFUSED_REPLY
+
+
+def _format_scan_section(*, body: str, parsed: dict[str, Any] | None) -> str:
+    """Wrap the MCP scan tool's response into a Discord-safe section.
 
     The MCP transport already concatenates the tool's text content into
     a single string; ``creek.redact.scan`` puts a Markdown summary in
-    that text. If the body looks like a raw JSON dict (e.g. because a
-    future tool revision returns structured content directly), pull the
-    ``report_markdown`` field out so users do not see a JSON blob.
+    that text. When *parsed* (from :func:`_parse_scan_body`) carries a
+    ``report_markdown`` field — e.g. because a future tool revision
+    returns structured content directly — render that so users do not
+    see a JSON blob; otherwise fall back to *body* verbatim in a fence.
     """
-    stripped = body.strip()
-    if stripped.startswith("{") and stripped.endswith("}"):
-        try:
-            parsed = json.loads(stripped)
-        except json.JSONDecodeError:
-            parsed = None
-        if isinstance(parsed, dict) and isinstance(parsed.get("report_markdown"), str):
-            return f"**Safety scan**\n\n{parsed['report_markdown']}"
+    if parsed is not None and isinstance(parsed.get("report_markdown"), str):
+        return f"**Safety scan**\n\n{parsed['report_markdown']}"
     return f"**Safety scan**\n```\n{body}\n```"
 
 

--- a/crawdad/crawdad/config.py
+++ b/crawdad/crawdad/config.py
@@ -79,7 +79,25 @@ _DEFAULT_DENIED_EXTENSIONS: tuple[str, ...] = (
     ".jar",
 )
 
-_DEFAULT_STAGING_SUBPATH = Path("00-Creek-Meta") / "Inbound"
+CANONICAL_STAGING_ROOT: Final[Path] = Path("00-Creek-Meta") / "Inbound"
+"""The one staging subtree ``creek.redact.scan`` admits at every ceiling.
+
+Mirrored from ``creek-tools/creek_mcp/tools/redact.py:98``
+(``_STAGING_SUBDIR``), which is the source of truth. That tool reads no
+per-file privacy tier, so it ranks every *other* vault path as intimate
+content and refuses any caller whose ceiling is not ``intimate``/``all``.
+CrawDad channels are ``personal`` by default, so an
+``attachments.staging_subpath`` outside this subtree draws
+``status="refused"`` on every scan and the safety pass silently never
+runs — that is #1088.
+
+Mirrored rather than imported, on the same precedent as
+:data:`crawdad.bot._REDACT_SCAN_TOOL`: CrawDad has no Python-level
+dependency on creek-tools beyond the MCP contract, and a two-segment path
+is not worth coupling the two packages' install graphs for.
+``test_canonical_staging_root_mirrors_the_mcp_scan_scope`` is the guard
+against the mirror drifting from its source.
+"""
 
 _ENV_DISCORD_TOKEN = "DISCORD_BOT_TOKEN"
 _ENV_PROVIDER = "CRAWDAD_PROVIDER"
@@ -264,7 +282,17 @@ class AttachmentConfig(BaseModel):
             the ingest pipeline cannot handle.
         staging_subpath: Vault-relative directory under which per-
             channel / per-message subdirectories are created. Default
-            ``00-Creek-Meta/Inbound``.
+            :data:`CANONICAL_STAGING_ROOT` (``00-Creek-Meta/Inbound``),
+            and it must stay inside that subtree — see
+            :meth:`_confine_staging_subpath` — because it is the only
+            scope ``creek.redact.scan`` admits at a CrawDad channel's
+            ceiling (#1088). That check is lexical and fail-fast: it is
+            defence in depth, **not** confinement. This model has no
+            ``vault_path`` and resolves nothing, so a symlink parked
+            under the canonical root still passes (#1087); the real
+            confinement boundary is creek-tools' ``resolve_within_vault``
+            plus the resolved ``is_relative_to`` at
+            ``creek_mcp/tools/redact.py:340``.
         channel_privacy_tiers: Optional per-channel privacy tier
             override (``open`` / ``personal`` / ``intimate`` / ``all``).
             When a channel id is absent, attachments inherit the bot's
@@ -283,7 +311,19 @@ class AttachmentConfig(BaseModel):
             to-md, etc.) before the user is even asked to ingest.
     """
 
-    model_config = ConfigDict(frozen=True)
+    # ``validate_default=True`` is load-bearing, and it belongs at the model
+    # level rather than on ``Field(...)``. Pydantic skips field validators for
+    # defaults unless asked, so without it a future edit to
+    # :data:`CANONICAL_STAGING_ROOT` — or a subclass re-declaring
+    # ``staging_subpath`` with an out-of-scope default — would reintroduce
+    # #1088 with every test still green. A per-field ``validate_default`` is
+    # NOT inherited by a subclass that re-declares the field; the model config
+    # is, which is why it lives here. Knock-on: the other defaults are now
+    # validated too — ``allowed_extensions``/``denied_extensions`` through
+    # :meth:`_normalise_extensions` and the empty ``channel_privacy_tiers``
+    # through :meth:`_validate_channel_tiers` — and each passes its own
+    # validator unchanged.
+    model_config = ConfigDict(frozen=True, validate_default=True)
 
     max_size_bytes: int = Field(
         default=_DEFAULT_MAX_ATTACHMENT_BYTES,
@@ -295,7 +335,7 @@ class AttachmentConfig(BaseModel):
     denied_extensions: frozenset[str] = Field(
         default_factory=lambda: frozenset(_DEFAULT_DENIED_EXTENSIONS),
     )
-    staging_subpath: Path = Field(default=_DEFAULT_STAGING_SUBPATH)
+    staging_subpath: Path = Field(default=CANONICAL_STAGING_ROOT)
     channel_privacy_tiers: dict[int, str] = Field(default_factory=dict)
     reject_on_mime_mismatch: bool = Field(default=False)
 
@@ -315,13 +355,46 @@ class AttachmentConfig(BaseModel):
 
     @field_validator("staging_subpath")
     @classmethod
-    def _refuse_absolute_subpath(cls, value: Path) -> Path:
-        """Refuse absolute and ``..``-traversing paths — must stay in the vault.
+    def _confine_staging_subpath(cls, value: Path) -> Path:
+        """Refuse a staging root the redaction scan could never reach.
 
-        ``Path.is_absolute()`` catches obvious ``/etc/foo`` cases; the
-        ``..`` check closes the defence-in-depth gap where a relative
-        path like ``../../tmp`` would still resolve outside the vault
-        root when joined against ``vault_path``.
+        Three arms, and **their order is load-bearing**:
+
+        1. ``Path.is_absolute()`` — catches the obvious ``/etc/foo`` case.
+        2. ``".." in value.parts`` — a relative ``../../tmp`` would still
+           land outside the vault root once joined onto ``vault_path``.
+        3. ``not value.is_relative_to(CANONICAL_STAGING_ROOT)`` — outside
+           :data:`CANONICAL_STAGING_ROOT` the scan ranks the target as
+           intimate content and refuses every ceiling a CrawDad channel
+           declares, so the safety pass silently never runs (#1088).
+
+        Arm 2 must stay ahead of arm 3: ``Path.is_relative_to`` is a pure
+        lexical prefix comparison and does not resolve ``..``, so
+        ``00-Creek-Meta/Inbound/../../01-Fragments`` *is* relative to the
+        canonical root and only the ``..`` arm catches it.
+
+        Every arm here is **lexical, fail-fast, defence in depth**. Nothing
+        calls ``resolve()``, and :class:`AttachmentConfig` is a nested model
+        with no ``vault_path`` to resolve against, so a symlink parked under
+        ``00-Creek-Meta/Inbound`` that points at ``01-Fragments`` still
+        passes — that is #1087. **The real confinement boundary is
+        creek-tools' ``resolve_within_vault`` plus the resolved
+        ``is_relative_to`` at ``creek_mcp/tools/redact.py:340``**; this
+        validator only turns an always-refused deployment into a startup
+        error that names the fix.
+
+        Normalisation is ``pathlib``'s, not ours: ``00-Creek-Meta/./Inbound``
+        and a trailing slash both collapse to ``('00-Creek-Meta',
+        'Inbound')`` and are accepted, while ``""`` becomes ``.`` and is
+        refused. Comparison is by parts and case-sensitive on every platform,
+        so ``00-Creek-Meta/Inbound-other`` and ``00-creek-meta/inbound`` are
+        both refused; case folding is deliberately NOT performed, because
+        ``redact.py:340`` compares literally and folding here would admit a
+        config the server then refuses — reopening the very hole this closes.
+
+        This is a parse-time gate, not an invariant: ``model_copy(update=…)``
+        and ``model_construct()`` bypass it, as they bypass any pydantic
+        validator. No such call site exists today.
         """
         if value.is_absolute():
             msg = (
@@ -333,6 +406,20 @@ class AttachmentConfig(BaseModel):
             msg = (
                 f"staging_subpath {value!r} must not contain '..'; "
                 "parent-directory segments could escape the vault root."
+            )
+            raise ValueError(msg)
+        if not value.is_relative_to(CANONICAL_STAGING_ROOT):
+            # Restates creek_mcp.tools.redact._OUT_OF_SCOPE_REASON so the
+            # operator reads the same sentence from either side of the MCP
+            # boundary (creek-tools/creek_mcp/tools/redact.py:101-106).
+            msg = (
+                f"staging_subpath {value!r} must live under "
+                f"{CANONICAL_STAGING_ROOT.as_posix()}/; creek.redact.scan is "
+                "scoped to that staging subtree, which every ceiling admits. "
+                "The scan reads no per-file privacy tier, so any other vault "
+                "path is ranked as intimate content and needs a ceiling of "
+                "intimate or all — which no Discord channel gets by default, "
+                "so the safety pass would never run."
             )
             raise ValueError(msg)
         return value

--- a/crawdad/tests/test_attachments.py
+++ b/crawdad/tests/test_attachments.py
@@ -433,6 +433,120 @@ def test_config_refuses_parent_traversal_in_staging_subpath() -> None:
         AttachmentConfig(staging_subpath=Path("../../tmp"))
 
 
+# ---------------------------------------------------------------------------
+# #1088 — staging_subpath must stay inside the one subtree creek.redact.scan
+# will actually scan. Outside it, the scan is refused at every ceiling a
+# CrawDad channel ever declares, so the safety pass silently never runs.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(Path("00-Creek-Meta/Inbound"), id="the-canonical-root-itself"),
+        pytest.param(Path("00-Creek-Meta/Inbound/discord"), id="one-level-below"),
+        pytest.param(Path("00-Creek-Meta/Inbound/a/b"), id="two-levels-below"),
+        pytest.param(Path("00-Creek-Meta/./Inbound"), id="dot-segment-normalised"),
+        pytest.param(Path("00-Creek-Meta/Inbound/"), id="trailing-slash-normalised"),
+        pytest.param("00-Creek-Meta/Inbound", id="plain-str-coerced-by-pydantic"),
+    ],
+)
+def test_config_accepts_staging_subpath_inside_canonical_root(
+    value: Path | str,
+) -> None:
+    """#1088: the canonical scan scope, and anything under it, are accepted.
+
+    ``creek.redact.scan`` is hard-scoped to ``00-Creek-Meta/Inbound/``
+    (``creek-tools/creek_mcp/tools/redact.py:98``) and admits that subtree
+    at *every* ceiling, so every value here can actually be scanned and
+    must keep parsing.
+
+    ``dot-segment-normalised`` and ``trailing-slash-normalised`` pin that
+    ``pathlib`` collapses ``.`` and a trailing separator before the
+    validator ever sees the value, so the scope check does not have to
+    re-implement normalisation. ``plain-str-coerced-by-pydantic`` pins
+    that a YAML string flows through the same validator as a ``Path``.
+    """
+    config = AttachmentConfig(staging_subpath=value)
+    assert config.staging_subpath.parts[:2] == ("00-Creek-Meta", "Inbound")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(Path("01-Fragments"), id="unrelated-vault-folder"),
+        pytest.param(Path("00-Creek-Meta/Inbound-other"), id="sibling-prefix"),
+        pytest.param(Path("00-Creek-Meta/Outbound"), id="sibling-folder"),
+        pytest.param(Path("00-Creek-Meta"), id="the-parent-is-not-inside"),
+        pytest.param(Path("00-creek-meta/inbound"), id="case-differs"),
+        pytest.param(Path(""), id="empty-normalises-to-dot"),
+    ],
+)
+def test_config_refuses_staging_subpath_outside_canonical_root(value: Path) -> None:
+    """#1088: a staging root the scan cannot reach is refused at parse time.
+
+    Outside ``00-Creek-Meta/Inbound/`` the scan ranks the target as
+    intimate content, so a ``personal``/``open`` CrawDad channel gets
+    ``status="refused"`` on every call and the safety pass never runs.
+    Refusing at config-parse time turns that silent runtime hole into a
+    startup error naming the fix.
+
+    ``sibling-prefix`` (``00-Creek-Meta/Inbound-other``) is the case that
+    forces ``Path.is_relative_to`` over ``str.startswith``: it shares the
+    canonical root's string prefix but is a different directory, and a
+    ``startswith`` check would wave it through.
+
+    ``case-differs`` (``00-creek-meta/inbound``) must be refused on every
+    platform, including case-insensitive filesystems. Case folding is
+    deliberately NOT performed: ``creek_mcp/tools/redact.py:340`` compares
+    the target against ``00-Creek-Meta/Inbound`` literally, so folding
+    here would admit a config the server then refuses — reopening the
+    exact never-scanned hole this issue closes.
+    """
+    with pytest.raises(ValueError, match="00-Creek-Meta/Inbound") as excinfo:
+        AttachmentConfig(staging_subpath=value)
+    # The message must restate the scope rule, not just name the folder —
+    # the operator needs to know *why* their path cannot be scanned.
+    assert "ranked as intimate content" in str(excinfo.value)
+
+
+def test_config_refuses_out_of_scope_staging_subpath_at_every_ceiling() -> None:
+    """#1088: the config gate does not merely shadow the downstream tier rule.
+
+    A channel declaring ``intimate`` *would* be admitted by
+    ``creek.redact.scan`` for an out-of-scope path, so a gate that only
+    fired for narrow ceilings would be a restatement of the server's rule
+    rather than an independent one. The refusal must turn on the path
+    alone, whatever ``channel_privacy_tiers`` says.
+    """
+    with pytest.raises(ValueError, match="00-Creek-Meta/Inbound"):
+        AttachmentConfig(
+            staging_subpath=Path("01-Fragments"),
+            channel_privacy_tiers={1: "intimate"},
+        )
+
+
+def test_config_refuses_traversal_out_of_canonical_root_via_the_dotdot_arm() -> None:
+    """#1088: ``..`` inside the canonical root is caught by the ``..`` arm.
+
+    ``00-Creek-Meta/Inbound/../../01-Fragments`` is *lexically*
+    ``is_relative_to`` the canonical root — ``Path.is_relative_to`` is a
+    pure prefix comparison and does not resolve ``..`` — so the new scope
+    arm alone would wave it through. Only the pre-existing ``..`` arm
+    catches it, which means the arms must stay in order: absolute, then
+    ``..``, then scope.
+
+    The negative assertion is the real discriminator: both arms
+    interpolate ``value!r``, so the path's own dots satisfy ``match``
+    either way, but only the scope arm restates the tier rule.
+    """
+    with pytest.raises(ValueError, match=r"\.\.") as excinfo:
+        AttachmentConfig(
+            staging_subpath=Path("00-Creek-Meta/Inbound/../../01-Fragments")
+        )
+    assert "ranked as intimate content" not in str(excinfo.value)
+
+
 async def test_empty_allowed_extensions_passes_anything_not_denied(
     tmp_path: Path,
 ) -> None:

--- a/crawdad/tests/test_bot.py
+++ b/crawdad/tests/test_bot.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -9,7 +10,9 @@ from typing import Any
 import pytest
 
 from crawdad.bot import (
+    _INGEST_CONSENT_PROMPT,
     _SCAN_BLOCKED_REPLY,
+    _SCAN_REFUSED_REPLY,
     handle_message,
     render_state_unavailable_reply,
 )
@@ -2953,3 +2956,362 @@ async def test_scanned_batch_still_ingests_after_the_gate_lands(
     final = store.get(999)
     assert final is not None
     assert final.state == "ingested"
+
+
+# ---------------------------------------------------------------------------
+# FEAT-027 — a *refused* scan response is not a scan (#1088)
+# ---------------------------------------------------------------------------
+
+# The out-of-scope refusal reason creek-tools returns when
+# ``creek.redact.scan`` is pointed at a path outside its canonical scope.
+# MIRRORED, not imported: CrawDad has no Python-level dependency on
+# creek-tools beyond the MCP contract (same rationale as the
+# ``_REDACT_SCAN_TOOL`` mirror in ``crawdad/bot.py``).
+#
+# Source of the text:  creek-tools/creek_mcp/tools/redact.py:101-106
+#                      (``_OUT_OF_SCOPE_REASON``).
+_OUT_OF_SCOPE_REASON = (
+    "creek.redact.scan is scoped to the 00-Creek-Meta/Inbound/ staging "
+    "subtree, which every ceiling admits; the scan reads no per-file privacy "
+    "tier, so any other vault path is ranked as intimate content and needs a "
+    "ceiling of intimate or all."
+)
+
+# The exact four-key refusal envelope CrawDad sees on the wire.
+#
+# Source of the shape:  creek-tools/creek_mcp/tier_ceiling.py:264-281 —
+#   ``refusal_response()`` returns exactly
+#   ``{"status", "tool", "tier_ceiling", "reason"}``.
+# Source of the serialisation:  creek-tools/creek_mcp/server.py:637-653
+#   registers ``creek.redact.scan`` as ``-> dict[str, Any]``, so FastMCP
+#   JSON-serialises the dict and ``MCPSession.call_tool``
+#   (crawdad/mcp_client.py:157-178) hands CrawDad that JSON as a plain
+#   string — which is why these tests reply with a ``str``, not a dict.
+#
+# ``tier_ceiling`` is ``"open"`` because :func:`_open_ceiling_config`
+# declares channel 999 as ``open``: the refusal is asserted under the
+# NARROWEST ceiling, where the hole is least excusable.
+_REFUSED_SCAN_BODY = json.dumps(
+    {
+        "status": "refused",
+        "tool": "creek.redact.scan",
+        "tier_ceiling": "open",
+        "reason": _OUT_OF_SCOPE_REASON,
+    }
+)
+
+_OK_SCAN_REPORT = "# Redaction Scan Summary\n\nNo findings.\n"
+_OK_SCAN_BODY = json.dumps(
+    {"status": "ok", "report_markdown": _OK_SCAN_REPORT, "findings": []}
+)
+
+
+def _refusing_scan_client(body: str = _REFUSED_SCAN_BODY) -> _StubMCPClient:
+    """Return an MCP client whose ``creek.redact.scan`` returns the refusal."""
+    return _StubMCPClient(_StubSession(replies={"creek.redact.scan": body}))
+
+
+# Words that would turn a "the scan did not run" message into a safety
+# assurance. crawdad/CLAUDE.md §5.3 records this as a hard constraint:
+# ``creek.redact.scan`` returns a permissive ``ok``/``empty`` even when it
+# finds secrets, so no reply may imply the files were checked and passed.
+_CLEANLINESS_CLAIMS = ("clean", "no findings", "no secrets", "safe to", "nothing found")
+
+
+def _assert_claims_no_cleanliness(text: str) -> None:
+    """Fail if *text* could be read as "these files are fine"."""
+    lowered = text.lower()
+    for claim in _CLEANLINESS_CLAIMS:
+        assert claim not in lowered, f"refusal copy implies cleanliness: {claim!r}"
+
+
+async def test_refused_scan_response_cannot_reach_creek_ingest(
+    session_state: SessionState, tmp_path: Path
+) -> None:
+    """#1088: a ``status="refused"`` payload must count as *not scanned*.
+
+    ``creek.redact.scan`` refuses any target outside
+    ``00-Creek-Meta/Inbound/`` unless the caller's ceiling is
+    ``intimate``/``all`` — which is exactly what an operator-configured,
+    non-canonical ``attachments.staging_subpath`` produces on a
+    ``personal`` (or, here, ``open``) channel.
+
+    Today ``_run_safety_scan`` returns ``scanned=True`` the moment
+    ``session.call_tool`` returns (bot.py:825), so the refusal envelope is
+    rendered to the user as a "Safety scan" section, the batch is recorded
+    ``scanned=True``, and the #1054 dispatch gate waves it through: a live
+    ``creek.ingest`` call for content that was never scanned, at the
+    narrowest declared ceiling. That dispatch is the defect.
+    """
+    config = _open_ceiling_config(tmp_path)
+    channel = _FakeChannel(id=999, sent=[])
+    store = _make_store()
+    await _stage_with_client(
+        config=config,
+        session_state=session_state,
+        channel=channel,
+        pending_batches=store,
+        mcp_client=_refusing_scan_client(),
+        known_tools=("creek.redact.scan", "creek.ingest"),
+    )
+    # Pin the staging turn's own copy BEFORE clearing: this is the only
+    # place _SCAN_REFUSED_REPLY reaches the user, so without this the
+    # string would be executed-but-unasserted and could silently drift
+    # into a cleanliness claim.
+    _assert_claims_no_cleanliness(channel.sent[0])
+    assert _SCAN_REFUSED_REPLY in channel.sent[0]
+    assert _OUT_OF_SCOPE_REASON in channel.sent[0]
+    assert channel.sent[-1] == _SCAN_BLOCKED_REPLY
+    channel.sent.clear()
+
+    calls = await _reply_and_record_ingests(
+        config=config,
+        session_state=session_state,
+        channel=channel,
+        pending_batches=store,
+        content="ingest",
+    )
+    _assert_refused(channel=channel, store=store, calls=calls)
+
+
+async def test_refused_scan_cannot_ingest_via_type_disambiguation_route(
+    session_state: SessionState, tmp_path: Path
+) -> None:
+    """#1088: the refusal also holds on the type-disambiguation route.
+
+    Mirrors ``test_unscanned_batch_cannot_ingest_via_type_disambiguation_route``
+    with the refusal body instead of an unadvertised tool, pinning the
+    second dispatch entry point (``_apply_disambiguation_reply``) so the
+    ``ingest`` → type-question → type-word path cannot launder a refused
+    scan into the vault.
+    """
+    from crawdad.config import AttachmentConfig
+
+    config = CrawDadConfig(
+        discord_bot_token="t",
+        vault_path=tmp_path,
+        allowed_user_ids=[111],
+        allowed_channel_ids=[999],
+        # Empty allow list permits ``.xyz`` so ``inferred_type`` is None.
+        attachments=AttachmentConfig(
+            allowed_extensions=frozenset(), channel_privacy_tiers={999: "open"}
+        ),
+    )
+    channel = _FakeChannel(id=999, sent=[])
+    store = _make_store()
+    await _stage_with_client(
+        config=config,
+        session_state=session_state,
+        channel=channel,
+        pending_batches=store,
+        mcp_client=_refusing_scan_client(),
+        known_tools=("creek.redact.scan", "creek.ingest"),
+        filename="weird.xyz",
+    )
+    channel.sent.clear()
+
+    # Turn 1: `ingest` → the bot asks which type (no dispatch yet).
+    first = await _reply_and_record_ingests(
+        config=config,
+        session_state=session_state,
+        channel=channel,
+        pending_batches=store,
+        content="ingest",
+    )
+    assert first == []
+    channel.sent.clear()
+
+    # Turn 2: the type word — the second route into the dispatch gate.
+    second = await _reply_and_record_ingests(
+        config=config,
+        session_state=session_state,
+        channel=channel,
+        pending_batches=store,
+        content="document",
+    )
+    _assert_refused(channel=channel, store=store, calls=second)
+
+
+async def test_refusal_for_another_reason_echoes_that_reason_not_a_guess(
+    session_state: SessionState, tmp_path: Path
+) -> None:
+    """#1088: the copy must not assert the staging root as the definite cause.
+
+    ``status="refused"`` covers every refusal creek-tools has, not only the
+    out-of-scope staging root — ``redact.py:200-205`` also refuses with
+    ``input_path not found`` (e.g. the staged file was removed before the
+    scan ran). The batch must still be refused, but the operator must be
+    shown the reason that actually fired rather than being sent to inspect
+    a correctly-configured `staging_subpath`.
+    """
+    reason = "input_path not found: 00-Creek-Meta/Inbound/999/100"
+    body = json.dumps(
+        {
+            "status": "refused",
+            "tool": "creek.redact.scan",
+            "tier_ceiling": "open",
+            "reason": reason,
+        }
+    )
+    config = _open_ceiling_config(tmp_path)
+    channel = _FakeChannel(id=999, sent=[])
+    store = _make_store()
+    await _stage_with_client(
+        config=config,
+        session_state=session_state,
+        channel=channel,
+        pending_batches=store,
+        mcp_client=_refusing_scan_client(body),
+        known_tools=("creek.redact.scan", "creek.ingest"),
+    )
+
+    batch = store.get(999)
+    assert batch is not None
+    assert batch.scanned is False
+    # The real reason is surfaced verbatim...
+    assert reason in channel.sent[0]
+    # ...and the fixed copy hedges rather than asserting the cause.
+    assert "most common cause" in channel.sent[0]
+    _assert_claims_no_cleanliness(channel.sent[0])
+
+
+@pytest.mark.parametrize(
+    "envelope",
+    [
+        pytest.param({"status": "refused"}, id="no-reason-key"),
+        pytest.param({"status": "refused", "reason": "   "}, id="blank-reason"),
+        pytest.param({"status": "refused", "reason": 17}, id="non-string-reason"),
+    ],
+)
+async def test_refusal_without_a_usable_reason_still_refuses(
+    session_state: SessionState, tmp_path: Path, envelope: dict[str, Any]
+) -> None:
+    """#1088: a refusal with no echoable reason still blocks the batch.
+
+    The ``reason`` echo is a courtesy, not the gate. A malformed or
+    reason-less refusal envelope must not fall through to ``scanned=True``
+    — the batch is refused on ``status`` alone, and the user still gets the
+    fixed copy without a dangling "creek-tools said:" fragment.
+    """
+    config = _open_ceiling_config(tmp_path)
+    channel = _FakeChannel(id=999, sent=[])
+    store = _make_store()
+    await _stage_with_client(
+        config=config,
+        session_state=session_state,
+        channel=channel,
+        pending_batches=store,
+        mcp_client=_refusing_scan_client(json.dumps(envelope)),
+        known_tools=("creek.redact.scan", "creek.ingest"),
+    )
+
+    batch = store.get(999)
+    assert batch is not None
+    assert batch.scanned is False
+    assert _SCAN_REFUSED_REPLY in channel.sent[0]
+    assert "creek-tools said:" not in channel.sent[0]
+    _assert_claims_no_cleanliness(channel.sent[0])
+
+
+async def test_successful_scan_response_still_ingests(
+    session_state: SessionState, tmp_path: Path
+) -> None:
+    """#1088 over-refusal guard: a non-refusal JSON payload still ingests.
+
+    The new status parse must key on ``status == "refused"`` exactly. If it
+    ever widens to "the body is a JSON object" or "the body carries a
+    status", every attachment turn would be refused and the feature would
+    be bricked — this test goes red first if that happens. It also pins
+    that the ``report_markdown`` extraction (``_format_scan_section``)
+    still runs, so the user sees rendered markdown rather than a code
+    fence full of JSON.
+    """
+    config = _open_ceiling_config(tmp_path)
+    channel = _FakeChannel(id=999, sent=[])
+    store = _make_store()
+    await _stage_with_client(
+        config=config,
+        session_state=session_state,
+        channel=channel,
+        pending_batches=store,
+        mcp_client=_StubMCPClient(
+            _StubSession(replies={"creek.redact.scan": _OK_SCAN_BODY})
+        ),
+        known_tools=("creek.redact.scan", "creek.ingest"),
+    )
+    staged = store.get(999)
+    assert staged is not None
+    assert staged.scanned is True
+
+    # Body + consent prompt, with the markdown rendered as markdown.
+    assert len(channel.sent) == 2
+    body, closing = channel.sent
+    assert "Redaction Scan Summary" in body
+    assert "```" not in body
+    assert '"findings"' not in body
+    assert closing == _INGEST_CONSENT_PROMPT
+    channel.sent.clear()
+
+    calls = await _reply_and_record_ingests(
+        config=config,
+        session_state=session_state,
+        channel=channel,
+        pending_batches=store,
+        content="ingest",
+    )
+    assert [c["name"] for c in calls] == ["creek.ingest"]
+    final = store.get(999)
+    assert final is not None
+    assert final.state == "ingested"
+
+
+@pytest.mark.parametrize(
+    "scan_body",
+    [
+        pytest.param("Scan summary: no findings", id="plain-text-not-json"),
+        pytest.param("{not really json}", id="brace-wrapped-but-unparseable"),
+        pytest.param(
+            json.dumps({"report_markdown": "# Report\n\nnone.\n"}),
+            id="json-object-without-a-status-key",
+        ),
+        pytest.param(
+            json.dumps({"status": "ok", "report_markdown": "# Report\n"}),
+            id="status-ok",
+        ),
+        pytest.param(
+            json.dumps({"status": "empty", "report_markdown": "# Report\n"}),
+            id="status-empty",
+        ),
+        pytest.param(json.dumps(["not", "an", "object"]), id="json-array"),
+    ],
+)
+async def test_non_refusal_scan_bodies_stay_scanned(
+    session_state: SessionState, tmp_path: Path, scan_body: str
+) -> None:
+    """#1088: only ``status="refused"`` flips ``scanned``; everything else stays.
+
+    Fail-open on an unparseable or unfamiliar body is deliberate — it is
+    the status quo, so the #1088 change only ever *removes* admissions and
+    can never newly refuse a turn that works today. These cases pin that
+    property: widening the parse (e.g. "any body without an explicit ok is
+    unscanned") would turn a bug fix into a behaviour change nobody
+    reviewed.
+    """
+    config = _open_ceiling_config(tmp_path)
+    channel = _FakeChannel(id=999, sent=[])
+    store = _make_store()
+    await _stage_with_client(
+        config=config,
+        session_state=session_state,
+        channel=channel,
+        pending_batches=store,
+        mcp_client=_StubMCPClient(
+            _StubSession(replies={"creek.redact.scan": scan_body})
+        ),
+        known_tools=("creek.redact.scan", "creek.ingest"),
+    )
+
+    batch = store.get(999)
+    assert batch is not None
+    assert batch.scanned is True
+    assert channel.sent[-1] == _INGEST_CONSENT_PROMPT

--- a/crawdad/tests/test_config.py
+++ b/crawdad/tests/test_config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from pydantic import ValidationError
+from pydantic import Field, ValidationError
 
 from crawdad.config import CrawDadConfig, load_config
 
@@ -138,6 +138,74 @@ def test_config_attachments_defaults_to_25_mib_and_inbound(tmp_path: Path) -> No
     assert config.attachments.staging_subpath == Path("00-Creek-Meta") / "Inbound"
     assert ".md" in config.attachments.allowed_extensions
     assert ".exe" in config.attachments.denied_extensions
+
+
+def test_canonical_staging_root_mirrors_the_mcp_scan_scope() -> None:
+    """#1088: the mirrored constant must equal creek-tools' scan scope.
+
+    ``creek-tools/creek_mcp/tools/redact.py:98`` defines
+    ``_STAGING_SUBDIR = Path("00-Creek-Meta/Inbound")`` — the single
+    subtree ``creek.redact.scan`` admits at every ceiling, and therefore
+    the only staging root a ``personal``-tier CrawDad channel can ever get
+    a real scan for. CrawDad mirrors the value rather than importing it
+    (no Python-level dependency on creek-tools beyond the MCP contract),
+    so this assertion is the guard against the mirror drifting away from
+    its source.
+    """
+    from crawdad.config import CANONICAL_STAGING_ROOT
+
+    assert Path("00-Creek-Meta") / "Inbound" == CANONICAL_STAGING_ROOT
+
+
+def test_attachment_config_validates_a_drifted_default_staging_subpath() -> None:
+    """#1088: an out-of-scope *default* is refused, not only an explicit value.
+
+    Pydantic skips field validators for defaults unless validation of
+    defaults is switched on, so without it a subclass — or a future edit
+    to the field's own default — could reintroduce an unscannable staging
+    root that no test ever passes explicitly. Bare construction of this
+    subclass must raise.
+
+    Constraint this imposes on the implementation: pydantic (2.13.4) does
+    NOT inherit a per-field ``Field(..., validate_default=True)`` into a
+    subclass that re-declares the field, but it DOES inherit
+    ``model_config = ConfigDict(..., validate_default=True)``. This test
+    therefore requires the model-level form.
+    """
+    from crawdad.config import AttachmentConfig
+
+    class _DriftedDefault(AttachmentConfig):
+        """An ``AttachmentConfig`` whose only change is an out-of-scope default."""
+
+        staging_subpath: Path = Field(default=Path("01-Fragments"))
+
+    with pytest.raises(ValidationError, match="00-Creek-Meta/Inbound"):
+        _DriftedDefault()
+
+
+def test_load_config_refuses_out_of_scope_staging_subpath(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1088: the refusal reaches the operator through the YAML load path.
+
+    ``crawdad.yaml`` is where an operator actually sets
+    ``attachments.staging_subpath``, so the gate has to fire on
+    :func:`load_config`, not only on direct model construction.
+    """
+    yaml_path = tmp_path / "crawdad.yaml"
+    yaml_path.write_text(
+        "vault_path: " + str(tmp_path) + "\n"
+        "allowed_user_ids: [1]\n"
+        "allowed_channel_ids: [2]\n"
+        "attachments:\n"
+        "  staging_subpath: 01-Fragments\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "t")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+
+    with pytest.raises(ValidationError, match="00-Creek-Meta/Inbound"):
+        load_config(yaml_path)
 
 
 def test_attachment_config_rejects_unknown_privacy_tier() -> None:

--- a/creek-tools/docs/mcp.md
+++ b/creek-tools/docs/mcp.md
@@ -169,12 +169,17 @@ types, line numbers, and whether it exists at all (it still counts toward
 disclosing the target's *path* — tracked by #1087. `rglob` does not descend
 into symlinked *directories*, which bounds the residual to symlinked files.
 
-One deployment knob is worth flagging on top of the fix itself: CrawDad's
-staging root is a configurable `staging_subpath`
-(`AttachmentConfig`, default `00-Creek-Meta/Inbound`), not a hardcoded
-constant, so an operator who points it elsewhere gets a subtree the scan's
-hardcoded scope does not recognise as admitted-at-every-ceiling — a real
-deployment gap, tracked by #1088.
+One deployment knob rode on top of the fix itself: CrawDad's staging root is
+a configurable `staging_subpath` (`AttachmentConfig`, default
+`00-Creek-Meta/Inbound`), not a hardcoded constant, so an operator who
+pointed it elsewhere got a subtree this scan's hardcoded scope does not
+recognise as admitted-at-every-ceiling. #1088 closed that gap from the
+CrawDad side: a `staging_subpath` outside `00-Creek-Meta/Inbound/` is now
+refused at config-parse time, and a `status="refused"` response is treated
+as *un-scanned*, so the batch can never be dispatched to `creek.ingest`.
+That CrawDad-side check is lexical — it resolves nothing — so this tool's
+`resolve_within_vault` plus its resolved `is_relative_to` remains the
+confinement boundary.
 
 ### Author tools (FEAT-041)
 


### PR DESCRIPTION
## Summary

CrawDad's `attachments.staging_subpath` is operator-configurable and its
validator refused only absolute paths and `..` segments. `creek.redact.scan`
is hard-scoped to `00-Creek-Meta/Inbound/` (#972): that subtree is admitted at
every ceiling, and any *other* vault path is ranked as intimate content and
needs `ceiling=intimate`/`all` — which no Discord channel gets by default. So
a deployment that pointed `staging_subpath` anywhere else drew
`status="refused"` on every safety scan, and the safety pass silently never
ran.

While fixing that I found the live half of the defect is worse than the issue
describes, and it survived #1285. `_run_safety_scan` returned `scanned=True`
the instant `session.call_tool` returned — **including when the tool answered
with a refusal envelope**. So the #1054 dispatch gate, which refuses any batch
with `scanned=False`, never saw the refusal: the batch was recorded as
scanned, the raw refusal JSON was rendered to the user under a "Safety scan"
heading, and `creek.ingest` was dispatched for content nothing had read.

The fix is two layers, because they close different windows:

**Layer 1 — config parse-time refusal (`crawdad/crawdad/config.py`).**
`_DEFAULT_STAGING_SUBPATH` becomes a public `CANONICAL_STAGING_ROOT: Final[Path]`,
mirrored (not imported) from `creek_mcp.tools.redact._STAGING_SUBDIR` on the
same precedent as `bot.py::_REDACT_SCAN_TOOL`. The `staging_subpath` validator
gains a third arm — last, after `is_absolute()` and `".." in parts` — refusing
anything not `is_relative_to(CANONICAL_STAGING_ROOT)`. `validate_default=True`
moves onto `model_config` so a future edit to the constant, or a subclass with
a drifted default, is caught at first construction rather than shipping green.

**Layer 2 — the runtime arm (`crawdad/crawdad/bot.py`).** A JSON object whose
`status` is exactly `"refused"` is the fifth "the scan did not run" mode, and
now yields `_ScanOutcome(scanned=False, …)`. The existing single chokepoint in
`_dispatch_ingest_for_batch` does the rest — no second gate, per §5.3.

### Why arm order is load-bearing

`Path.is_relative_to` is a pure lexical prefix test and does not resolve `..`,
so `00-Creek-Meta/Inbound/../../01-Fragments` **is** lexically relative to the
canonical root. Only the pre-existing `..` arm catches it, which is why the
scope arm must stay last. A test pins this by asserting the `..` message fires
and the scope message does not.

### What this does *not* claim

The config check is **lexical, fail-fast, defence in depth — not
confinement**. It calls no `resolve()`, and `AttachmentConfig` is a nested
model with no `vault_path`, so a symlink parked under the canonical root
pointing at `01-Fragments` still passes; that is #1087, still open. The real
confinement boundary remains creek-tools' `resolve_within_vault` plus the
resolved `is_relative_to` at `creek_mcp/tools/redact.py:340`. Every docstring
says so.

The new user-facing string claims only that no scan ran. It does not say the
files are clean and makes no counterfactual claim about what a successful scan
would have established — `creek.redact.scan` returns a permissive `ok`/`empty`
even when it finds secrets, which is the recorded non-goal in
`crawdad/CLAUDE.md` §5.3. **That non-goal is undisturbed:** `ok` and `empty`
both still clear the gate; only `refused` — a scan that was *declined*, never
a scan that found something — flips `scanned`.

It also does not assert *which* refusal fired. `status="refused"` covers every
refusal reason creek-tools has, not just the out-of-scope staging root —
`input_path not found` (`redact.py:200-205`) and the off-vault-symlink case
land there too. Naming the staging root as the definite cause would misdirect
an operator debugging something else, so the fixed copy hedges and
`_scan_refusal_text` echoes creek-tools' own `reason` verbatim, which is
authoritative for whichever refusal actually fired. The echo discloses nothing
new: an out-of-scope reason is a fixed string, and a "not found" reason names
a staging path the download summary already showed the user in the same turn.

Fail-open on anything else is deliberate. Non-JSON, malformed JSON, a JSON
array, and a status-less object all keep today's `scanned=True`, so this
change can only ever *remove* admissions and can never newly refuse a turn
that works now. Six parametrised cases pin that.

## Breaking config change

A deployment already overriding `attachments.staging_subpath` to a
non-canonical path now **fails at startup** instead of degrading to a
permanently-refused scan. That is the issue's explicit preference ("prefer
refusing early over a runtime warning"), and the startup error names the
canonical root and the fix. No `CONTRACT_VERSION` bump and no wire-shape
change. The in-repo `crawdad/crawdad.yaml` is untracked and carries no
`attachments` block, so no committed fixture moves.

Also corrected: `crawdad/CLAUDE.md` claimed `capture_subpath` gets "the same
absolute/`..` validation as `attachments.staging_subpath`". The third arm made
that false, so the bullet now says what actually holds — `capture_subpath`
gets arms 1 and 2 but not the canonical-root arm, because nothing scans the
capture dir.

## Test plan

**RED first, and behavioural.** Before the fix, the headline test failed with
a live ingest dispatched for never-scanned content, at `open` — the *narrowest*
declared ceiling:

```
FAILED tests/test_bot.py::test_refused_scan_response_cannot_reach_creek_ingest
E   AssertionError: assert [{'name': 'cr...ng': 'open'}}] == []
E     Left contains one more item: {'name': 'creek.ingest', 'args':
E       {'source_type': 'markdown',
E        'input_path': '00-Creek-Meta/Inbound/999/100/note.md',
E        'privacy_tier_ceiling': 'open'}}
```

12 tests red before, 689 green after, no pre-existing test modified.

**Each guard proven load-bearing** by disabling it in isolation and confirming
exactly the intended tests go red:

| Guard disabled | Tests red |
|---|---|
| the refusal block in `_run_safety_scan` | exactly 6 |
| the third arm in `_confine_staging_subpath` | exactly 9 |
| `validate_default=True` on `model_config` | exactly 1 |
| (regression probe) a cleanliness claim injected into the refusal copy | exactly 2 |

**Coverage of the behaviour:**
- Refusal cannot reach `creek.ingest` via the `ingest` route or the
  `ingest` → type-question → type-word disambiguation route (both dispatch
  entry points).
- Over-refusal guard: a `status="ok"` body still ingests and still renders
  `report_markdown` as markdown, not a JSON code fence.
- Fail-open pins ×6: plain text, brace-wrapped-unparseable, object without
  `status`, `status="ok"`, `status="empty"`, and a JSON **array** (which forces
  the `isinstance(parsed, dict)` guard).
- Validator accept table ×6 including `00-Creek-Meta/./Inbound`, a trailing
  slash, and a `str` (pydantic coerces through the same chain).
- Validator refuse table ×6 including the sibling prefix
  `00-Creek-Meta/Inbound-other` (forces `is_relative_to` over `startswith`),
  `00-creek-meta/inbound` (case folding deliberately not done — `redact.py:340`
  compares literally, so folding would admit a config the server then refuses),
  the parent `00-Creek-Meta`, and `""`.
- Refusal holds at every ceiling, including `intimate`.
- Constant-mirror pin against `creek_mcp/tools/redact.py:98`.
- The refusal copy's *delivered content* is pinned, not just executed:
  `_assert_claims_no_cleanliness` fails if any delivered refusal message
  contains "clean", "no findings", "no secrets", "safe to" or "nothing found".
- A refusal whose reason is *not* the staging root echoes that reason instead
  of misdirecting; a refusal with a missing, blank, or non-string reason still
  refuses and emits no dangling "creek-tools said:" fragment.

**Gates.** `crawdad/scripts/check-all.sh` → 7/7 green, 689 passed, coverage
94.74% (`bot.py` 94.86% → 95.00%); `ruff check --no-cache` re-verified clean,
and the change adds no newly-uncovered line. The `creek-tools` gate is
unaffected: the only file touched there is `docs/mcp.md`, that gate has no
markdown step, and nothing reads the file at runtime or in tests.

## Gate 2.5 self-review

Returned FIX_REQUIRED with one MAJOR, both fixed before this PR opened:

- **MAJOR** — `_SCAN_REFUSED_REPLY` was executed but its content was never
  asserted; both refusal tests cleared the channel before checking, so only
  the pre-existing `_SCAN_BLOCKED_REPLY` was pinned. A future edit could have
  reintroduced a cleanliness claim with no test going red — exactly the
  failure mode §5.3 warns about. Now pinned on the staging turn.
- **Related (folded in, not deferred)** — the copy asserted the staging root
  as the definite cause, which is false for the other refusal reasons. Now
  hedged, with creek-tools' `reason` echoed verbatim.
- Two NITs (the mirror-pin test's docstring overclaiming what a same-file
  literal comparison can detect; `_confine_staging_subpath`'s name vs. its
  "this is not confinement" docstring) were judged not worth churn — the
  docstrings already state the limitation honestly in both cases.

## Notes for the reviewer

- Open PR #1070 ("centralize Discord text contracts") also touches
  `crawdad/crawdad/bot.py`; whichever lands second may need a trivial textual
  merge around the new module constant.
- `creek-tools/docs/mcp.md:163-171` (the #1087 symlink residual) is left
  byte-identical on purpose — only the following paragraph, which ended
  "tracked by #1088", was rewritten.

Closes #1088
Refs #972, #1054, #1087, #1152
