### PR TITLE
fix(vault): a torn index append costs one entry, not two, and is recoverable

### DIFF
--- a/creek-tools/creek/vault/writer.py
+++ b/creek-tools/creek/vault/writer.py
@@ -26,7 +26,7 @@ import tempfile
 import threading
 from datetime import UTC, date, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 import frontmatter
 import yaml
@@ -436,6 +436,30 @@ def _file_declares_id(path: Path, model_id: str) -> bool:
         return False
     declared = post.get("id")
     return isinstance(declared, str) and declared == model_id
+
+
+class _IndexLoad(NamedTuple):
+    """The outcome of parsing one ``.id-index.jsonl`` file (#1120).
+
+    Separates *what the file said* from *whether the file was intact*,
+    so a caller can tell an index that legitimately names nothing from
+    one that was damaged and therefore names less than it should.
+
+    Attributes:
+        entries: The ``{id: filename}`` mappings that parsed cleanly.
+        torn_lines: How many lines failed ``json.loads``. A torn append
+            leaves exactly one; a crash-heavy history can leave several.
+        read_failed: ``True`` when the file could not be read at all.
+    """
+
+    entries: dict[str, str]
+    torn_lines: int
+    read_failed: bool
+
+    @property
+    def damaged(self) -> bool:
+        """Return ``True`` when *entries* may be missing a real mapping."""
+        return self.torn_lines > 0 or self.read_failed
 
 
 def _is_material_change(old_body: str, new_body: str, threshold: float) -> bool:
@@ -888,6 +912,12 @@ class VaultWriter:
             _atomic_write_text(dest, frontmatter.dumps(post))
             existing.unlink()
             index = self._load_index_locked(orphan_dir)
+            # Deliberate ordering, preserved by #1120: the in-memory
+            # mapping is set BEFORE the append, so a failed append leaves
+            # this process still resolving the tombed file (already moved
+            # above) while a fresh process re-derives it from the damage
+            # rescan in ``_load_index_locked``. Reversing this would make
+            # a torn append lose the tomb for the rest of the run.
             index[fragment_id] = dest.name
             self._append_index_entry(orphan_dir, fragment_id, dest.name)
             self._log_provenance_locked(fragment_id, "fragment", dest)
@@ -923,6 +953,10 @@ class VaultWriter:
             _atomic_write_text(dest, frontmatter.dumps(post))
             existing.unlink()
             index = self._load_index_locked(target_dir)
+            # Same deliberate ordering as ``tomb_fragment`` — see the
+            # note there; the restored file is already on disk (above),
+            # so an in-memory mapping that outlives a torn append is the
+            # conservative side of the trade (#1120).
             index[fragment.id] = dest.name
             self._append_index_entry(target_dir, fragment.id, dest.name)
             self._log_provenance_locked(fragment.id, fragment.type, dest)
@@ -1123,6 +1157,11 @@ class VaultWriter:
             # it, but a future refactor that skips the dup-check
             # branch would otherwise hit a ``KeyError`` here.
             index = self._load_index_locked(target_dir)
+            # In-memory first, on-disk second — deliberate, and preserved
+            # by #1120. ``_atomic_create`` above already put the note on
+            # disk, so a torn append leaves this process resolving the
+            # id correctly and a fresh process recovering it from the
+            # damage rescan rather than minting a duplicate.
             index[model_id] = file_path.name
             self._append_index_entry(target_dir, model_id, file_path.name)
 
@@ -1200,7 +1239,10 @@ class VaultWriter:
                 :meth:`_append_index_entry`. A lookup-shaped method can
                 therefore raise, because a mismatch persists its repair.
             OSError: If persisting a repaired entry fails to write — same
-                origin, same reason it can escape a lookup.
+                origin, same reason it can escape a lookup. Since #1120
+                the partial record such a failure leaves behind is
+                self-terminating, so a torn repair no longer damages the
+                index it was repairing.
         """
         index = self._load_index_locked(target_dir)
         filename = index.get(model_id)
@@ -1256,7 +1298,10 @@ class VaultWriter:
         Both propagate from :meth:`_append_index_entry`. The in-memory
         mapping is corrected *before* the append, so a failure to persist
         leaves this process holding ground truth and the on-disk index
-        merely stale — a cost, not a correctness loss.
+        merely stale — a cost, not a correctness loss. Across processes
+        the same holds since #1120: the torn record this path can leave
+        is self-delimiting, and the unparseable line it forms is exactly
+        the damage signal that makes the next load re-resolve by scan.
         """
         resolved = self._rebuild_index(target_dir).get(model_id)
         if resolved is None:
@@ -1292,13 +1337,46 @@ class VaultWriter:
         last successful write wins). If the JSONL file is missing the
         index is rebuilt by scanning the directory's ``.md`` files and
         the result is persisted so subsequent processes skip the scan.
