### PR TITLE
feat(crawdad): audit/purge helper for a pre-#1052 bot-capture tree

### DIFF
--- a/crawdad/CLAUDE.md
+++ b/crawdad/CLAUDE.md
@@ -198,6 +198,39 @@ tier end-to-end from the capture record through staging into fragment
 frontmatter, so an `intimate` channel can be captured faithfully
 instead of refused outright.
 
+**Remediating a pre-#1052 tree (#1264).** The gate above is
+write-time-only; it never re-examines what an older build already
+wrote, and the creek-tools read side
+(`stage_capture_as_data_package`) applies no allowlist or tier filter
+of its own. `crawdad/crawdad/capture_audit.py` plus
+`crawdad capture audit|purge` is the offline remediation helper —
+audit read-only by default, purge dry-run unless `--apply`. It
+re-derives the gate's verdict from `crawdad.yaml`, so it must never
+grow a second copy of the gate's rules: `_verdict_for` reads
+`allowed_channel_ids` and `CAPTURE_ADMITTED_TIERS` directly, in the
+same order `_capture_allowed` does.
+
+Two limits are structural, not provisional. **Only channel-level
+conditions are re-derivable**: `_record_for` writes no user id and no
+channel id, so `allowed_user_ids` cannot be re-evaluated from disk and
+purge therefore operates on whole channel directories, never on
+individual records. **Only id-labelled directories get a verdict**:
+`_channel_label` prefers the channel *name*, and a name cannot be
+mapped back to an id offline, so name-labelled dirs are reported
+`UNRESOLVED` and left alone until the operator names one with
+`--channel`. Note the trap `_resolve_channel_id` exists to avoid:
+digit-only channel *names* are ordinary (`2024`, `420`, `911`), so
+"all digits" alone must never mean "is an id" — a short numeric name
+read as an id misses the allowlist, becomes `REFUSED`, and is deleted
+by a default `--apply` with no confirmation. Hence the
+`_MIN_SNOWFLAKE_DIGITS` floor. Do not relax it; the failure it
+prevents is silent, irreversible data loss, while its cost when it
+over-triggers is one `--channel` flag. A gate-`ADMITTED` directory is refused even when named
+explicitly — that refusal is what makes "never deletes what the gate
+would admit" a property of the tool rather than of how carefully it
+was invoked. Both limits are stated in the tool's own output; do not
+remove them from the report to tidy it up.
+
 ### 5.3 Redaction-scan gate (FEAT-027, #1054)
 
 **Policy: record the batch, refuse at dispatch.** An attachment turn

--- a/crawdad/README.md
+++ b/crawdad/README.md
@@ -91,14 +91,70 @@ vault, because a captured message currently can't carry its channel's
 privacy tier with it. #1262 tracks carrying that tier end-to-end so
 `intimate` channels can be captured faithfully instead of refused.
 
-**Upgrading from a pre-#1052 build.** If you ran with
-`capture_enabled: true` before this fix, `<vault>/discord-capture/`
-may already hold records from non-allowlisted users, other bots, or
-an `intimate` channel — the old capture path bypassed all three
-gates. These records are still ingestible today. #1264 tracks the
-fix; until then the manual mitigation is deleting the offending
-channel subdirectories under `discord-capture/` before running
-`creek sync`.
+#### Upgrading from a pre-#1052 build — audit your capture tree
+
+#1052 stopped future bad writes; it did nothing about what an older build
+already wrote. If you ever ran with `capture_enabled: true` before that fix,
+`<vault>/discord-capture/` may hold records from non-allowlisted users, other
+bots, or a channel you declared `intimate` — the old capture path bypassed all
+three gates, and those records are **still ingestible**, landing as
+`unclassified`, which ranks with `personal`. Run the audit before your next
+`creek sync`:
+
+```bash
+crawdad capture audit                       # read-only; changes nothing
+```
+
+It reports, for every channel directory under the capture root: the verdict the
+*current* gate would give it, the declared privacy tier, the record count, the
+date range, and the distinct author names. Then:
+
+```bash
+crawdad capture purge                       # DRY RUN — shows what would go
+crawdad capture purge --apply               # actually delete (irreversible)
+```
+
+Both read the same `crawdad.yaml` the bot does, so they judge the tree against
+your live allowlist and tier table.
+
+**What purge deletes, and what it deliberately does not.**
+
+| Verdict | Meaning | Purged? |
+|---|---|---|
+| `admitted` | An allowlisted channel at an admitted tier — the gate would write it today. | **Never**, even if you name it. Delete it by hand if you want it gone. |
+| `refused` | A numeric-labelled dir whose id is not in `allowed_channel_ids`, or is declared `intimate`/`all`. | Yes, by default. |
+| `unresolved` | The dir is named after the channel (`general`), not its id, so it cannot be matched against `allowed_channel_ids`. | Only when you name it: `crawdad capture purge --channel general --apply`. |
+
+Most directories will be `unresolved`: CrawDad names each capture directory
+after the channel's *name*, and a name cannot be mapped back to a channel id
+offline. Guessing is the one way this tool could destroy legitimate data, so it
+does not — it shows you the contents and waits for you to name the directory.
+
+A directory is only read as a channel **id** when its name could plausibly be
+one: all digits, no leading zero, and at least 15 of them (Discord ids are
+`(ms since the 2015 epoch) << 22`, so real ones run 15-19 digits). This matters
+because channel *names* made only of digits are ordinary — `2024`, `420`, `911`.
+Without the length floor, `2024` would be read as channel id 2024, miss your
+allowlist, and be auto-purged even though the channel itself is allowlisted. If
+you have a genuinely id-labelled directory from very early 2015 it will show as
+`unresolved` instead; that costs you one `--channel` flag, not your data.
+
+Anything under the capture root that is not a real channel directory — a loose
+file, or a symlink — is skipped and listed at the end of the audit, so the
+report never quietly under-states what is on disk. Purge never follows a
+symlink.
+
+**Purge removes whole channel directories, never individual records.** A capture
+record stores the author's display name but no user id and no channel id, so
+`allowed_user_ids` cannot be re-evaluated from disk. An `admitted` directory may
+therefore still contain messages from users who were never allowlisted; the
+audit's authors column is how you spot them, and removing them means removing
+the whole directory. Filtering on a display name instead would match on a
+spoofable, mutable key — it would either destroy legitimate messages or leave
+the leak while reporting it fixed.
+
+#1262 tracks carrying the tier end-to-end so `intimate` channels can be captured
+faithfully instead of refused outright.
 
 ### LLM provider selection
 

--- a/crawdad/crawdad/capture.py
+++ b/crawdad/crawdad/capture.py
@@ -69,6 +69,40 @@ class _BackfillChannel(Protocol):
     ) -> AsyncIterator[_MessageLike]: ...  # pragma: no cover - protocol stub
 
 
+def iter_channel_records(channel_dir: Path) -> Iterator[dict[str, object]]:
+    """Yield every parsed JSON record under a single capture channel dir.
+
+    The one reader of the on-disk capture format. :class:`MessageCapture` uses it
+    for dedup and gap-filling; :mod:`crawdad.capture_audit` uses it to summarise
+    a pre-#1052 tree (#1264). Both must agree on what "a record" is, so neither
+    parses JSONL itself.
+
+    Malformed lines, blank lines, and non-object JSON are skipped rather than
+    raised: a corrupt line must not hide the intact records around it from an
+    audit, and it never blocked the writer either.
+
+    Args:
+        channel_dir: A ``<capture_dir>/<channel>`` directory. A path that is not
+            a directory yields nothing.
+
+    Yields:
+        Each JSON object found, in filename then line order.
+    """
+    if not channel_dir.is_dir():
+        return
+    for jsonl in sorted(channel_dir.glob("*.jsonl")):
+        for line in jsonl.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                obj = json.loads(stripped)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(obj, dict):
+                yield obj
+
+
 def _author_name(message: _MessageLike) -> str:
     """The display name if the author has one, else the plain name."""
     display = getattr(message.author, "display_name", "")
@@ -189,17 +223,4 @@ class MessageCapture:
 
     def _iter_records(self, channel: str) -> Iterator[dict[str, object]]:
         """Yield every parsed JSON record under ``<capture_dir>/<channel>/``."""
-        channel_dir = self._dir / channel
-        if not channel_dir.is_dir():
-            return
-        for jsonl in sorted(channel_dir.glob("*.jsonl")):
-            for line in jsonl.read_text(encoding="utf-8").splitlines():
-                stripped = line.strip()
-                if not stripped:
-                    continue
-                try:
-                    obj = json.loads(stripped)
-                except json.JSONDecodeError:
-                    continue
-                if isinstance(obj, dict):
-                    yield obj
+        return iter_channel_records(self._dir / channel)

