### PR TITLE
fix(classify): a failed weighted LLM call stamps rules, not a lying llm (#1330)

### DIFF
--- a/creek-tools/creek/classify/classify_engine.py
+++ b/creek-tools/creek/classify/classify_engine.py
@@ -1544,10 +1544,12 @@ def _classify_one_weighted(
     :meth:`WeightedFragmentClassification.to_legacy` so existing
     consumers (lint, compile, voice-skill generation) stay
     synchronised. When the underlying call fails soft to an empty
-    profile (provider unavailable, transport error, malformed YAML)
-    the legacy fields collapse to ``UNCLASSIFIED`` — the operator
-    sees the same "no signal" verdict the single-pick path produces
-    on failure.
+    profile (whitespace-only body, provider unavailable, transport
+    error, malformed YAML) nothing is derived from it: the input
+    fragment is handed back untouched — rule verdict intact,
+    :attr:`Fragment.weighted` still ``None`` — and reported as a
+    skip, exactly as the single-pick path reports its own failures
+    (#744, #1330).
 
     Args:
         fragment: Fragment carrying any rule-classifier output that
@@ -1558,14 +1560,27 @@ def _classify_one_weighted(
             Anthropic selection the legacy LLM path uses.
 
     Returns:
+        ``(fragment, skipped, reasoning)``. On success,
         ``(updated_fragment, False, reasoning)``: the weighted profile
-        plus its derived legacy fields land on the returned Fragment;
-        ``False`` reflects "the LLM was actually invoked"; the
+        plus its derived legacy fields land on the returned Fragment,
+        ``False`` reflects "the LLM was actually invoked", and the
         reasoning trace mirrors the model's preamble for FEAT-017
-        observability.
+        observability. On failure, ``(fragment, True, "")``: the input
+        fragment unchanged, and ``True`` so the caller treats it like
+        the rules-sufficed skip.
     """
     ingested = IngestedFragment(fragment=fragment, body=body)
-    weighted = classify_weighted(ingested, llm_config)
+    result = classify_weighted(ingested, llm_config)
+    if not result.succeeded:
+        # The weighted call produced nothing (whitespace-only body, provider
+        # unavailable, transport error, malformed YAML) and there is no profile
+        # to derive from. Treat it like the rules-sufficed skip so the write
+        # path stamps ``rules`` (the result that actually stands), NOT a lying
+        # ``classification_method: llm`` — and the fragment stays eligible for
+        # a later re-classify rather than being skipped by
+        # ``_record_if_preserved`` forever (#744, #1330).
+        return fragment, True, ""
+    weighted = result.classification
     freq, wave, voice = weighted.to_legacy()
     updated = fragment.model_copy(
         update={

--- a/creek-tools/creek/classify/weighted.py
+++ b/creek-tools/creek/classify/weighted.py
@@ -72,6 +72,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "WEIGHTED_CLASSIFICATION_TEMPLATE",
+    "WeightedClassificationResult",
     "WeightedDimension",
     "WeightedFragmentClassification",
     "build_weighted_classification_prompt",
@@ -794,10 +795,30 @@ def parse_weighted_yaml(response: str) -> WeightedFragmentClassification:
     )
 
 
+@dataclass(frozen=True)
+class WeightedClassificationResult:
+    """Outcome of a single weighted-profile classification call.
+
+    Attributes:
+        classification: The detected weighted ontology profile. When
+            the call short-circuits (whitespace-only body, provider
+            unavailable, transport error, unparseable payload), this is
+            the empty :class:`WeightedFragmentClassification` default.
+        succeeded: ``True`` when the LLM actually produced a weighted
+            profile; ``False`` when the call short-circuited or failed
+            and ``classification`` is the empty default. Lets the engine
+            avoid stamping ``classification_method: llm`` on a failed
+            call (#1330).
+    """
+
+    classification: WeightedFragmentClassification
+    succeeded: bool = True
+
+
 def classify_weighted(
     fragment: IngestedFragment,
     config: LLMConfig,
-) -> WeightedFragmentClassification:
+) -> WeightedClassificationResult:
     """Classify a fragment, returning a weighted ontology profile.
 
     Fragment-level twin of
@@ -808,10 +829,14 @@ def classify_weighted(
     descending, the model's reasoning preamble, and the model's
     self-reported overall confidence.
 
-    Short-circuits to an empty :class:`WeightedFragmentClassification`
-    when the fragment body is whitespace-only, when the provider is
-    unavailable, or when the call raises — the caller can then decide
-    whether to abort or to proceed without weighted guidance.
+    That profile is wrapped in a :class:`WeightedClassificationResult`
+    rather than handed back bare because an empty profile is
+    indistinguishable from a genuine all-unclassified verdict: a caller
+    that cannot tell the two apart stamps a provenance the run did not
+    earn (#1330). So the wrapper reports ``succeeded=False`` when the
+    provider is unavailable and when the call raises — and equally for
+    a whitespace-only body, which short-circuits before a classifier is
+    even built: no LLM ran there either.
 
     Args:
         fragment: The fragment (paired with its body via
@@ -819,11 +844,16 @@ def classify_weighted(
         config: LLM provider configuration (provider, model, threshold).
 
     Returns:
-        The detected :class:`WeightedFragmentClassification`; empty
-        (all-zeros) when classification could not run.
+        The detected :class:`WeightedFragmentClassification` paired with
+        whether an LLM actually produced it. When classification could
+        not run the classification is empty (all-zeros) and
+        ``succeeded`` is ``False``.
     """
     if not fragment.body.strip():
-        return WeightedFragmentClassification()
+        return WeightedClassificationResult(
+            classification=WeightedFragmentClassification(),
+            succeeded=False,
+        )
 
     # Import inside the function to avoid pulling the heavy classify
     # package into module-load time — :mod:`creek.classify.weighted`
@@ -839,7 +869,10 @@ def classify_weighted(
             "LLM provider %r unavailable; returning empty weighted classification",
             config.provider,
         )
-        return WeightedFragmentClassification()
+        return WeightedClassificationResult(
+            classification=WeightedFragmentClassification(),
+            succeeded=False,
+        )
 
     prompt = build_weighted_classification_prompt(
         body=fragment.body,
@@ -853,11 +886,15 @@ def classify_weighted(
     except (RuntimeError, OSError, ValueError) as exc:
         # ValueError covers malformed YAML and schema violations from
         # the parser; RuntimeError/OSError cover provider transport
-        # failures. Both collapse to "no signal" so the caller can
-        # decide whether to proceed without weighted guidance.
+        # failures. Both report ``succeeded=False`` so the caller can
+        # tell a failed call from a genuine all-unclassified verdict
+        # and decide whether to proceed without weighted guidance.
         logger.warning(
             "Weighted fragment classification failed (%s); returning empty result",
             exc,
         )
-        return WeightedFragmentClassification()
-    return parsed
+        return WeightedClassificationResult(
+            classification=WeightedFragmentClassification(),
+            succeeded=False,
+        )
+    return WeightedClassificationResult(classification=parsed)

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -694,7 +694,12 @@ class ClassificationConfig(BaseModel):
     Rule-confident fragments are NOT re-classified —
     :attr:`Fragment.weighted` stays ``None`` for those even with this
     flag on. This preserves the FEAT-017 cost gate that already keeps
-    the LLM from re-running over high-confidence rule picks.
+    the LLM from re-running over high-confidence rule picks. A fragment
+    whose weighted call reaches the LLM but *fails* (provider
+    unavailable, transport error, unparseable payload) likewise keeps
+    :attr:`Fragment.weighted` as ``None``, along with its honest
+    ``rules`` provenance, rather than persisting a fabricated all-zero
+    profile (#1330).
     """
 
 

--- a/creek-tools/tests/test_classify_failed_weighted_provenance.py
+++ b/creek-tools/tests/test_classify_failed_weighted_provenance.py
@@ -1,0 +1,583 @@
+"""A failed *weighted* classification must not be stamped ``llm`` (#1330).
+
+The weighted-classification path
+(:func:`creek.classify.classify_engine._classify_one_weighted` ->
+:func:`creek.classify.weighted.classify_weighted`) fails soft to a bare
+``WeightedFragmentClassification()`` in three places — whitespace-only body,
+provider unavailable, and the ``(RuntimeError, OSError, ValueError)`` catch —
+and the engine has no ``succeeded`` check to notice. The consequences, all
+observed end-to-end on a tmp vault at HEAD:
+
+* ``classification_method: llm`` and ``classification_provider: ollama`` are
+  stamped for a call that produced nothing;
+* the rule classifier's surviving verdict (``frequency.primary: F3``) is
+  overwritten with ``unclassified``;
+* a fabricated all-zero ``weighted`` profile is persisted;
+* the fragment id is appended to the OPS-001 resume ledger; and
+* the next non-``--force`` run therefore reports ``preserved_llm=1`` and skips
+  the fragment permanently, because a prior ``llm`` stamp means "already paid
+  for".
+
+This is the weighted twin of :mod:`tests.test_classify_failed_llm_provenance`
+(#744), which pinned the same contract on the single-pick LLM path at
+``classify_engine.py:1519-1529``. Every assertion here is on the **persisted
+frontmatter** (or on the run summary / the vault's file tree), never on mock
+call counts.
+
+Test seam: ``classify_weighted`` builds its *own* :class:`LLMClassifier` via a
+function-local import, which is a different object from the engine's, and
+``_assert_classifiers_available`` aborts the run up front if the engine's
+classifier is unavailable. So both ends are patched: the engine's class is
+swapped for :class:`_EngineStub` (available, and loud if the single-pick path
+is ever reached), while the *failure* is injected onto the real class that
+``classify_weighted`` constructs for itself.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Final
+from unittest.mock import patch
+
+import frontmatter
+import pytest
+
+from creek.classify.classify_engine import run_classify
+from creek.classify.constants import CLASSIFICATION_PROVIDER_KEY
+from creek.classify.llm.orchestrator import LLMClassificationResult
+from creek.config import (
+    ClassificationConfig,
+    CreekConfig,
+    LLMConfig,
+    LLMRoutingConfig,
+)
+from creek.models import Fragment, FragmentSource, SourcePlatform
+from tests.helpers import write_fragment_file
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+    from pathlib import Path
+
+# ---- Patch targets ----
+
+_ENGINE_CLASSIFIER: Final[str] = "creek.classify.classify_engine.LLMClassifier"
+"""The engine's own classifier reference — swapped for a stub wholesale."""
+
+_AVAILABILITY: Final[str] = "creek.classify.llm.LLMClassifier._check_availability"
+"""Availability hook on the real class ``classify_weighted`` builds itself."""
+
+_INVOKE: Final[str] = "creek.classify.llm.LLMClassifier.invoke_prompt"
+"""Transport hook on the real class ``classify_weighted`` builds itself."""
+
+# ---- Fixture data ----
+
+FRAGMENT_ID: Final[str] = "frag-0000weighted"
+"""Id of the single seeded fragment; also what the resume ledger would log."""
+
+F3_BODY: Final[str] = "I feel rage and anger and power and dominance and conflict."
+"""A body the rule classifier scores as ``F3`` at confidence 0.56."""
+
+F3_TWO_PARAGRAPH_BODY: Final[str] = (
+    "I feel rage and anger and power and dominance and conflict.\n\n"
+    "Anger and rage keep returning as dominance and conflict."
+)
+"""Two single-sentence paragraphs, so the FEAT-021 splitter has real work."""
+
+WHITESPACE_BODY: Final[str] = "   \n   "
+"""A body that trips ``classify_weighted``'s whitespace short-circuit."""
+
+PROGRESS_LOG_PARTS: Final[tuple[str, str, str]] = (
+    "00-Creek-Meta",
+    "Processing-Log",
+    "llm-progress.jsonl",
+)
+"""Vault-relative path of the OPS-001 resume ledger."""
+
+VALID_WEIGHTED_RESPONSE: Final[str] = """The fragment lands at F3 / Red.
+
+```yaml
+frequencies:
+  - value: F3
+    weight: 0.8
+phases:
+  - value: rising
+    weight: 0.7
+overall_confidence: 0.7
+```
+"""
+"""A well-formed weighted response, shaped like ``_weighted_yaml_payload()``."""
+
+
+# ---- Provider stubs and failure injection ----
+
+
+class _EngineStub:
+    """Stands in for the *engine's* ``LLMClassifier`` (the #1330 test seam).
+
+    Only two things are asked of it: pass
+    :func:`~creek.classify.classify_engine._assert_classifiers_available`'s
+    up-front check, and expose the ``config`` that
+    ``_classify_one_weighted`` forwards to ``classify_weighted``. The
+    single-pick entry point raises, so a silent fall-through off the weighted
+    path fails loudly instead of quietly passing these tests.
+    """
+
+    def __init__(self, config: LLMConfig) -> None:
+        """Retain the routed config the weighted path will re-use.
+
+        Args:
+            config: The per-stage config the ModelRouter resolved.
+        """
+        self.config = config
+
+    @property
+    def available(self) -> bool:
+        """Report the engine-side provider as reachable.
+
+        Returns:
+            Always ``True`` — the failure under test is injected further
+            down, inside ``classify_weighted``'s own classifier.
+        """
+        return True
+
+    def classify_with_reasoning(
+        self,
+        fragment: Fragment,
+        content: str = "",
+    ) -> LLMClassificationResult:
+        """Fail loudly: the weighted run must never reach the single-pick call.
+
+        Args:
+            fragment: Unused; the call is a contract violation.
+            content: Unused; the call is a contract violation.
+
+        Returns:
+            Never returns.
+
+        Raises:
+            AssertionError: Always.
+        """
+        del fragment, content
+        msg = "weighted run must not fall through to classify_with_reasoning"
+        raise AssertionError(msg)
+
+
+class _ReatomizingEngineStub(_EngineStub):
+    """An :class:`_EngineStub` whose single-pick call *succeeds*.
+
+    FEAT-023 re-atomization re-enters ``_classify_one`` **without** the
+    weighted flag (``classify_engine.py:1607-1614``), so the child classifier
+    legitimately uses the single-pick entry point. Letting it succeed keeps
+    the re-atomization test's red/green signal about child *files*, not about
+    a stub raising.
+    """
+
+    def classify_with_reasoning(
+        self,
+        fragment: Fragment,
+        content: str = "",
+    ) -> LLMClassificationResult:
+        """Return *fragment* unchanged as a successful classification.
+
+        Args:
+            fragment: The fragment to hand straight back.
+            content: Unused body text.
+
+        Returns:
+            A succeeded :class:`LLMClassificationResult` wrapping *fragment*.
+        """
+        del content
+        return LLMClassificationResult(fragment=fragment, reasoning="")
+
+
+def _raise_transport_error(self: object, prompt: str) -> str:
+    """Simulate a provider transport failure.
+
+    Args:
+        self: Unused bound instance.
+        prompt: Unused prompt text.
+
+    Returns:
+        Never returns.
+
+    Raises:
+        OSError: Always.
+    """
+    del self, prompt
+    msg = "network down"
+    raise OSError(msg)
+
+
+def _return_malformed_yaml(self: object, prompt: str) -> str:
+    """Return a payload the weighted parser rejects with ``ValueError``.
+
+    Args:
+        self: Unused bound instance.
+        prompt: Unused prompt text.
+
+    Returns:
+        The malformed payload pinned by ``tests/test_weighted.py:908``.
+    """
+    del self, prompt
+    return "```yaml\nnot: a: valid: yaml: ::\n```"
+
+
+def _return_valid_weighted_yaml(self: object, prompt: str) -> str:
+    """Return a well-formed weighted classification payload.
+
+    Args:
+        self: Unused bound instance.
+        prompt: Unused prompt text.
+
+    Returns:
+        :data:`VALID_WEIGHTED_RESPONSE`.
+    """
+    del self, prompt
+    return VALID_WEIGHTED_RESPONSE
+
+
+def _forbid_invocation(self: object, prompt: str) -> str:
+    """Fail loudly if the provider is contacted at all.
+
+    Args:
+        self: Unused bound instance.
+        prompt: Unused prompt text.
+
+    Returns:
+        Never returns.
+
+    Raises:
+        AssertionError: Always.
+    """
+    del self, prompt
+    msg = "the provider must not be contacted for a whitespace-only body"
+    raise AssertionError(msg)
+
+
+_RESPONDERS: Final[dict[str, Callable[[object, str], str]]] = {
+    "transport_error": _raise_transport_error,
+    "malformed_yaml": _return_malformed_yaml,
+}
+"""Per-mode ``invoke_prompt`` replacements; keyed by the parametrize id."""
+
+
+@contextmanager
+def _failing_weighted_provider(mode: str) -> Iterator[None]:
+    """Make ``classify_weighted``'s own classifier fail in the named way.
+
+    Args:
+        mode: ``"provider_unavailable"`` (the availability check says no),
+            ``"transport_error"`` (``OSError`` out of the provider call), or
+            ``"malformed_yaml"`` (a payload the parser rejects).
+
+    Yields:
+        ``None`` while the failure is injected.
+    """
+    if mode == "provider_unavailable":
+        with patch(_AVAILABILITY, return_value=False):
+            yield
+        return
+    responder = _RESPONDERS[mode]
+    with patch(_AVAILABILITY, return_value=True), patch(_INVOKE, new=responder):
+        yield
+
+
+# ---- Vault + config helpers ----
+
+
+def _weighted_config(*, reatomize: bool = False) -> CreekConfig:
+    """Build a local-provider config that forces the weighted LLM path.
+
+    ``confidence_threshold=1.0`` is above anything the rule classifier can
+    score, so every fragment reaches the LLM branch of ``_classify_one``;
+    ``ollama`` keeps both the non-Intimate and Intimate routes local so the
+    run never needs credentials or a routing fallback.
+
+    Args:
+        reatomize: Whether to enable the FEAT-023 re-atomization opt-in.
+
+    Returns:
+        The assembled :class:`CreekConfig`.
+    """
+    return CreekConfig(
+        llm=LLMRoutingConfig(
+            default=LLMConfig(provider="ollama", model="qwen3:8b"),
+            classification=LLMConfig(provider="ollama", model="qwen3:8b"),
+        ),
+        classification=ClassificationConfig(
+            weighted_classification=True,
+            reatomize=reatomize,
+            confidence_threshold=1.0,
+        ),
+    )
+
+
+def _seed(vault: Path, body: str) -> Path:
+    """Write one unclassified fragment carrying *body* into *vault*.
+
+    Args:
+        vault: Vault root (created on demand).
+        body: Markdown body for the fragment.
+
+    Returns:
+        Path to the freshly-written fragment file.
+    """
+    return write_fragment_file(
+        vault=vault,
+        fragment=Fragment(
+            id=FRAGMENT_ID,
+            title="Weighted provenance",
+            source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+        ),
+        body=body,
+    )
+
+
+def _fragment_files(vault: Path) -> list[Path]:
+    """Return every markdown file under the vault's fragment tree.
+
+    Args:
+        vault: Vault root.
+
+    Returns:
+        Sorted list of ``01-Fragments/**/*.md`` paths.
+    """
+    return sorted((vault / "01-Fragments").rglob("*.md"))
+
+
+# ---- T1: provenance across all three provider-side failure modes ----
+
+
+@pytest.mark.parametrize(
+    "failure_mode",
+    ["provider_unavailable", "transport_error", "malformed_yaml"],
+)
+def test_failed_weighted_call_keeps_honest_rules_provenance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_mode: str,
+) -> None:
+    """A failed weighted call stamps ``rules`` and preserves the rules verdict.
+
+    Args:
+        tmp_path: Pytest-provided scratch directory.
+        monkeypatch: Used to swap the engine's classifier for a stub.
+        failure_mode: Which of the three soft-failure paths to trigger.
+    """
+    monkeypatch.setattr(_ENGINE_CLASSIFIER, _EngineStub)
+    vault = tmp_path / "vault"
+    md = _seed(vault, F3_BODY)
+
+    with _failing_weighted_provider(failure_mode):
+        summary = run_classify(
+            vault_path=vault,
+            config=_weighted_config(),
+            method="llm",
+            force=True,
+        )
+
+    meta = frontmatter.load(md).metadata
+    # The provenance tells the truth about what actually classified this.
+    assert meta.get("classification_method") == "rules"
+    assert CLASSIFICATION_PROVIDER_KEY not in meta
+    # No fabricated all-zero profile is persisted.
+    assert meta.get("weighted") is None
+    # The rules verdict that actually stands survives the failed call.
+    assert meta["frequency"]["primary"] == "F3"
+    assert meta["frequency"]["primary"] != "unclassified"
+    # We skip the LLM *call*, never the write: the fragment is still persisted.
+    assert summary.classified == 1
+
+
+# ---- T2: the success control ----
+
+
+def test_successful_weighted_call_still_stamps_llm(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A real weighted classification still stamps ``llm`` + its provider.
+
+    The narrowness control for T1: only the *failed* call loses the ``llm``
+    provenance.
+
+    Args:
+        tmp_path: Pytest-provided scratch directory.
+        monkeypatch: Used to swap the engine's classifier for a stub.
+    """
+    monkeypatch.setattr(_ENGINE_CLASSIFIER, _EngineStub)
+    vault = tmp_path / "vault"
+    md = _seed(vault, F3_BODY)
+
+    with (
+        patch(_AVAILABILITY, return_value=True),
+        patch(_INVOKE, new=_return_valid_weighted_yaml),
+    ):
+        summary = run_classify(
+            vault_path=vault,
+            config=_weighted_config(),
+            method="llm",
+            force=True,
+        )
+
+    meta = frontmatter.load(md).metadata
+    assert meta.get("classification_method") == "llm"
+    assert meta.get(CLASSIFICATION_PROVIDER_KEY) == "ollama"
+    assert meta["weighted"]["frequencies"] == [{"value": "F3", "weight": 0.8}]
+    assert meta["weighted"]["overall_confidence"] == 0.7
+    # And the legacy single-pick fields are derived from that profile.
+    assert meta["frequency"]["primary"] == "F3"
+    assert summary.classified == 1
+
+
+# ---- T3: the OPS-001 resume ledger ----
+
+
+def test_failed_weighted_call_leaves_the_resume_ledger_clean(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No progress-ledger entry is written for a call that produced nothing.
+
+    An entry here is a claim that a paid LLM call succeeded for this
+    fragment; at HEAD the failed weighted run appends
+    ``{"id": "frag-0000weighted"}``.
+
+    Args:
+        tmp_path: Pytest-provided scratch directory.
+        monkeypatch: Used to swap the engine's classifier for a stub.
+    """
+    monkeypatch.setattr(_ENGINE_CLASSIFIER, _EngineStub)
+    vault = tmp_path / "vault"
+    _seed(vault, F3_BODY)
+
+    with _failing_weighted_provider("transport_error"):
+        run_classify(
+            vault_path=vault,
+            config=_weighted_config(),
+            method="llm",
+            force=True,
+        )
+
+    ledger = vault.joinpath(*PROGRESS_LOG_PARTS)
+    recorded = ledger.read_text(encoding="utf-8") if ledger.exists() else ""
+    assert FRAGMENT_ID not in recorded
+
+
+# ---- T4: the fragment stays eligible ----
+
+
+def test_failed_weighted_fragment_is_reclassifiable_without_force(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed weighted run must not make the fragment "already paid for".
+
+    The acceptance criterion the whole severity rests on: because the failed
+    run stamps ``llm`` today, ``_record_if_preserved`` skips the fragment on
+    every subsequent non-``--force`` run — permanently. At HEAD the second run
+    reports ``preserved_llm=1, classified=0``.
+
+    Args:
+        tmp_path: Pytest-provided scratch directory.
+        monkeypatch: Used to swap the engine's classifier for a stub.
+    """
+    monkeypatch.setattr(_ENGINE_CLASSIFIER, _EngineStub)
+    vault = tmp_path / "vault"
+    _seed(vault, F3_BODY)
+    config = _weighted_config()
+
+    with _failing_weighted_provider("provider_unavailable"):
+        first = run_classify(
+            vault_path=vault,
+            config=config,
+            method="llm",
+            force=True,
+        )
+        second = run_classify(
+            vault_path=vault,
+            config=config,
+            method="llm",
+            force=False,
+        )
+
+    assert first.classified == 1
+    assert second.preserved_llm == 0
+    assert second.classified == 1
+
+
+# ---- T5: no re-atomization off a failed run ----
+
+
+def test_failed_weighted_call_spawns_no_reatomized_children(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed weighted call must not trigger FEAT-023 decomposition.
+
+    ``classify_engine.py:1082`` gates re-atomization on ``not was_skipped``.
+    While the failed weighted path reports "the LLM was invoked", a vault gets
+    child fragments carved out of a classification that never happened.
+
+    Args:
+        tmp_path: Pytest-provided scratch directory.
+        monkeypatch: Used to swap the engine's classifier for a stub whose
+            single-pick call succeeds (the re-atomization child classifier
+            legitimately uses it).
+    """
+    monkeypatch.setattr(_ENGINE_CLASSIFIER, _ReatomizingEngineStub)
+    vault = tmp_path / "vault"
+    _seed(vault, F3_TWO_PARAGRAPH_BODY)
+
+    with _failing_weighted_provider("transport_error"):
+        summary = run_classify(
+            vault_path=vault,
+            config=_weighted_config(reatomize=True),
+            method="llm",
+            force=True,
+        )
+
+    # No child was written — and none *failed* to write either, so the count
+    # below cannot be green for the wrong reason.
+    assert summary.errors == ()
+    assert len(_fragment_files(vault)) == 1
+
+
+# ---- T6: the whitespace short-circuit ----
+
+
+def test_whitespace_body_is_not_stamped_llm(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A whitespace-only body never reaches a provider, so it is not ``llm``.
+
+    ``classify_weighted`` short-circuits before it builds a classifier, so
+    claiming ``classification_method: llm`` (with a provider, and a fabricated
+    empty profile) is the same lie the three provider-side failures tell. The
+    ``invoke_prompt`` patch asserts the short-circuit really is a
+    short-circuit.
+
+    Args:
+        tmp_path: Pytest-provided scratch directory.
+        monkeypatch: Used to swap the engine's classifier for a stub.
+    """
+    monkeypatch.setattr(_ENGINE_CLASSIFIER, _EngineStub)
+    vault = tmp_path / "vault"
+    md = _seed(vault, WHITESPACE_BODY)
+
+    with (
+        patch(_AVAILABILITY, return_value=True),
+        patch(_INVOKE, new=_forbid_invocation),
+    ):
+        run_classify(
+            vault_path=vault,
+            config=_weighted_config(),
+            method="llm",
+            force=True,
+        )
+
+    meta = frontmatter.load(md).metadata
+    assert meta.get("classification_method") == "rules"
+    assert CLASSIFICATION_PROVIDER_KEY not in meta
+    assert meta.get("weighted") is None

--- a/creek-tools/tests/test_weighted.py
+++ b/creek-tools/tests/test_weighted.py
@@ -124,6 +124,7 @@ class TestPublicSurface:
         """``weighted.py``'s ``__all__`` names the public-API symbols."""
         assert set(weighted_module.__all__) == {
             "WEIGHTED_CLASSIFICATION_TEMPLATE",
+            "WeightedClassificationResult",
             "WeightedDimension",
             "WeightedFragmentClassification",
             "build_weighted_classification_prompt",
@@ -825,7 +826,9 @@ class TestClassifyWeighted:
     def test_empty_body_short_circuits(self, llm_config: LLMConfig) -> None:
         """A whitespace-only body returns an empty WFC without invoking the LLM."""
         result = classify_weighted(_make_ingested("   \n   "), llm_config)
-        assert result == WeightedFragmentClassification()
+        assert result.classification == WeightedFragmentClassification()
+        # No LLM ran, so the caller must not be told one did (#1330).
+        assert result.succeeded is False
 
     def test_representative_classification(
         self,
@@ -838,11 +841,15 @@ class TestClassifyWeighted:
             _make_ingested("Paranoia is a Red Frequency phenomenon..."),
             llm_config,
         )
-        assert result.frequencies == (
+        assert result.succeeded is True
+        classification = result.classification
+        assert classification.frequencies == (
             WeightedDimension(value=Frequency.F3, weight=0.8),
         )
-        assert result.phases == (WeightedDimension(value=Phase.RISING, weight=0.7),)
-        assert result.overall_confidence == 0.7
+        assert classification.phases == (
+            WeightedDimension(value=Phase.RISING, weight=0.7),
+        )
+        assert classification.overall_confidence == 0.7
 
     @pytest.mark.parametrize(
         ("body", "freqs_yaml", "expected_top_freq"),
@@ -885,7 +892,8 @@ class TestClassifyWeighted:
         """Five representative bodies classify with their canned LLM responses."""
         fake_invoke[0] = _weighted_yaml_payload(frequencies=freqs_yaml)
         result = classify_weighted(_make_ingested(body), llm_config)
-        assert result.frequencies[0].value == expected_top_freq
+        assert result.succeeded is True
+        assert result.classification.frequencies[0].value == expected_top_freq
 
     def test_provider_unavailable_returns_empty(
         self,
@@ -897,7 +905,9 @@ class TestClassifyWeighted:
             return_value=False,
         ):
             result = classify_weighted(_make_ingested("body"), llm_config)
-        assert result == WeightedFragmentClassification()
+        assert result.classification == WeightedFragmentClassification()
+        # An unreachable provider is a failure, not an empty verdict (#1330).
+        assert result.succeeded is False
 
     def test_malformed_yaml_returns_empty(
         self,
@@ -907,7 +917,9 @@ class TestClassifyWeighted:
         """A parse failure collapses to an empty WFC without re-raising."""
         fake_invoke[0] = "```yaml\nnot: a: valid: yaml: ::\n```"
         result = classify_weighted(_make_ingested("body"), llm_config)
-        assert result == WeightedFragmentClassification()
+        assert result.classification == WeightedFragmentClassification()
+        # A parse failure is a failure, not an empty verdict (#1330).
+        assert result.succeeded is False
 
     def test_unknown_top_level_key_returns_empty(
         self,
@@ -919,7 +931,9 @@ class TestClassifyWeighted:
             "reasoning\n\n```yaml\nfrequencies: []\nbogus_top_level_key: 1\n```"
         )
         result = classify_weighted(_make_ingested("body"), llm_config)
-        assert result == WeightedFragmentClassification()
+        assert result.classification == WeightedFragmentClassification()
+        # A schema violation is a failure, not an empty verdict (#1330).
+        assert result.succeeded is False
 
     def test_transport_failure_returns_empty(
         self,
@@ -943,7 +957,9 @@ class TestClassifyWeighted:
             ),
         ):
             result = classify_weighted(_make_ingested("body"), llm_config)
-        assert result == WeightedFragmentClassification()
+        assert result.classification == WeightedFragmentClassification()
+        # A transport error is a failure, not an empty verdict (#1330).
+        assert result.succeeded is False
 
 
 # ---- classify_engine wiring (#366 integration) -----------------------------


### PR DESCRIPTION
## Summary

- **A soft LLM failure on the weighted classification path stamped `classification_method: llm` and buried the fragment forever.** `_classify_one_weighted` had no `succeeded` check, unlike its single-pick sibling eight lines above it (`classify_engine.py:1519-1529`, added by #744 for this exact failure mode). `classify_weighted` fails soft to a bare `WeightedFragmentClassification()` on provider-unavailable, transport error, or malformed YAML — a value indistinguishable from a genuine all-unclassified verdict — and the engine assigned it wholesale with `was_skipped=False`.
- **`classify_weighted` now returns a `WeightedClassificationResult(classification, succeeded)`**, mirroring `LLMClassificationResult` (`llm/orchestrator.py:48-70`), the wrapper the sibling path already uses for this. Its fail-soft behaviour is unchanged; the caller is simply told which of "no signal" and "no answer" it received. The engine returns `(fragment, True, "")` on failure — the input fragment untouched — so the write path stamps the honest `rules`.
- **Forward-only.** Fragments already mis-stamped by this bug are not healed; see the follow-up below.

## The bug, reproduced end-to-end before the fix

Run over a tmp vault with `weighted_classification=True` and a fragment the rule classifier scores `F3`, for each of the three soft-failure modes:

```
classification_method: llm                                   <- the lie
classification_provider: ollama                              <- for a call that produced nothing
frequency: {'primary': 'unclassified', 'secondary': []}      <- the F3 rules verdict destroyed
weighted:  {all six dimension lists empty, overall_confidence: 0.0, reasoning: ''}
                                                             <- a fabricated profile persisted
progress-log: {"id": "frag-0000weighted"}                    <- OPS-001 resume ledger poisoned
```

A second, non-`--force` run then reported `preserved_llm=1, classified=0`: `_record_if_preserved` (`classify_engine.py:689-695`) treats `llm` as "already paid for", so the fragment was permanently `unclassified` **and** permanently skipped. The `weighted:` block and the ledger entry were not in the original issue report; both were found while verifying it.

The whitespace-only-body short-circuit (`weighted.py:825-826`) told the same lie for a call where no provider was ever contacted, and is fixed with the same flag. Cost of the extra eligibility: none — that path returns before a classifier is even constructed.

## What changed

| File | Change |
|---|---|
| `creek/classify/weighted.py` | New frozen `WeightedClassificationResult`; `classify_weighted` returns it, `succeeded=False` at all three soft-failure returns |
| `creek/classify/classify_engine.py` | `_classify_one_weighted` returns `(fragment, True, "")` when `not result.succeeded`; docstring corrected (it previously rationalised the bug) |
| `creek/config.py` | `weighted_classification` docstring notes that a failed call leaves `weighted` as `None` |
| `tests/test_classify_failed_weighted_provenance.py` | New — the weighted twin of `test_classify_failed_llm_provenance.py` (#744) |
| `tests/test_weighted.py` | The 8 direct `classify_weighted` callers unwrap `.classification` and additionally assert `.succeeded`; `__all__` set updated. No assertion removed. |

## Test plan

RED first, proven against unmodified source: 19 failed / 70 passed, every new test failing on a behavioural assertion about persisted frontmatter, not on a missing symbol.

```
assert 'llm' == 'rules'                                  x3 (the three failure modes)
assert 'frag-0000weighted' not in '{"id": "frag-...}'    (resume ledger)
assert 1 == 0                                            (second run's preserved_llm)
assert 3 == 1                                            (children reatomized off a failed call)
assert 'llm' == 'rules'                                  (whitespace body)
```

The success control `test_successful_weighted_call_still_stamps_llm` passed *before* the fix and after it — the change is narrow.

Mutation battery — each of the four guards reverted alone, on top of the full fix. No guard survived; each reddens exactly its own tests and nothing else.

| Mutation | Tests reddened |
|---|---|
| baseline (unmutated) | 0 |
| whitespace short-circuit → `succeeded=True` | 2 — `test_whitespace_body_is_not_stamped_llm`, `test_empty_body_short_circuits` |
| provider-unavailable → `succeeded=True` | 3 — `…provenance[provider_unavailable]`, `…reclassifiable_without_force`, `test_provider_unavailable_returns_empty` |
| `except` arm → `succeeded=True` | 7 — `…[transport_error]`, `…[malformed_yaml]`, `…resume_ledger_clean`, `…no_reatomized_children`, + 3 in `test_weighted.py` |
| drop the engine's `not result.succeeded` guard | 7 — every test in the new provenance file |

Gate 2: `./scripts/check-all.sh` exit **0** — 12/12 checks passed, 8849 passed / 5 skipped, 94.39% branch coverage, per-file gate green (256 files >= 80%).

Gate 2.5: `code-review-orchestrator` over the full diff — **CLEAN**, no blockers.

## Follow-ups filed, not fixed here

- #1356 — `skipped_high_confidence` counts failed-LLM skips on both the single-pick (#744) and weighted paths while its docstring claims high-confidence rule short-circuits. Pre-existing; deliberately left untested here so the wrong label is not frozen into the suite.
- #1357 — remediation for fragments already mis-stamped by this bug. The on-disk signature is unambiguous (`llm` + all-zero `weighted` + `unclassified`), so a heal is feasible; `weighted_classification` defaults to `False`, so the blast radius is opt-in vaults only.

## Operator-visible note

A failed weighted run now writes the surviving rules verdict and no `weighted` block, where it previously wrote `unclassified` and an empty profile. That fragment is re-attempted on the next ordinary `--method llm` run instead of needing `--force`.

Closes #1330