+
+        When the JSONL file is *present but damaged* — an unparseable
+        line, or a file that cannot be read at all — the mappings it
+        failed to yield are re-derived by scanning the directory (#1120).
+        Without that, a mapping lost to a torn append was permanent: a
+        rescan only ever ran when the file was missing, so an id absent
+        from a present index was never re-resolved and the next write
+        minted a second file for it.
+
+        Precedence on the recovery path is **scan wins**: any id a live
+        file declares takes the on-disk truth, and the parsed JSONL
+        entries only fill gaps the scan cannot see (an id whose file
+        was tombed, or whose frontmatter the scanner declines). The
+        direction matches :meth:`_repair_index_locked`, which also
+        prefers what the directory says over what the index claimed —
+        though that method resolves *purely* by scan and drops the id
+        when the scan misses, where this one keeps the parsed entry as a
+        fallback rather than discarding a mapping it cannot disprove.
+        Letting the parsed value win instead would preserve a mapping the
+        scan just disproved, and every later lookup would pay
+        verification, a second scan and a repair append to arrive at the
+        answer this load already had.
+
+        The recovery never calls :meth:`_persist_full_index`: a
+        whole-file rewrite from this process's snapshot would destroy
+        entries another process appended. The recovered index is cached
+        in ``self._dir_indexes``, so the scan is paid at most once per
+        directory per :class:`VaultWriter` instance — not once per
+        process, since a caller that builds several writers pays it once
+        for each.
         """
         cached = self._dir_indexes.get(target_dir)
         if cached is not None:
             return cached
         index_path = target_dir / INDEX_FILENAME
         if index_path.exists():
-            index = self._load_index_file(index_path)
+            load = self._read_index_records(index_path)
+            index = load.entries
+            if load.damaged:
+                index = self._recover_damaged_index(index_path, target_dir, load)
         elif target_dir.is_dir():
             index = self._rebuild_index(target_dir)
             self._persist_full_index(target_dir, index)
@@ -1308,6 +1386,34 @@ class VaultWriter:
         return index
 
     @staticmethod
+    def _recover_damaged_index(
+        index_path: Path,
+        target_dir: Path,
+        load: _IndexLoad,
+    ) -> dict[str, str]:
+        """Re-derive a damaged index by scanning *target_dir* (#1120).
+
+        Args:
+            index_path: The damaged JSONL file, named in the warning.
+            target_dir: The directory whose ``.md`` files are the truth.
+            load: The partial parse, whose surviving entries fill any
+                gap the scan cannot see.
+
+        Returns:
+            The merged index, with the disk scan taking precedence.
+        """
+        logger.warning(
+            "index %s has %d unparseable line(s)%s; re-resolving by directory scan",
+            index_path,
+            load.torn_lines,
+            " and could not be read" if load.read_failed else "",
+        )
+        recovered = VaultWriter._rebuild_index(target_dir)
+        for model_id, filename in load.entries.items():
+            recovered.setdefault(model_id, filename)
+        return recovered
+
+    @staticmethod
     def _load_index_file(index_path: Path) -> dict[str, str]:
         """Parse a JSONL index file into ``{id: filename}``.
 
@@ -1315,19 +1421,60 @@ class VaultWriter:
         cannot poison the rest of the index. Later entries overwrite
         earlier ones — appending an entry for an existing id therefore
         rewrites the mapping in-place.
+
+        Reports only the mappings. Callers that must also know whether
+        the file was *intact* — and therefore whether the mappings are
+        complete — use :meth:`_read_index_records` instead.
+        """
+        return VaultWriter._read_index_records(index_path).entries
+
+    @staticmethod
+    def _read_index_records(index_path: Path) -> _IndexLoad:
+        """Parse a JSONL index file, reporting damage alongside the entries.
+
+        Only two outcomes count as damage, because only they mean a
+        mapping that *should* be here is missing: a failure to read or
+        decode the file at all, and a ``json.JSONDecodeError`` (a torn
+        record, per #1120). A line that parses as valid JSON but is not
+        a ``{id: str, filename: str}`` object is *not* damage — it is a
+        well-formed line the schema declines, and treating it as damage
+        would buy a directory-wide scan for a file that is perfectly
+        intact.
+
+        ``UnicodeDecodeError`` joins ``OSError`` in the read guard. Our
+        own writers can only emit ASCII (``json.dumps`` escapes
+        non-ASCII by default), so a torn append cannot split a
+        multi-byte character — but a hand-edited or externally corrupted
+        index can still be undecodable, and letting that escape would
+        take down every vault write into the directory rather than
+        costing one directory scan.
+
+        Args:
+            index_path: The ``.id-index.jsonl`` file to parse.
+
+        Returns:
+            An :class:`_IndexLoad` holding the parsed mappings, the
+            count of unparseable lines, and whether the read failed.
         """
         index: dict[str, str] = {}
         try:
             raw = index_path.read_text(encoding="utf-8")
-        except OSError:
-            return index
+        except (OSError, UnicodeDecodeError):
+            return _IndexLoad(index, 0, read_failed=True)
+        torn_lines = 0
         for line in raw.splitlines():
             stripped = line.strip()
             if not stripped:
+                # Load-bearing for the #1120 framing: every appended
+                # record opens with its own newline, so a healthy file
+                # carries a blank line before each one. Dropping this
+                # skip would make every index written after #1120 look
+                # damaged.
                 continue
             try:
                 entry = json.loads(stripped)
             except json.JSONDecodeError:
+                torn_lines += 1
                 continue
             if not isinstance(entry, dict):
                 continue
@@ -1335,7 +1482,7 @@ class VaultWriter:
             filename = entry.get("filename")
             if isinstance(mid, str) and isinstance(filename, str):
                 index[mid] = filename
-        return index
+        return _IndexLoad(index, torn_lines, read_failed=False)
 
     @staticmethod
     def _rebuild_index(target_dir: Path) -> dict[str, str]:
@@ -1384,24 +1531,39 @@ class VaultWriter:
 
         The line is drained through :func:`creek._fsio.write_all`, so an
         ordinary short ``write(2)`` no longer leaves half a JSON line at
-        the tail (#987). If the line is genuinely un-drainable the
-        ``OSError`` propagates and a partial line survives at the tail.
-        That residual is worse than a single lost entry: ``O_APPEND``
-        writes always land at EOF with no separator of their own — the
-        trailing newline is part of the payload — so a remnant left
-        *without* its trailing newline is silently concatenated onto the
-        next successful append. The merged line is not valid JSON, so
-        :meth:`_load_index_file` skips it wholesale at
-        ``json.JSONDecodeError`` and **both** the failed entry and the
-        next legitimate one drop out of the index.
+        the tail (#987).
 
-        ``ftruncate``-back is not a safe alternative: under concurrent
-        ``O_APPEND`` writers the write offset is chosen atomically inside
-        the syscall, so we never reliably learn our own start offset, and
-        another appender may already have landed a complete line past
-        ours that the truncation would destroy. Tracked as issue #1120 —
-        a real fix needs a rewrite-under-lock or a framing change, both
-        out of scope for #987.
+        Each record is framed as ``\\n{json}\\n`` — a newline on *both*
+        sides, so it is self-delimiting at its start as well as its end
+        (#1120). ``O_APPEND`` writes land at EOF with no separator the
+        filesystem supplies, so a record that ends but does not begin
+        with a newline is silently concatenated onto whatever remnant
+        precedes it; the merged line is not valid JSON and takes the
+        innocent record down with the torn one. The leading newline
+        terminates any remnant, so a tear costs at most its own entry.
+        Both newlines are kept deliberately: leading-only is a byte
+        cheaper, but a mixed-version straddle — old code appending
+        ``{b}\\n`` straight after a new-code ``\\n{a}`` — would merge the
+        two and reintroduce the defect on live vault data.
+
+        The framing needs no migration. :meth:`_read_index_records`
+        already skips blank lines, so pre-#1120 files (and the
+        :meth:`_persist_full_index` output, which renames atomically and
+        can never tear) keep parsing byte-for-byte unchanged.
+
+        This method does **not** ``fsync``, unlike
+        :meth:`creek.audit.AuditLog.append`. The index is a
+        reconstructible cache, not a ledger: losing an unsynced tail to
+        a power cut costs a directory scan, not data. That is defensible
+        only because :meth:`_load_index_locked` now supplies the paired
+        recovery — a damaged or short index re-derives its mappings by
+        scanning the directory instead of reporting them as absent.
+
+        ``ftruncate``-back remains the rejected alternative: under
+        concurrent ``O_APPEND`` writers the write offset is chosen
+        atomically inside the syscall, so we never reliably learn our own
+        start offset, and another appender may already have landed a
+        complete line past ours that the truncation would destroy.
 
         Args:
             target_dir: Directory holding the index file.
@@ -1411,14 +1573,19 @@ class VaultWriter:
         Raises:
             ValueError: If the encoded line exceeds :data:`_PIPE_BUF_BYTES`,
                 which would void the ``O_APPEND`` atomicity guarantee.
-            OSError: If the line cannot be written in full. A
-                newline-less partial line may survive at the tail, taking
-                the next appended entry down with it (#1120, above).
+                The check counts the two framing bytes, so the ceiling is
+                honoured for what actually reaches the descriptor.
+            OSError: If the line cannot be written in full. The partial
+                record left at the tail is self-terminating, so it costs
+                only itself; the id it named is re-resolved by scan on
+                the next load (#1120).
         """
         target_dir.mkdir(parents=True, exist_ok=True)
         index_path = target_dir / INDEX_FILENAME
         encoded = (
-            json.dumps({"id": model_id, "filename": filename}, sort_keys=True) + "\n"
+            "\n"
+            + json.dumps({"id": model_id, "filename": filename}, sort_keys=True)
+            + "\n"
         ).encode("utf-8")
         if len(encoded) > _PIPE_BUF_BYTES:
             msg = (

--- a/creek-tools/tests/test_vault_writer.py
+++ b/creek-tools/tests/test_vault_writer.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 import errno
 import json
+import logging
+import os
 from datetime import date, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -1870,6 +1872,11 @@ class TestAtomicWriteHardening:
         Half a line is not valid JSON, so ``_load_index_file`` skips it and
         the id-to-filename mapping is silently dropped — the fragment
         becomes invisible to duplicate detection and to ``update_fragment``.
+
+        Also pins the on-the-wire framing: the record is bracketed by a
+        newline on *both* sides. The leading one is the record delimiter
+        that makes any remnant ahead of it self-terminating (#1120), so
+        it is part of the contract, not incidental whitespace.
         """
         from creek.vault.writer import INDEX_FILENAME
 
@@ -1882,7 +1889,9 @@ class TestAtomicWriteHardening:
 
         index_path = target_dir / INDEX_FILENAME
         expected = (
-            json.dumps({"id": model_id, "filename": filename}, sort_keys=True) + "\n"
+            "\n"
+            + json.dumps({"id": model_id, "filename": filename}, sort_keys=True)
+            + "\n"
         )
         assert index_path.read_text(encoding="utf-8") == expected
         assert VaultWriter._load_index_file(index_path) == {model_id: filename}
@@ -1908,30 +1917,26 @@ class TestAtomicWriteHardening:
         assert excinfo.value.errno == errno.EIO
         assert VaultWriter._load_index_file(target_dir / INDEX_FILENAME) == {}
 
-    def test_failed_index_append_also_swallows_the_next_entry(
+    def test_torn_index_append_does_not_swallow_the_next_entry(
         self,
         vault_path: Path,
         short_write: ShortWriteController,
     ) -> None:
-        """A half-written index line takes the *next* entry down with it.
+        """A half-written index line costs at most *its own* entry (#1120).
 
-        KNOWN DEFECT, tracked as issue #1120. This is a characterization
-        test: it pins the behaviour the code has **today**, not the
-        behaviour anybody wants. ``_append_index_entry`` opens with
-        ``O_APPEND``, so every line lands at EOF with no separator of its
-        own — the trailing newline is part of the payload. When a drain
-        fails part-way (``ENOSPC`` here, after half the bytes are on
-        disk) the remnant survives *without* that newline, and the next
-        successful append is concatenated straight onto it. The merged
-        line is not valid JSON, so ``_load_index_file`` skips it wholesale
-        at ``json.JSONDecodeError`` and **both** the failed entry and the
-        innocent next one drop out of the index.
+        The inversion of the #987-era characterization test that pinned
+        the defect. ``_append_index_entry`` opens with ``O_APPEND``, so
+        every record lands at EOF with no separator the filesystem
+        supplies. When a drain fails part-way (``ENOSPC`` here, after
+        half the bytes are on disk) a remnant survives at the tail.
 
-        ``ftruncate``-back is not a safe repair under concurrent
-        ``O_APPEND`` writers, so a real fix needs a rewrite-under-lock or
-        a framing change — out of scope for #987. When #1120 lands, this
-        test must be **inverted** (``frag-next`` at minimum, ideally both
-        entries, must survive), never deleted.
+        Each record is now framed as ``\\n{json}\\n``, so the *next*
+        record opens with a newline of its own: it terminates whatever
+        remnant precedes it instead of being concatenated onto it. The
+        torn entry is still lost at this layer — it never got its own
+        content on disk — but the innocent next entry parses cleanly.
+        Recovery of the torn id itself is the damage-rescan half of
+        #1120, covered by ``TestIndexDamageRecovery``.
         """
         from creek.vault.writer import INDEX_FILENAME
 
@@ -1970,16 +1975,130 @@ class TestAtomicWriteHardening:
         assert raw
         assert raw.endswith(next_line + "\n")
         assert len(raw) > len(next_line) + 1
-        # ...and the remnant carried no newline of its own, so the two
-        # collided into a single, unparseable line.
-        assert len(raw.splitlines()) == 1
+        # ...and the second record's leading newline terminated the
+        # remnant, so the two are separate lines rather than one merged,
+        # unparseable one. (Three elements, not two: the file now opens
+        # with a newline, so ``splitlines`` yields a leading empty item.)
+        assert len(raw.splitlines()) >= 2
 
         index = VaultWriter._load_index_file(index_path)
-        # State both absences explicitly: the failed entry is gone (bad
-        # but expected) and so is the *successful* one (the defect).
+        # The torn entry never reached disk in full, so it is genuinely
+        # absent — but the innocent next one survives.
         assert "frag-partial" not in index
-        assert "frag-next" not in index
-        assert index == {}
+        assert index["frag-next"] == "2025-01-16-next.md"
+        # A remnant must never be misread as some *other* valid mapping.
+        assert set(index) <= {"frag-partial", "frag-next"}
+
+    def test_any_torn_tail_prefix_leaves_the_next_entry_parseable(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Every byte-prefix of a record is a tolerable tail (#1120).
+
+        The forcing function. No exception is in flight anywhere here:
+        the torn tail is written straight to disk, which is what a
+        ``SIGKILL``/OOM/power loss between two ``os.write`` iterations
+        inside :func:`creek._fsio.write_all` actually leaves behind. A
+        fix that only cleans up inside an ``except OSError:`` handler
+        cannot satisfy this, because there is no handler to run.
+        """
+        from creek.vault.writer import INDEX_FILENAME
+
+        encoded = (
+            "\n"
+            + json.dumps({"id": "frag-torn", "filename": "torn.md"}, sort_keys=True)
+            + "\n"
+        ).encode()
+
+        for cut in range(len(encoded)):
+            target_dir = tmp_path / f"cut-{cut:03d}"
+            target_dir.mkdir()
+            index_path = target_dir / INDEX_FILENAME
+            index_path.write_bytes(encoded[:cut])
+
+            VaultWriter._append_index_entry(target_dir, "frag-next", "next.md")
+
+            index = VaultWriter._load_index_file(index_path)
+            assert index.get("frag-next") == "next.md", f"lost at cut={cut}"
+            assert set(index) <= {"frag-torn", "frag-next"}, f"phantom at cut={cut}"
+
+    def test_a_legacy_format_remnant_does_not_swallow_the_next_entry(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """An OLD-format torn tail is tolerated by a NEW-format append (#1120).
+
+        Every ``.id-index.jsonl`` in a live vault was written by the
+        pre-#1120 encoder, so any torn tail already on disk at upgrade
+        time has **no** leading newline. The new record supplies the
+        delimiter, so the legacy remnant terminates without a migration.
+        """
+        from creek.vault.writer import INDEX_FILENAME
+
+        target_dir = tmp_path / "legacy-remnant"
+        target_dir.mkdir()
+        index_path = target_dir / INDEX_FILENAME
+        index_path.write_bytes(b'{"filename": "old.md", "id": "frag-le')
+
+        VaultWriter._append_index_entry(target_dir, "frag-next", "next.md")
+
+        index = VaultWriter._load_index_file(index_path)
+        assert index["frag-next"] == "next.md"
+        assert set(index) == {"frag-next"}
+
+    def test_a_legacy_format_index_still_parses_unchanged(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Old-format complete records keep parsing beside new-format ones.
+
+        Pins the no-migration claim: the reader already skips blank
+        lines, so a file mixing both framings resolves every id.
+        """
+        from creek.vault.writer import INDEX_FILENAME
+
+        target_dir = tmp_path / "legacy-mixed"
+        target_dir.mkdir()
+        index_path = target_dir / INDEX_FILENAME
+        legacy = "".join(
+            json.dumps({"id": mid, "filename": f"{mid}.md"}, sort_keys=True) + "\n"
+            for mid in ("frag-old-a", "frag-old-b")
+        )
+        index_path.write_text(legacy, encoding="utf-8")
+
+        VaultWriter._append_index_entry(target_dir, "frag-new", "frag-new.md")
+
+        assert VaultWriter._load_index_file(index_path) == {
+            "frag-old-a": "frag-old-a.md",
+            "frag-old-b": "frag-old-b.md",
+            "frag-new": "frag-new.md",
+        }
+
+    def test_consecutive_torn_tails_do_not_compound(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Two remnants in a row still cost only themselves (#1120).
+
+        Two processes can tear back-to-back — one running pre-#1120 code
+        (no leading newline), one running post-#1120 code. Neither is
+        allowed to take the following healthy record down with it.
+        """
+        from creek.vault.writer import INDEX_FILENAME
+
+        target_dir = tmp_path / "consecutive"
+        target_dir.mkdir()
+        index_path = target_dir / INDEX_FILENAME
+        index_path.write_bytes(
+            b'{"filename": "old.md", "id": "frag-le'
+            b'\n{"filename": "newer.md", "id": "frag-ne',
+        )
+
+        VaultWriter._append_index_entry(target_dir, "frag-healthy", "healthy.md")
+
+        index = VaultWriter._load_index_file(index_path)
+        assert index["frag-healthy"] == "healthy.md"
+        assert set(index) == {"frag-healthy"}
 
     def test_write_fragment_survives_short_writes_end_to_end(
         self,
@@ -2017,6 +2136,236 @@ class TestAtomicWriteHardening:
         index_path = vault_path / "01-Fragments" / "Conversations" / INDEX_FILENAME
         index = VaultWriter._load_index_file(index_path)
         assert index == {"frag-short-e2e": path.name}
+
+
+class TestIndexDamageRecovery:
+    """A damaged ``.id-index.jsonl`` re-resolves by scan rather than lying (#1120).
+
+    Self-delimiting records stop a torn append from taking the *next*
+    one down with it, but the torn record's own mapping is still absent.
+    Before #1120 that absence was permanent: ``_load_index_locked``
+    rescanned only when the index file was *missing*, so an id absent
+    from a *present* index was never re-derived and ``_write_model``
+    minted a second file for it. These tests pin the recovery half.
+    """
+
+    def test_damaged_index_rescans_and_recovers_the_dropped_id(
+        self,
+        vault_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """An unparseable line makes the reader re-resolve, and say so."""
+        from creek.vault.writer import INDEX_FILENAME
+
+        seed = VaultWriter(vault_path=vault_path)
+        victim_path = _seed_victim(seed)
+        target_dir = victim_path.parent
+        edited = _edited_fragment()
+        owner_path = seed.write_fragment(edited, body="owner body")
+
+        # Hand-write an index that names only the victim and carries a
+        # torn line where the owner's record should be.
+        index_path = target_dir / INDEX_FILENAME
+        good = json.dumps(
+            {"id": "frag-victim001", "filename": victim_path.name},
+            sort_keys=True,
+        )
+        index_path.write_text(
+            f'{good}\n{{"filename": "{owner_path.name}", "id": "frag-edi',
+            encoding="utf-8",
+        )
+
+        fresh = VaultWriter(vault_path=vault_path)
+        with caplog.at_level(logging.WARNING, logger="creek.vault.writer"):
+            resolved = fresh._find_existing(edited.id, target_dir)
+
+        assert resolved == owner_path
+        messages = [record.getMessage() for record in caplog.records]
+        assert any(
+            INDEX_FILENAME in message and "1 unparseable line" in message
+            for message in messages
+        ), messages
+
+    def test_unreadable_index_rescans_instead_of_looking_empty(
+        self,
+        vault_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """An index that cannot be read is damage, not an empty directory.
+
+        The adjacent hole #1120 exposed: a read ``OSError`` used to
+        return ``{}``, which ``_load_index_locked`` then cached because
+        the file *existed* — silently identical to a vault with no
+        fragments, and every subsequent write a duplicate.
+        """
+        from pathlib import Path as RuntimePath
+
+        from creek.vault.writer import INDEX_FILENAME
+
+        seed = VaultWriter(vault_path=vault_path)
+        victim_path = _seed_victim(seed)
+        target_dir = victim_path.parent
+
+        real_read_text = RuntimePath.read_text
+
+        def _deny_index(path: Path, *args: Any, **kwargs: Any) -> str:
+            """Refuse to read the index file; pass everything else through."""
+            if path.name == INDEX_FILENAME:
+                raise OSError(errno.EACCES, os.strerror(errno.EACCES))
+            return real_read_text(path, *args, **kwargs)
+
+        monkeypatch.setattr(RuntimePath, "read_text", _deny_index)
+
+        fresh = VaultWriter(vault_path=vault_path)
+        with caplog.at_level(logging.WARNING, logger="creek.vault.writer"):
+            resolved = fresh._find_existing("frag-victim001", target_dir)
+
+        assert resolved == victim_path
+        messages = [record.getMessage() for record in caplog.records]
+        assert any("could not be read" in message for message in messages), messages
+
+    def test_undecodable_index_rescans_instead_of_crashing_the_write(
+        self,
+        vault_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Invalid UTF-8 in the index is damage, not an exception to the caller.
+
+        ``UnicodeDecodeError`` is a ``ValueError``, not an ``OSError``,
+        so it used to escape the read guard and take down every vault
+        write into the directory. Our own writers only ever emit ASCII
+        (``json.dumps`` escapes non-ASCII), so a torn append cannot
+        cause this — but a hand-edited or externally corrupted index
+        can, and a directory scan is the right price for it.
+        """
+        from creek.vault.writer import INDEX_FILENAME
+
+        seed = VaultWriter(vault_path=vault_path)
+        victim_path = _seed_victim(seed)
+        target_dir = victim_path.parent
+        (target_dir / INDEX_FILENAME).write_bytes(b'\n{"id": "\xff\xfe", "filen')
+
+        fresh = VaultWriter(vault_path=vault_path)
+        with caplog.at_level(logging.WARNING, logger="creek.vault.writer"):
+            resolved = fresh._find_existing("frag-victim001", target_dir)
+
+        assert resolved == victim_path
+        messages = [record.getMessage() for record in caplog.records]
+        assert any("could not be read" in message for message in messages), messages
+
+    def test_clean_index_never_rescans(
+        self,
+        vault_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An undamaged index still resolves in O(1) — no directory sweep.
+
+        Regression guard for PERF-001: the damage-triggered rescan must
+        stay triggered by damage, not paid on every cold load.
+        """
+
+        def _no_rescan(target_dir: Path) -> dict[str, str]:
+            """Fail loudly instead of scanning the directory."""
+            msg = f"unexpected directory rescan of {target_dir}"
+            raise AssertionError(msg)
+
+        seed = VaultWriter(vault_path=vault_path)
+        victim_path = _seed_victim(seed)
+        target_dir = victim_path.parent
+        monkeypatch.setattr(VaultWriter, "_rebuild_index", staticmethod(_no_rescan))
+
+        fresh = VaultWriter(vault_path=vault_path)
+
+        assert fresh._find_existing("frag-victim001", target_dir) == victim_path
+
+    def test_a_torn_index_tail_does_not_mint_a_duplicate_file(
+        self,
+        vault_path: Path,
+    ) -> None:
+        """The end-to-end consequence: no second file for the same id.
+
+        This is the harm #1120 actually causes in a vault. A torn tail
+        drops a mapping; a later ``write_fragment`` for that id sees no
+        entry, ``_atomic_create``s a counter-suffixed sibling, and the
+        fragment now exists twice with ``update_fragment`` reaching
+        neither reliably.
+        """
+        from creek.vault.writer import INDEX_FILENAME
+
+        seed = VaultWriter(vault_path=vault_path)
+        fragment = _edited_fragment()
+        original = seed.write_fragment(fragment, body="original body")
+        target_dir = original.parent
+        index_path = target_dir / INDEX_FILENAME
+
+        # Truncate the tail so the last record is torn — the on-disk
+        # residue of a crash mid-append, with no exception in flight.
+        index_path.write_bytes(index_path.read_bytes()[:-8])
+
+        fresh = VaultWriter(vault_path=vault_path)
+        again = fresh.write_fragment(fragment, body="original body")
+
+        assert again == original
+        assert len(list(target_dir.glob("*.md"))) == 1
+        assert fresh.update_fragment(fragment, "revised body") == original
+
+    def test_torn_repair_append_does_not_poison_the_index_it_repairs(
+        self,
+        vault_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The fourth call site: a tear during *recovery* stays contained.
+
+        PR #1295 put an index append on the read path —
+        ``_find_existing_locked`` -> ``_repair_index_locked`` -> append.
+        A torn write there used to poison the very file the repair was
+        fixing, swallowing the next healthy record written to it.
+        """
+        from creek._fsio import write_all as real_write_all
+        from creek.vault import writer as writer_mod
+        from creek.vault.writer import INDEX_FILENAME
+
+        seed = VaultWriter(vault_path=vault_path)
+        victim_path = _seed_victim(seed)
+        target_dir = victim_path.parent
+        edited = _edited_fragment()
+        owner_path = seed.write_fragment(edited, body="owner body")
+        # Poison: the edited id now names the victim's file, which EXISTS
+        # and declares a different id — the only shape that reaches the
+        # repair append. (Deleting the file instead takes the
+        # ``del index[model_id]; return None`` branch and never appends.)
+        seed._append_index_entry(target_dir, edited.id, victim_path.name)
+
+        torn = {"done": False}
+
+        def _tear_once(fd: int, data: bytes | memoryview) -> None:
+            """Half-write the first drain and fail; drain fully after that."""
+            if not torn["done"]:
+                torn["done"] = True
+                payload = bytes(data)
+                os.write(fd, payload[: max(1, len(payload) // 2)])
+                raise OSError(errno.ENOSPC, os.strerror(errno.ENOSPC))
+            real_write_all(fd, data)
+
+        monkeypatch.setattr(writer_mod, "write_all", _tear_once)
+
+        fresh = VaultWriter(vault_path=vault_path)
+        with pytest.raises(OSError) as excinfo:
+            fresh._find_existing(edited.id, target_dir)
+        assert excinfo.value.errno == errno.ENOSPC
+
+        # A healthy append to the index the repair just tore must not be
+        # swallowed by the remnant the repair left behind.
+        seed._append_index_entry(target_dir, "frag-bystander", "bystander.md")
+
+        index_path = target_dir / INDEX_FILENAME
+        on_disk = VaultWriter._load_index_file(index_path)
+        assert on_disk["frag-bystander"] == "bystander.md"
+
+        second = VaultWriter(vault_path=vault_path)
+        assert second._find_existing(edited.id, target_dir) == owner_path
+        assert second._find_existing("frag-victim001", target_dir) == victim_path
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Summary

A torn `.id-index.jsonl` append used to cost **two** entries, not one, and the loss
was permanent. `_append_index_entry` writes under `O_APPEND` with the terminating
newline as part of the payload, so a partial write leaves a newline-less remnant at
the tail — and the next successful record lands directly against it. The merged line
is not valid JSON, so the reader skipped it wholesale and both the torn entry and the
innocent next one dropped out of the index.

The harm did not stop there. `_load_index_locked` rescanned the directory only when
the index file was **missing**, so an id absent from a *present* index was never
re-derived — not by this process, not by any future one. `_write_model` then saw no
existing file and `_atomic_create`d a **second `.md` for the same id**. Silent,
permanent duplication.

### Three things worth arguing up front

**1. The two halves have to land together.** Framing alone makes the headline
"next entry survives" test pass while leaving the duplicate-file criterion
unmet; recovery alone leaves the next entry still being swallowed. This is
measured, not asserted: reverting the whole source change turns exactly 9 tests
red, and reverting *only* the one-expression framing change turns 6 of those 9
red — the other 3 belong to the recovery half.

- **Framing (write side).** Each record is now encoded `"\n" + json + "\n"`
  instead of `json + "\n"`, so it is self-delimiting at its *start* as well as
  its end. A remnant is terminated by the next record's leading newline and
  costs at most its own entry. Both newlines are kept deliberately:
  leading-only is a byte cheaper, but a mixed-version straddle (old code
  appending `{b}\n` after a new-code `\n{a}`) would merge the two and
  reintroduce the defect on live vault data.
- **Recovery (read side).** A new `_IndexLoad` (`entries` / `torn_lines` /
  `read_failed`, with a `damaged` property) lets the reader distinguish "this
  index legitimately names nothing" from "this index was damaged and therefore
  names less than it should". When damaged, `_load_index_locked` logs a warning
  and re-derives by directory scan. That makes a dropped mapping recoverable
  instead of permanent.

**2. The accepted blind spot.** A *stalled* append that writes **zero** bytes
leaves no remnant, hence no damage signal, hence no rescan — a duplicate is
still possible on that path. It is the least bad of the options: that path
raises a loud `OSError(EIO)` from `creek/_fsio.py` rather than corrupting
silently, and closing it would mean either an O(N) rescan on every index miss
(quadratic ingest at 35k fragments, and it would break
`test_vanished_file_does_not_trigger_a_rescan`) or reworking `_atomic_create`'s
collision path. Filed as #1299 rather than smuggled in here.

**3. The concurrency false positive.** `write_all` loops over `os.write`, so a
healthy multi-byte append has a real window in which the file holds a partial
record with no exception in flight anywhere. A reader in another process can
observe that tail, classify it as damage, and pay one spurious `_rebuild_index`.
It is bounded at **one scan per directory per `VaultWriter` instance** by the
`_dir_indexes` cache (instance state — a caller that builds several writers pays
it once for each), and the merge is `setdefault` over the scan, so a spurious
rescan is a cost, never a correctness loss. It is also self-correcting: the index
append only ever runs *after* the corresponding `.md` is fully on disk, so a
scan triggered by a transient tear still resolves the right mapping.

### Design decisions, stated rather than implied

- **Precedence is scan-wins.** `_recover_damaged_index` merges
  `_rebuild_index(target_dir)` with the parsed entries via `setdefault`: any id a
  live file declares takes the on-disk truth, and parsed JSONL entries only fill
  gaps the scan cannot see. This is the same precedence `_repair_index_locked`
  already applies (`_rebuild_index(...).get(model_id)`). Parsed-wins would keep a
  mapping the scan just disproved, and every later lookup would pay verification,
  a second scan, and a repair append to reach the answer the load already had.
- **Damage is narrow on purpose.** Only a read `OSError` and a
  `json.JSONDecodeError` count. A line that is valid JSON but not a
  `{id: str, filename: str}` object is *not* damage — it is a well-formed line
  the schema declines, and treating it as damage would buy a directory-wide scan
  for a perfectly intact file.
- **No fsync, said out loud.** `_append_index_entry` still does not fsync, unlike
  `AuditLog.append`. The index is a reconstructible cache, not a ledger. That was
  only ever defensible paired with a recovery path — which this PR is what
  supplies.
- **The in-memory-before-on-disk ordering at all three write sites is preserved
  deliberately**, now with a comment at each saying so. The file is already
  moved/created by the time the append runs, so a mapping that outlives a torn
  append is the conservative side of the trade; reversing it silently would be a
  tomb/restore durability regression.
- **`_persist_full_index` is deliberately NOT re-framed.** It renames atomically
  and can never leave a torn record, so it needs no self-delimitation — and
  framing it would insert a blank line per entry, roughly doubling the line count
  of every first-time rebuild at vault scale.
- **`_load_index_file` keeps its exact signature** as a thin wrapper over
  `_read_index_records(...).entries`, so no caller moves.

### Properties preserved

- **O(1) per append.** No full-file read, no rescan, no directory walk on the
  write path. The `_PIPE_BUF_BYTES` guard measures `len(encoded)`, so it now
  counts the two framing bytes automatically — one byte stricter, the safe
  direction. Routing through `AuditLog` was rejected for exactly this reason: its
  `_compute_prev_hash` falls back to a full-file rescan whenever another process
  appended.
- **O(1) per clean load**, pinned by a test that makes `_rebuild_index` raise and
  asserts an undamaged load never reaches it.
- **`O_APPEND` atomicity, no `ftruncate`, no lock, no `fcntl`.** No whole-file
  rewrite is added anywhere; the `_persist_full_index` prohibition on the repair
  path stays true.
- **Backward compatibility, tested directly.** Every `.id-index.jsonl` in a live
  vault was written by the old encoder. Two tests pin it: a complete legacy file
  mixed with a new-format record resolves all three ids, and an *old-format* torn
  tail (no leading newline — the only remnant shape that can exist at upgrade
  time) is terminated by the new record's leading newline. No migration, no
  version marker, no vault-wide rewrite.

## Test plan

Gate 1 was RED on behavioural assertions, never on a missing symbol. With the
source reverted to `HEAD` and the new tests in place:

```
FAILED test_torn_index_append_does_not_swallow_the_next_entry - assert 1 >= 2
FAILED test_any_torn_tail_prefix_leaves_the_next_entry_parseable - AssertionError: lost at cut=2
FAILED test_a_legacy_format_remnant_does_not_swallow_the_next_entry - KeyError: 'frag-next'
FAILED test_consecutive_torn_tails_do_not_compound - KeyError: 'frag-healthy'
FAILED test_damaged_index_rescans_and_recovers_the_dropped_id - assert None == PosixPath(...)
FAILED test_unreadable_index_rescans_instead_of_looking_empty - assert None == PosixPath(...)
FAILED test_a_torn_index_tail_does_not_mint_a_duplicate_file - assert PosixPath(...-1.md) == PosixPath(...)
FAILED test_torn_repair_append_does_not_poison_the_index_it_repairs - KeyError: 'frag-bystander'
FAILED test_append_index_entry_writes_complete_line_under_short_writes - framing byte-pin
9 failed, 100 passed
```

Exactly those 9, nothing else. Reverting only the framing expression leaves 6 red.

New and changed tests:

- `test_torn_index_append_does_not_swallow_the_next_entry` — the #987
  characterization test **inverted in place**, per its own docstring's
  instruction. Never deleted. Same staging (`fail_after_half(ENOSPC)` →
  `passthrough()`); the three assertions that still hold are untouched, and the
  three that pinned the defect now pin the contract.
- `test_any_torn_tail_prefix_leaves_the_next_entry_parseable` — the forcing
  function. Writes **every byte prefix** of an encoded record straight to disk
  and appends over it. No exception is in flight anywhere: this is what a
  SIGKILL/OOM/power loss between two `os.write` iterations actually leaves. A fix
  that only cleaned up inside an `except OSError:` handler could not pass it.
- `test_a_legacy_format_remnant_does_not_swallow_the_next_entry` and
  `test_a_legacy_format_index_still_parses_unchanged` — the no-migration claim,
  tested rather than asserted.
- `test_consecutive_torn_tails_do_not_compound` — two remnants back to back, one
  old-shaped and one new-shaped, as two processes at different versions would
  leave them.
- `test_a_torn_index_tail_does_not_mint_a_duplicate_file` — the end-to-end
  consequence closed: after a torn tail, a second `write_fragment` for the same
  id returns the original path, the directory still holds exactly one `.md`, and
  `update_fragment` still finds it. Deliberately does **not** use the
  `short_write` fixture — `fail_after_half` fires on the first tracked
  descriptor, which in `write_fragment` is the fragment *body*, and
  `create_exclusive` unlinks that partial file, so the index append would never
  be reached.
- `test_torn_repair_append_does_not_poison_the_index_it_repairs` — **the fourth
  call site**, the one PR #1295 put on the read path. Goes through the real route
  (`_find_existing` → mismatch → `_repair_index_locked` → append), with the
  genuine file **present** and a different existing file indexed for that id —
  the only setup that actually reaches the append rather than the
  `del index[model_id]; return None` branch. Asserts the documented `OSError`
  still escapes the lookup, and that a healthy record written to the index
  afterwards is not swallowed by the remnant the repair left behind.
- `test_damaged_index_rescans_and_recovers_the_dropped_id`,
  `test_unreadable_index_rescans_instead_of_looking_empty`,
  `test_clean_index_never_rescans` — the recovery half, plus the O(1) guard.

- `test_undecodable_index_rescans_instead_of_crashing_the_write` — raised by
  self-review. `UnicodeDecodeError` is a `ValueError`, not an `OSError`, so it
  escaped the read guard and would take down *every* vault write into the
  directory. Not reachable from a torn append (our writers emit ASCII only,
  since `json.dumps` escapes non-ASCII by default), but reachable from a
  hand-edited or externally corrupted index — and squarely inside the threat
  model this PR is about, so it is fixed here rather than deferred. Reverting
  just that clause turns exactly this one test red with the exception
  propagating uncaught.

The unreadable-index test also closes an **adjacent hole in the same reader**
(fixed here rather than deferred, because it produces the identical
duplicate-everything outcome as #1120 through a different door): a read `OSError`
returned `{}`, which `_load_index_locked` then cached *because the file existed*
— an unreadable index was indistinguishable from an empty directory, with no
rescan and no log line.

Gate 2: `./scripts/check-all.sh` → **exit 0**, 12/12 checks, 8758 passed,
aggregate coverage 94.39%, per-file gate green (`creek/vault/writer.py` is not
waivered, so the 80% floor applies to every new branch). Complexity measured, not
assumed: `_read_index_records` B(8), `_load_index_locked` A(5),
`_recover_damaged_index` A(3), `_append_index_entry` A(2) — no extraction needed.
`tests/test_ingest_update_in_place.py` and `tests/test_cli_fill.py` run clean;
they exercise the same locator through the continuous-ingest update-in-place path.

Every prose site that documented #1120 as an unfixable known defect has been
rewritten — leaving stale "KNOWN DEFECT" narration behind a landed fix is its own
failure.

## Self-review (Gate 2.5)

`code-review-orchestrator` over the full diff returned **CLEAN — no blockers**,
having hand-traced the `setdefault` merge for the tombed / non-`str`-id /
transient-unreadable cases against the pre-fix reader on `main` (additive only;
no new drop, duplication or misresolution path), the framed-vs-unframed boundary
where a `_persist_full_index` file is later appended to, and the repair-site
test's byte stream. Its three non-blocking nits are all addressed in this PR
rather than deferred: the "once per process" cache bound corrected to "once per
`VaultWriter` instance", the overstated "same precedence as
`_repair_index_locked`" claim tightened to name where the two differ, and the
`UnicodeDecodeError` gap closed with a test.

## Follow-ups filed

- **#1299** (P2) — a *stalled* zero-byte append leaves no remnant, hence no
  damage signal, hence no rescan. The one path where a duplicate is still
  possible; argued above.
- **#1300** (P2) — compaction. A torn line is never removed, so one historical
  crash permanently converts that directory's cold load from O(1) to O(N). This
  PR makes the damage observable; it does not reclaim it.
- Measured cost (+2 bytes and +1 line per appended record, plus the conditional
  read-side scan and its bound) [cross-referenced on #1290](https://github.com/Geoffe-Ga/Creek-Vault/issues/1290#issuecomment-5235178827),
  which is open about index cost at scale and will collide textually with this
  change in `_find_existing_locked` if both land in parallel.

Closes #1120