--- a/crawdad/crawdad/capture_audit.py
+++ b/crawdad/crawdad/capture_audit.py
@@ -1,0 +1,543 @@
+"""Audit and purge a pre-#1052 bot-capture tree (#1264).
+
+#1052 moved the capture write behind the allowlist + tier gate, so no *new*
+record can name a non-allowlisted user or channel, and no ``intimate``/``all``
+channel is written at all. It did nothing about what a pre-fix build already
+wrote. An operator who ran with ``capture_enabled: true`` before that fix has a
+``<vault>/<capture_subpath>/`` tree holding messages from strangers, other
+bots, and channels they declared ``intimate`` — all of it untiered, and all of
+it still ingestible, because ``creek.ingest.discord.stage_capture_as_data_package``
+iterates every channel dir with no allowlist or tier filter and the result lands
+as ``unclassified``, which ranks *with* ``personal``.
+
+This module is the remediation helper. Two design rules bound it:
+
+**Audit is the default; purge is explicit and dry-run first.** Deletion is
+irreversible, so nothing is removed until the operator has been shown, in the
+same vocabulary, exactly what would go.
+
+**Privacy is a one-way ratchet.** Every path here can only ever make the
+on-disk tree *less* exposed. Nothing widens what is ingestible and nothing
+lowers a tier — the worst outcome of a bug is that a refused directory survives
+and the operator deletes it by hand, which is the status quo.
+
+The purge unit
+--------------
+
+**A whole channel directory, never an individual record.** A capture record
+carries only ``author.name`` — a mutable display name, not a user id — and no
+channel id at all (:func:`crawdad.capture._record_for`). So of the three things
+the gate checks, only the channel-level ones are re-derivable from disk:
+
+===========================  ====================================
+Gate condition               Re-derivable from a capture record?
+===========================  ====================================
+channel in allowlist         only when the dir is id-labelled
+channel tier admitted        only when the dir is id-labelled
+author in ``allowed_user_ids``  **no** — no user id is stored
+===========================  ====================================
+
+Selectively deleting the records of a non-allowlisted *user* would therefore
+mean matching on a spoofable display name and either destroying legitimate
+messages or leaving the leak while reporting it fixed. Neither is acceptable,
+so purge does not attempt it: it operates on directories, and the audit reports
+the distinct author names per directory so the operator can see who is in there
+and decide. That limitation is printed in the tool's own output, not buried
+here.
+
+Directory labels
+----------------
+
+:func:`crawdad.capture._channel_label` names each directory after the channel's
+*name*, falling back to its numeric id only when the name is unusable. A name
+cannot be mapped back to a channel id offline, so a name-labelled directory gets
+no verdict at all (:attr:`CaptureVerdict.UNRESOLVED`) — guessing would be the
+one way this helper could delete admitted data. Those directories are reported
+and left alone until the operator names one explicitly with ``--channel``.
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+from crawdad.capture import iter_channel_records
+from crawdad.config import CAPTURE_ADMITTED_TIERS, DEFAULT_CHANNEL_TIER
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+    from crawdad.config import CrawDadConfig
+
+# Why an explicit request for a gate-admitted directory is turned down. Purge is
+# a remediation tool for pre-fix leakage, not a general delete-my-data command;
+# refusing here is what makes "never deletes what the gate would admit" a
+# property of the tool rather than of how carefully it was invoked.
+DECLINE_ADMITTED: str = (
+    "the current capture gate admits this channel, so purge will not delete it "
+    "(remove it by hand if you want it gone)"
+)
+
+# Why a requested label matched nothing. Reported rather than ignored so a typo
+# — or a `..` traversal attempt — is visible instead of looking like success.
+DECLINE_UNKNOWN: str = "no such channel directory under the capture root"
+
+# Fewest digits a capture directory label must have before it is read as a
+# Discord channel id rather than a channel name. See :func:`_resolve_channel_id`
+# for the epoch arithmetic and why the floor errs on the safe side.
+_MIN_SNOWFLAKE_DIGITS: int = 15
+
+_LIMITATION_NOTE: str = (
+    "Note: purge removes whole channel directories, never individual records. A\n"
+    "capture record stores the author's display name but no user id and no\n"
+    "channel id, so allowed_user_ids cannot be re-evaluated from disk: an\n"
+    "admitted directory may still hold messages from users who were never\n"
+    "allowlisted. The authors column is how you spot them; removing them means\n"
+    "removing the whole directory."
+)
+
+
+class CaptureVerdict(StrEnum):
+    """What the *current* capture gate would do with a directory's records."""
+
+    ADMITTED = "admitted"
+    """The gate would write these records today — never purged by default."""
+
+    REFUSED = "refused"
+    """The gate would refuse these records today — purged by default."""
+
+    UNRESOLVED = "unresolved"
+    """The directory is name-labelled, so no gate verdict is derivable offline."""
+
+
+@dataclass(frozen=True, slots=True)
+class ChannelAudit:
+    """What one channel directory under the capture root contains, and its verdict.
+
+    Attributes:
+        label: The directory name — a channel name, or its numeric id when the
+            name was unusable at capture time.
+        verdict: The current gate's verdict for this directory.
+        reason: One sentence explaining *verdict*, safe to show an operator.
+        channel_id: The channel id when *label* is numeric, else ``None``.
+        declared_tier: The ``channel_privacy_tiers`` ceiling in force for
+            *channel_id* (including the ``personal`` default), or ``None`` when
+            the label could not be resolved to an id.
+        record_count: Parseable JSON records found in the directory.
+        first_timestamp: Earliest record ``timestamp``, or ``None`` if none had
+            one. Compared as **strings**, not parsed — see the note below.
+        last_timestamp: Latest record ``timestamp``, same caveat.
+        authors: Distinct ``author.name`` values, sorted.
+    """
+
+    label: str
+    verdict: CaptureVerdict
+    reason: str
+    channel_id: int | None
+    declared_tier: str | None
+    record_count: int
+    first_timestamp: str | None
+    last_timestamp: str | None
+    authors: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class PurgePlan:
+    """The directories a purge would remove, and the requests it turned down.
+
+    Attributes:
+        targets: Channel directories to delete. Every :attr:`CaptureVerdict.REFUSED`
+            audit, plus any :attr:`CaptureVerdict.UNRESOLVED` directory the
+            operator named. Never contains an admitted directory.
+        declined: ``(label, reason)`` pairs for requested labels that were not
+            promoted to targets.
+    """
+
+    targets: tuple[ChannelAudit, ...] = ()
+    declined: tuple[tuple[str, str], ...] = field(default=())
+
+
+def _resolve_channel_id(label: str) -> int | None:
+    """The channel id *label* encodes, or ``None`` if it is a channel name.
+
+    Being all-digits is **not** enough. Discord channel names may be nothing but
+    digits — ``2024``, ``420``, ``911`` are ordinary channel names — and
+    :func:`crawdad.capture._channel_label` labels a directory with the channel's
+    *name* whenever it is usable. Reading ``2024`` as channel id 2024 would miss
+    the allowlist and mark a possibly-allowlisted channel ``REFUSED``, which
+    :func:`plan_purge` then deletes with no operator confirmation at all. That is
+    the one direction this tool must never fail in.
+
+    So a label is only read as an id when it could plausibly *be* a snowflake:
+    ASCII digits, no leading zero, and at least :data:`_MIN_SNOWFLAKE_DIGITS`
+    long. Discord ids are ``(ms since the 2015 epoch) << 22``, so anything
+    created since 2016 is 18-19 digits and even early-2015 ids are 15-16.
+
+    The floor errs safe in both directions. A short numeric *name* becomes
+    ``UNRESOLVED`` — reported, never auto-purged, still removable with
+    ``--channel``. A genuine id-labelled directory from very early 2015 would
+    also fall through to ``UNRESOLVED``, which costs the operator one
+    ``--channel`` flag rather than costing them data.
+    """
+    if not (label.isascii() and label.isdigit()):
+        return None
+    if label.startswith("0") or len(label) < _MIN_SNOWFLAKE_DIGITS:
+        return None
+    return int(label)
+
+
+def _verdict_for(
+    channel_id: int | None, tier: str | None, *, config: CrawDadConfig
+) -> tuple[CaptureVerdict, str]:
+    """Apply the current capture gate to a resolved channel, returning why.
+
+    Mirrors :func:`crawdad.bot._capture_allowed`'s channel-level conditions in
+    the same order — allowlist first, then tier membership in
+    :data:`~crawdad.config.CAPTURE_ADMITTED_TIERS`. The user-level condition is
+    deliberately absent; see the module docstring.
+    """
+    if channel_id is None:
+        return (
+            CaptureVerdict.UNRESOLVED,
+            "directory is named after the channel, not its id, so it cannot be "
+            "matched against allowed_channel_ids or channel_privacy_tiers",
+        )
+    if channel_id not in config.allowed_channel_ids:
+        return (
+            CaptureVerdict.REFUSED,
+            f"channel {channel_id} is not in allowed_channel_ids",
+        )
+    if tier not in CAPTURE_ADMITTED_TIERS:
+        return (
+            CaptureVerdict.REFUSED,
+            f"channel {channel_id} is declared {tier!r}, which capture refuses "
+            "because a capture record cannot carry that ceiling",
+        )
+    return (
+        CaptureVerdict.ADMITTED,
+        f"channel {channel_id} is allowlisted at tier {tier!r}",
+    )
+
+
+def _record_timestamp(record: dict[str, object]) -> str | None:
+    """The record's ``timestamp`` when it is a string, else ``None``.
+
+    Kept as a string and ordered lexicographically rather than parsed. That is
+    exact **only** because of two properties of what the writer emits
+    (``created_at.isoformat()`` on Discord's always-UTC, always-aware
+    timestamps): every string carries the same fixed-width date-time prefix and
+    the same ``+00:00`` offset, and where ``isoformat`` omits a zero microsecond
+    field, the ``+`` of the offset (ASCII 43) sorts before the ``.`` of a
+    microsecond field (46), so ``…:00+00:00`` still orders before
+    ``…:00.5+00:00``.
+
+    Both properties are assumptions about the writer, not guarantees of ISO-8601
+    in general — mixed offsets or a ``Z`` suffix would break the ordering
+    silently. If ``crawdad.capture._record_for`` ever changes its timestamp
+    format, this must switch to parsed comparison. Ordering only affects the
+    reported date range, never a purge decision.
+    """
+    raw = record.get("timestamp")
+    return raw if isinstance(raw, str) else None
+
+
+def _record_author(record: dict[str, object]) -> str | None:
+    """The record's ``author.name`` when present and non-empty, else ``None``."""
+    author = record.get("author")
+    if not isinstance(author, dict):
+        return None
+    name = author.get("name")
+    return name if isinstance(name, str) and name else None
+
+
+@dataclass(frozen=True, slots=True)
+class _Summary:
+    """Aggregate statistics for one channel directory's records."""
+
+    record_count: int
+    first_timestamp: str | None
+    last_timestamp: str | None
+    authors: tuple[str, ...]
+
+
+def _summarise(channel_dir: Path) -> _Summary:
+    """Count records and collect the timestamp range + distinct authors."""
+    count = 0
+    timestamps: list[str] = []
+    authors: set[str] = set()
+    for record in iter_channel_records(channel_dir):
+        count += 1
+        stamp = _record_timestamp(record)
+        if stamp is not None:
+            timestamps.append(stamp)
+        author = _record_author(record)
+        if author is not None:
+            authors.add(author)
+    return _Summary(
+        record_count=count,
+        first_timestamp=min(timestamps, default=None),
+        last_timestamp=max(timestamps, default=None),
+        authors=tuple(sorted(authors)),
+    )
+
+
+def _audit_channel_dir(channel_dir: Path, config: CrawDadConfig) -> ChannelAudit:
+    """Audit a single channel directory against the current gate."""
+    label = channel_dir.name
+    channel_id = _resolve_channel_id(label)
+    tier = (
+        None
+        if channel_id is None
+        else config.attachments.channel_privacy_tiers.get(
+            channel_id, DEFAULT_CHANNEL_TIER
+        )
+    )
+    verdict, reason = _verdict_for(channel_id, tier, config=config)
+    summary = _summarise(channel_dir)
+    return ChannelAudit(
+        label=label,
+        verdict=verdict,
+        reason=reason,
+        channel_id=channel_id,
+        declared_tier=tier,
+        record_count=summary.record_count,
+        first_timestamp=summary.first_timestamp,
+        last_timestamp=summary.last_timestamp,
+        authors=summary.authors,
+    )
+
+
+def audit_capture_tree(
+    *, capture_dir: Path, config: CrawDadConfig
+) -> tuple[ChannelAudit, ...]:
+    """Audit every channel directory under *capture_dir*. Read-only.
+
+    Symlinked entries are skipped entirely: the capture writer never creates
+    one, and auditing a symlink would invite a later purge to follow it out of
+    the vault. Loose files at the root are skipped too.
+
+    Args:
+        capture_dir: The ``<vault>/<capture_subpath>`` root.
+        config: The live bot config supplying the allowlist and tier table.
+
+    Returns:
+        One :class:`ChannelAudit` per channel directory, sorted by label. Empty
+        when the capture root does not exist.
+    """
+    if not capture_dir.is_dir():
+        return ()
+    return tuple(
+        _audit_channel_dir(child, config)
+        for child in sorted(capture_dir.iterdir())
+        if child.is_dir() and not child.is_symlink()
+    )
+
+
+def list_skipped_entries(capture_dir: Path) -> tuple[str, ...]:
+    """Names of entries under *capture_dir* that :func:`audit_capture_tree` ignores.
+
+    Loose files and symlinks. Reported alongside the audit so the tool never
+    silently under-states what is on disk: the audit claims to be sufficient on
+    its own to decide a purge, and an entry it dropped without saying so would
+    make that claim false.
+
+    Returns:
+        The sorted entry names, or empty when the capture root is absent.
+    """
+    if not capture_dir.is_dir():
+        return ()
+    return tuple(
+        sorted(
+            child.name
+            for child in capture_dir.iterdir()
+            if child.is_symlink() or not child.is_dir()
+        )
+    )
+
+
+def plan_purge(
+    *,
+    audits: Sequence[ChannelAudit],
+    requested_labels: Sequence[str] = (),
+) -> PurgePlan:
+    """Decide what a purge would delete, without touching disk.
+
+    Every refused directory is targeted automatically — the gate's verdict on it
+    is unambiguous. An unresolved directory is targeted only when the operator
+    names it, because its records may be entirely legitimate. An admitted
+    directory is never targeted, named or not.
+
+    Args:
+        audits: The audit of the tree, from :func:`audit_capture_tree`.
+        requested_labels: Directory labels the operator asked for explicitly.
+
+    Returns:
+        The plan. Targets are unique and ordered by label.
+    """
+    by_label = {audit.label: audit for audit in audits}
+    targets = {a.label: a for a in audits if a.verdict is CaptureVerdict.REFUSED}
+    declined: list[tuple[str, str]] = []
+    for label in requested_labels:
+        audit = by_label.get(label)
+        if audit is None:
+            declined.append((label, DECLINE_UNKNOWN))
+        elif audit.verdict is CaptureVerdict.ADMITTED:
+            declined.append((label, DECLINE_ADMITTED))
+        else:
+            targets[label] = audit
+    return PurgePlan(
+        targets=tuple(targets[label] for label in sorted(targets)),
+        declined=tuple(declined),
+    )
+
+
+def apply_purge(*, capture_dir: Path, plan: PurgePlan) -> tuple[str, ...]:
+    """Delete the plan's target directories. Irreversible.
+
+    Every target is confined to the capture root *before* the first deletion, so
+    a plan that somehow names a path outside it removes nothing at all rather
+    than part of the tree. Targets always come from :func:`audit_capture_tree`'s
+    own ``iterdir`` walk in normal use; this is defence in depth against a
+    future caller constructing a plan by hand.
+
+    Args:
+        capture_dir: The capture root every target must live under.
+        plan: The plan from :func:`plan_purge`.
+
+    Returns:
+        The labels deleted, in plan order.
+
+    Raises:
+        ValueError: if any target resolves outside *capture_dir*. Nothing is
+            deleted in that case.
+    """
+    root = capture_dir.resolve()
+    paths: list[tuple[str, Path]] = []
+    for target in plan.targets:
+        path = (capture_dir / target.label).resolve()
+        if path == root or not path.is_relative_to(root):
+            msg = (
+                f"refusing to purge {target.label!r}: it resolves outside the "
+                f"capture root {capture_dir}"
+            )
+            raise ValueError(msg)
+        paths.append((target.label, path))
+    deleted: list[str] = []
+    for label, path in paths:
+        if path.is_dir() and not path.is_symlink():
+            shutil.rmtree(path)
+            deleted.append(label)
+    return tuple(deleted)
+
+
+def _plural(count: int, singular: str, plural: str | None = None) -> str:
+    """Render ``<count> <noun>``, picking the singular only when *count* is 1."""
+    if count == 1:
+        return f"{count} {singular}"
+    return f"{count} {plural or singular + 's'}"
+
+
+def _format_audit_line(audit: ChannelAudit) -> str:
+    """Render one channel directory as four lines: header, span, authors, reason."""
+    span = (
+        f"{audit.first_timestamp} .. {audit.last_timestamp}"
+        if audit.first_timestamp and audit.last_timestamp
+        else "no timestamps"
+    )
+    authors = ", ".join(audit.authors) if audit.authors else "none"
+    return (
+        f"  [{audit.verdict.value:<10}] {audit.label}\n"
+        f"      {_plural(audit.record_count, 'record')}  {span}\n"
+        f"      authors: {authors}\n"
+        f"      {audit.reason}"
+    )
+
+
+def _format_skipped(skipped: Sequence[str]) -> str:
+    """Render the skipped-entries disclosure, or empty when nothing was skipped."""
+    if not skipped:
+        return ""
+    names = ", ".join(skipped)
+    return (
+        f"\n\nSkipped {_plural(len(skipped), 'entry', 'entries')} that is not a "
+        f"real channel directory (a loose file or a symlink — the capture writer "
+        f"creates neither, and purge never follows a symlink): {names}"
+    )
+
+
+def format_audit_report(
+    *,
+    capture_dir: Path,
+    audits: Sequence[ChannelAudit],
+    skipped: Sequence[str] = (),
+) -> str:
+    """Render the audit as operator-readable text.
+
+    The output is designed to be sufficient on its own to decide a purge — every
+    verdict carries its reason, the whole-directory limitation is stated rather
+    than assumed, and anything on disk the walk ignored is disclosed.
+
+    Args:
+        capture_dir: The capture root that was audited.
+        audits: The per-directory audits from :func:`audit_capture_tree`.
+        skipped: Entry names from :func:`list_skipped_entries`.
+    """
+    header = f"Capture audit — {capture_dir}"
+    if not audits:
+        return (
+            f"{header}\n\nno channel directories found; nothing to audit."
+            f"{_format_skipped(skipped)}"
+        )
+    total = sum(audit.record_count for audit in audits)
+    body = "\n".join(_format_audit_line(audit) for audit in audits)
+    counts = ", ".join(
+        f"{sum(1 for a in audits if a.verdict is verdict)} {verdict.value}"
+        for verdict in CaptureVerdict
+    )
+    return (
+        f"{header}\n\n"
+        f"{_plural(len(audits), 'channel directory', 'channel directories')}, "
+        f"{_plural(total, 'record')} ({counts}).\n\n"
+        f"{body}\n\n"
+        f"{_LIMITATION_NOTE}"
+        f"{_format_skipped(skipped)}"
+    )
+
+
+def _format_purge_targets(plan: PurgePlan, *, applied: bool) -> str:
+    """Render the target block for the purge report."""
+    verb = "Deleted" if applied else "Would delete"
+    total = sum(target.record_count for target in plan.targets)
+    lines = "\n".join(_format_audit_line(target) for target in plan.targets)
+    count = _plural(len(plan.targets), "channel directory", "channel directories")
+    return f"{verb} {count} ({_plural(total, 'record')}):\n{lines}"
+
+
+def format_purge_report(*, capture_dir: Path, plan: PurgePlan, applied: bool) -> str:
+    """Render what a purge did, or would do, as operator-readable text.
+
+    Args:
+        capture_dir: The capture root the plan applies to.
+        plan: The plan from :func:`plan_purge`.
+        applied: ``True`` after :func:`apply_purge` ran; ``False`` for a dry run,
+            which says so unmissably and points at ``--apply``.
+    """
+    mode = (
+        "APPLIED (this is irreversible)"
+        if applied
+        else "DRY RUN (nothing was deleted; re-run with --apply to delete)"
+    )
+    parts = [f"Capture purge — {mode}", f"Capture root: {capture_dir}", ""]
+    if plan.targets:
+        parts.append(_format_purge_targets(plan, applied=applied))
+    else:
+        parts.append("nothing to purge: no channel directory the gate would refuse.")
+    if plan.declined:
+        declined = "\n".join(f"  {label} — {reason}" for label, reason in plan.declined)
+        count = _plural(len(plan.declined), "request")
+        parts.append(f"\nDeclined {count}:\n{declined}")
+    parts.append(f"\n{_LIMITATION_NOTE}")
+    return "\n".join(parts)

