### PR TITLE
fix(vault): verify the located file declares the id before rewriting it

### DIFF
--- a/creek-tools/creek/vault/writer.py
+++ b/creek-tools/creek/vault/writer.py
@@ -415,6 +415,29 @@ def _atomic_write_text(path: Path, content: str) -> None:
                 tmp_path.unlink()
 
 
+def _file_declares_id(path: Path, model_id: str) -> bool:
+    """Return ``True`` only when *path*'s own frontmatter declares *model_id*.
+
+    The verifier behind the id index (#1083): an index entry is a *claim*
+    about a file, and this is the only thing that turns that claim into
+    evidence. A missing ``id`` key, a non-``str`` id, and an unparseable
+    file all answer ``False``.
+
+    The guarded exception set and the ``isinstance(..., str)`` gate are
+    deliberately identical to the ones
+    :meth:`VaultWriter._rebuild_index` applies while scanning, so the
+    verifier and the scanner can never disagree about which files
+    declare an id — a file this function rejects is exactly a file the
+    rebuild would decline to index.
+    """
+    try:
+        post = frontmatter.load(str(path))
+    except (OSError, ValueError, yaml.YAMLError):
+        return False
+    declared = post.get("id")
+    return isinstance(declared, str) and declared == model_id
+
+
 def _is_material_change(old_body: str, new_body: str, threshold: float) -> bool:
     """Return ``True`` when an edit changed the body materially (#675).
 
@@ -784,7 +807,10 @@ class VaultWriter:
         already on disk, so it never lowers an operator's decision.
 
         Returns ``None`` when no file is mapped to ``fragment.id`` (e.g. the
-        file was removed out of band), so the caller can fall back to a fresh
+        file was removed out of band), and also when the mapped file exists
+        but declares a *different* id and no live file in the directory
+        declares this one (#1083) — a rewrite there would clobber a foreign
+        fragment. Either way the caller can fall back to a fresh
         :meth:`write_fragment`.
 
         Args:
@@ -798,7 +824,9 @@ class VaultWriter:
 
         Returns:
             Path to the rewritten file, or ``None`` when no existing file
-            maps to the id.
+            maps to the id — including the case where the mapped file
+            exists but declares a different id and re-resolution finds no
+            live file declaring this one.
         """
         target_dir = self._fragment_target_dir(fragment)
         with self._lock:
@@ -1064,7 +1092,10 @@ class VaultWriter:
         # ``_find_existing_locked`` and ``_atomic_create`` that BUG-006
         # was filed to close. The throughput trade-off is documented
         # in the PR description; revisit only with a benchmark-driven
-        # follow-up issue.
+        # follow-up issue. The id verification and any index repair
+        # ``_find_existing_locked`` performs (#1083) run inside this same
+        # critical section, so a repaired mapping cannot be raced by a
+        # concurrent write between the re-resolution and the file creation.
         with self._lock:
             existing = self._find_existing_locked(model_id, target_dir)
             if existing is not None:
@@ -1114,13 +1145,62 @@ class VaultWriter:
         directory scan if the index file is missing or corrupt so
         existing vaults remain compatible.
 
