### PR TITLE
fix(api): map only routing HTTPExceptions to 404 (#1127)

### DIFF
--- a/creek-tools/creek_mcp/httpapi/app.py
+++ b/creek-tools/creek_mcp/httpapi/app.py
@@ -20,9 +20,25 @@ accepts both spellings is a parser two implementations will disagree about.
 published status set ``{200, 401, 403, 404, 409, 422, 500, 501, 503}``, and a
 conforming client maps an out-of-set status to "unreachable" — losing the vault
 entirely over a wrong verb. It would also publish which verbs a path serves,
-which is a small enumeration primitive. So Starlette's ``HTTPException`` is
-handled here and both the unmatched path and the method mismatch become ``404
-not_found``.
+which is a small enumeration primitive. So the dispatch to :func:`_routing_miss`
+is keyed on the two *statuses* that mean "no such route", ``404`` and ``405``,
+and both the unmatched path and the method mismatch become ``404 not_found``.
+
+**Keyed on the status, not on the exception class (#1127).** Registered against
+:class:`starlette.exceptions.HTTPException` itself, *every* one of them became
+``404 not_found``, which did two kinds of harm. It made a published promise
+false — ``not_found`` is documented as a *routing* code, never emitted for a
+vault object — and, less visibly, it **swallowed the fault**: masked at the
+handler, the exception never reached
+:class:`~creek_mcp.httpapi.middleware.boundary.ErrorBoundaryMiddleware`, so it
+was logged nowhere. That is the un-diagnosable ``500`` #1122 was filed to end,
+wearing a ``404``. The corollary is the whole design: **in this contract
+refusals are returned, never raised** — every published refusal is a ``return
+error_response(...)`` — so the only legitimate raiser of ``HTTPException`` is
+Starlette's own router, at ``404`` or ``405``. Anything else is by construction
+a bug in this server, and a bug is a ``500``. :func:`_not_a_routing_miss`
+therefore holds the class key and does nothing but re-raise, sending the fault
+up to the error boundary to be logged and enveloped there.
 
 This module is therefore the **only** one in :mod:`creek_mcp.httpapi` that names
 :attr:`~creek_mcp.api.models.ErrorCode.NOT_FOUND`, and an AST guard pins that.
@@ -37,14 +53,14 @@ version of that guard — an allowlist over every construction site in
 from __future__ import annotations
 
 from functools import update_wrapper
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final, NoReturn
 
 from starlette.applications import Starlette
 from starlette.exceptions import HTTPException
 from starlette.middleware import Middleware
 from starlette.routing import Route
 
-from creek_mcp.api.models import SUPPORTED_CONTRACT_MINORS, ErrorCode
+from creek_mcp.api.models import ERROR_STATUS, SUPPORTED_CONTRACT_MINORS, ErrorCode
 from creek_mcp.api.routes import CONTRACT_VERSION_HEADER, ROUTES
 from creek_mcp.httpapi import handlers
 from creek_mcp.httpapi.auth import BearerAuthMiddleware, build_verifier
@@ -73,6 +89,22 @@ if TYPE_CHECKING:
     from creek_mcp.httpapi.handlers import Handler
     from creek_mcp.remote_auth import ConsumerTokenVerifier
     from creek_mcp.tools.reflect import _LLMFactory
+
+METHOD_NOT_ALLOWED: Final[int] = 405
+"""The status Starlette's router raises on a verb mismatch.
+
+Spelled as a literal precisely because the contract has **no**
+:class:`~creek_mcp.api.models.ErrorCode` for it. ``405`` is outside the
+published status set ``{200, 401, 403, 404, 409, 422, 500, 501, 503}`` *on
+purpose* — see the module docstring for why a method miss must be
+indistinguishable from a path miss — so there is no table to derive it from,
+and inventing a code to derive it from would put it back in the set.
+
+Its sibling key is written ``ERROR_STATUS[ErrorCode.NOT_FOUND]`` rather than a
+bare ``404`` for the mirror-image reason: that status *does* have a table, and
+the key dispatch matches on must not be able to drift from the code
+:func:`_routing_miss` renders.
+"""
 
 
 def _speaks_a_served_minor(request: Request) -> bool:
@@ -149,17 +181,71 @@ def _route_for(spec: RouteSpec) -> Route:
 async def _routing_miss(request: Request, _exc: Exception) -> Response:
     """Render an unmatched path or a mismatched method as ``404 not_found``.
 
+    Registered against the two routing statuses rather than against
+    :class:`~starlette.exceptions.HTTPException`, so this handler can only ever
+    be entered at ``404`` or ``405``. The "status deliberately unread" claim
+    below used to rest on the author's restraint; status-keyed dispatch makes it
+    structural, because there is no longer any other status that can arrive.
+
     Args:
         request: The request in flight.
-        _exc: The ``HTTPException`` Starlette's router raised. Deliberately
-            unread: its status code (``404`` or ``405``) and its ``Allow``
-            header are exactly the two facts that must not reach the caller.
+        _exc: The ``HTTPException`` that carried one of the two routing
+            statuses here. Deliberately unread: its status code (``404`` or
+            ``405``) and its ``Allow`` header are exactly the two facts that
+            must not reach the caller, and reading the status could now only
+            re-derive the key dispatch already matched on.
 
     Returns:
         The published routing refusal, carrying the standing ``Vary`` like
         every other response.
     """
     return error_response(ErrorCode.NOT_FOUND, context_of(request.scope))
+
+
+async def _not_a_routing_miss(_request: Request, exc: Exception) -> NoReturn:
+    """Re-raise an ``HTTPException`` that is not a routing miss, untouched.
+
+    This handler exists to *displace* Starlette's own class-keyed default, not
+    to answer anything. Leaving that default in place — the "just let it take
+    its own path" reading — was probed against the real stack and answers a
+    raised ``403`` as ``403``, ``content-type: text/plain``, no ``Vary``, and
+    the exception's ``detail`` verbatim as the body. Four contract violations at
+    once: the wrong envelope, the standing ``Vary`` that
+    :mod:`creek_mcp.httpapi.errors` exists to make unconditional now absent, an
+    author-written string on the wire where the contract guarantees only
+    constants from :data:`~creek_mcp.api.models.ERROR_MESSAGES`, and a status
+    outside the published set. So that repair is refused.
+
+    Re-raising is what is left, and it is also what is wanted. The fault escapes
+    Starlette's ``ExceptionMiddleware``,
+    :class:`~creek_mcp.httpapi.middleware.boundary.ErrorBoundaryMiddleware`
+    catches it, logs the traceback on ``creek_mcp.httpapi.error``, and renders
+    ``500 internal_error`` through the single ``error_response`` builder: no
+    second envelope construction site, no duplicated logging, and an operator
+    who gets the traceback for what is, by the module docstring's argument,
+    always a bug in this server.
+
+    The body must stay a bare re-raise. Starlette wraps exception handling
+    twice — once per route in :func:`starlette.routing.request_response` and
+    again at ``ExceptionMiddleware`` — so this is entered **twice** per fault.
+    Purity is what makes that observationally invisible; a log line, a metric or
+    a counter here would each fire twice, and a test pins the fault-log record
+    count at exactly one.
+
+    Args:
+        _request: The request in flight. Unread — dispatch has already made the
+            whole decision by selecting this handler over
+            :func:`_routing_miss`, so there is no branch here to inform, and
+            none anywhere: keying the two handlers on status is what replaces
+            the ``if status_code in {404, 405}`` test a single handler would
+            have needed.
+        exc: The fault Starlette's exception handling caught.
+
+    Raises:
+        Exception: *exc* itself, unchanged and with its traceback intact, for
+            the error boundary above to log and envelope.
+    """
+    raise exc
 
 
 def _middleware(
@@ -242,7 +328,11 @@ def create_app(
             timeout_seconds,
             max_concurrency,
         ),
-        exception_handlers={HTTPException: _routing_miss},
+        exception_handlers={
+            ERROR_STATUS[ErrorCode.NOT_FOUND]: _routing_miss,
+            METHOD_NOT_ALLOWED: _routing_miss,
+            HTTPException: _not_a_routing_miss,
+        },
     )
     app.state.vault_path = vault_path
     app.state.reflect_llm_factory = reflect_llm_factory

--- a/creek-tools/docs/api.md
+++ b/creek-tools/docs/api.md
@@ -308,6 +308,17 @@ vault-object non-answer collapses to `403 privacy_refused` with one fixed
 reason. A method mismatch (`PUT /v1/wheel`) also renders `404`, because `405` is
 not in the contract's published status set.
 
+**`404` is keyed on the routing statuses, not on the exception class.** The two
+answers the router can reach — `404` for a path it does not serve and `405` for
+a verb it does not serve on a path it does — are the only ones that become
+`not_found`. Any *other* internal `HTTPException` is a bug in this server rather
+than a routing outcome, because every published refusal is returned through the
+error table and none is ever raised; it therefore takes the error boundary's
+path and renders `500 internal_error`, with the traceback going to the operator
+log and nothing but the constant envelope going to the caller. Folding those
+into `404` instead would have made the promise directly above this paragraph
+false, and would have hidden the fault from the operator as well as the client.
+
 ## Hardening
 
 | Limit | Default | Behaviour when exceeded |

--- a/creek-tools/tests/test_v1_api_hardening.py
+++ b/creek-tools/tests/test_v1_api_hardening.py
@@ -56,10 +56,11 @@ from anyio import Event, create_task_group, sleep_forever
 from anyio import run as run_async
 from anyio import sleep as async_sleep
 from anyio.to_thread import run_sync
+from starlette.exceptions import HTTPException
 from starlette.responses import JSONResponse
 
 from creek.audit import log as audit_log_module
-from creek_mcp.api.models import ERROR_MESSAGES, ErrorCode
+from creek_mcp.api.models import ERROR_MESSAGES, ERROR_STATUS, ErrorCode
 from creek_mcp.audit import MCP_AUDIT_RELPATH, verify_mcp_audit_chain
 from creek_mcp.httpapi import capabilities as capabilities_module
 from creek_mcp.httpapi import handlers as handlers_module
@@ -78,6 +79,7 @@ from creek_mcp.httpapi.middleware.limits import (
 from tests.v1_api_support import (
     ANONYMOUS_CONSUMER,
     CAPABILITIES_PATH,
+    CEILING_HEADER,
     CONSUMER,
     HEALTH_PATH,
     JOURNAL_PATH,
@@ -98,7 +100,7 @@ from tests.v1_api_support import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterator
+    from collections.abc import Awaitable, Callable, Iterator
     from pathlib import Path
 
     from starlette.applications import Starlette
@@ -113,6 +115,22 @@ _UNAVAILABLE_STATUS: Final[int] = 503
 _INTERNAL_ERROR_STATUS: Final[int] = 500
 _UNSUPPORTED_STATUS: Final[int] = 501
 _UNAUTHENTICATED_STATUS: Final[int] = 401
+_NOT_FOUND_STATUS: Final[int] = 404
+_METHOD_NOT_ALLOWED_STATUS: Final[int] = 405
+_BAD_REQUEST_STATUS: Final[int] = 400
+_FORBIDDEN_STATUS: Final[int] = 403
+_BAD_GATEWAY_STATUS: Final[int] = 502
+
+ALLOWED_HTTP_STATUSES: Final[frozenset[int]] = frozenset(
+    set(ERROR_STATUS.values()) | {_OK_STATUS}
+)
+"""The closed status set the contract publishes, derived not restated.
+
+Spelled the same way ``tests/test_v1_api_not_implemented.py`` spells it, and
+derived in both places rather than imported from one into the other: no test
+module here imports from another, because a shared fixture that two suites
+disagreed about would make their refusal tests measure different things.
+"""
 
 _SMALL_LIMIT: Final[int] = 64
 """A tiny body cap, so the size tests stay in-memory and instant."""
@@ -1296,6 +1314,256 @@ def test_the_fault_does_not_reach_the_access_logger(
     assert access[0].exc_info is None
     assert _SENTINEL_BODY not in str(access[0].__dict__)
     assert len(_error_records(caplog)) == 1
+
+
+_NON_ROUTING_STATUSES: Final[tuple[int, ...]] = (
+    _BAD_REQUEST_STATUS,
+    _FORBIDDEN_STATUS,
+    _BAD_GATEWAY_STATUS,
+)
+"""Three ``HTTPException`` statuses that are not routing outcomes (#1127).
+
+``403`` is :attr:`~creek_mcp.api.models.ErrorCode.PRIVACY_REFUSED`'s status, so
+a blanket class-keyed routing handler *mislabels* the most contract-loaded code
+in the vocabulary: the single answer this surface gives for every vault-object
+non-answer would reach the caller as ``not_found``, which is precisely the
+existence oracle #846 / #970 / #972 / #1090 spent five issues collapsing.
+
+``400`` and ``502`` sit outside the published status set altogether, and that
+is what disqualifies the tempting alternative of simply letting Starlette's own
+default handler render a non-routing ``HTTPException``: it would emit a literal
+``400``, as ``text/plain``, echoing the detail, with no ``Vary`` — four
+contract violations for the price of one line.
+"""
+
+_NON_ROUTING_IDS: Final[tuple[str, ...]] = (
+    "400-bad-request",
+    "403-forbidden",
+    "502-bad-gateway",
+)
+"""Stable parametrize ids for :data:`_NON_ROUTING_STATUSES`, in that order."""
+
+_ROUTING_STATUSES: Final[tuple[int, ...]] = (
+    _NOT_FOUND_STATUS,
+    _METHOD_NOT_ALLOWED_STATUS,
+)
+"""The two statuses that *are* routing outcomes, whoever raised them."""
+
+_ROUTING_IDS: Final[tuple[str, ...]] = ("404-not-found", "405-method-not-allowed")
+"""Stable parametrize ids for :data:`_ROUTING_STATUSES`, in that order."""
+
+
+def _raise_http_exception(status: int) -> Callable[[Request], Awaitable[Response]]:
+    """Return a handler that always raises ``HTTPException(status)``.
+
+    The detail deliberately carries :data:`_SENTINEL_BODY`. A raiser whose
+    message nobody could mind seeing would make "the detail is not echoed" true
+    by construction rather than by the server's doing — and real details do
+    carry vault material, since the shape an author reaches for is
+    ``fragment 'abc' is above your ceiling``.
+
+    Args:
+        status: The status the raised
+            :class:`~starlette.exceptions.HTTPException` declares.
+
+    Returns:
+        An async handler with the mounted-endpoint signature that never
+        returns.
+    """
+
+    async def _raiser(_request: Request) -> Response:
+        """Raise the configured ``HTTPException``.
+
+        Args:
+            _request: Ignored.
+
+        Returns:
+            Never.
+
+        Raises:
+            HTTPException: Always, at the configured status, detailed with the
+                sentinel the envelope must not echo.
+        """
+        raise HTTPException(status, detail=f"refused {_SENTINEL_BODY}")
+
+    return _raiser
+
+
+@pytest.mark.parametrize("status", _NON_ROUTING_STATUSES, ids=_NON_ROUTING_IDS)
+def test_a_non_routing_http_exception_is_the_published_500(
+    vault: Path, monkeypatch: pytest.MonkeyPatch, status: int
+) -> None:
+    """A non-routing ``HTTPException`` is ``500 internal_error`` (#1127).
+
+    The routing miss belongs to the *statuses* that mean "no such route", not
+    to the exception class. Keyed on the class, every ``HTTPException`` the
+    surface can raise — a ``403``, a ``502``, anything — renders as ``404
+    not_found`` instead, and the fault never reaches the error boundary, so it
+    is never logged either.
+
+    The negative assertion is the whole issue, so it is stated out loud rather
+    than left implied by the positive one: ``not_found`` is documented as a
+    *routing* code that is never emitted for a vault object, and a masked fault
+    wearing it makes that published promise false.
+
+    Args:
+        vault: A seeded vault.
+        monkeypatch: Swaps the health handler for one raising at *status*.
+        status: The non-routing status the handler raises; see
+            :data:`_NON_ROUTING_STATUSES` for why these three.
+    """
+    monkeypatch.setitem(
+        handlers_module.HANDLERS, OP_HEALTH, _raise_http_exception(status)
+    )
+    with client(vault_path=vault) as test_client:
+        response = test_client.get(HEALTH_PATH, headers=headers())
+
+    body = envelope(response)
+    assert response.status_code == _INTERNAL_ERROR_STATUS
+    assert body["code"] == ErrorCode.INTERNAL_ERROR.value
+    assert body["code"] != ErrorCode.NOT_FOUND.value
+    assert body["message"] == ERROR_MESSAGES[ErrorCode.INTERNAL_ERROR]
+    assert set(body) == {"code", "message", "request_id"}
+
+
+@pytest.mark.parametrize("status", _NON_ROUTING_STATUSES, ids=_NON_ROUTING_IDS)
+def test_a_non_routing_http_exception_echoes_no_detail(
+    vault: Path, monkeypatch: pytest.MonkeyPatch, status: int
+) -> None:
+    """The detail is discarded, and the envelope's shape and headers hold.
+
+    An ``HTTPException``'s detail is author-written and routinely names the
+    thing that was refused, so echoing it hands back the identifier the ceiling
+    gate exists to leave unconfirmed.
+
+    ``content-type`` is asserted because it is what fails loudly if anyone
+    "fixes" this by falling back to Starlette's default handler: that answers
+    ``text/plain`` with the detail *as* the body. ``Vary`` is asserted because
+    it is only unconditional while every response — this one included — is
+    built by the single response builder in
+    :mod:`creek_mcp.httpapi.errors`.
+
+    Args:
+        vault: A seeded vault.
+        monkeypatch: Swaps the health handler for one raising at *status*.
+        status: The non-routing status the handler raises; see
+            :data:`_NON_ROUTING_STATUSES` for why these three.
+    """
+    monkeypatch.setitem(
+        handlers_module.HANDLERS, OP_HEALTH, _raise_http_exception(status)
+    )
+    with client(vault_path=vault) as test_client:
+        response = test_client.get(HEALTH_PATH, headers=headers())
+
+    assert _SENTINEL_BODY not in response.text
+    assert "Traceback" not in response.text
+    assert "HTTPException" not in response.text
+    assert not contains_a_path(response.text)
+    assert response.headers["content-type"].startswith("application/json")
+    assert response.headers["vary"] == CEILING_HEADER
+
+
+def test_a_non_routing_http_exception_is_logged_exactly_once(
+    vault: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """One record, with the traceback; the caller still gets the bare envelope.
+
+    Starlette wraps exception handling twice — once per route in
+    ``routing.request_response`` and again at ``ExceptionMiddleware`` — so the
+    class-keyed handler that lets a non-routing fault through is entered twice
+    per fault. It is a pure re-raise, which makes that observationally
+    invisible, and ``== 1`` is what keeps it so: the count turns red the moment
+    anyone adds a log line, a metric or a counter to that handler, and a fault
+    reported twice is a fault an operator triages twice.
+
+    ``403`` alone is enough. The count is a property of the dispatch, not of
+    the status. The contrast — sentinel present in the log, absent from the
+    body — is asserted here in one place for the same reason
+    :func:`test_a_handler_fault_is_logged_with_its_traceback` asserts it in
+    one place: it is their conjunction that is the invariant.
+
+    Args:
+        vault: A seeded vault.
+        monkeypatch: Swaps the health handler for one raising ``403``.
+        caplog: Captures the fault log.
+    """
+    monkeypatch.setitem(
+        handlers_module.HANDLERS, OP_HEALTH, _raise_http_exception(_FORBIDDEN_STATUS)
+    )
+    caplog.set_level(logging.ERROR, logger=ERROR_LOGGER_NAME)
+    with client(vault_path=vault) as test_client:
+        response = test_client.get(HEALTH_PATH, headers=headers())
+
+    records = _error_records(caplog)
+    assert len(records) == 1
+    record = records[0]
+    assert record.exc_info is not None
+    assert record.exc_info[0] is HTTPException
+    assert "Traceback (most recent call last)" in caplog.text
+    assert _SENTINEL_BODY in caplog.text
+    assert _field(record, "request_id") == envelope(response)["request_id"]
+
+    assert _SENTINEL_BODY not in response.text
+
+
+@pytest.mark.parametrize("status", _ROUTING_STATUSES, ids=_ROUTING_IDS)
+def test_a_handler_raised_routing_status_is_still_the_routing_miss(
+    vault: Path, monkeypatch: pytest.MonkeyPatch, status: int
+) -> None:
+    """``404`` and ``405`` render as ``404 not_found`` whoever raised them.
+
+    The discriminator is the **status**, not the raiser. This server cannot
+    tell a ``404`` raised inside a handler from one raised by the router — the
+    exception carries no provenance — and it deliberately does not try: a
+    handler that concluded "no such route" has said what the router says, and
+    answering the two differently would publish which of them concluded it. So
+    both keep the published routing refusal, and the ``405``'s ``Allow``
+    header — a verb-enumeration primitive attached to a status outside the
+    contract's set — never reaches the caller.
+
+    Args:
+        vault: A seeded vault.
+        monkeypatch: Swaps the health handler for one raising at *status*.
+        status: The routing status the handler raises.
+    """
+    monkeypatch.setitem(
+        handlers_module.HANDLERS, OP_HEALTH, _raise_http_exception(status)
+    )
+    with client(vault_path=vault) as test_client:
+        response = test_client.get(HEALTH_PATH, headers=headers())
+
+    body = envelope(response)
+    assert response.status_code == _NOT_FOUND_STATUS
+    assert body["code"] == ErrorCode.NOT_FOUND.value
+    assert body["message"] == ERROR_MESSAGES[ErrorCode.NOT_FOUND]
+    assert _SENTINEL_BODY not in response.text
+    assert "allow" not in {name.lower() for name in response.headers}
+
+
+@pytest.mark.parametrize("status", _NON_ROUTING_STATUSES, ids=_NON_ROUTING_IDS)
+def test_a_non_routing_http_exception_stays_in_the_published_set(
+    vault: Path, monkeypatch: pytest.MonkeyPatch, status: int
+) -> None:
+    """Whatever a handler raises, the wire status is one the contract publishes.
+
+    ``400`` and ``502`` are not in the closed set, and a conforming client maps
+    an out-of-set status to "unreachable" — losing the vault over a fault it
+    could have retried. This is the assertion that refuses the "just let
+    Starlette render it" repair, which would put the raised status on the wire
+    verbatim.
+
+    Args:
+        vault: A seeded vault.
+        monkeypatch: Swaps the health handler for one raising at *status*.
+        status: The non-routing status the handler raises.
+    """
+    monkeypatch.setitem(
+        handlers_module.HANDLERS, OP_HEALTH, _raise_http_exception(status)
+    )
+    with client(vault_path=vault) as test_client:
+        response = test_client.get(HEALTH_PATH, headers=headers())
+
+    assert response.status_code in ALLOWED_HTTP_STATUSES
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

`creek_mcp/httpapi/app.py` registered `exception_handlers={HTTPException: _routing_miss}`, so
**every** `HTTPException` — whatever its status — rendered as `404 not_found`. The issue cited
`:234`; the line had drifted to **`:245`**.

That did two kinds of harm, and only the first was in the issue.

**It made a published promise false.** `not_found` is documented at `creek_mcp/api/models.py:265-269`
and in `docs/api.md` as a *routing* code, never emitted for a vault object, because a caller who
can tell "no such fragment" from "you may not see this fragment" can enumerate the corpus. A
future handler's `HTTPException(403)` wearing `not_found` breaks that.

**It also swallowed the fault.** Masked at the handler, the exception never reached
`ErrorBoundaryMiddleware`, so it was logged *nowhere* — the un-diagnosable-500 condition #1122 was
filed to end, wearing a `404`. A new test caught this (`assert 0 == 1` on the fault-log record
count); the issue did not mention it.

### The fix

Dispatch is now keyed on the two **statuses** that mean "no such route", with the class key
overridden by a handler whose whole body is `raise exc`:

```python
exception_handlers={
    ERROR_STATUS[ErrorCode.NOT_FOUND]: _routing_miss,
    METHOD_NOT_ALLOWED: _routing_miss,
    HTTPException: _not_a_routing_miss,
}
```

Status-keyed registration adds **no branch at all**, rather than the `if status_code in {404, 405}`
the issue proposed, and it makes `_routing_miss`'s standing docstring claim that its status is
"deliberately unread" *structural* — no other status can now arrive there.

### What renders a non-routing `HTTPException`, and why not Starlette

"Let anything else take its own path" has a tempting literal reading — drop the class key and let
Starlette's default handler have it. **I probed that against the real stack and it is a new
defect, not a fix.** A raised `HTTPException(403, detail="fragment 'abc' is above your ceiling")`
comes back as:

```
status: 403 · content-type: text/plain · vary: None
body: fragment 'abc' is above your ceiling
```

Four contract violations at once: not the error envelope, the standing `Vary` that
`httpapi/errors.py` exists to make unconditional is gone, an author-written string is on the wire
where the contract guarantees only constants from `ERROR_MESSAGES`, and `403`/`400`/`502` are
statuses a conforming client maps to "unreachable".

So the class handler re-raises instead. The fault escapes `ExceptionMiddleware`,
`ErrorBoundaryMiddleware` catches it, logs the traceback on `creek_mcp.httpapi.error`, and renders
`500 internal_error` through the single `error_response` builder — one envelope construction site,
one logging site, `Vary` intact.

The premise that makes `500` the honest answer, verified by grep rather than assumed: **there is
no `raise HTTPException` anywhere in `creek_mcp/`.** Every published refusal is a
`return error_response(...)`. Refusals are returned, never raised — so the only legitimate raiser
is Starlette's own router, at `404` or `405`, and anything else is by construction a bug in this
server. A bug is a `500`.

### Error-disclosure went down, not up

Masking a `403` as `404` *hides* information, so unmasking it had to be checked for the reverse.
It discloses nothing new: the caller now sees `500 internal_error` with the same constant message
and the same `Vary`, and the only fact added is "this server has a bug" — never "this object
exists". The exception's `detail` is asserted absent from the body and present only in the
operator log, which is the audience split #1122 established.

`405` is untouched and still invisible — verified live: `PUT /v1/wheel` returns `404 not_found`
with **no** `Allow` header.

## Test plan

- New tests in `tests/test_v1_api_hardening.py`'s "Error boundary" section, all driving the real
  app and asserting on the **rendered response**:
  - `test_a_non_routing_http_exception_is_the_published_500` — `[400, 403, 502]`, asserts
    `500 internal_error` **and explicitly `!= not_found`**
  - `test_a_non_routing_http_exception_echoes_no_detail` — sentinel absent, `content-type:
    application/json` (the assertion that fails loudly if anyone reinstates Starlette's
    `PlainTextResponse` default), `Vary` present
  - `test_a_non_routing_http_exception_is_logged_exactly_once` — record count `== 1`, `exc_info[0]
    is HTTPException`, sentinel in the log and absent from the body
  - `test_a_handler_raised_routing_status_is_still_the_routing_miss` — `[404, 405]` still render
    `404 not_found` with no `Allow`
  - `test_a_non_routing_http_exception_stays_in_the_published_set`
- **RED proved before the fix:** `assert 404 == 500` ×3 and `assert 0 == 1`.
- **Load-bearing proved:** reverting *only* the `exception_handlers` dict turns exactly those four
  red and nothing else — `4 failed, 388 passed`.
- `tests/test_v1_api_not_implemented.py` is deliberately **untouched**: its 54-request router
  sweeps at `:406-492` are the regression tripwire for the `404`/`405` half and had to keep
  passing unmodified. They do.
- Gate 2 `./scripts/check-all.sh` → **literal exit 0**; 12 passed / 0 failed, 8826 tests,
  coverage 94.39%.
- No `crawdad/` files touched. No `noqa`, `type: ignore`, skips, or threshold changes.

## Notes

- `METHOD_NOT_ALLOWED` is a literal because the contract deliberately has **no** `ErrorCode` for
  `405` — it is outside the published status set on purpose, so there is no table to derive it
  from. Its sibling key is `ERROR_STATUS[ErrorCode.NOT_FOUND]` rather than a bare `404` for the
  mirror-image reason: that status *does* have a table, and the dispatch key must not drift from
  the code `_routing_miss` renders.
- `_not_a_routing_miss` is entered **twice** per fault, because Starlette wraps exception handling
  both per-route (`routing.request_response`) and at `ExceptionMiddleware`. A pure re-raise makes
  that observationally invisible; the `== 1` log-record assertion is what keeps it pure.
- No collision with the sibling follow-ups from the same review: **#1128** and **#1129** touch
  `httpapi/errors.py`, **#1130** touches `test_v1_api_hardening.py:407` (~1000 lines from this
  diff's additions). This change routes its new `500` through `error_response`, so it inherits
  #1128's `Vary` merge fix and #1129's `Cache-Control` work automatically.

Closes #1127