--- a/crawdad/crawdad/cli.py
+++ b/crawdad/crawdad/cli.py
@@ -16,6 +16,14 @@ from typing import TYPE_CHECKING
 
 from crawdad.bot import CrawDadClient
 from crawdad.capture import MessageCapture
+from crawdad.capture_audit import (
+    apply_purge,
+    audit_capture_tree,
+    format_audit_report,
+    format_purge_report,
+    list_skipped_entries,
+    plan_purge,
+)
 from crawdad.composer import SonnetComposer
 from crawdad.config import (
     composer_model_for,
@@ -58,26 +66,100 @@ def _truncate_for_discord(text: str) -> str:
 
 
 def main(argv: Sequence[str] | None = None) -> None:
-    """Parse *argv*, resolve config, and start the runtime."""
+    """Parse *argv*, resolve config, and dispatch to the selected subcommand."""
     parser = _build_parser()
     args = parser.parse_args(argv)
     if args.subcommand == "run":
-        config = load_config(args.config)
-        run_bot(config)
+        run_bot(load_config(args.config))
+    else:
+        run_capture_command(args)
+
+
+def _add_config_flag(parser: argparse.ArgumentParser) -> None:
+    """Attach the shared ``--config`` flag to *parser*."""
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        help="Path to crawdad.yaml (defaults to ./crawdad.yaml).",
+    )
 
 
 def _build_parser() -> argparse.ArgumentParser:
     """Return the top-level argument parser."""
     parser = argparse.ArgumentParser(prog="crawdad")
     sub = parser.add_subparsers(dest="subcommand", required=True)
