### PR TITLE
fix(vault): tomb and restore allocate a free filename instead of overwriting (#1302)

### DIFF
--- a/creek-tools/creek/vault/writer.py
+++ b/creek-tools/creek/vault/writer.py
@@ -884,6 +884,96 @@ class VaultWriter:
                 return found
         return None
 
+    def _relocate_fragment_locked(
+        self,
+        existing: Path,
+        dest_dir: Path,
+        post: frontmatter.Post,
+        model_id: str,
+        model_type: str,
+    ) -> Path:
+        """Move *existing* into *dest_dir*, never overwriting what is there.
+
+        Caller must hold ``self._lock``. Shared by :meth:`tomb_fragment`
+        and :meth:`restore_fragment`, which differ only in how they locate
+        *existing* and in the frontmatter marker they stamp or clear; the
+        relocation itself — create, unlink, re-index, log — is identical
+        and lives here (#1302). Both directions previously composed
+        ``<dir> / existing.name`` and wrote it with an unconditional
+        ``os.replace``, so a same-named file at the destination was
+        silently destroyed. Allocation now goes through
+        :meth:`_atomic_create`, the same ``O_CREAT | O_EXCL`` path every
+        other create in this module uses.
+
+        The stem handed to :meth:`_atomic_create` is ``existing.stem``,
+        never :meth:`_compute_base_name`: a title that drifted since the
+        original write would rename the file out from under every
+        ``[[wikilink]]`` pointing at it. Suffix stacking (``-1-1``)
+        therefore only occurs under a genuine live collision, which is
+        exactly when a distinguishing suffix is required; an uncontended
+        tomb → restore round trip is name-stable, because the tomb frees
+        the origin name before the restore asks for it back.
+
+        Three orderings below are load-bearing:
+
+        - The destination is created **before** the source is unlinked.
+          :meth:`_atomic_create` can raise — retry exhaustion, or a short
+          write that :func:`creek._fsio.create_exclusive` cleans up — and
+          create-first means both escape with the source file fully
+          intact. The worst case is a recoverable duplicate, never a
+          fragment that exists nowhere. The mirror case — a create that
+          succeeded followed by an ``unlink`` that failed — leaks an
+          unindexed copy at the destination for the same reason, which
+          is the same safe direction and is tracked in #1325.
+        - The origin's in-memory entry is dropped **after** the unlink and
+          **before** the destination entry is set. ``self._dir_indexes``
+          is keyed by :class:`~pathlib.Path`, so were origin and
+          destination ever the same directory, popping second would
+          delete the mapping just written. The on-disk origin JSONL is
+          deliberately left alone: a :meth:`_persist_full_index` rewrite
+          from this process's snapshot would destroy entries another
+          process appended (the rejection is argued in
+          :meth:`_repair_index_locked` and :meth:`_load_index_locked`),
+          and the stale line is harmless — a fresh process re-resolves it
+          through the #1083 verification path.
+        - The destination's in-memory mapping is set **before** the
+          on-disk append, preserved from #1120. The relocated file is
+          already on disk by then, so a torn append leaves this process
+          still resolving the moved file while a fresh process re-derives
+          it from the damage rescan in :meth:`_load_index_locked`.
+          Reversing this would lose the relocation for the rest of the run.
+
+        Args:
+            existing: The live file to move; unlinked once its copy at the
+                destination exists.
+            dest_dir: Directory to move into, created if absent.
+            post: The already-mutated frontmatter document to write.
+            model_id: Id to re-point at the relocated file.
+            model_type: Type string recorded in the provenance log.
+
+        Returns:
+            The path actually created, which carries a ``-N`` counter
+            suffix when the stem was already taken in *dest_dir*.
+
+        Raises:
+            RuntimeError: If a unique filename cannot be allocated within
+                :data:`_MAX_FILENAME_COLLISION_RETRIES` attempts.
+            OSError: If the destination cannot be written, or its index
+                entry cannot be appended.
+        """
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest = self._atomic_create(dest_dir, existing.stem, frontmatter.dumps(post))
+        origin_dir = existing.parent
+        existing.unlink()
+        # ``pop``, not ``del``: ``_find_existing_locked`` may already have
+        # healed this entry away on its repair path (#1083).
+        self._load_index_locked(origin_dir).pop(model_id, None)
+        index = self._load_index_locked(dest_dir)
+        index[model_id] = dest.name
+        self._append_index_entry(dest_dir, model_id, dest.name)
+        self._log_provenance_locked(model_id, model_type, dest)
+        return dest
+
     def tomb_fragment(self, fragment_id: str) -> Path | None:
         """Soft-tomb a fragment: move it to ``10-Liminal/Orphaned/`` (#674).
 
@@ -893,11 +983,34 @@ class VaultWriter:
         the fragment. Returns the tombed path, or ``None`` when no live fragment
         maps to the id (already moved/removed).
 
+        ``10-Liminal/Orphaned/`` is a single flat sink fed by every
+        ``01-Fragments/<platform>/`` subfolder, while a filename stem is unique
+        only *within* one of those subfolders — so tombstones genuinely
+        collide. The move therefore runs through
+        :meth:`_relocate_fragment_locked`, which gives the arriving tombstone a
+        counter suffix instead of replacing the one already there (#1302). The
+        returned path is authoritative: it, and not ``<orphan dir>/<old
+        name>``, is what the id index now points at.
+
         Args:
             fragment_id: Id of the fragment to soft-tomb.
 
         Returns:
-            Path to the tombed file, or ``None`` if no live fragment was found.
+            Path to the tombed file, or ``None`` if no live fragment was
+            found. May carry a ``-N`` counter suffix when the name was taken.
+
+        Raises:
+            RuntimeError: If a unique filename cannot be allocated in the
+                orphan directory within
+                :data:`_MAX_FILENAME_COLLISION_RETRIES` attempts.
+            OSError: If the tombstone cannot be created, or its index entry
+                cannot be appended.
+
+        Both propagate from :meth:`_relocate_fragment_locked`.
+        :func:`creek.ingest.pipeline.tomb_missing_units` catches only
+        ``(OSError, KeyError)`` around this call, so the exhaustion
+        ``RuntimeError`` aborts the whole ingest run — deliberately loud, and
+        out of scope to widen here. Tracked in #1325.
         """
         orphan_dir = self.vault_path.joinpath(*_ORPHANED_RELPARTS)
         with self._lock:
@@ -907,21 +1020,15 @@ class VaultWriter:
             post = frontmatter.load(str(existing))
             post["lifecycle"] = "orphaned"
             post["orphaned_at"] = datetime.now(UTC).isoformat()
-            orphan_dir.mkdir(parents=True, exist_ok=True)
-            dest = orphan_dir / existing.name
-            _atomic_write_text(dest, frontmatter.dumps(post))
-            existing.unlink()
-            index = self._load_index_locked(orphan_dir)
-            # Deliberate ordering, preserved by #1120: the in-memory
-            # mapping is set BEFORE the append, so a failed append leaves
-            # this process still resolving the tombed file (already moved
-            # above) while a fresh process re-derives it from the damage
-            # rescan in ``_load_index_locked``. Reversing this would make
-            # a torn append lose the tomb for the rest of the run.
-            index[fragment_id] = dest.name
-            self._append_index_entry(orphan_dir, fragment_id, dest.name)
-            self._log_provenance_locked(fragment_id, "fragment", dest)
-        return dest
+            # Create-before-unlink and the #1120 in-memory-before-append
+            # ordering both live in the helper; see its docstring.
+            return self._relocate_fragment_locked(
+                existing,
+                orphan_dir,
+                post,
+                fragment_id,
+                "fragment",
+            )
 
     def restore_fragment(self, fragment: Fragment) -> Path | None:
         """Un-tomb a fragment: move it back from ``10-Liminal/Orphaned/`` (#674).
@@ -932,12 +1039,34 @@ class VaultWriter:
         preserved id. Returns the restored path, or ``None`` when no tombed
         file maps to the id.
 
+        The tomb freed the origin filename, so an uncontended restore lands
+        back on the original name. When a *newer* fragment has since claimed
+        that stem, :meth:`_relocate_fragment_locked` gives the returning file a
+        counter suffix rather than overwriting the newcomer (#1302), and the
+        returned path — not ``<target dir>/<tombstone name>`` — is the
+        authoritative one the id index points at.
+
         Args:
             fragment: The fragment whose id locates the tombed file and whose
                 platform/slug routes the restore destination.
 
         Returns:
-            Path to the restored file, or ``None`` if no tombed file was found.
+            Path to the restored file, or ``None`` if no tombed file was
+            found. May carry a ``-N`` counter suffix when the name was taken.
+
+        Raises:
+            RuntimeError: If a unique filename cannot be allocated in the
+                target directory within
+                :data:`_MAX_FILENAME_COLLISION_RETRIES` attempts.
+            OSError: If the restored file cannot be created, or its index
+                entry cannot be appended.
+
+        Both propagate from :meth:`_relocate_fragment_locked`.
+        :func:`creek.ingest.pipeline.restore_tombed` wraps this call in no
+        handler at all — and the sibling tomb path catches only ``(OSError,
+        KeyError)`` — so the exhaustion ``RuntimeError`` aborts the ingest
+        run. That is deliberately loud, and out of scope to widen here.
+        Tracked in #1325.
         """
         orphan_dir = self.vault_path.joinpath(*_ORPHANED_RELPARTS)
         target_dir = self._fragment_target_dir(fragment)
@@ -948,19 +1077,15 @@ class VaultWriter:
             post = frontmatter.load(str(existing))
             post.metadata.pop("lifecycle", None)
             post.metadata.pop("orphaned_at", None)
-            target_dir.mkdir(parents=True, exist_ok=True)
-            dest = target_dir / existing.name
-            _atomic_write_text(dest, frontmatter.dumps(post))
-            existing.unlink()
-            index = self._load_index_locked(target_dir)
-            # Same deliberate ordering as ``tomb_fragment`` — see the
-            # note there; the restored file is already on disk (above),
-            # so an in-memory mapping that outlives a torn append is the
-            # conservative side of the trade (#1120).
-            index[fragment.id] = dest.name
-            self._append_index_entry(target_dir, fragment.id, dest.name)
-            self._log_provenance_locked(fragment.id, fragment.type, dest)
-        return dest
+            # Same helper, same ordering guarantees as ``tomb_fragment``
+            # (create-before-unlink; #1120 in-memory-before-append).
+            return self._relocate_fragment_locked(
+                existing,
+                target_dir,
+                post,
+                fragment.id,
+                fragment.type,
+            )
 
     def write_thread(self, thread: Thread) -> Path:
         """Write a Thread to 02-Threads/{status}/.

--- a/creek-tools/tests/test_ingest_orphan_tomb.py
+++ b/creek-tools/tests/test_ingest_orphan_tomb.py
@@ -9,9 +9,12 @@ single-file ``--input`` run never tombs (guards the incremental epic).
 
 from __future__ import annotations
 
+import json
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 import frontmatter
+import pytest
 
 from creek.cli import _run_ingest
 from creek.ingest import INGESTOR_REGISTRY
@@ -21,8 +24,6 @@ from creek.vault.writer import VaultWriter
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-    import pytest
 
 
 def _make_vault(tmp_path: Path) -> Path:
@@ -64,6 +65,57 @@ def _journal_fragment(platform: SourcePlatform = SourcePlatform.JOURNAL) -> Frag
     return Fragment(
         id="frag-fixed01", title="Day", source=FragmentSource(platform=platform)
     )
+
+
+# A fragment's filename stem is ``{date}-{sanitised title}`` (``_compute_base_name``),
+# which is unique only *within* one ``01-Fragments/<platform>/`` subfolder. Fixing the
+# date and the title makes two fragments in different subfolders land on the same
+# stem, which is what collides in the flat ``10-Liminal/Orphaned/`` sink (#1302).
+_COLLIDING_CREATED = datetime(2026, 8, 9, tzinfo=UTC)
+_COLLIDING_STEM = "2026-08-09-Notes.md"
+_MARKER_A = "IRREPLACEABLE-MARKER-ALPHA-7f21"
+_MARKER_B = "IRREPLACEABLE-MARKER-BRAVO-3c94"
+
+
+def _colliding_fragment(frag_id: str, platform: SourcePlatform) -> Fragment:
+    """Build a fragment pinned to the shared ``_COLLIDING_STEM`` filename."""
+    return Fragment(
+        id=frag_id,
+        title="Notes",
+        source=FragmentSource(platform=platform),
+        created=_COLLIDING_CREATED,
+    )
+
+
+def _raw_id_index(target_dir: Path) -> dict[str, str]:
+    """Parse ``.id-index.jsonl`` by hand, later-wins, with no repair pass.
+
+    Deliberately bypasses ``VaultWriter._load_index_locked`` and
+    ``_find_existing``: both re-resolve a mis-mapped entry by directory scan
+    and persist the correction (#1083), which is exactly the healing this
+    reader must not perform. Records are self-delimiting since #1120, so the
+    file carries blank separator lines; they are skipped.
+    """
+    index_path = target_dir / ".id-index.jsonl"
+    mapping: dict[str, str] = {}
+    for line in index_path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        record = json.loads(line)
+        mapping[str(record["id"])] = str(record["filename"])
+    return mapping
+
+
+def _provenance_paths(vault: Path) -> dict[str, str]:
+    """Return each id's most recent recorded provenance ``path``."""
+    log_path = vault / "00-Creek-Meta" / "Processing-Log" / "provenance.jsonl"
+    latest: dict[str, str] = {}
+    for line in log_path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        record = json.loads(line)
+        latest[str(record["id"])] = str(record["path"])
+    return latest
 
 
 # ---- Ledger tombed flag -------------------------------------------------
@@ -135,6 +187,267 @@ class TestTombAndRestore:
         assert (
             VaultWriter(vault_path=vault).restore_fragment(_journal_fragment()) is None
         )
+
+
+# ---- Writer tomb / restore: filename collisions (#1302) ----------------
+
+
+class TestTombRestoreFilenameCollisions:
+    """Neither tomb nor restore may destroy a same-named bystander file.
+
+    Both directions used to compose their destination as
+    ``<dir> / existing.name`` and write it with ``_atomic_write_text`` — an
+    ``os.replace`` that overwrites unconditionally. Because a filename stem is
+    unique only within one ``01-Fragments/<platform>/`` subfolder, while
+    ``10-Liminal/Orphaned/`` is a single flat sink for all of them, a second
+    tomb of a same-stemmed fragment silently replaced the first tombstone, and
+    a restore lost the same way to a newer fragment holding the freed stem.
+    Allocation now runs through ``_atomic_create`` (``O_CREAT | O_EXCL`` plus a
+    counter suffix), and these tests keep it that way (#1302).
+    """
+
+    def test_tomb_preserves_a_same_named_bystander(self, tmp_path: Path) -> None:
+        """A second tomb sharing a filename stem must not clobber the first."""
+        vault = _make_vault(tmp_path)
+        writer = VaultWriter(vault_path=vault)
+        # Journal -> 01-Fragments/Journal, Discord -> 01-Fragments/Messages.
+        # ``_write_model`` mkdirs the Messages folder that ``_make_vault`` omits.
+        frag_a = _colliding_fragment("frag-coll-a", SourcePlatform.JOURNAL)
+        frag_b = _colliding_fragment("frag-coll-b", SourcePlatform.DISCORD)
+        path_a = writer.write_fragment(frag_a, body=_MARKER_A)
+        path_b = writer.write_fragment(frag_b, body=_MARKER_B)
+        assert path_a != path_b
+        assert path_a.name == _COLLIDING_STEM
+        assert path_b.name == _COLLIDING_STEM
+
+        tombed_a = writer.tomb_fragment("frag-coll-a")
+        tombed_b = writer.tomb_fragment("frag-coll-b")
+
+        assert tombed_a is not None
+        assert tombed_b is not None
+        bodies = [p.read_text(encoding="utf-8") for p in _orphan_files(vault)]
+        # A's body has no other copy in the vault: the live file was unlinked by
+        # its own tomb, so if B's tomb replaced the tombstone A is simply gone.
+        assert any(_MARKER_A in text for text in bodies)
+        assert any(_MARKER_B in text for text in bodies)
+        assert len(_orphan_files(vault)) == 2
+        assert tombed_a != tombed_b
+        assert tombed_a.exists()
+        assert tombed_b.exists()
+        assert frontmatter.load(str(tombed_a))["id"] == "frag-coll-a"
+        assert frontmatter.load(str(tombed_b))["id"] == "frag-coll-b"
+
+    def test_restore_preserves_a_same_named_bystander(self, tmp_path: Path) -> None:
+        """A restore must not clobber a newer fragment holding the freed stem."""
+        vault = _make_vault(tmp_path)
+        writer = VaultWriter(vault_path=vault)
+        frag_c = _colliding_fragment("frag-coll-c", SourcePlatform.JOURNAL)
+        writer.write_fragment(frag_c, body=_MARKER_A)
+        assert writer.tomb_fragment("frag-coll-c") is not None
+
+        # D takes the stem C freed inside 01-Fragments/Journal.
+        frag_d = _colliding_fragment("frag-coll-d", SourcePlatform.JOURNAL)
+        path_d = writer.write_fragment(frag_d, body=_MARKER_B)
+        assert path_d.name == _COLLIDING_STEM
+        bytes_d = path_d.read_text(encoding="utf-8")
+        assert _MARKER_B in bytes_d
+
+        restored = writer.restore_fragment(frag_c)
+
+        assert restored is not None
+        # D was never tombed and never rewritten: its bytes must be untouched.
+        assert path_d.read_text(encoding="utf-8") == bytes_d
+        assert restored != path_d
+        assert restored.exists()
+        assert path_d.exists()
+        assert frontmatter.load(str(path_d))["id"] == "frag-coll-d"
+        assert frontmatter.load(str(restored))["id"] == "frag-coll-c"
+
+    def test_colliding_tombs_index_to_distinct_filenames(self, tmp_path: Path) -> None:
+        """Each tombed id resolves, from disk, to its own tombstone file."""
+        vault = _make_vault(tmp_path)
+        writer = VaultWriter(vault_path=vault)
+        writer.write_fragment(
+            _colliding_fragment("frag-coll-a", SourcePlatform.JOURNAL),
+            body=_MARKER_A,
+        )
+        writer.write_fragment(
+            _colliding_fragment("frag-coll-b", SourcePlatform.DISCORD),
+            body=_MARKER_B,
+        )
+        writer.tomb_fragment("frag-coll-a")
+        writer.tomb_fragment("frag-coll-b")
+
+        # A fresh writer reloads ``.id-index.jsonl`` from disk instead of reading
+        # the first writer's in-process dict, so this pins what the tomb actually
+        # *recorded* — the path the create returned, not a locally composed name.
+        fresh = VaultWriter(vault_path=vault)
+        orphan_dir = vault / "10-Liminal" / "Orphaned"
+        found_a = fresh._find_existing("frag-coll-a", orphan_dir)
+        found_b = fresh._find_existing("frag-coll-b", orphan_dir)
+
+        assert found_a is not None
+        assert found_b is not None
+        assert found_a != found_b
+        assert frontmatter.load(str(found_a))["id"] == "frag-coll-a"
+        assert frontmatter.load(str(found_b))["id"] == "frag-coll-b"
+
+    def test_colliding_tombs_record_the_created_path_not_the_old_name(
+        self, tmp_path: Path
+    ) -> None:
+        """The index and provenance name the file the create actually made.
+
+        Getting the destination right but recording the pre-move filename
+        would trade a silent overwrite for a silent orphan: the bystander
+        survives, but the id points at a stranger's file.
+        """
+        vault = _make_vault(tmp_path)
+        writer = VaultWriter(vault_path=vault)
+        writer.write_fragment(
+            _colliding_fragment("frag-coll-a", SourcePlatform.JOURNAL),
+            body=_MARKER_A,
+        )
+        writer.write_fragment(
+            _colliding_fragment("frag-coll-b", SourcePlatform.DISCORD),
+            body=_MARKER_B,
+        )
+
+        tombed_a = writer.tomb_fragment("frag-coll-a")
+        tombed_b = writer.tomb_fragment("frag-coll-b")
+
+        assert tombed_a is not None
+        assert tombed_b is not None
+        # Read the raw artifacts, not ``_find_existing``: a mis-mapped entry
+        # is re-resolved by scan and silently repaired on first lookup
+        # (#1083), so a lookup-based assertion cannot tell "recorded
+        # correctly" apart from "recorded wrong and healed on the way out".
+        recorded = _raw_id_index(vault / "10-Liminal" / "Orphaned")
+        assert recorded["frag-coll-a"] == tombed_a.name
+        assert recorded["frag-coll-b"] == tombed_b.name
+        assert recorded["frag-coll-a"] != recorded["frag-coll-b"]
+
+        provenance = _provenance_paths(vault)
+        assert provenance["frag-coll-a"] == str(tombed_a)
+        assert provenance["frag-coll-b"] == str(tombed_b)
+
+    def test_tomb_drops_the_origin_index_entry(self, tmp_path: Path) -> None:
+        """Tombing removes the id from the origin directory's id index."""
+        vault = _make_vault(tmp_path)
+        writer = VaultWriter(vault_path=vault)
+        writer.write_fragment(
+            _colliding_fragment("frag-coll-a", SourcePlatform.JOURNAL),
+            body=_MARKER_A,
+        )
+        origin_dir = vault / "01-Fragments" / "Journal"
+        # Deliberately white-box. A tomb leaves the origin index pointing at a
+        # filename it just unlinked; ``_find_existing_locked`` self-heals that
+        # lazily on the next lookup, so an eager drop is indistinguishable from
+        # the status quo through the public surface. Reading the index directly
+        # is the only assertion that tells them apart, and the writer already
+        # documents ``_find_existing`` as retained "for tests and tooling".
+        assert "frag-coll-a" in writer._dir_indexes[origin_dir]
+
+        writer.tomb_fragment("frag-coll-a")
+
+        assert "frag-coll-a" not in writer._dir_indexes[origin_dir]
+
+    def test_a_failed_destination_create_leaves_the_source_intact(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A tomb that cannot allocate a destination must not unlink the source.
+
+        Pins the create-before-unlink ordering. ``_atomic_create`` gained two
+        ways to raise that ``_atomic_write_text`` never had — ``RuntimeError``
+        at counter-suffix exhaustion and ``OSError`` from a short write that
+        ``create_exclusive`` cleans up. Unlink-first would turn either into a
+        window where the fragment exists nowhere; create-first makes the worst
+        case a recoverable duplicate.
+        """
+        vault = _make_vault(tmp_path)
+        writer = VaultWriter(vault_path=vault)
+        frag = _colliding_fragment("frag-coll-doomed", SourcePlatform.JOURNAL)
+        live = writer.write_fragment(frag, body=_MARKER_A)
+        before = live.read_bytes()
+
+        def _exhausted(_target_dir: Path, _base_name: str, _content: str) -> Path:
+            """Stand in for a destination allocator that cannot succeed."""
+            msg = "Could not allocate a unique filename"
+            raise RuntimeError(msg)
+
+        monkeypatch.setattr(VaultWriter, "_atomic_create", staticmethod(_exhausted))
+
+        with pytest.raises(RuntimeError):
+            writer.tomb_fragment("frag-coll-doomed")
+
+        # The source survives untouched: loud failure, no data loss.
+        assert live.exists()
+        assert live.read_bytes() == before
+        assert _orphan_files(vault) == []
+
+    def test_a_failed_restore_create_leaves_the_tombstone_intact(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The restore direction keeps its source on a failed allocation too.
+
+        Both directions share ``_relocate_fragment_locked``, so this is the
+        symmetric half of the ordering guarantee asserted above — held
+        explicitly rather than by inference from the tomb path.
+        """
+        vault = _make_vault(tmp_path)
+        writer = VaultWriter(vault_path=vault)
+        frag = _colliding_fragment("frag-coll-doomed", SourcePlatform.JOURNAL)
+        writer.write_fragment(frag, body=_MARKER_A)
+        tombed = writer.tomb_fragment("frag-coll-doomed")
+        assert tombed is not None  # setup guard
+        before = tombed.read_bytes()
+
+        def _exhausted(_target_dir: Path, _base_name: str, _content: str) -> Path:
+            """Stand in for a destination allocator that cannot succeed."""
+            msg = "Could not allocate a unique filename"
+            raise RuntimeError(msg)
+
+        monkeypatch.setattr(VaultWriter, "_atomic_create", staticmethod(_exhausted))
+
+        with pytest.raises(RuntimeError):
+            writer.restore_fragment(frag)
+
+        assert tombed.exists()
+        assert tombed.read_bytes() == before
+        assert _journal_files(vault) == []
+
+    def test_round_trip_without_collision_keeps_the_original_filename(
+        self, tmp_path: Path
+    ) -> None:
+        """A tomb+restore with no competitor preserves the existing filename.
+
+        Expected to PASS at HEAD — this is a lock, not a RED. It pins the
+        surviving half of the contract so a collision fix that recomputes the
+        stem from the fragment (``_compute_base_name``) instead of preserving
+        ``existing.name`` is caught: the title is drifted between the tomb and
+        the restore, so a recomputed name would differ and silently rename the
+        file out from under every ``[[wikilink]]`` pointing at it.
+        """
+        vault = _make_vault(tmp_path)
+        writer = VaultWriter(vault_path=vault)
+        frag = _colliding_fragment("frag-coll-solo", SourcePlatform.JOURNAL)
+        original_name = writer.write_fragment(frag, body=_MARKER_A).name
+        assert original_name == _COLLIDING_STEM
+
+        tombed = writer.tomb_fragment("frag-coll-solo")
+        assert tombed is not None
+        assert tombed.name == original_name
+
+        frag.title = "Notes Retitled Much Later"
+        restored = writer.restore_fragment(frag)
+
+        assert restored is not None
+        assert restored.name == original_name
+        assert restored.parent == vault / "01-Fragments" / "Journal"
+        assert _MARKER_A in restored.read_text(encoding="utf-8")
 
 
 # ---- End-to-end: delete -> tomb -> restore -----------------------------


### PR DESCRIPTION
## Summary

`VaultWriter.tomb_fragment` and `VaultWriter.restore_fragment` relocated a fragment by
composing `dest = <dir> / existing.name` and writing it with `_atomic_write_text` —
`mkstemp` + `os.replace`, an **unconditional overwrite** — then unlinking the source.
Every other create path in the module already went through `_atomic_create` →
`creek._fsio.create_exclusive` (`O_CREAT | O_EXCL`) with a counter-suffix retry, which
exists precisely so "two concurrent callers picking the same filename will not clobber
each other". These two were the only writes that bypassed it.

A filename stem is `{date}-{sanitised title}`, which is unique only *within* one
`01-Fragments/<platform>/` subfolder — while `10-Liminal/Orphaned/` is a single flat sink
fed by all of them. So the collision is reachable on a routine mutable-source re-ingest
(`creek/ingest/pipeline.py:293` tombs, `:208` restores), and it destroyed a fragment body
permanently and silently.

Reproduced live at the pre-fix HEAD, both directions:

```
written: 01-Fragments/Journal/2026-08-09-Notes.md
         01-Fragments/Messages/2026-08-09-Notes.md
files in Orphaned after tombing both: ['2026-08-09-Notes.md']
surviving tombstone contains: BODY OF B
BODY OF A anywhere in the vault: False
```

and the mirror — tomb C, ingest a D that reuses the freed stem, restore C, and D's bytes
are gone.

### The fix

A new private `VaultWriter._relocate_fragment_locked` owns the relocation for both
directions; the two public methods keep only what genuinely differs (how `existing` is
located, and whether the frontmatter marker is stamped or cleared). The helper allocates
through `_atomic_create`, so an arriving file takes a `-N` counter suffix instead of
replacing the one already there.

Four orderings in it are load-bearing, and each is pinned by a test:

- **Create the destination before unlinking the source.** `_atomic_create` has two ways
  to raise that `_atomic_write_text` never had — `RuntimeError` at counter-suffix
  exhaustion, and `OSError` from a short write that `create_exclusive` cleans up.
  Create-first means both escape with the source file fully intact: the worst case is a
  recoverable duplicate, never a fragment that exists nowhere.
- **Everything downstream consumes the path `_atomic_create` returned** — the index
  entry, the `_append_index_entry` argument, the provenance path and the return value.
  Getting the destination right but recording the pre-move name would have traded a
  silent overwrite for a silent orphan.
- **The origin's in-memory index entry is dropped after the unlink and before the
  destination assignment.** `self._dir_indexes` is keyed by `Path`, so were origin and
  destination ever the same directory, popping second would delete the mapping just
  written. The on-disk origin `.id-index.jsonl` is deliberately left alone: a
  `_persist_full_index` rewrite from this process's snapshot would destroy entries
  another process appended, and the stale line self-heals through the #1083 verification
  path.
- **The destination's in-memory mapping is set before the on-disk append**, preserved
  from #1120. That rationale previously existed as two hand-maintained copies inside the
  two methods; it now lives once in the helper docstring with a pointer at each call
  site.

`existing.stem` is used as the base name, never `_compute_base_name(fragment)`:
`restore_fragment` does hold a `Fragment`, but a title that drifted since the original
write would silently rename the file out from under every `[[wikilink]]` pointing at it.
Suffix stacking (`-1-1`) therefore only happens under a genuine live collision, which is
exactly when a distinguishing suffix is required — an uncontended tomb → restore round
trip is name-stable, because the tomb frees the origin name before the restore asks for
it back. A test locks that.

`_atomic_write_text` stays: `update_fragment` uses it for an in-place rewrite, where an
unconditional overwrite is the correct semantics.

## Test plan

Eight new tests in `TestTombRestoreFilenameCollisions`
(`tests/test_ingest_orphan_tomb.py`). Four failed at HEAD on behavioural assertions
about destroyed bytes; the rest lock the surviving half of the contract and the
failure-path orderings.

Each guard was then proven load-bearing by reverting **only** it and confirming exactly
the intended tests go red (mutations applied and reverted byte-identical from a saved
copy — no `git stash`, which is a shared ref across live worktrees):

| Mutation | Result |
|---|---|
| `_atomic_create` → back to `_atomic_write_text` on a composed path | 4 fail |
| drop the origin-index `.pop` | exactly 1 fails |
| record `existing.name` instead of the returned `dest.name` | exactly 1 fails |
| reorder to unlink-before-create | exactly 2 fail (tomb + restore) |

The third and fourth mutations initially **survived** and the gaps were closed before
this PR. The `existing.name` mis-indexing was invisible because #1083's
`_find_existing_locked` transparently repairs a mis-mapped entry on the next lookup, so
every lookup-based assertion self-heals; the test that catches it parses
`.id-index.jsonl` and `provenance.jsonl` raw, deliberately bypassing the healing readers.

Gate 2: `./scripts/check-all.sh` — **literal exit code 0**. 12/12 checks, 8793 passed,
5 skipped, aggregate branch coverage 94.39%, per-file gate green (256 files ≥ 80%).
No `# noqa`, no `# type: ignore`, no skips, no threshold changes, no deleted tests.

Gate 2.5 (`code-review-orchestrator` over the diff): **CLEAN**, no blockers. Its three
nits are addressed below — one new symmetric test, and a tracking issue cited from the
docstrings so the deliberate decisions are findable outside the source.

## Acceptance criteria

- [x] Tombing two fragments whose routed filenames collide leaves **two** files in
      `10-Liminal/Orphaned/`, and both bodies are readable.
- [x] Restoring a fragment whose destination stem is now occupied leaves both files intact.
- [x] `.id-index.jsonl` in the destination directory maps each id to a distinct filename
      (asserted against the raw file, not the self-healing loader).
- [x] The origin directory's index no longer resolves the relocated id.
- [x] No existing tests break; coverage stays ≥ 90%.

## Noted, deliberately not changed — filed as #1325

- `tomb_missing_units` (`creek/ingest/pipeline.py:293`) catches only `(OSError, KeyError)`
  and `restore_tombed` (`:208`) catches nothing, so the counter-suffix exhaustion
  `RuntimeError` would abort a whole ingest run rather than being collected as a per-unit
  error. At 10 000 retries it is effectively unreachable and loud by design, which is the
  safe direction for a data-integrity path — but widening the handler is a behaviour
  change outside this issue.
- If `_atomic_create` succeeds and `existing.unlink()` then raises, the new destination
  file is left on disk unindexed. Nothing is lost and no bystander is harmed, and the
  same ordering predates this PR, so it is not a regression — but it is not fully closed
  either.

Both are now cited from the docstrings as `#1325` rather than being discoverable only by
reading the source.

Closes #1302