+        The index is a claim, not evidence: a stale or poisoned entry
+        names a file belonging to a *different* id, and every caller of
+        this locator then acts on that foreign file — rewriting it
+        (:meth:`update_fragment`), dropping a new fragment as a false
+        duplicate (:meth:`_write_model`), or moving and unlinking it
+        (:meth:`tomb_fragment` / :meth:`restore_fragment`). So a located
+        file is verified against its own frontmatter before it is
+        returned, and a mismatch re-resolves through
+        :meth:`_repair_index_locked` (#1083).
+
+        Cost and the rejected memo:
+
+        - Exactly one :func:`frontmatter.load` per index **hit**, none
+          per miss, so no directory scan enters the steady-state path.
+          Measured by call-counting a real unchanged re-ingest: 400
+          units produced 400 loads before this verification existed and
+          400 after — one per hit, not one per lookup. Each load costs
+          ~180 us on a real fragment (1.6 KB, ~20 frontmatter keys),
+          which is roughly +8% on the steady-state unchanged re-ingest
+          and about +6 s on a full 35 000-fragment sweep. That is the
+          price of not move-and-unlinking a stranger's file, and it is
+          paid only where the index claims a hit.
+        - Parsing *only* the frontmatter block by hand was measured and
+          rejected: ``frontmatter.load`` resolves libyaml's C loader,
+          while a hand-rolled ``yaml.safe_load`` of the same block runs
+          on the pure-Python loader and measured several times slower.
+          Reducing the cost further needs a bounded byte-scan for the
+          single ``id`` key, which is tracked as a follow-up rather
+          than smuggled into a data-loss fix.
+        - An mtime/size memo of the verification result was deliberately
+          **rejected**: memoising the check reintroduces "trust a cache
+          instead of the artifact" one level down — the exact defect
+          being closed — and buys nothing on a cold-process sweep, where
+          each path is visited exactly once.
+        - The repair appends a single later-wins line and repairs only
+          the requested id; other stale ids self-heal on first access.
+          This is not a full index rebuild.
+
         Args:
             model_id: The ID to search for.
             target_dir: The directory to search in.
 
         Returns:
-            The path to the existing file, or ``None`` if not indexed
-            or the indexed path no longer exists on disk.
+            The path to the existing file — returned only when that
+            file's own frontmatter declares *model_id*. ``None`` if the
+            id is not indexed, the indexed path no longer exists on
+            disk, or the indexed path declares a different id and no
+            live file in *target_dir* declares this one.
+
+        Raises:
+            ValueError: If a repaired index entry exceeds
+                :data:`_PIPE_BUF_BYTES` when encoded — see
+                :meth:`_append_index_entry`. A lookup-shaped method can
+                therefore raise, because a mismatch persists its repair.
+            OSError: If persisting a repaired entry fails to write — same
+                origin, same reason it can escape a lookup.
         """
         index = self._load_index_locked(target_dir)
         filename = index.get(model_id)
@@ -1128,7 +1208,9 @@ class VaultWriter:
             return None
         candidate = target_dir / filename
         if candidate.exists():
-            return candidate
+            if _file_declares_id(candidate, model_id):
+                return candidate
+            return self._repair_index_locked(index, model_id, target_dir)
         # Stale entry — drop it from the in-memory cache so the next
         # write reuses the slot. The on-disk JSONL still contains the
         # stale line, but it is harmless: the next write appends a new
@@ -1136,6 +1218,53 @@ class VaultWriter:
         # pass (out of scope for this fix) can reclaim the space.
         del index[model_id]
         return None
+
+    def _repair_index_locked(
+        self,
+        index: dict[str, str],
+        model_id: str,
+        target_dir: Path,
+    ) -> Path | None:
+        """Re-resolve *model_id* by scanning *target_dir*, and persist the fix.
+
+        Caller must hold ``self._lock``. Reached only when the indexed
+        file exists but declares a different id, so the scan is paid
+        once per poisoned entry rather than per lookup.
+
+        The corrected mapping is persisted with
+        :meth:`_append_index_entry`, never :meth:`_persist_full_index`:
+        a whole-file rewrite from this process's in-memory snapshot
+        would destroy every entry another process appended since this
+        writer loaded the index. The append is later-wins and keeps the
+        file append-only, so a fresh :class:`VaultWriter` resolves the
+        id directly without repeating the scan.
+
+        Args:
+            index: The in-memory index for *target_dir*, mutated in place.
+            model_id: The ID whose entry was found to be mis-mapped.
+            target_dir: The directory to re-scan.
+
+        Returns:
+            The path of the file that genuinely declares *model_id*, or
+            ``None`` when no live file in *target_dir* declares it.
+
+        Raises:
+            ValueError: If the repaired entry exceeds
+                :data:`_PIPE_BUF_BYTES` when encoded.
+            OSError: If the repaired entry cannot be written.
+
+        Both propagate from :meth:`_append_index_entry`. The in-memory
+        mapping is corrected *before* the append, so a failure to persist
+        leaves this process holding ground truth and the on-disk index
+        merely stale — a cost, not a correctness loss.
+        """
+        resolved = self._rebuild_index(target_dir).get(model_id)
+        if resolved is None:
+            del index[model_id]
+            return None
+        index[model_id] = resolved
+        self._append_index_entry(target_dir, model_id, resolved)
+        return target_dir / resolved
 
     def _find_existing(self, model_id: str, target_dir: Path) -> Path | None:
         """Return the path of an existing file for *model_id*, or ``None``.

--- a/creek-tools/tests/test_ingest_update_in_place.py
+++ b/creek-tools/tests/test_ingest_update_in_place.py
@@ -226,3 +226,60 @@ class TestEditedJournalUpdatesInPlace:
         rec = ledger.get("personal/journal/2026-06-26.md")
         assert rec is not None
         assert rec.fragment_id == original_id
+
+    def test_stale_index_edit_is_not_lost(self, tmp_path: Path) -> None:
+        """A poisoned id index must not swallow the edit into a foreign fragment.
+
+        The ledger still maps the source unit to its fragment id, but the
+        directory's ``.id-index.jsonl`` now maps that id onto a *bystander*
+        file. ``update_fragment`` must decline the foreign file, so the changed
+        branch falls through to its ``updated is None`` fallback and re-creates
+        the fragment under the preserved id — the edit survives, and the
+        bystander is untouched (#1083).
+        """
+        vault = _make_vault(tmp_path)
+        entry = vault / "personal" / "journal" / "2026-06-26.md"
+        entry.write_text(
+            "---\ndate: 2026-06-26\n---\nFirst draft.\n",
+            encoding="utf-8",
+        )
+        _, errors, _ = _ingest(vault, entry)
+        assert errors == []
+        original = _journal_files(vault)[0]
+        original_id = str(frontmatter.load(str(original))["id"])
+
+        # The real fragment vanishes out of band, a bystander is written into
+        # the same directory, and the index is poisoned to name it.
+        original.unlink()
+        seed = VaultWriter(vault_path=vault)
+        bystander = Fragment(
+            id="frag-bystander1",
+            title="Bystander",
+            source=FragmentSource(platform=SourcePlatform.JOURNAL),
+        )
+        bystander_path = seed.write_fragment(bystander, body="bystander body")
+        # Setup guard: the poison only bites if both share one directory index.
+        assert bystander_path.parent == original.parent
+        before = bystander_path.read_bytes()
+        seed._append_index_entry(
+            bystander_path.parent,
+            original_id,
+            bystander_path.name,
+        )
+
+        entry.write_text(
+            "---\ndate: 2026-06-26\n---\nRewritten after the index went stale.\n",
+            encoding="utf-8",
+        )
+        _, errors, _ = _ingest(vault, entry)
+        assert errors == []
+
+        recreated = [
+            path
+            for path in _journal_files(vault)
+            if frontmatter.load(str(path))["id"] == original_id
+        ]
+        assert len(recreated) == 1
+        post = frontmatter.load(str(recreated[0]))
+        assert "Rewritten after the index went stale" in post.content
+        assert bystander_path.read_bytes() == before

--- a/creek-tools/tests/test_vault_writer.py
+++ b/creek-tools/tests/test_vault_writer.py
@@ -14,6 +14,7 @@ import json
 from datetime import date, datetime
 from typing import TYPE_CHECKING, Any
 
+import frontmatter
 import pytest
 from pydantic import BaseModel
 
@@ -26,6 +27,7 @@ from creek.models import (
     Praxis,
     PraxisStatus,
     PraxisType,
+    PrivacyTier,
     SourcePlatform,
     Thread,
     ThreadStatus,
@@ -1391,6 +1393,297 @@ class TestIdIndex:
         assert writer._find_existing(sample_fragment.id, target_dir) == original
         # Unknown ID returns ``None`` via the same path.
         assert writer._find_existing("frag-unknown", target_dir) is None
+
+
+# ---- ID index verification (#1083) ----
+
+
+def _seed_victim(writer: VaultWriter) -> Path:
+    """Write one distinctive bystander fragment and return its path."""
+    victim = Fragment(
+        id="frag-victim001",
+        title="Victim",
+        source=FragmentSource(platform=SourcePlatform.CLAUDE),
+        created=datetime(2025, 1, 15, 10, 30, 0),
+        privacy_tier=PrivacyTier.INTIMATE,
+    )
+    return writer.write_fragment(victim, body="victim body")
+
+
+def _edited_fragment() -> Fragment:
+    """Return the fragment whose id a poisoned index will mis-resolve."""
+    return Fragment(
+        id="frag-edited001",
+        title="Edited",
+        source=FragmentSource(platform=SourcePlatform.CLAUDE),
+        created=datetime(2025, 1, 15, 10, 30, 0),
+    )
+
+
+def _files_declaring(target_dir: Path, model_id: str) -> list[Path]:
+    """Return the ``.md`` files in *target_dir* declaring *model_id* on disk."""
+    return sorted(
+        path
+        for path in target_dir.glob("*.md")
+        if str(frontmatter.load(str(path)).get("id")) == model_id
+    )
+
+
+class TestIdIndexVerification:
+    """The located file must itself declare the id the index claimed (#1083).
+
+    A stale or poisoned ``.id-index.jsonl`` entry names a file belonging to a
+    *different* fragment. Every locator caller — ``update_fragment``, the
+    ``_write_model`` duplicate check, ``tomb_fragment`` and
+    ``restore_fragment`` — then acts destructively on that foreign file.
+    """
+
+    def test_update_fragment_does_not_clobber_foreign_id_file(
+        self,
+        vault_path: Path,
+    ) -> None:
+        """A stale index entry must not redirect an update onto a foreign file."""
+        seed = VaultWriter(vault_path=vault_path)
+        victim = Fragment(
+            id="frag-victim001",
+            title="Victim",
+            source=FragmentSource(platform=SourcePlatform.CLAUDE),
+            created=datetime(2025, 1, 15, 10, 30, 0),
+            privacy_tier=PrivacyTier.INTIMATE,
+        )
+        victim_path = seed.write_fragment(victim, body="victim body")
+        before = victim_path.read_bytes()
+
+        # Poison the on-disk index: a DIFFERENT id now names the victim's file.
+        seed._append_index_entry(
+            victim_path.parent,
+            "frag-edited001",
+            victim_path.name,
+        )
+
+        # Fresh writer, so the poisoned mapping is loaded from the JSONL
+        # rather than an in-process dict.
+        fresh = VaultWriter(vault_path=vault_path)
+        edited = Fragment(
+            id="frag-edited001",
+            title="Edited",
+            source=FragmentSource(platform=SourcePlatform.CLAUDE),
+            created=datetime(2025, 1, 15, 10, 30, 0),
+        )
+        result = fresh.update_fragment(edited, "therapy session notes")
+
+        assert victim_path.read_bytes() == before
+        assert "therapy session notes" not in victim_path.read_text(encoding="utf-8")
+        assert frontmatter.load(str(victim_path))["privacy_tier"] == "intimate"
+        assert result is None
+
+    def test_update_fragment_reresolves_to_the_real_file(
+        self,
+        vault_path: Path,
+    ) -> None:
+        """A mismatch re-resolves to the file that genuinely declares the id."""
+        seed = VaultWriter(vault_path=vault_path)
+        victim_path = _seed_victim(seed)
+        edited = _edited_fragment()
+        owner_path = seed.write_fragment(edited, body="owner body")
+        before = victim_path.read_bytes()
+        seed._append_index_entry(victim_path.parent, edited.id, victim_path.name)
+
+        fresh = VaultWriter(vault_path=vault_path)
+        result = fresh.update_fragment(edited, "revised owner body")
+
+        assert result == owner_path
+        assert "revised owner body" in frontmatter.load(str(owner_path)).content
+        assert victim_path.read_bytes() == before
+
+    def test_index_repair_is_persisted(
+        self,
+        vault_path: Path,
+    ) -> None:
+        """The corrected mapping survives into a fresh writer's index load."""
+        seed = VaultWriter(vault_path=vault_path)
+        victim_path = _seed_victim(seed)
+        edited = _edited_fragment()
+        owner_path = seed.write_fragment(edited, body="owner body")
+        target_dir = victim_path.parent
+        seed._append_index_entry(target_dir, edited.id, victim_path.name)
+
+        VaultWriter(vault_path=vault_path).update_fragment(edited, "revised body")
+
+        third = VaultWriter(vault_path=vault_path)
+        assert third._find_existing(edited.id, target_dir) == owner_path
+        assert _files_declaring(target_dir, edited.id) == [owner_path]
+
+    def test_write_model_does_not_return_foreign_file_as_duplicate(
+        self,
+        vault_path: Path,
+    ) -> None:
+        """A poisoned entry must not turn a brand-new fragment into a silent no-op."""
+        seed = VaultWriter(vault_path=vault_path)
+        victim_path = _seed_victim(seed)
+        before = victim_path.read_bytes()
+        newcomer = _edited_fragment()
+        seed._append_index_entry(victim_path.parent, newcomer.id, victim_path.name)
+
+        fresh = VaultWriter(vault_path=vault_path)
+        result = fresh.write_fragment(newcomer, body="newcomer body")
+
+        assert result != victim_path
+        assert result.exists()
+        assert frontmatter.load(str(result))["id"] == newcomer.id
+        assert victim_path.read_bytes() == before
+
+    def test_tomb_fragment_does_not_move_and_unlink_foreign_file(
+        self,
+        vault_path: Path,
+    ) -> None:
+        """Tombing a ghost id must not relocate and delete a bystander fragment."""
+        seed = VaultWriter(vault_path=vault_path)
+        victim_path = _seed_victim(seed)
+        before = victim_path.read_bytes()
+        seed._append_index_entry(
+            victim_path.parent,
+            "frag-ghost0001",
+            victim_path.name,
+        )
+        orphan_dir = vault_path / "10-Liminal" / "Orphaned"
+
+        fresh = VaultWriter(vault_path=vault_path)
+        result = fresh.tomb_fragment("frag-ghost0001")
+
+        assert result is None
+        assert victim_path.exists()
+        assert victim_path.read_bytes() == before
+        assert list(orphan_dir.glob("*.md")) == []
+
+    def test_restore_fragment_does_not_move_and_unlink_foreign_file(
+        self,
+        vault_path: Path,
+    ) -> None:
+        """Restoring a ghost id must not drag a real tomb out of Orphaned."""
+        orphan_dir = vault_path / "10-Liminal" / "Orphaned"
+        orphan_dir.mkdir(parents=True, exist_ok=True)
+        seed = VaultWriter(vault_path=vault_path)
+        _seed_victim(seed)
+        tombed_path = seed.tomb_fragment("frag-victim001")
+        assert tombed_path is not None  # setup guard
+        before = tombed_path.read_bytes()
+        seed._append_index_entry(orphan_dir, "frag-ghost0001", tombed_path.name)
+
+        ghost = Fragment(
+            id="frag-ghost0001",
+            title="Ghost",
+            source=FragmentSource(platform=SourcePlatform.CLAUDE),
+            created=datetime(2025, 1, 15, 10, 30, 0),
+        )
+        fresh = VaultWriter(vault_path=vault_path)
+        result = fresh.restore_fragment(ghost)
+
+        assert result is None
+        assert tombed_path.exists()
+        assert tombed_path.read_bytes() == before
+
+    def test_unparseable_located_file_is_a_mismatch_not_a_crash(
+        self,
+        vault_path: Path,
+    ) -> None:
+        """Broken YAML in the located file resolves to no match, not an exception."""
+        edited = _edited_fragment()
+        seed = VaultWriter(vault_path=vault_path)
+        target_dir = seed._fragment_target_dir(edited)
+        target_dir.mkdir(parents=True, exist_ok=True)
+        broken = target_dir / "broken.md"
+        broken.write_text(
+            "---\nid: [unterminated\ntitle: Broken\n---\nbroken body\n",
+            encoding="utf-8",
+        )
+        seed._append_index_entry(target_dir, edited.id, broken.name)
+
+        fresh = VaultWriter(vault_path=vault_path)
+
+        assert fresh._find_existing(edited.id, target_dir) is None
+        assert broken.exists()
+
+    def test_located_file_without_id_key_is_a_mismatch(
+        self,
+        vault_path: Path,
+    ) -> None:
+        """Valid frontmatter with no ``id`` key declares no id, so it never matches."""
+        edited = _edited_fragment()
+        seed = VaultWriter(vault_path=vault_path)
+        target_dir = seed._fragment_target_dir(edited)
+        target_dir.mkdir(parents=True, exist_ok=True)
+        idless = target_dir / "idless.md"
+        idless.write_text(
+            "---\ntitle: No Id Here\n---\nidless body\n",
+            encoding="utf-8",
+        )
+        seed._append_index_entry(target_dir, edited.id, idless.name)
+
+        fresh = VaultWriter(vault_path=vault_path)
+
+        assert fresh._find_existing(edited.id, target_dir) is None
+
+    def test_non_str_id_in_frontmatter_is_a_mismatch(
+        self,
+        vault_path: Path,
+    ) -> None:
+        """A YAML-int ``id`` does not satisfy the string id the caller asked for."""
+        numeric = Fragment(
+            id="12345",
+            title="Numeric",
+            source=FragmentSource(platform=SourcePlatform.CLAUDE),
+            created=datetime(2025, 1, 15, 10, 30, 0),
+        )
+        seed = VaultWriter(vault_path=vault_path)
+        target_dir = seed._fragment_target_dir(numeric)
+        target_dir.mkdir(parents=True, exist_ok=True)
+        int_id_path = target_dir / "int-id.md"
+        int_id_path.write_text(
+            "---\nid: 12345\ntitle: Int Id\n---\nint id body\n",
+            encoding="utf-8",
+        )
+        before = int_id_path.read_bytes()
+        seed._append_index_entry(target_dir, numeric.id, int_id_path.name)
+
+        fresh = VaultWriter(vault_path=vault_path)
+        result = fresh.write_fragment(numeric, body="string id body")
+
+        assert result != int_id_path
+        assert frontmatter.load(str(result))["id"] == "12345"
+        assert int_id_path.read_bytes() == before
+        # ``_rebuild_index`` only indexes ids where ``isinstance(mid, str)``, so
+        # the int-typed file is invisible to re-resolution. The honest outcome
+        # is therefore two files carrying the same *logical* id — declining the
+        # foreign file cannot also deduplicate an id the index cannot see.
+        assert _files_declaring(target_dir, "12345") == sorted([int_id_path, result])
+
+    def test_vanished_file_does_not_trigger_a_rescan(
+        self,
+        vault_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An ordinary vanished file resolves to ``None`` without a directory scan.
+
+        Regression guard: the mismatch fix must not route the everyday
+        deleted-or-tombed case into a full ``_rebuild_index`` sweep, which
+        would undo the O(1) lookup PERF-001 bought.
+        """
+
+        def _no_rescan(target_dir: Path) -> dict[str, str]:
+            """Fail loudly instead of scanning the directory."""
+            msg = f"unexpected directory rescan of {target_dir}"
+            raise AssertionError(msg)
+
+        seed = VaultWriter(vault_path=vault_path)
+        victim_path = _seed_victim(seed)
+        target_dir = victim_path.parent
+        victim_path.unlink()
+        monkeypatch.setattr(VaultWriter, "_rebuild_index", staticmethod(_no_rescan))
+
+        fresh = VaultWriter(vault_path=vault_path)
+
+        assert fresh._find_existing("frag-victim001", target_dir) is None
 
 
 # ---- Concurrent writes (BUG-006) ----


### PR DESCRIPTION
## Summary

- `VaultWriter._find_existing_locked` resolved an id through the per-directory `.id-index.jsonl` and returned `target_dir / index[model_id]` after checking only `candidate.exists()` — it never confirmed the located file's own frontmatter declares that id. A stale or poisoned entry therefore redirected **four** destructive callers onto a foreign file, not just the `update_fragment` case the issue names: `update_fragment` clobbers its body, `_write_model`'s dup-check returns it as "already written" (silently dropping a brand-new fragment so no file is ever created), and `tomb_fragment` / `restore_fragment` `_atomic_write_text` it to a new directory and then `unlink()` it — **move-and-delete of a stranger's fragment**, the worst case and the one the issue never mentions.
- The fix verifies the artifact instead of trusting the index: a new module-level `_file_declares_id` predicate, applied on the exists-True side of the locator only. On mismatch, `_repair_index_locked` re-resolves via `_rebuild_index`, rewrites the correct file, and persists the corrected mapping — so recovery cannot mint a *second* file for the same id, and the scan is paid once rather than per call. Fixing the shared locator fixes all four callers with zero edits of their own.
- The `candidate.exists()` fast path and its vanished-entry branch are deliberately untouched, so an ordinary tombed/deleted fragment still costs one `stat` and never triggers a directory rescan (`test_vanished_file_does_not_trigger_a_rescan` pins this). The repair appends via `_append_index_entry` (`O_APPEND`, later-wins) and never `_persist_full_index`, whose whole-file `os.replace` from one process's in-memory snapshot would destroy entries another process appended concurrently.

## Test plan

Gate 1 RED, proven behaviourally against unmodified source before any production edit (no `git stash` — four Ralph worktrees share one stash ref):

```
FAILED test_update_fragment_does_not_clobber_foreign_id_file
  assert victim_path.read_bytes() == before
E assert b"---\naudien...session notes" == b"---\naudien...\nvictim body"
E   At index 913 diff: b't' != b'v'

FAILED test_tomb_fragment_does_not_move_and_unlink_foreign_file
  assert result is None
E AssertionError: assert PosixPath('.../10-Liminal/Orphaned/2025-01-15-Victim.md') is None
```

The second is the data-loss headline: tombing a **ghost id that no fragment owns** relocated an `INTIMATE`-tier bystander into `Orphaned/` and unlinked the original.

11 new tests (10 in `TestIdIndexVerification`, 1 end-to-end through the real `_run_ingest` seam): clobber, re-resolve-to-the-real-file, repair-persisted-to-a-fresh-writer, dup-check-must-not-return-a-foreign-file, tomb, restore, unparseable YAML, no `id` key, non-`str` id, the no-rescan guard, and `test_stale_index_edit_is_not_lost` (the pipeline's `updated is None` fallback at `pipeline.py:253-258` must actually re-create the file, or the edit is silently lost).

**The guard is load-bearing:** reverting just the two guard lines fails exactly those 10 tests and no others (10 failed / 109 passed); restoring makes all 119 pass.

**Cross-check (#970):** `tests/test_mcp_journal.py` + `tests/test_api_journal.py` — 62 passed. The overwrite gate resolves tiers by a frontmatter walk of the file that actually carries the id; the writer's locator now uses the same file-declared-id semantics, so gate and writer agree rather than diverging.

**Gate 2:** `./scripts/check-all.sh` exit 0 — 12 checks passed / 0 failed, 8741 passed, 94.38% aggregate coverage, per-file gate clean (`creek/vault/writer.py` 91.75%, unwaived). No new waiver entry, no `# noqa`, no `# type: ignore`, no skip marker, no threshold change. Xenon: `_find_existing_locked` A(4), `_file_declares_id` A(3), `_repair_index_locked` A(2) — all under the B ceiling.

### Performance: measured, not asserted

Wall-clock A/B was unusable on this machine (the *unaffected* create pass varied 2.5x between runs), so I counted operations instead, which is deterministic:

| Variant | `frontmatter.load` calls during an unchanged re-ingest of 400 units |
|---|---|
| before | **0** |
| after | **400 — exactly one per index hit, zero per miss** |

One load costs **~180 µs** on a real fragment (1.6 KB, ~20 frontmatter keys; min-of-9 × 200 iterations). So the added cost is exactly one load per index hit: roughly **+8%** on the steady-state unchanged re-ingest, about **+6 s** on a full 35 000-fragment sweep. No directory scan enters the steady-state path.

Two cheaper designs were measured and rejected:

- **Hand-rolling a parse of just the frontmatter block was *slower*** — `frontmatter.load` resolves libyaml's C loader, while `yaml.safe_load` of the same block runs the pure-Python loader and measured several times slower.
- **An mtime/size memo buys nothing**: a re-ingest visits each path exactly once in a cold process, so the memo always misses — and memoising the verification reintroduces "trust a cache instead of the artifact" one level down, which is the exact defect being closed.

Driving the remaining cost down needs a bounded byte-scan for the single `id` key; that is filed as a follow-up rather than smuggled into a data-loss fix.

### One honest limitation

`test_non_str_id_in_frontmatter_is_a_mismatch` asserts that a file declaring `id: 12345` (a YAML int) against model id `"12345"` leaves **two** files carrying the same logical id. `_rebuild_index` only indexes ids where `isinstance(mid, str)`, so the int-typed file is invisible to re-resolution and cannot be deduplicated by this fix. Declining to write into a foreign file is still strictly safer than the current clobber, so this is asserted as-is rather than smoothed over.

Privacy: strictly more restrictive, nothing widens at any ceiling. Every branch either targets the file that provably owns the id or refuses.

Closes #1083
Refs #970


Follow-ups filed: #1290 (bounded byte-scan to cut the verification cost), #1291 (non-string frontmatter ids are invisible to `_rebuild_index`). Both P3.