-    run = sub.add_parser("run", help="Start the Discord bot.")
-    run.add_argument(
-        "--config",
-        type=Path,
-        default=None,
-        help="Path to crawdad.yaml (defaults to ./crawdad.yaml).",
-    )
+    _add_config_flag(sub.add_parser("run", help="Start the Discord bot."))
+    _add_capture_parser(sub)
     return parser
+
+
+def _add_capture_parser(
+    sub: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    """Attach ``crawdad capture audit|purge`` — the #1264 remediation helper.
+
+    ``audit`` is the default-shaped, read-only mode. ``purge`` is a dry run
+    unless ``--apply`` is passed, because deletion is irreversible and the
+    operator must see the target list before it is acted on.
+    """
+    capture = sub.add_parser(
+        "capture",
+        help="Inspect or clean up an existing bot-capture tree (#1264).",
+    )
+    modes = capture.add_subparsers(dest="capture_mode", required=True)
+    _add_config_flag(
+        modes.add_parser(
+            "audit",
+            help="Report what each captured channel dir holds. Read-only.",
+        )
+    )
+    purge = modes.add_parser(
+        "purge",
+        help="Delete capture dirs the current gate would refuse. Dry run by default.",
+    )
+    _add_config_flag(purge)
+    purge.add_argument(
+        "--channel",
+        action="append",
+        default=[],
+        metavar="LABEL",
+        help=(
+            "Also purge this channel directory, for a name-labelled dir the "
+            "audit could not resolve to a channel id. Repeatable. A directory "
+            "the current gate admits is refused even when named."
+        ),
+    )
+    purge.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually delete. Without it, purge only reports what it would do.",
+    )
+
+
+def run_capture_command(args: argparse.Namespace) -> None:
+    """Run ``crawdad capture audit|purge`` and print the report to stdout.
+
+    Loads the live config so the audit judges the tree against the *current*
+    allowlist and tier table — the same two inputs :func:`crawdad.bot._capture_allowed`
+    reads — rather than a second, driftable copy of the gate.
+    """
+    config = load_config(args.config)
+    capture_dir = config.vault_path / config.capture_subpath
+    audits = audit_capture_tree(capture_dir=capture_dir, config=config)
+    if args.capture_mode == "audit":
+        print(
+            format_audit_report(
+                capture_dir=capture_dir,
+                audits=audits,
+                skipped=list_skipped_entries(capture_dir),
+            )
+        )
+        return
+    plan = plan_purge(audits=audits, requested_labels=tuple(args.channel))
+    if args.apply:
+        apply_purge(capture_dir=capture_dir, plan=plan)
+    print(format_purge_report(capture_dir=capture_dir, plan=plan, applied=args.apply))
 
 
 def run_bot(config: CrawDadConfig) -> None:

