### PR TITLE
fix(voice): refuse non-self-authored prose at the voice-corpus gate (#1213)

### DIFF
--- a/creek-tools/creek/generate/voice.py
+++ b/creek-tools/creek/generate/voice.py
@@ -13,6 +13,16 @@ body texts to extract sentence structure, paragraph structure, transition
 patterns, metaphor families, rhetorical moves, vocabulary fingerprint, and
 punctuation habits.
 
+**Voice fidelity** is guarded separately from privacy, by three additive
+gates in :func:`_eligible_register` and the walks around it. The primary
+one is authorship (#1213): a fragment whose ``source.author`` is not
+``self`` is refused outright, which is what enforces the guarantee
+:attr:`~creek.models.Fragment.voice_proxy_eligible` documents. Behind it
+sit two backstops from #466 — ``voice_weight > 0``, stamped to ``0.0`` on
+AI turns at ingest, and the ``11-Other-Authors`` path exclusion
+(:data:`_OTHER_AUTHORS_SEGMENT`). Both are retained deliberately: they
+catch a fragment whose authorship axis is missing or mis-set.
+
 The collector is deliberately conservative about privacy, and two
 independent gates say so. ``allow_intimate`` is a **consent** gate: the
 voice proxy is opt-in even at ``--include-tier intimate``
@@ -52,6 +62,7 @@ from pydantic import ValidationError
 from creek.classify.privacy_filter import PrivacyTierOverride, within_ceiling
 from creek.config import VoiceAudienceWeightingConfig
 from creek.models import (
+    Authorship,
     Confidence,
     Fragment,
     Frequency,
@@ -84,6 +95,15 @@ _OTHER_AUTHORS_SEGMENT: str = "11-Other-Authors"
 Any fragment whose source path contains this segment is excluded from the
 voice corpus regardless of its ``voice_weight``, as a defensive backstop
 against voice drift.
+
+Since #1213 this is a backstop to a real frontmatter gate rather than a
+front-line defence, and it is **retained deliberately** — it still catches
+a fragment whose ``source.author`` axis is absent or mis-set. It was never
+load-bearing on its own: the walks only rglob :data:`_FRAGMENTS_SUBDIR`,
+while :meth:`creek.vault.writer.VaultWriter._fragment_target_dir` routes
+borrowed fragments to a vault-root ``11-Other-Authors/<slug>/`` that is
+outside the scan root entirely. What this segment check actually catches
+is a nested or symlinked occurrence *inside* ``01-Fragments/``.
 """
 
 _SAMPLES_SUBPATH: tuple[str, str] = ("07-Voice", "Register-Samples")
@@ -302,14 +322,36 @@ def _eligible_register(
             fragments are rejected.
 
     Returns:
-        The canonical register string when the fragment has qualifying
-        confidence, a positive ``voice_weight``, allowed privacy tier,
-        and a canonical register; otherwise ``None``.
+        The canonical register string when the fragment is self-authored
+        and has qualifying confidence, a positive ``voice_weight``, allowed
+        privacy tier, and a canonical register; otherwise ``None``.
     """
-    # Voice-fidelity fail-closed gate (Issue #466): borrowed / AI-authored
-    # text (notably ``ai-as-user`` content with ``voice_weight=0.0``) must
-    # never train the voice proxy. ``voice_weight`` is already coerced to a
-    # float in ``[0, 1]`` by the model, so a plain comparison is safe.
+    # Authorship gate (Issue #1213), first because it is the primary one:
+    # this is what enforces the guarantee
+    # :attr:`~creek.models.Fragment.voice_proxy_eligible` documents — that
+    # AI-, collaborator- and other-authored prose can never train the voice
+    # proxy. Before this clause the corpus consulted no authorship axis at
+    # all, and the two gates below were the whole defence.
+    #
+    # Re-derived rather than delegated to the property, exactly as
+    # :func:`creek.generate.skills._is_snapshot_fragment` is and for the
+    # same documented reason: the property bakes in the INTIMATE exclusion,
+    # while ``allow_intimate=True`` deliberately overrides it, so
+    # ``return fragment.voice_proxy_eligible`` would silently revoke the
+    # operator's opt-in to their *own* intimate writing.
+    #
+    # Compared by value, not identity: ``FragmentSource`` sets
+    # ``use_enum_values=True``, so ``author`` is a plain ``str`` at runtime
+    # — the same idiom as the privacy-tier comparison below. Deliberately
+    # not ``Authorship(...) is Authorship.SELF``, which raises on a
+    # hand-corrupted frontmatter value instead of failing closed.
+    if str(fragment.source.author) != Authorship.SELF.value:
+        return None
+    # Voice-fidelity backstop (Issue #466): ``ai-as-user`` content is
+    # stamped ``voice_weight=0.0`` at ingest, which refuses it a second
+    # time even if its authorship axis is ever mis-set. ``voice_weight`` is
+    # already coerced to a float in ``[0, 1]`` by the model, so a plain
+    # comparison is safe.
     if fragment.voice_weight <= 0:
         return None
     if _confidence_value(fragment) not in _QUALIFYING_CONFIDENCE:
@@ -578,9 +620,10 @@ class VoiceExemplarCollector:
     def collect_exemplars(self, vault_path: Path) -> dict[str, list[Fragment]]:
         """Scan ``01-Fragments/`` and group qualifying exemplars by register.
 
-        Fragments are kept when their ``voice.confidence`` is ``settled``
-        or ``conviction`` and their ``voice.register`` is set. Intimate
-        privacy tier fragments are filtered out unless
+        Fragments are kept when they are **self-authored** (#1213), their
+        ``voice.confidence`` is ``settled`` or ``conviction``, their
+        ``voice_weight`` is positive, and their ``voice.register`` is set.
+        Intimate privacy tier fragments are filtered out unless
         :attr:`allow_intimate` is ``True``, and every fragment must
         additionally sit within :attr:`override` (#968). Each register key
         in the returned dict is always present; empty registers map to
@@ -631,8 +674,9 @@ class VoiceExemplarCollector:
     def collect_all_exemplars(self, vault_path: Path) -> list[Exemplar]:
         """Collect every qualifying exemplar across all registers, with bodies.
 
-        Shares the eligibility gate with :meth:`collect_exemplars` (``settled``
-        or ``conviction`` confidence, a set register, intimate filtered unless
+        Shares the eligibility gate with :meth:`collect_exemplars`
+        (self-authored, ``settled`` or ``conviction`` confidence, positive
+        ``voice_weight``, a set register, intimate filtered unless
         :attr:`allow_intimate`, within :attr:`override`, ``11-Other-Authors``
         excluded) but returns a flat :class:`Exemplar` list — fragment paired
         with its on-disk body — rather than per-register ``Fragment`` buckets.
@@ -670,7 +714,8 @@ class VoiceExemplarCollector:
         """Return the fragment's register if it qualifies, else ``None``.
 
         This answers the *consent* question only (``allow_intimate``, plus
-        confidence / voice-weight / register eligibility). The *ceiling*
+        authorship / confidence / voice-weight / register eligibility).
+        The *ceiling*
         question is asked separately by
         :func:`~creek.classify.privacy_filter.within_ceiling` at each walk,
         because it needs the raw frontmatter this method never sees. Do not

--- a/creek-tools/creek/ingest/chatgpt.py
+++ b/creek-tools/creek/ingest/chatgpt.py
@@ -167,7 +167,9 @@ class ChatGPTIngestor(Ingestor):
             source["conversation_id"] = conv_id
         if is_ai:
             # AI turns are AI-authored, excluded from the voice proxy via
-            # ``voice_proxy_eligible``; zero weight is belt-and-braces.
+            # ``voice_proxy_eligible``; zero weight is belt-and-braces. The
+            # authorship half is enforced by
+            # ``creek.generate.voice._eligible_register`` (#1213).
             source["author"] = _ROLE_AI
         frontmatter_dict: dict[str, Any] = {
             "title": fragment.metadata.get("title", "Untitled Conversation"),

--- a/creek-tools/creek/ingest/claude.py
+++ b/creek-tools/creek/ingest/claude.py
@@ -365,7 +365,11 @@ class ClaudeIngestor(Ingestor):
         if is_ai:
             # The AI turn is AI-authored, so it can never feed the voice proxy
             # (``source.author=ai`` makes ``voice_proxy_eligible`` False); zero
-            # weight is belt-and-braces against future selectors.
+            # weight is belt-and-braces against future selectors. The voice
+            # corpus enforces the authorship half in
+            # ``creek.generate.voice._eligible_register`` (#1213); before that
+            # it read only the weight, and this comment described a mechanism
+            # nothing consulted.
             source["author"] = _ROLE_AI
 
         suffix = ", AI" if is_ai else ""

--- a/creek-tools/docs/ingestion.md
+++ b/creek-tools/docs/ingestion.md
@@ -93,7 +93,7 @@ The caveat: a source keyed on mtime treats *any* filesystem touch as a change, n
 
 ## AI-chat attribution (per turn)
 
-Ingesting a Claude or ChatGPT conversation emits **two attributed fragments per turn**: the human turn is the owner's voice (`source.author = self`, full `voice_weight`) and the AI turn is AI-authored (`source.author = ai`, `voice_weight = 0.0`). Because `Fragment.voice_proxy_eligible` excludes non-`self` authors, the assistant's prose can never train the voice proxy, while threading/linking survives — both turns share the conversation id, turn index, and timestamp.
+Ingesting a Claude or ChatGPT conversation emits **two attributed fragments per turn**: the human turn is the owner's voice (`source.author = self`, full `voice_weight`) and the AI turn is AI-authored (`source.author = ai`, `voice_weight = 0.0`). Because `Fragment.voice_proxy_eligible` excludes non-`self` authors, the assistant's prose can never train the voice proxy, while threading/linking survives — both turns share the conversation id, turn index, and timestamp. That guarantee is *enforced* rather than aspirational as of [#1213](https://github.com/Geoffe-Ga/Creek-Vault/issues/1213): the voice corpus refuses any fragment whose `source.author` is not `self` in `creek.generate.voice._eligible_register`, so it holds for `other`- and `collaborative`-authored content too — including a document whose file metadata named someone else — not only for the AI turns that also carry `voice_weight = 0.0`.
 
 ### Migrating an existing vault
 

--- a/creek-tools/tests/test_lexicon.py
+++ b/creek-tools/tests/test_lexicon.py
@@ -36,6 +36,7 @@ from creek.generate.voice import (
     VoicePatterns,
 )
 from creek.models import (
+    Authorship,
     Confidence,
     Fragment,
     FragmentSource,
@@ -57,12 +58,20 @@ if TYPE_CHECKING:
 # ---- Helpers ----
 
 
-def _make_fragment(frag_id: str, title: str = "Untitled") -> Fragment:
-    """Build a minimal valid fragment for lexicon tests."""
+def _make_fragment(
+    frag_id: str,
+    title: str = "Untitled",
+    author: Authorship = Authorship.SELF,
+) -> Fragment:
+    """Build a minimal valid fragment for lexicon tests.
+
+    No ``voice_weight`` is passed, so the model default of ``1.0`` applies
+    and a non-self *author* has to be refused on authorship alone (#1213).
+    """
     return Fragment(
         id=frag_id,
         title=title,
-        source=FragmentSource(platform=SourcePlatform.JOURNAL),
+        source=FragmentSource(platform=SourcePlatform.JOURNAL, author=author),
         created=datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC),
         ingested=datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC),
         frequency=FrequencyClassification(primary=Frequency.F5),
@@ -83,13 +92,18 @@ def _exemplar(frag_id: str, body: str) -> Exemplar:
     return Exemplar(fragment=_make_fragment(frag_id), body=body)
 
 
-def _seed_exemplar_file(vault: Path, frag_id: str, body: str) -> None:
+def _seed_exemplar_file(
+    vault: Path,
+    frag_id: str,
+    body: str,
+    author: Authorship = Authorship.SELF,
+) -> None:
     """Write a qualifying voice-exemplar fragment file under the vault."""
     fragments_dir = vault / "01-Fragments" / "Journal"
     fragments_dir.mkdir(parents=True, exist_ok=True)
     post = frontmatter.Post(
         content=body,
-        **_make_fragment(frag_id).model_dump(mode="json"),
+        **_make_fragment(frag_id, author=author).model_dump(mode="json"),
     )
     (fragments_dir / f"{frag_id}.md").write_text(
         frontmatter.dumps(post),
@@ -125,6 +139,46 @@ def test_generate_lexicon_writes_populated_glossary(tmp_path: Path) -> None:
     assert "voice lexicon" in text
     # The Buddhist borrowed terms were detected — a non-empty glossary section.
     assert "dharma" in text
+
+
+@pytest.mark.parametrize(
+    "author",
+    [Authorship.AI, Authorship.OTHER, Authorship.COLLABORATIVE],
+)
+def test_generate_lexicon_excludes_non_self_authors(
+    tmp_path: Path,
+    author: Authorship,
+) -> None:
+    """A borrowed fragment's verbatim sentence never reaches the glossary (#1213).
+
+    The sharpest exposure of the whole bug: ``_build_borrowed_terms`` records
+    the *whole surrounding sentence* around a detected tradition keyword, so
+    an unfixed gate writes third-party prose verbatim into a generated vault
+    file. The self-authored fragment supplies its own keyword so the glossary
+    is written at all — the assertion is what is missing from a file that
+    exists.
+    """
+    _seed_exemplar_file(
+        tmp_path,
+        "lex-mine",
+        "The dharma teaches that the river flows toward the sea; the river flows on.",
+    )
+    _seed_exemplar_file(
+        tmp_path,
+        "lex-borrowed",
+        "Their karma was a zarquon of borrowed prose that nobody here ever wrote.",
+        author=author,
+    )
+
+    lexicon, _paths = generate_lexicon(tmp_path)
+
+    assert lexicon is not None
+    text = (tmp_path / "07-Voice" / "Lexicon" / "glossary.md").read_text(
+        encoding="utf-8",
+    )
+    assert "dharma" in text.lower()
+    assert "zarquon" not in text.lower()
+    assert "lex-borrowed" not in text
 
 
 def test_generate_lexicon_empty_vault_returns_none(tmp_path: Path) -> None:

--- a/creek-tools/tests/test_voice_exemplars.py
+++ b/creek-tools/tests/test_voice_exemplars.py
@@ -20,10 +20,12 @@ from creek.generate.voice import (
     DEFAULT_MIN_PER_REGISTER,
     VOICE_REGISTERS,
     VoiceExemplarCollector,
+    _eligible_register,
     _is_other_authors_path,
     _is_safe_sample_stem,
 )
 from creek.models import (
+    Authorship,
     Confidence,
     Fragment,
     FragmentSource,
@@ -72,9 +74,17 @@ def _build_fragment(
     confidence: Confidence | None,
     privacy: PrivacyTier = PrivacyTier.PERSONAL,
     fully_classified: bool = True,
-    voice_weight: float = 1.0,
+    voice_weight: float | None = None,
+    author: Authorship = Authorship.SELF,
 ) -> Fragment:
-    """Build a Fragment with the desired voice / privacy / classification state."""
+    """Build a Fragment with the desired voice / privacy / classification state.
+
+    ``voice_weight`` is omitted from the constructor call when ``None`` so a
+    test can exercise the *model default* (``1.0``, ``creek/models.py``)
+    rather than a value the helper supplied — the distinction #1213 turns on,
+    since a non-self fragment with no explicit weight is exactly what
+    ``DocumentIngestor`` produces.
+    """
     if fully_classified:
         frequency = FrequencyClassification(primary=Frequency.F5)
         wavelength = WavelengthClassification(
@@ -84,17 +94,18 @@ def _build_fragment(
     else:
         frequency = FrequencyClassification()
         wavelength = WavelengthClassification()
+    weight_kwargs = {} if voice_weight is None else {"voice_weight": voice_weight}
     return Fragment(
         id=frag_id,
         title=title,
-        source=FragmentSource(platform=SourcePlatform.JOURNAL),
+        source=FragmentSource(platform=SourcePlatform.JOURNAL, author=author),
         created=datetime(2026, 1, 15, 12, 0, 0),
         ingested=datetime(2026, 1, 15, 12, 0, 0),
         frequency=frequency,
         wavelength=wavelength,
         voice=VoiceClassification(voice_register=register, confidence=confidence),
         privacy_tier=privacy,
-        voice_weight=voice_weight,
+        **weight_kwargs,
     )
 
 
@@ -315,12 +326,15 @@ class TestCollectExemplars:
 class TestVoiceCorpusExcludesBorrowedContent:
     """Issue #466: borrowed / AI-authored text must never reach the voice corpus.
 
-    Two additive gates protect voice fidelity, mirroring the privacy
+    Three additive gates protect voice fidelity, mirroring the privacy
     fail-closed rule:
 
-    1. ``voice_weight > 0`` — a fragment with ``voice_weight <= 0`` (the
+    1. ``source.author == self`` — the frontmatter axis that
+       :attr:`~creek.models.Fragment.voice_proxy_eligible` is derived from.
+       This is the primary gate (#1213); the two below are backstops to it.
+    2. ``voice_weight > 0`` — a fragment with ``voice_weight <= 0`` (the
        ``ai-as-user`` analogue with ``voice_weight=0.0``) is ineligible.
-    2. ``11-Other-Authors/`` path exclusion — any fragment whose source
+    3. ``11-Other-Authors/`` path exclusion — any fragment whose source
        path contains that segment is skipped regardless of weight.
     """
 
@@ -407,6 +421,244 @@ class TestVoiceCorpusExcludesBorrowedContent:
         native = tmp_path / "01-Fragments" / "Journal" / "f.md"
         assert _is_other_authors_path(other) is True
         assert _is_other_authors_path(native) is False
+
+    @pytest.mark.parametrize(
+        "author",
+        [Authorship.AI, Authorship.OTHER, Authorship.COLLABORATIVE],
+    )
+    def test_excludes_non_self_authors_at_default_voice_weight(
+        self,
+        vault: Path,
+        collector: VoiceExemplarCollector,
+        author: Authorship,
+    ) -> None:
+        """Non-self prose is refused on authorship alone, with no weight help.
+
+        Issue #1213. Neither backstop applies here: the fragment sits in
+        ``01-Fragments/Journal/`` (so the ``11-Other-Authors`` path gate
+        never sees it) and carries no explicit ``voice_weight``, so the
+        model default of ``1.0`` applies. ``other`` is the live case —
+        ``DocumentIngestor`` resolves a DOCX ``core_properties.author`` /
+        PDF ``/Author`` to :attr:`~creek.models.Authorship.OTHER` and sets
+        no weight, so a stranger's document reaches this walk today.
+
+        The fragment round-trips through ``frontmatter`` and
+        ``Fragment.model_validate``, so the gate is exercised against the
+        plain ``str`` that ``FragmentSource``'s ``use_enum_values=True``
+        yields at runtime — not against an enum member.
+        """
+        borrowed = _build_fragment(
+            frag_id=f"frag-authored-{author.value}",
+            title=f"Written by {author.value}",
+            register=VoiceRegister.CONFESSIONAL,
+            confidence=Confidence.SETTLED,
+            author=author,
+        )
+        assert borrowed.voice_weight == 1.0
+        _write_fragment(vault, borrowed, body_words=400)
+
+        exemplars = collector.collect_exemplars(vault)
+
+        assert [f.id for f in exemplars["confessional"]] == []
+
+    @pytest.mark.parametrize("author", list(Authorship))
+    @pytest.mark.parametrize(
+        "tier",
+        [PrivacyTier.OPEN, PrivacyTier.PERSONAL, PrivacyTier.INTIMATE],
+    )
+    def test_gate_matches_the_canonical_property_and_the_intimate_override(
+        self,
+        author: Authorship,
+        tier: PrivacyTier,
+    ) -> None:
+        """The gate is equivalent to the canonical predicate, override aside.
+
+        Two arms, and both are load-bearing (#1213):
+
+        * At ``allow_intimate=False`` admission must equal
+          :attr:`~creek.models.Fragment.voice_proxy_eligible` exactly.
+        * At ``allow_intimate=True`` admission must equal *self-authorship
+          alone* — the opt-in overrides the INTIMATE exclusion the property
+          bakes in, and nothing else. This arm is what fails if anyone
+          "simplifies" ``_eligible_register`` to
+          ``return fragment.voice_proxy_eligible``: that would silently
+          revoke the operator's opt-in to their own intimate writing.
+
+        ``list(Authorship)`` is deliberate: a fifth member added later is
+        excluded by the property and must be excluded here too, without
+        anyone remembering to extend a hand-written list.
+
+        The tier axis is deliberately **not** ``list(PrivacyTier)``.
+        ``PrivacyTier.UNCLASSIFIED`` is omitted because #1212 will make
+        ``_eligible_register`` stop admitting a self-authored *untiered*
+        fragment, at which point the first arm stops holding for that cell
+        while the property (which only excludes INTIMATE) still reports
+        ``True``. Widening this parametrization is green today and a
+        landmine tomorrow.
+        """
+        fragment = _build_fragment(
+            frag_id="frag-equivalence",
+            title="Equivalence probe",
+            register=VoiceRegister.CONFESSIONAL,
+            confidence=Confidence.SETTLED,
+            privacy=tier,
+            author=author,
+        )
+
+        admitted_default = _eligible_register(fragment, allow_intimate=False)
+        admitted_opted_in = _eligible_register(fragment, allow_intimate=True)
+
+        assert (admitted_default is not None) == fragment.voice_proxy_eligible
+        assert (admitted_opted_in is not None) == (
+            str(fragment.source.author) == Authorship.SELF.value
+        )
+
+    def test_self_authored_intimate_admitted_when_allow_intimate(
+        self,
+        vault: Path,
+    ) -> None:
+        """The operator's own intimate writing survives the authorship gate.
+
+        The regression the issue body's suggested fix would have caused
+        (#1213): delegating to ``voice_proxy_eligible`` bakes in the
+        INTIMATE exclusion and silently drops this fragment even though the
+        operator opted the voice proxy in.
+        """
+        mine = _build_fragment(
+            frag_id="frag-self-intimate",
+            title="My own intimate writing",
+            register=VoiceRegister.CONFESSIONAL,
+            confidence=Confidence.SETTLED,
+            privacy=PrivacyTier.INTIMATE,
+        )
+        _write_fragment(vault, mine, body_words=400)
+
+        exemplars = VoiceExemplarCollector(allow_intimate=True).collect_exemplars(vault)
+
+        assert [f.id for f in exemplars["confessional"]] == ["frag-self-intimate"]
+
+    def test_self_author_with_positive_weight_is_still_admitted(
+        self,
+        vault: Path,
+        collector: VoiceExemplarCollector,
+    ) -> None:
+        """The admit direction is pinned independently of the weight gate (#1213)."""
+        mine = _build_fragment(
+            frag_id="frag-self-default",
+            title="My own writing",
+            register=VoiceRegister.PROPHETIC,
+            confidence=Confidence.CONVICTION,
+        )
+        _write_fragment(vault, mine, body_words=400)
+
+        exemplars = collector.collect_exemplars(vault)
+
+        assert [f.id for f in exemplars["prophetic"]] == ["frag-self-default"]
+
+    @pytest.mark.parametrize(
+        "author",
+        [Authorship.AI, Authorship.OTHER, Authorship.COLLABORATIVE],
+    )
+    def test_collect_all_exemplars_excludes_non_self_authors(
+        self,
+        vault: Path,
+        collector: VoiceExemplarCollector,
+        author: Authorship,
+    ) -> None:
+        """The flat lexicon-facing walk shares the authorship gate (#1213).
+
+        ``collect_all_exemplars`` is a second, independent walk; asserting
+        the gate on ``collect_exemplars`` alone would not cover it.
+        """
+        _write_fragment(
+            vault,
+            _build_fragment(
+                frag_id=f"frag-flat-{author.value}",
+                title="Borrowed",
+                register=VoiceRegister.ANALYTICAL,
+                confidence=Confidence.SETTLED,
+                author=author,
+            ),
+            body_words=400,
+        )
+
+        assert collector.collect_all_exemplars(vault) == []
+
+    def test_register_samples_are_not_written_for_non_self_authors(
+        self,
+        vault: Path,
+    ) -> None:
+        """No verbatim copy of borrowed prose lands in ``Register-Samples`` (#1213).
+
+        ``generate_register_samples`` ``shutil.copy2``-s the source file into
+        the vault byte for byte, so this surface turns an excerpt into a
+        durable copy of someone else's writing.
+        """
+        from creek.generate.voice import generate_register_samples
+
+        _write_fragment(
+            vault,
+            _build_fragment(
+                frag_id="frag-samples-other",
+                title="Stranger's document",
+                register=VoiceRegister.INSTRUCTIONAL,
+                confidence=Confidence.CONVICTION,
+                author=Authorship.OTHER,
+            ),
+            body_words=400,
+        )
+
+        assert generate_register_samples(vault) == {}
+        register_dir = vault / "07-Voice" / "Register-Samples" / "instructional"
+        assert not register_dir.exists()
+
+    def test_previously_written_non_self_samples_are_pruned(
+        self,
+        vault: Path,
+    ) -> None:
+        """A sample written before the fix is deleted on the next run (#1213/#879).
+
+        Two runs through the public entry point. The first writes the copy
+        while the fragment is still self-authored; the frontmatter is then
+        rewritten on disk to ``author: other`` — the state a pre-fix vault is
+        already in — and the second run must remove the copy it recorded
+        writing and rewrite the summary to an honest zero. ``_save_register``
+        prunes above its empty-bucket branch precisely so an emptied register
+        is cleared rather than left describing a cohort that has gone.
+        """
+        from creek.generate.voice import generate_register_samples
+
+        source = _write_fragment(
+            vault,
+            _build_fragment(
+                frag_id="frag-prune-other",
+                title="Later reattributed",
+                register=VoiceRegister.RAW,
+                confidence=Confidence.CONVICTION,
+            ),
+            body_words=400,
+        )
+        register_dir = vault / "07-Voice" / "Register-Samples" / "raw"
+        copy = register_dir / "frag-prune-other.md"
+        summary = register_dir / "_Summary.md"
+
+        first_pruned: list[Path] = []
+        generate_register_samples(vault, on_prune=first_pruned.append)
+        assert copy.is_file()
+        assert summary.is_file()
+        assert first_pruned == []
+
+        post = frontmatter.load(str(source))
+        post["source"] = {**post["source"], "author": Authorship.OTHER.value}
+        source.write_text(frontmatter.dumps(post), encoding="utf-8")
+
+        second_pruned: list[Path] = []
+        result = generate_register_samples(vault, on_prune=second_pruned.append)
+
+        assert second_pruned == [copy]
+        assert not copy.exists()
+        assert "raw" not in result
+        assert "frag-prune-other" not in summary.read_text(encoding="utf-8")
 
     def test_path_helper_no_substring_false_positive(self, tmp_path: Path) -> None:
         """A folder merely containing the text is not excluded (segment match only)."""

--- a/creek-tools/tests/test_voice_profiles.py
+++ b/creek-tools/tests/test_voice_profiles.py
@@ -28,6 +28,7 @@ from creek.generate.voice import (
     VoiceProfileGenerator,
 )
 from creek.models import (
+    Authorship,
     Confidence,
     Fragment,
     FragmentSource,
@@ -54,12 +55,18 @@ def _make_fragment(
     title: str,
     register: VoiceRegister = VoiceRegister.CONFESSIONAL,
     confidence: Confidence = Confidence.CONVICTION,
+    author: Authorship = Authorship.SELF,
 ) -> Fragment:
-    """Build a fully classified fragment for exemplar use."""
+    """Build a fully classified fragment for exemplar use.
+
+    No ``voice_weight`` is passed, so the model default of ``1.0`` applies —
+    the shape ``DocumentIngestor`` produces for a DOCX/PDF carrying an
+    ``author`` in its file metadata (#1213).
+    """
     return Fragment(
         id=frag_id,
         title=title,
-        source=FragmentSource(platform=SourcePlatform.JOURNAL),
+        source=FragmentSource(platform=SourcePlatform.JOURNAL, author=author),
         created=datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC),
         ingested=datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC),
         frequency=FrequencyClassification(primary=Frequency.F5),
@@ -261,6 +268,79 @@ def test_generate_rhetorical_patterns_empty_vault_writes_nothing(vault: Path) ->
 
     assert written == []
     assert not (vault / "07-Voice" / "Rhetorical-Patterns").exists()
+
+
+# ---- Authorship gate on the streaming walk (Issue #1213) ----
+
+
+@pytest.mark.parametrize(
+    "author",
+    [Authorship.AI, Authorship.OTHER, Authorship.COLLABORATIVE],
+)
+def test_generate_all_profiles_excludes_non_self_authors(
+    vault: Path,
+    generator: VoiceProfileGenerator,
+    author: Authorship,
+) -> None:
+    """Borrowed prose never reaches a written voice profile (#1213).
+
+    ``_stream_into`` is the third walk over ``01-Fragments/``, independent
+    of both collector walks, and it is the one that feeds
+    ``report --type voice`` profiles and ``report --type rhetorical-patterns``.
+    The self-authored fragment is present so the register note is written at
+    all — the assertion is about what is *missing* from a note that exists.
+    """
+    _write_fragment_file(
+        vault,
+        _make_fragment("prof-mine", "Mine"),
+        "The tide turns and I turn with it. I said what I meant to say.",
+    )
+    _write_fragment_file(
+        vault,
+        _make_fragment("prof-borrowed", "Borrowed", author=author),
+        "Zarquon vitrifies the perambulating quotidian. Zarquon persists.",
+    )
+
+    paths = generator.generate_all_profiles(vault)
+
+    note = vault / "07-Voice" / "confessional-profile.md"
+    assert note in paths
+    text = note.read_text(encoding="utf-8")
+    assert "tide turns" in text
+    assert "Zarquon" not in text
+    assert "perambulating" not in text
+
+
+def test_generate_rhetorical_patterns_excludes_non_self_authors(
+    vault: Path,
+) -> None:
+    """Borrowed rhetorical moves never reach the patterns note (#1213).
+
+    Same ``_stream_into`` walk as the profiles, but a separately-written
+    surface, so it is asserted separately. This note reports *counts*, not
+    quoted text, so the assertion is that the counts are the self-authored
+    body's alone: the borrowed body carries every hedge and every paradox
+    in the vault, and the self-authored one carries none.
+    """
+    _write_fragment_file(
+        vault,
+        _make_fragment("rhet-mine", "Mine"),
+        "The truth is we rise. We rise, and the rising is the whole of it.",
+    )
+    _write_fragment_file(
+        vault,
+        _make_fragment("rhet-borrowed", "Borrowed", author=Authorship.OTHER),
+        "I'm probably wrong. And yet it holds. As I mentioned, it holds.",
+    )
+
+    written = VoiceProfileGenerator().generate_rhetorical_patterns(vault)
+
+    note = vault / "07-Voice" / "Rhetorical-Patterns" / "confessional.md"
+    assert note in written
+    text = note.read_text(encoding="utf-8")
+    assert "- Self-deprecation before insight: 0." in text
+    assert "- Paradox constructions: 0." in text
+    assert "- Callbacks to earlier points: 0." in text
 
 
 # ---- Module surface ----


### PR DESCRIPTION
## Summary

`creek.generate.voice._eligible_register` is the single chokepoint for the entire voice corpus. It gated on `voice_weight`, confidence, privacy tier and register — and never on `source.author`. So the guarantee `Fragment.voice_proxy_eligible` documents ("only self-authored, non-INTIMATE fragments are eligible … AI / collaborator / other-authored content is excluded") was never enforced by the corpus that depends on it, and `docs/ingestion.md`'s promise that "the assistant's prose can never train the voice proxy" was aspirational.

This PR adds the missing clause, first in the function:

```python
if str(fragment.source.author) != Authorship.SELF.value:
    return None
```

`Authorship` was not previously imported into `creek/generate/voice.py` — the clause was never written, not merely mis-ordered.

### Three corrections to the issue body

**1. The body's suggested fix would have caused a regression.** It proposes having `_eligible_register` "consult `fragment.voice_proxy_eligible` rather than re-deriving a subset of it." That breaks `allow_intimate=True`: the property bakes in `privacy_tier != INTIMATE`, but `_eligible_register` takes `allow_intimate` precisely so an operator who opted the voice proxy in to intimate content still gets *their own* intimate fragments. Delegating wholesale silently revokes that opt-in.

This PR re-derives instead, mirroring `creek.generate.skills._is_snapshot_fragment`, whose docstring already documents refusing to delegate for exactly this reason. (Cited by symbol name, not line number — PR #1286 just moved it.) There is a dedicated regression test for this, and it is green both before and after the fix.

**2. "Why it doesn't currently bite" is false — there is a live, shipping producer.** `creek/ingest/documents.py` resolves a DOCX `core_properties.author` / PDF `/Author` to `Authorship.OTHER` and never sets `voice_weight`, so the model default of `1.0` applies. Those fragments carry no `author_slug`, so `VaultWriter._fragment_target_dir` routes them to `01-Fragments/Documents/` — inside the scan root, outside the `11-Other-Authors/` path gate. Reproduced end-to-end (below).

**3. The body names only `ai`; the predicate excludes three values.** `voice_proxy_eligible` requires `author == SELF`, so `ai`, `other` **and** `collaborative` are all excluded. The actually-reachable live case is `other`. Every new test covers all three.

Also worth recording: the `11-Other-Authors/` path gate is close to inert in the real vault layout. The walks only rglob `01-Fragments/`, while borrowed fragments live at vault-root `11-Other-Authors/<slug>/` — outside the scan root entirely; the segment check only ever catches a nested or symlinked occurrence. So `voice_weight > 0` was effectively the sole live gate. Both are retained deliberately as backstops (they still catch a fragment whose authorship axis is missing or mis-set) and are byte-identical in this diff.

### Live-path reproduction

A throwaway DOCX carrying `core_properties.author = "Jane Stranger"`, through the real `DocumentIngestor`, written where `VaultWriter` would put it, then handed to the real collector:

```
--- frontmatter DocumentIngestor produced ---
source.author      : other
source.author_name : Jane Stranger
source.author_slug : <absent>
voice_weight       : <absent -> model default 1.0>
voice_weight on the validated model : 1.0
--- voice corpus ---
path written       : 01-Fragments/Documents/stranger-docx.md
admitted to corpus : ['stranger-docx']      # before the fix
VERDICT            : ADMITTED (bug reproduced)
```

After the fix, the same script on the same input: `admitted to corpus : []` → `EXCLUDED (fixed)`.

### The chokepoint covers four surfaces, via two direct callers and three walks

Getting the enumeration right, since it is easy to miscount: the module-level `_eligible_register` has exactly **two direct callers** — the `VoiceExemplarCollector._eligible_register` forwarder, and `VoiceProfileGenerator._stream_into`. `collect_exemplars` and `collect_all_exemplars` reach it through the forwarder. That is **three walks** over `01-Fragments/`, feeding **four user-visible surfaces**, and this PR asserts the exclusion at each:

| Surface | Walk | Asserted in |
|---|---|---|
| `report --type voice` → profiles | `_stream_into` | `test_generate_all_profiles_excludes_non_self_authors` |
| `report --type voice` → register-samples | `collect_exemplars` | `test_register_samples_are_not_written_for_non_self_authors` |
| `report --type lexicon` | `collect_all_exemplars` | `test_generate_lexicon_excludes_non_self_authors` |
| `report --type rhetorical-patterns` | `_stream_into` | `test_generate_rhetorical_patterns_excludes_non_self_authors` |

The lexicon case is the sharpest: `_build_borrowed_terms` records the **whole surrounding sentence** around a detected keyword, so before this fix a third party's prose was written verbatim into `07-Voice/Lexicon/glossary.md`. The test asserts the sentence is gone.

### Vault-delta measurement (read-only)

Measured against the populated demo vault by walking `01-Fragments/` directly — **not** by running `creek report`, which mutates `07-Voice/` and fires the prune:

```
fragments scanned: 35330
authors: {'self': 33585, 'ai': 1745}
non-self with voice_weight > 0: 0
admitted pre-fix, per register: {'conversational': 10672, 'playful': 1709, 'raw': 1112,
                                 'analytical': 709, 'instructional': 642,
                                 'confessional': 337, 'prophetic': 269}
NEWLY EXCLUDED by #1213, per register: {}
NEWLY EXCLUDED total: 0
```

Honestly zero on that vault: all 1,745 `ai` fragments already carry `voice_weight: 0.0` from `creek/ingest/claude.py`, so the weight backstop was already refusing them, and it contains no `other`/`collaborative` fragments. The zero is not evidence the bug is harmless — the DOCX reproduction above is the case that carries the argument, and it is one `creek ingest --type documents` away.

### Behaviour change on merge (please read before merging)

- The first post-fix `creek report --type voice` **deletes** previously-written non-self register samples via the #879 prune. Correct, and announced through `on_prune`, but irreversible. `creek fill` runs this **unattended**. The manifest guard is what stops the prune touching operator-curated files in `Register-Samples/` and must not be weakened.
- Anything trained on `07-Voice/` — the Writing Desk / `creek draft` voice node, the voice skill tree, CrawDad's voice-core mirror — produces different prose after this merge.
- `creek/generate/ai_style/fingerprint.py` is **unaffected**: it walks fragments itself and already filters `source.get("author") != _SELF`.
- The change is purely **narrowing**: the corpus can now only ever admit less, so the privacy one-way ratchet holds.

### Sequencing with #1212 — do not run both lanes in parallel

#1212 (OPEN, P0, `do-not-auto-merge`, no PR yet) edits the **same function** and the **same three walks**: its candidate fix inserts a raw-tier consent check adjacent to where this clause goes, and rewrites the intimate branch this clause sits beside. Land #1213 first (smaller, purely additive, does not move the tier read), then rebase #1212 onto it. Whichever lands second must re-derive its vault-delta measurement, because the first changes the denominator.

Relatedly, the new cross-product test's tier axis is deliberately `[OPEN, PERSONAL, INTIMATE]` and **not** `list(PrivacyTier)`. `UNCLASSIFIED` is omitted with an explanatory comment in the test, because #1212 will make `_eligible_register` stop admitting a self-authored untiered fragment — at which point the equivalence arm stops holding for that cell while the property still reports `True`. Widening it is green today and a landmine tomorrow.

### `documents.py` decision

Declined, with reasoning, and filed rather than buried in this paragraph: **#1319**.

Short version: in `claude.py`/`chatgpt.py`, `author=ai` is a certainty about an immutable fact, so a redundant `voice_weight=0.0` costs nothing. In `documents.py`, `OTHER` is an explicit *guess* — the docstring says "guessing OTHER for the owner's own document merely under-uses it — and the returned name is what makes that recoverable" — and nothing recomputes `voice_weight`. A stamped zero would leave an operator who later corrects `author: other` to `self` on their own document silently frozen out of the corpus, with no visible cause. The authorship gate refuses the fragment exactly as long as the guess stands, and stops the moment it is corrected. #1319 records the revisit predicate.

## Test plan

**Proven red.** The fix was committed first, then `git restore --source=5dfd278 -- creek/generate/voice.py` reverted the source alone (no `git stash` — the stash ref is shared across live worktrees), and the final test set was run against it:

```
24 failed, 150 passed in 6.37s

FAILED test_excludes_non_self_authors_at_default_voice_weight[ai]
    - AssertionError: assert ['frag-authored-ai'] == []
FAILED test_excludes_non_self_authors_at_default_voice_weight[other]
    - AssertionError: assert ['frag-authored-other'] == []
FAILED test_excludes_non_self_authors_at_default_voice_weight[collaborative]
    - AssertionError: assert ['frag-authored-collaborative'] == []
FAILED test_gate_matches_the_canonical_property_and_the_intimate_override[open-ai]
FAILED test_gate_matches_the_canonical_property_and_the_intimate_override[open-other]
FAILED test_gate_matches_the_canonical_property_and_the_intimate_override[open-collaborative]
FAILED test_gate_matches_the_canonical_property_and_the_intimate_override[personal-ai]
FAILED test_gate_matches_the_canonical_property_and_the_intimate_override[personal-other]
FAILED test_gate_matches_the_canonical_property_and_the_intimate_override[personal-collaborative]
FAILED test_gate_matches_the_canonical_property_and_the_intimate_override[intimate-ai]
FAILED test_gate_matches_the_canonical_property_and_the_intimate_override[intimate-other]
FAILED test_gate_matches_the_canonical_property_and_the_intimate_override[intimate-collaborative]
FAILED test_collect_all_exemplars_excludes_non_self_authors[ai|other|collaborative]
    - AssertionError: assert [Exemplar(...)] == []
FAILED test_register_samples_are_not_written_for_non_self_authors
    - AssertionError: assert {'instructional': .../_Summary.md} == {}
FAILED test_previously_written_non_self_samples_are_pruned
    - AssertionError: assert [] == [PosixPath('.../frag-prune-other.md')]
FAILED test_generate_all_profiles_excludes_non_self_authors[ai|other|collaborative]
    - AssertionError: assert 'Zarquon' not in '---\nexempl...llet points.'
FAILED test_generate_rhetorical_patterns_excludes_non_self_authors
    - assert '- Self-deprecation before insight: 0.' in "..."
FAILED test_generate_lexicon_excludes_non_self_authors[ai|other|collaborative]
    - AssertionError: assert 'zarquon' not in '---\nborrow... ever wrote.'
```

Every failure is a **behavioural assertion on admitted content** — the fragment present in the bucket, the borrowed sentence present in the glossary — not an `ImportError` or `AttributeError`. `Authorship`, `FragmentSource.author` and all three values already existed at base.

**The 12-cell equivalence contract** (`list(Authorship)` × `[OPEN, PERSONAL, INTIMATE]`), which is the forcing function against reintroduction:

- Before the fix: **9 non-self cells red, all 3 `self` cells green.**
- After the fix: **all 12 green.**

`list(Authorship)` is deliberate — a fifth member added later is excluded by the property and must be excluded here too, without anyone remembering to extend a hand-written list.

**The regression that the wrong fix would have caused.** `test_self_authored_intimate_admitted_when_allow_intimate` — a self-authored INTIMATE fragment with `allow_intimate=True` — **passes both before and after**, and so do all three `self` cells of the cross-product including `self` + INTIMATE + `allow_intimate=True`. Nothing that was admitted before is refused now.

**Load-bearing check.** Reverting the clause alone turns exactly those 24 cells red and leaves the other 150 tests in the three files green.

**Blast radius.** Nine voice-corpus test files, not the three the issue implies — plus the e2e lane, which walks `01-Fragments/` for `author == "ai"` and then calls `generate_all_profiles`:

```
tests/test_voice_exemplars.py tests/test_voice_profiles.py tests/test_lexicon.py
tests/test_cli.py tests/test_mcp_report_tier_ceiling.py tests/test_purge_voice_artifacts.py
tests/test_voice_audience_authority.py tests/test_voice_citation_density.py
tests/test_voice_patterns.py tests/test_voice_proxy_eligible_computed.py
    → 500 passed

./scripts/test.sh --e2e   → 14 passed
```

No existing test was deleted, skipped or loosened. Three test helpers gained a default-valued `author` parameter; `_build_fragment` additionally changed `voice_weight` from `float = 1.0` to `float | None = None` so a test can exercise the *model* default rather than one the helper supplied — the distinction this bug turns on. Every existing call site is unaffected.

**Gate 2** — `./scripts/check-all.sh` exit 0:

```
=== Quality Checks Summary ===
Passed: 12
Failed: 0
✓ All quality checks passed!

8804 passed, 5 skipped, 370 deselected
Required test coverage of 90% reached. Total coverage: 94.38%
✓ 256 files >= 80.0%, 2 waivered files >= 65.0%
```

`_eligible_register` measures `B (7)` after the added branch (radon), clearing the real gate `xenon --max-absolute B --max-modules B --max-average B`. No threshold changed, no `# noqa`, no `# type: ignore`, no skip. Nothing under `crawdad/` is touched.

Closes #1213
Refs #1212, #1319