--- a/crawdad/tests/test_capture_audit.py
+++ b/crawdad/tests/test_capture_audit.py
@@ -1,0 +1,742 @@
+"""Tests for ``crawdad.capture_audit`` — the pre-#1052 capture remediation helper.
+
+The tree under test always mixes directories the current gate would admit with
+directories it would refuse, so every assertion is behavioural: what the audit
+*reports* and what the purge *removes*, never merely that a symbol exists.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from crawdad import cli
+from crawdad.capture_audit import (
+    CaptureVerdict,
+    apply_purge,
+    audit_capture_tree,
+    format_audit_report,
+    format_purge_report,
+    list_skipped_entries,
+    plan_purge,
+)
+from crawdad.config import AttachmentConfig, CrawDadConfig
+
+# Channel ids used across the fixtures. Real Discord snowflakes, not toy ints:
+# the audit only resolves a digit label that could plausibly *be* a snowflake,
+# so a 3-digit id would exercise a code path no real capture tree can produce.
+ADMITTED_ID = 111111111111111111
+INTIMATE_ID = 222222222222222222
+ALL_TIER_ID = 333333333333333333
+STRANGER_ID = 999999999999999999
+NAMED_LABEL = "random-chat"
+
+# A channel whose *name* is nothing but digits — legal on Discord and common
+# ("2024", "420", "911"). Its directory label is that name, never its id.
+NUMERIC_NAME = "2024"
+
+
+def _record(msg_id: str, timestamp: str, author: str) -> dict[str, Any]:
+    """Build one capture record in the writer's on-disk schema."""
+    return {
+        "id": msg_id,
+        "timestamp": timestamp,
+        "content": f"message {msg_id}",
+        "author": {"name": author},
+    }
+
+
+def _write_channel(
+    capture_dir: Path, label: str, records: list[dict[str, Any]], *, date: str
+) -> Path:
+    """Write *records* into ``<capture_dir>/<label>/<date>.jsonl``."""
+    channel_dir = capture_dir / label
+    channel_dir.mkdir(parents=True, exist_ok=True)
+    (channel_dir / f"{date}.jsonl").write_text(
+        "".join(json.dumps(rec) + "\n" for rec in records), encoding="utf-8"
+    )
+    return channel_dir
+
+
+@pytest.fixture
+def config(tmp_path: Path) -> CrawDadConfig:
+    """A config allowlisting three channels, two of them tiered out of capture."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    return CrawDadConfig(
+        discord_bot_token="t",
+        vault_path=vault,
+        allowed_user_ids=(1,),
+        allowed_channel_ids=(ADMITTED_ID, INTIMATE_ID, ALL_TIER_ID),
+        attachments=AttachmentConfig(
+            channel_privacy_tiers={INTIMATE_ID: "intimate", ALL_TIER_ID: "all"}
+        ),
+    )
+
+
+@pytest.fixture
+def capture_dir(config: CrawDadConfig) -> Path:
+    """A pre-fix capture tree: one admitted dir, three refused, one unresolved."""
+    root = config.vault_path / config.capture_subpath
+    _write_channel(
+        root,
+        str(ADMITTED_ID),
+        [
+            _record("1", "2026-01-02T10:00:00+00:00", "geoff"),
+            _record("2", "2026-01-05T11:30:00+00:00", "geoff"),
+        ],
+        date="2026-01-02",
+    )
+    _write_channel(
+        root,
+        str(INTIMATE_ID),
+        [_record("3", "2026-02-01T09:00:00+00:00", "geoff")],
+        date="2026-02-01",
+    )
+    _write_channel(
+        root,
+        str(ALL_TIER_ID),
+        [_record("4", "2026-02-02T09:00:00+00:00", "geoff")],
+        date="2026-02-02",
+    )
+    _write_channel(
+        root,
+        str(STRANGER_ID),
+        [
+            _record("5", "2026-03-01T08:00:00+00:00", "stranger"),
+            _record("6", "2026-03-04T08:00:00+00:00", "otherbot"),
+        ],
+        date="2026-03-01",
+    )
+    _write_channel(
+        root,
+        NAMED_LABEL,
+        [_record("7", "2026-04-01T08:00:00+00:00", "stranger")],
+        date="2026-04-01",
+    )
+    _write_channel(
+        root,
+        NUMERIC_NAME,
+        [_record("8", "2026-05-01T08:00:00+00:00", "geoff")],
+        date="2026-05-01",
+    )
+    return root
+
+
+def _by_label(config: CrawDadConfig, capture_dir: Path) -> dict[str, Any]:
+    """Audit the tree and index the results by channel label."""
+    return {
+        audit.label: audit
+        for audit in audit_capture_tree(capture_dir=capture_dir, config=config)
+    }
+
+
+# --------------------------------------------------------------------------
+# Audit
+# --------------------------------------------------------------------------
+
+
+def test_audit_covers_every_channel_directory(
+    config: CrawDadConfig, capture_dir: Path
+) -> None:
+    """Every channel dir on disk appears in the audit, sorted by label."""
+    audits = audit_capture_tree(capture_dir=capture_dir, config=config)
+
+    assert [a.label for a in audits] == sorted(
+        [
+            str(ADMITTED_ID),
+            str(INTIMATE_ID),
+            str(ALL_TIER_ID),
+            str(STRANGER_ID),
+            NAMED_LABEL,
+            NUMERIC_NAME,
+        ]
+    )
+
+
+def test_audit_reports_record_count_and_date_range(
+    config: CrawDadConfig, capture_dir: Path
+) -> None:
+    """A channel's record count and first/last timestamp come back exactly."""
+    audit = _by_label(config, capture_dir)[str(ADMITTED_ID)]
+
+    assert audit.record_count == 2
+    assert audit.first_timestamp == "2026-01-02T10:00:00+00:00"
+    assert audit.last_timestamp == "2026-01-05T11:30:00+00:00"
+
+
+def test_audit_reports_distinct_author_names(
+    config: CrawDadConfig, capture_dir: Path
+) -> None:
+    """Authors are the sorted distinct display names captured in the dir."""
+    audit = _by_label(config, capture_dir)[str(STRANGER_ID)]
+
+    assert audit.authors == ("otherbot", "stranger")
+
+
+def test_audit_admits_an_allowlisted_default_tier_channel(
+    config: CrawDadConfig, capture_dir: Path
+) -> None:
+    """An allowlisted channel with no tier override is ADMITTED at ``personal``."""
+    audit = _by_label(config, capture_dir)[str(ADMITTED_ID)]
+
+    assert audit.verdict is CaptureVerdict.ADMITTED
+    assert audit.channel_id == ADMITTED_ID
+    assert audit.declared_tier == "personal"
+
+
+def test_audit_refuses_a_channel_absent_from_the_allowlist(
+    config: CrawDadConfig, capture_dir: Path
+) -> None:
+    """A numeric dir whose id is not allowlisted is REFUSED, and says why."""
+    audit = _by_label(config, capture_dir)[str(STRANGER_ID)]
+
+    assert audit.verdict is CaptureVerdict.REFUSED
+    assert "allowed_channel_ids" in audit.reason
+
+
+def test_audit_refuses_an_intimate_channel(
+    config: CrawDadConfig, capture_dir: Path
+) -> None:
+    """An allowlisted channel declared ``intimate`` is REFUSED on the tier."""
+    audit = _by_label(config, capture_dir)[str(INTIMATE_ID)]
+
+    assert audit.verdict is CaptureVerdict.REFUSED
+    assert audit.declared_tier == "intimate"
+    assert "intimate" in audit.reason
+
+
+def test_audit_refuses_a_channel_declared_all(
+    config: CrawDadConfig, capture_dir: Path
+) -> None:
+    """``all`` admits intimate content by definition, so it is REFUSED too."""
+    audit = _by_label(config, capture_dir)[str(ALL_TIER_ID)]
+
+    assert audit.verdict is CaptureVerdict.REFUSED
+    assert audit.declared_tier == "all"
+
+
+def test_audit_leaves_a_name_labelled_directory_unresolved(
+    config: CrawDadConfig, capture_dir: Path
+) -> None:
+    """A dir named after the channel carries no id, so no verdict is derivable."""
+    audit = _by_label(config, capture_dir)[NAMED_LABEL]
+
+    assert audit.verdict is CaptureVerdict.UNRESOLVED
+    assert audit.channel_id is None
+    assert audit.declared_tier is None
+
+
+def test_audit_leaves_an_all_digit_channel_name_unresolved(
+    config: CrawDadConfig, capture_dir: Path
+) -> None:
+    """A channel *named* ``2024`` is a name, not id 2024 — so it gets no verdict.
+
+    Discord snowflakes are ~17-19 digits; a short numeric name can never be a
+    real channel id. Reading one as an id would look up 2024 in the allowlist,
+    miss, and mark a possibly-allowlisted channel REFUSED.
+    """
+    audit = _by_label(config, capture_dir)[NUMERIC_NAME]
+
+    assert audit.verdict is CaptureVerdict.UNRESOLVED
+    assert audit.channel_id is None
+
+
+def test_purge_never_auto_targets_an_all_digit_channel_name(
+    config: CrawDadConfig, capture_dir: Path
+) -> None:
+    """The teeth of it: a digit-named channel survives a default ``--apply``.
+
+    Misreading the name as an id would make it REFUSED, and refused dirs are
+    purged with no ``--channel`` flag and no confirmation — silently destroying
+    a legitimate channel's whole capture history.
+    """
+    plan = plan_purge(audits=audit_capture_tree(capture_dir=capture_dir, config=config))
+
+    apply_purge(capture_dir=capture_dir, plan=plan)
+
+    assert (capture_dir / NUMERIC_NAME).is_dir()
+    assert NUMERIC_NAME not in {t.label for t in plan.targets}
+
+
+def test_audit_resolves_a_label_with_a_leading_zero_as_a_name(
+    config: CrawDadConfig, capture_dir: Path
+) -> None:
+    """A zero-padded digit string is a name — no snowflake ever leads with 0."""
+    _write_channel(
+        capture_dir,
+        "0" + str(STRANGER_ID)[1:],
+        [_record("9", "2026-06-01T08:00:00+00:00", "stranger")],
+        date="2026-06-01",
+    )
+
+    audit = _by_label(config, capture_dir)["0" + str(STRANGER_ID)[1:]]
+
+    assert audit.verdict is CaptureVerdict.UNRESOLVED
+
+
+def test_audit_of_a_missing_capture_root_is_empty(
+    config: CrawDadConfig, tmp_path: Path
+) -> None:
+    """No capture tree on disk audits to nothing rather than raising."""
+    assert audit_capture_tree(capture_dir=tmp_path / "absent", config=config) == ()
+
+
+def test_audit_skips_loose_files_at_the_capture_root(
+    config: CrawDadConfig, capture_dir: Path
+) -> None:
+    """A stray file beside the channel dirs is not reported as a channel."""
+    (capture_dir / "README.txt").write_text("not a channel", encoding="utf-8")
+
+    assert "README.txt" not in _by_label(config, capture_dir)
+
+
+def test_audit_tolerates_a_malformed_jsonl_line(
+    config: CrawDadConfig, capture_dir: Path
+) -> None:
+    """A corrupt line is skipped; the surrounding records still count."""
+    (capture_dir / str(ADMITTED_ID) / "2026-01-09.jsonl").write_text(
+        "{not json\n" + json.dumps(_record("8", "2026-01-09T00:00:00+00:00", "geoff")),
+        encoding="utf-8",
+    )
+
+    assert _by_label(config, capture_dir)[str(ADMITTED_ID)].record_count == 3
+
+
+def test_audit_does_not_modify_the_capture_tree(
+    config: CrawDadConfig, capture_dir: Path
+) -> None:
+    """Audit is read-only — every file survives byte-identical."""
+    before = {path: path.read_bytes() for path in sorted(capture_dir.rglob("*.jsonl"))}
+
+    audit_capture_tree(capture_dir=capture_dir, config=config)
+
+    assert {
+        path: path.read_bytes() for path in sorted(capture_dir.rglob("*.jsonl"))
+    } == before
+
+
+def test_audit_report_names_every_channel_and_its_verdict(
+    config: CrawDadConfig, capture_dir: Path
+) -> None:
+    """The rendered report is usable on its own to decide what to purge."""
+    audits = audit_capture_tree(capture_dir=capture_dir, config=config)
+
+    report = format_audit_report(capture_dir=capture_dir, audits=audits)
+
+    assert str(STRANGER_ID) in report
+    assert NAMED_LABEL in report
+    assert "refused" in report
+    assert "unresolved" in report
+    assert "stranger" in report  # the author column
+
+
+def test_audit_report_states_the_whole_directory_limitation(
+    config: CrawDadConfig, capture_dir: Path
+) -> None:
+    """The report says out loud that per-record purge is not possible."""
+    audits = audit_capture_tree(capture_dir=capture_dir, config=config)
+
+    report = format_audit_report(capture_dir=capture_dir, audits=audits)
+
+    assert "whole channel directories" in report
+    assert "allowed_user_ids" in report
+
+
+def test_audit_report_counts_read_naturally(
+    config: CrawDadConfig, capture_dir: Path
+) -> None:
+    """Counts are pluralised, so a one-record dir does not read ``1 records``."""
+    audits = audit_capture_tree(capture_dir=capture_dir, config=config)
+
+    report = format_audit_report(capture_dir=capture_dir, audits=audits)
+
+    assert "1 record " in report
+    assert "1 records" not in report
+    assert "6 channel directories" in report
+
+
+def test_audit_report_discloses_skipped_symlinks(
+    config: CrawDadConfig, capture_dir: Path, tmp_path: Path
+) -> None:
+    """A symlink in the tree is named in the report, not silently omitted.
+
+    The report claims to be sufficient on its own to decide a purge; silently
+    dropping an entry that exists on disk would make that claim false.
+    """
+    (capture_dir / "linked").symlink_to(tmp_path, target_is_directory=True)
+    audits = audit_capture_tree(capture_dir=capture_dir, config=config)
+
+    report = format_audit_report(
+        capture_dir=capture_dir,
+        audits=audits,
+        skipped=list_skipped_entries(capture_dir),
+    )
+
+    assert "linked" in report
+    assert "symlink" in report.lower()
+
+
+def test_list_skipped_entries_names_symlinks_and_loose_files(
+    config: CrawDadConfig, capture_dir: Path, tmp_path: Path
+) -> None:
+    """Both kinds of non-channel entry are reported, and real dirs are not."""
+    (capture_dir / "linked").symlink_to(tmp_path, target_is_directory=True)
+    (capture_dir / "README.txt").write_text("notes", encoding="utf-8")
+
+    skipped = list_skipped_entries(capture_dir)
+
+    assert sorted(skipped) == ["README.txt", "linked"]
+
+
+def test_list_skipped_entries_of_a_missing_root_is_empty(tmp_path: Path) -> None:
+    """No capture tree means nothing was skipped."""
+    assert list_skipped_entries(tmp_path / "absent") == ()
+
+
+def test_audit_report_of_an_empty_tree_says_so(
+    config: CrawDadConfig, tmp_path: Path
+) -> None:
+    """An empty tree renders a report rather than a blank string."""
+    report = format_audit_report(capture_dir=tmp_path / "absent", audits=())
+
+    assert "no channel directories" in report.lower()
+
+
+# --------------------------------------------------------------------------
+# Purge planning
+# --------------------------------------------------------------------------
+
+
+def test_purge_plan_targets_every_refused_channel(
+    config: CrawDadConfig, capture_dir: Path
+) -> None:
+    """Refused channels are targeted with no operator request needed."""
+    plan = plan_purge(audits=audit_capture_tree(capture_dir=capture_dir, config=config))
+
+    assert sorted(t.label for t in plan.targets) == sorted(
+        [str(INTIMATE_ID), str(ALL_TIER_ID), str(STRANGER_ID)]
+    )
+
+
+def test_purge_plan_never_targets_an_admitted_channel(
+    config: CrawDadConfig, capture_dir: Path
+) -> None:
+    """The gate-admitted channel is absent from the default plan."""
+    plan = plan_purge(audits=audit_capture_tree(capture_dir=capture_dir, config=config))
+
+    assert str(ADMITTED_ID) not in {t.label for t in plan.targets}
+
+
+def test_purge_plan_never_targets_an_unresolved_channel_by_default(
+    config: CrawDadConfig, capture_dir: Path
+) -> None:
+    """An unresolved dir may hold legitimate data, so it needs an explicit ask."""
+    plan = plan_purge(audits=audit_capture_tree(capture_dir=capture_dir, config=config))
+
+    assert NAMED_LABEL not in {t.label for t in plan.targets}
+
+
+def test_purge_plan_accepts_an_explicit_unresolved_channel(
+    config: CrawDadConfig, capture_dir: Path
+) -> None:
+    """Naming an unresolved dir on the command line promotes it to a target."""
+    plan = plan_purge(
+        audits=audit_capture_tree(capture_dir=capture_dir, config=config),
+        requested_labels=(NAMED_LABEL,),
+    )
+
+    assert NAMED_LABEL in {t.label for t in plan.targets}
+
+
+def test_purge_plan_declines_an_explicit_admitted_channel(
+    config: CrawDadConfig, capture_dir: Path
+) -> None:
+    """Even named explicitly, a gate-admitted channel is refused, with a reason."""
+    plan = plan_purge(
+        audits=audit_capture_tree(capture_dir=capture_dir, config=config),
+        requested_labels=(str(ADMITTED_ID),),
+    )
+
+    assert str(ADMITTED_ID) not in {t.label for t in plan.targets}
+    assert dict(plan.declined)[str(ADMITTED_ID)].startswith("the current capture gate")
+
+
+def test_purge_plan_declines_an_unknown_label(
+    config: CrawDadConfig, capture_dir: Path
+) -> None:
+    """A label with no directory is declined rather than silently ignored."""
+    audits = audit_capture_tree(capture_dir=capture_dir, config=config)
+
+    plan = plan_purge(audits=audits, requested_labels=("no-such-channel",))
+
+    assert [t.label for t in plan.targets] == [
+        t.label for t in plan_purge(audits=audits).targets
+    ]
+    assert "no such channel directory" in dict(plan.declined)["no-such-channel"]
+
+
+def test_purge_plan_declines_a_traversal_label(
+    config: CrawDadConfig, capture_dir: Path
+) -> None:
+    """A ``..`` label matches no audited dir and can never become a target."""
+    plan = plan_purge(
+        audits=audit_capture_tree(capture_dir=capture_dir, config=config),
+        requested_labels=("../../etc",),
+    )
+
+    assert "../../etc" not in {t.label for t in plan.targets}
+    assert "no such channel directory" in dict(plan.declined)["../../etc"]
+
+
+def test_purge_plan_does_not_duplicate_an_explicit_refused_channel(
+    config: CrawDadConfig, capture_dir: Path
+) -> None:
+    """Asking for an already-targeted refused dir is idempotent."""
+    plan = plan_purge(
+        audits=audit_capture_tree(capture_dir=capture_dir, config=config),
+        requested_labels=(str(STRANGER_ID),),
+    )
+
+    assert [t.label for t in plan.targets].count(str(STRANGER_ID)) == 1
+    assert plan.declined == ()
+
+
+# --------------------------------------------------------------------------
+# Purge application
+# --------------------------------------------------------------------------
+
+
+def test_apply_purge_removes_every_refused_directory(
+    config: CrawDadConfig, capture_dir: Path
+) -> None:
+    """The refused dirs are gone from disk after the purge is applied."""
+    plan = plan_purge(audits=audit_capture_tree(capture_dir=capture_dir, config=config))
+
+    apply_purge(capture_dir=capture_dir, plan=plan)
+
+    assert not (capture_dir / str(INTIMATE_ID)).exists()
+    assert not (capture_dir / str(ALL_TIER_ID)).exists()
+    assert not (capture_dir / str(STRANGER_ID)).exists()
+
+
+def test_apply_purge_never_deletes_records_the_gate_would_admit(
+    config: CrawDadConfig, capture_dir: Path
+) -> None:
+    """The acceptance pin: admitted records survive a purge byte-identical."""
+    admitted = capture_dir / str(ADMITTED_ID)
+    before = {p.name: p.read_bytes() for p in sorted(admitted.glob("*.jsonl"))}
+    plan = plan_purge(
+        audits=audit_capture_tree(capture_dir=capture_dir, config=config),
+        requested_labels=(str(ADMITTED_ID), NAMED_LABEL),
+    )
+
+    apply_purge(capture_dir=capture_dir, plan=plan)
+
+    assert admitted.is_dir()
+    assert {p.name: p.read_bytes() for p in sorted(admitted.glob("*.jsonl"))} == before
+
+
+def test_apply_purge_leaves_an_unrequested_unresolved_directory_alone(
+    config: CrawDadConfig, capture_dir: Path
+) -> None:
+    """Unresolved data is preserved unless the operator names it."""
+    plan = plan_purge(audits=audit_capture_tree(capture_dir=capture_dir, config=config))
+
+    apply_purge(capture_dir=capture_dir, plan=plan)
+
+    assert (capture_dir / NAMED_LABEL).is_dir()
+
+
+def test_apply_purge_removes_an_explicitly_named_unresolved_directory(
+    config: CrawDadConfig, capture_dir: Path
+) -> None:
+    """An explicitly named unresolved dir is deleted once ``--apply`` is given."""
+    plan = plan_purge(
+        audits=audit_capture_tree(capture_dir=capture_dir, config=config),
+        requested_labels=(NAMED_LABEL,),
+    )
+
+    apply_purge(capture_dir=capture_dir, plan=plan)
+
+    assert not (capture_dir / NAMED_LABEL).exists()
+
+
+def test_apply_purge_returns_the_labels_it_deleted(
+    config: CrawDadConfig, capture_dir: Path
+) -> None:
+    """The applied labels come back so a caller can report them exactly."""
+    plan = plan_purge(audits=audit_capture_tree(capture_dir=capture_dir, config=config))
+
+    deleted = apply_purge(capture_dir=capture_dir, plan=plan)
+
+    assert sorted(deleted) == sorted(
+        [str(INTIMATE_ID), str(ALL_TIER_ID), str(STRANGER_ID)]
+    )
+
+
+def test_apply_purge_refuses_a_target_outside_the_capture_root(
+    config: CrawDadConfig, capture_dir: Path, tmp_path: Path
+) -> None:
+    """A hand-built plan pointing outside the root raises before deleting."""
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "keep.txt").write_text("keep", encoding="utf-8")
+    audits = audit_capture_tree(capture_dir=capture_dir, config=config)
+    stranger = next(a for a in audits if a.label == str(STRANGER_ID))
+    escaped = replace(
+        plan_purge(audits=(stranger,)),
+        targets=(replace(stranger, label="../outside"),),
+    )
+
+    with pytest.raises(ValueError, match="capture root"):
+        apply_purge(capture_dir=capture_dir, plan=escaped)
+
+    assert (outside / "keep.txt").exists()
+    assert (capture_dir / str(STRANGER_ID)).is_dir()
+
+
+def test_apply_purge_never_follows_a_symlinked_channel_directory(
+    config: CrawDadConfig, capture_dir: Path, tmp_path: Path
+) -> None:
+    """A symlink parked in the capture tree is neither audited nor deleted."""
+    outside = tmp_path / "elsewhere"
+    outside.mkdir()
+    (outside / "keep.txt").write_text("keep", encoding="utf-8")
+    (capture_dir / "8888").symlink_to(outside, target_is_directory=True)
+
+    plan = plan_purge(audits=audit_capture_tree(capture_dir=capture_dir, config=config))
+    apply_purge(capture_dir=capture_dir, plan=plan)
+
+    assert (outside / "keep.txt").exists()
+    assert "8888" not in {t.label for t in plan.targets}
+
+
+def test_purge_report_dry_run_says_nothing_was_deleted(
+    config: CrawDadConfig, capture_dir: Path
+) -> None:
+    """The dry-run report shows the targets and denies having deleted them."""
+    plan = plan_purge(audits=audit_capture_tree(capture_dir=capture_dir, config=config))
+
+    report = format_purge_report(capture_dir=capture_dir, plan=plan, applied=False)
+
+    assert "DRY RUN" in report
+    assert "--apply" in report
+    assert str(STRANGER_ID) in report
+
+
+def test_purge_report_applied_says_what_it_deleted(
+    config: CrawDadConfig, capture_dir: Path
+) -> None:
+    """The applied report names the deleted dirs and warns it is irreversible."""
+    plan = plan_purge(audits=audit_capture_tree(capture_dir=capture_dir, config=config))
+
+    report = format_purge_report(capture_dir=capture_dir, plan=plan, applied=True)
+
+    assert "DRY RUN" not in report
+    assert "Deleted" in report
+    assert str(INTIMATE_ID) in report
+
+
+def test_purge_report_lists_declined_requests(
+    config: CrawDadConfig, capture_dir: Path
+) -> None:
+    """A declined request is visible in the report, not swallowed."""
+    plan = plan_purge(
+        audits=audit_capture_tree(capture_dir=capture_dir, config=config),
+        requested_labels=(str(ADMITTED_ID),),
+    )
+
+    report = format_purge_report(capture_dir=capture_dir, plan=plan, applied=False)
+
+    assert "Declined" in report
+    assert str(ADMITTED_ID) in report
+
+
+def test_purge_report_with_no_targets_says_so(
+    config: CrawDadConfig, tmp_path: Path
+) -> None:
+    """An already-clean tree reports nothing to do."""
+    report = format_purge_report(
+        capture_dir=tmp_path / "absent", plan=plan_purge(audits=()), applied=False
+    )
+
+    assert "nothing to purge" in report.lower()
+
+
+# --------------------------------------------------------------------------
+# CLI wiring
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def patched_load(
+    config: CrawDadConfig, capture_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> Path:
+    """Point ``cli.load_config`` at the fixture config; return the capture root."""
+    monkeypatch.setattr(cli, "load_config", lambda _path=None: config)
+    return capture_dir
+
+
+def test_cli_capture_audit_prints_the_report(
+    patched_load: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``crawdad capture audit`` writes the audit to stdout and deletes nothing."""
+    cli.main(["capture", "audit"])
+
+    out = capsys.readouterr().out
+    assert str(STRANGER_ID) in out
+    assert (patched_load / str(STRANGER_ID)).is_dir()
+
+
+def test_cli_capture_purge_defaults_to_a_dry_run(
+    patched_load: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``crawdad capture purge`` with no ``--apply`` deletes nothing at all."""
+    cli.main(["capture", "purge"])
+
+    assert "DRY RUN" in capsys.readouterr().out
+    assert (patched_load / str(STRANGER_ID)).is_dir()
+    assert (patched_load / str(INTIMATE_ID)).is_dir()
+
+
+def test_cli_capture_purge_apply_deletes_the_refused_dirs(
+    patched_load: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``--apply`` performs the deletion the dry run described."""
+    cli.main(["capture", "purge", "--apply"])
+
+    capsys.readouterr()
+    assert not (patched_load / str(STRANGER_ID)).exists()
+    assert (patched_load / str(ADMITTED_ID)).is_dir()
+
+
+def test_cli_capture_purge_channel_flag_targets_an_unresolved_dir(
+    patched_load: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``--channel`` promotes a named dir into the purge set."""
+    cli.main(["capture", "purge", "--channel", NAMED_LABEL, "--apply"])
+
+    capsys.readouterr()
+    assert not (patched_load / NAMED_LABEL).exists()
+
+
+def test_cli_capture_requires_a_mode(patched_load: Path) -> None:
+    """Bare ``crawdad capture`` exits with usage rather than guessing."""
+    with pytest.raises(SystemExit):
+        cli.main(["capture"])
+
+
+def test_cli_capture_purge_never_deletes_an_admitted_dir_on_request(
+    patched_load: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """End to end: naming the admitted channel is declined, not obeyed."""
+    cli.main(["capture", "purge", "--channel", str(ADMITTED_ID), "--apply"])
+
+    out = capsys.readouterr().out
+    assert (patched_load / str(ADMITTED_ID)).is_dir()
+    assert "Declined" in out


### PR DESCRIPTION
## Summary

#1052 stopped future bad bot-capture writes. It did nothing about what a pre-fix
build already wrote. An operator who ran with `capture_enabled: true` before that
fix has a `<vault>/discord-capture/` tree holding messages from non-allowlisted
users, other bots, and channels declared `intimate` — all untiered, and all still
ingestible: `stage_capture_as_data_package` iterates every channel dir with no
allowlist or tier filter, and the result lands as `unclassified`, which ranks
*with* `personal`.

This adds the offline remediation helper — `crawdad capture audit|purge` — plus
the operator documentation. It does **not** change the live capture gate (#1052
owns that) or the capture file format.

### Premise re-verified

All three `file:line` references in the issue body still hold exactly, despite
#1052/#1152/#1054/#1088 all merging since it was filed:

| Cited | Status |
|---|---|
| `creek-tools/creek/ingest/discord.py:819-831` (`stage_capture_as_data_package` unfiltered walk) | exact |
| `creek-tools/creek/ingest/discord.py:864-889` (`ingest_capture_dir`) | exact |
| `crawdad/crawdad/capture.py:165-173` (`_seen_ids` dedup seeded from stale files) | exact |

### Design

**Audit is the default and read-only. Purge is a dry run unless `--apply`.**
Deletion is irreversible, so nothing goes until the operator has been shown the
target list in the same vocabulary the audit uses.

**The purge unit is a whole channel directory, never an individual record.**
This is the partial-match decision, and it is forced by the on-disk format
rather than chosen for convenience. `capture.py::_record_for` writes `id`,
`timestamp`, `content`, `author.name` and an optional `reference` — no user id
and no channel id. So of the three conditions `bot.py::_capture_allowed` checks,
only the two channel-level ones are re-derivable from disk; `allowed_user_ids`
is not. Filtering records by display name would match on a mutable, spoofable
key and would either destroy legitimate messages or leave the leak while
reporting it fixed. Instead the audit reports the distinct author names per
directory so the operator can see who is in there, and the limitation is printed
in the tool's own output — not just in the docs.

**A name-labelled directory gets no verdict.** `_channel_label` prefers the
channel *name*, and a name cannot be mapped back to an id offline. Guessing is
the one way this helper could delete admitted data, so those dirs are reported
`unresolved` and left alone until the operator names one with `--channel`.

**"All digits" does not mean "is an id."** A directory is read as a channel id
only when it could plausibly be a snowflake: ASCII digits, no leading zero, and
at least 15 of them (Discord ids are `(ms since the 2015 epoch) << 22`). Digit-
only channel *names* are ordinary — `2024`, `420`, `911` — and reading one as an
id misses the allowlist, marks the directory `refused`, and deletes it on a
default `--apply` with no confirmation. The floor errs safe both ways: a very
early-2015 id-labelled dir would fall through to `unresolved`, costing one
`--channel` flag rather than costing data.

| Verdict | Purged? |
|---|---|
| `admitted` — allowlisted channel at an admitted tier | **Never**, even when named explicitly |
| `refused` — id not in `allowed_channel_ids`, or tier `intimate`/`all` | Yes, by default |
| `unresolved` — name-labelled, no id derivable | Only when named with `--channel` |

**Privacy ratchet.** Every path can only make the tree *less* exposed. The worst
outcome of a bug here is that a refused directory survives and the operator
deletes it by hand — the status quo. Nothing widens what is ingestible and
nothing lowers a tier.

`_verdict_for` reads `allowed_channel_ids` and `CAPTURE_ADMITTED_TIERS` directly,
in the same order `_capture_allowed` does, rather than keeping a second copy of
the gate's rules. `apply_purge` validates every target against the resolved
capture root *before* deleting any, so a hand-built plan naming a path outside
the root removes nothing at all.

### Files

All changes are under `crawdad/`. **No creek-tools source was touched**, so only
the crawdad gate applies.

- new `crawdad/crawdad/capture_audit.py` — audit + purge logic
- new `crawdad/tests/test_capture_audit.py` — 41 tests
- `crawdad/crawdad/cli.py` — `crawdad capture audit|purge` subcommands
- `crawdad/crawdad/capture.py` — extracted `iter_channel_records(channel_dir)`;
  `MessageCapture._iter_records` delegates to it so the audit does not grow a
  second JSONL parser. No format or gate change.
- `crawdad/README.md` — the upgrade note (Task 4)
- `crawdad/CLAUDE.md` — §5.2 maintainer note on the two structural limits

## Test plan

`crawdad/scripts/check-all.sh` — 7/7 green (lint, format, mypy strict, bandit +
pip-audit, interrogate, xenon, tests). 736 tests pass; coverage 94.88% against a
90% floor. 47 tests in `test_capture_audit.py`.

Five guards were each reverted in turn to prove they are load-bearing, and each
took down exactly the intended tests and no others:

| Guard reverted | Tests that went red |
|---|---|
| snowflake length floor in `_resolve_channel_id` | 5 — incl. `test_purge_never_auto_targets_an_all_digit_channel_name` |
| `plan_purge` declining an explicitly-named admitted dir | 4 — incl. `test_apply_purge_never_deletes_records_the_gate_would_admit` and the CLI end-to-end |
| `apply_purge` capture-root confinement | 1 — `test_apply_purge_refuses_a_target_outside_the_capture_root` |
| unresolved dirs not auto-targeted | 4 — incl. `test_apply_purge_leaves_an_unrequested_unresolved_directory_alone` |
| CLI dry-run default (`if args.apply`) | 1 — `test_cli_capture_purge_defaults_to_a_dry_run` |

## Gate 2.5

`code-review-orchestrator` returned **FIX_REQUIRED** with one blocker and two
nits. All three are fixed; the blocker was fixed test-first.

**🔴 Blocker — digit-only channel names auto-purged.** `_resolve_channel_id`
treated any all-digit label as a channel id, so a channel *named* `2024` was
misread as id 2024, missed the allowlist, and was classified `refused` — which
`plan_purge` auto-targets with no `--channel` flag and no confirmation. The RED
test failed exactly as predicted before the fix:

```
>       assert (capture_dir / NUMERIC_NAME).is_dir()
E       AssertionError: assert False
E        +    where is_dir = (PosixPath('.../vault/discord-capture') / '2024').is_dir
```

That is silent, irreversible deletion of a legitimate channel's whole capture
history — the one direction this tool must never fail in, and a direct
contradiction of its own stated invariant. Fixed with the snowflake floor above,
plus three regression tests (numeric name, leading zero, and the destructive
end-to-end case). Test fixtures now use realistic 18-digit snowflakes rather than
toy ints, so they exercise the path a real capture tree produces.

**🟡 Nit — symlinks silently skipped.** The audit skipped symlinks and loose
files without saying so, undercutting the report's claim to be sufficient on its
own. Added `list_skipped_entries` and a disclosure line naming them.

**🔵 Nit — undocumented ordering assumption.** Timestamps are compared as strings.
Now documents *why* that is exact (fixed-width UTC prefix; `+` at ASCII 43 sorts
before `.` at 46, so a zero-microsecond stamp still orders correctly) and that a
writer format change would break it silently.

The reviewer separately confirmed clean: `_verdict_for` has no drift from
`bot.py::_capture_allowed`; `apply_purge` confinement holds against traversal,
hand-built plans and TOCTOU (`shutil.rmtree` refuses a symlink argument); the
tests are behavioural throughout; and the `iter_channel_records` extraction is a
pure refactor.

The fixture tree deliberately mixes directories the gate would admit with
directories it would refuse, so every assertion is behavioural — what the audit
*reports* and what the purge *removes*, never that a symbol exists.

Also smoke-tested against a real on-disk tree via `python -m crawdad.cli capture
audit|purge` to confirm the report reads correctly for an operator.

## Acceptance criteria

- [x] An operator can enumerate what a pre-fix capture tree holds without reading
      JSONL by hand — `crawdad capture audit` reports verdict, declared tier,
      record count, date range and distinct authors per channel dir.
- [x] Purge is opt-in and dry-run-by-default; `test_apply_purge_never_deletes_records_the_gate_would_admit`
      pins that it never deletes records the current gate would admit.
- [x] The upgrade note is in `crawdad/README.md`.
- [x] `crawdad/scripts/check-all.sh` passes. `creek-tools/scripts/check-all.sh` is
      not applicable — no creek-tools file was touched.

## Notes

No independent `chief-architect` pass was run: the issue's Tasks section already
fixed the shape and the orchestrator authorised skipping it. The design decisions
above are mine, not an architect's — the partial-match and unresolved-label calls
in particular deserve a reviewer's eye. Gate 2.5 review *was* run independently
and did catch a real blocker, which is some evidence the shortcut was survivable
here, not that it was free.

One gap is documented rather than closed: an `admitted` directory may still hold
messages from users who were never in `allowed_user_ids`, and no purge can
selectively remove them, for the reason given above. The audit surfaces the
author names so the operator can spot them and drop the whole directory.

Closes #1264
Refs #1052
