### PR TITLE
fix(redact): contain the paths the operator names, not just the walked tree

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -1430,7 +1430,10 @@ def _dispatch_redact(
         apply: ``--apply`` flag.
         review: ``--review`` flag.
         source: ``--source`` path (scan/apply).
-        vault: ``--vault`` path (review).
+        vault: ``--vault`` path. Required by ``--review`` as the tree to
+            re-scan; optional for ``--scan``/``--apply``, where it locates
+            ``creek_config.yaml`` and, for ``--apply``, receives the audit
+            record.
         report: ``--report`` flag (scan).
         dry_run: ``--dry-run`` flag (apply).
         verbose: ``--verbose`` flag.
@@ -1479,7 +1482,11 @@ def redact(
     source: Path | None = typer.Option(
         None, "--source", help="Source path (scan/apply)"
     ),
-    vault: Path | None = typer.Option(None, "--vault", help="Vault path (review)"),
+    vault: Path | None = typer.Option(
+        None,
+        "--vault",
+        help="Vault path (review; also config/audit root for scan/apply)",
+    ),
     report: bool = typer.Option(
         False, "--report", help="Include the detailed markdown report (scan)"
     ),

--- a/creek-tools/creek/redact/cli_commands.py
+++ b/creek-tools/creek/redact/cli_commands.py
@@ -16,6 +16,7 @@ import logging
 import os
 import tempfile
 from collections import Counter
+from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, NoReturn
 
@@ -32,6 +33,7 @@ from creek.redact.scanner import (
     SYMLINK_SKIP_LABEL,
     RedactionScanner,
     ScanSummary,
+    resolves_within,
 )
 
 logger = logging.getLogger(__name__)
@@ -197,21 +199,75 @@ def render_matches(summary: ScanSummary, console: Console) -> None:
 # ---------------------------------------------------------------------------
 
 
+class SymlinkPolicy(Enum):
+    """What a redaction mode does with a directly-named escaping symlink.
+
+    The read and write contracts differ in kind, and the fix for #1293 has to
+    keep them distinct rather than collapsing both into one refusal:
+
+    * ``REFUSE`` — ``--apply`` and ``--review``. Both may write, so following
+      a link named on the command line risks rewriting a file outside the
+      tree the operator named. They abort with exit ``1`` before anything is
+      read through the link.
+    * ``SKIP`` — ``--scan``. It writes nothing, so refusing a whole scan over
+      one bad link would be a denial of service on the safety pass itself —
+      the operator's only way of learning what is exposed. The path is
+      declined, counted under ``files_skipped_symlink``, and the scan still
+      exits ``0``.
+
+    The distinction is pinned by ``tests/test_cli_redact.py:545-553``.
+
+    Attributes:
+        REFUSE: Abort the run — the write path (``--apply``, ``--review``).
+        SKIP: Decline the path and carry on — the read path (``--scan``).
+    """
+
+    REFUSE = "refuse"
+    SKIP = "skip"
+
+
 def _scan_source(
     source: Path,
     config: CreekConfig,
+    *,
+    console: Console,
+    label: str,
+    policy: SymlinkPolicy,
 ) -> tuple[RedactionScanner, ScanSummary]:
     """Scan *source* (file or directory) and return the scanner + summary.
 
+    The single chokepoint through which every redaction mode reaches the
+    filesystem, and therefore the right place to decide what happens when the
+    operator names an escaping symlink outright (#1293). *policy* has no
+    default on purpose: mypy strict then makes it a build error to add a
+    fourth mode without stating a symlink policy, which is precisely the
+    omission that left ``run_scan`` unguarded in the first place.
+
     Args:
-        source: File or directory to scan.
+        source: File or directory to scan, exactly as the operator named it.
         config: Loaded Creek configuration.
+        console: Rich console sink for the refusal banner.
+        label: Human-readable label for the root in the refusal message
+            (e.g. ``"source"`` or ``"vault"``).
+        policy: What to do when *source* itself escapes its own parent —
+            see :class:`SymlinkPolicy`.
 
     Returns:
         Tuple of ``(scanner, summary)``. The scanner is returned so that
-        the caller can reuse its session salt for redaction or review.
+        the caller can reuse its session salt for redaction or review. Under
+        :attr:`SymlinkPolicy.SKIP` an escaping *source* yields an empty
+        summary carrying a single ``files_skipped_symlink``.
+
+    Raises:
+        typer.Exit: With code ``1`` under :attr:`SymlinkPolicy.REFUSE` when
+            *source* is a symlink resolving outside its own parent.
     """
     scanner = RedactionScanner(config=config.redaction)
+    if _named_path_escapes(source):
+        if policy is SymlinkPolicy.REFUSE:
+            _assert_named_path_contained(source, console=console, label=label)
+        logger.warning("Skipping symlink that escapes the scan root: %s", source)
+        return scanner, ScanSummary(files_skipped_symlink=1)
     if source.is_file():
         matches = scanner.scan_file(source)
         summary = ScanSummary(matches=matches, files_scanned=1)
@@ -233,6 +289,96 @@ def _error_exit(console: Console, message: str, *, code: int = 2) -> NoReturn:
     """
     console.print(f"[red]{message}[/red]")
     raise typer.Exit(code=code)
+
+
+def _named_path_escapes(path: Path) -> bool:
+    """Report whether *path* is itself a symlink leaving its own parent.
+
+    The containment question for a path the operator names on the command
+    line, as opposed to one the scanner discovers while walking a tree. It
+    delegates to :func:`creek.redact.scanner.resolves_within` rather than
+    restating the predicate, so the named-leaf surface and the walked-child
+    surface cannot drift into two definitions of "inside".
+
+    Three properties carry the correctness argument:
+
+    * ``is_symlink()`` is an ``lstat`` on the leaf, so a path that is not
+      itself a link is never resolved and never compared. That is what makes
+      this guard behave identically on darwin and on Linux CI: a root reached
+      *through* a symlinked component (``/tmp`` → ``/private/tmp`` on macOS)
+      is not flagged. Same reasoning as the scanner's own walk policy.
+    * When the leaf *is* a link, BOTH sides are resolved — the target inside
+      ``resolves_within``, the parent here — so ``/tmp`` → ``/private/tmp``
+      cannot manufacture a spurious refusal for a link that never left its
+      own directory.
+    * The predicate is LEAF-ONLY, and deliberately so: a named path whose
+      escaping link is an ANCESTOR component (``<root>/linkdir/a.md``, where
+      ``linkdir`` is the link) is admitted. That is a known, accepted
+      residual — not full coverage of path traversal.
+
+    ``strict=False`` matches the shipped guard: a target that does not exist
+    still resolves to a candidate location worth comparing. Dangling and
+    looping links do not reach here in the CLI anyway — ``_require_existing``
+    reports them as "not found" first.
+
+    Args:
+        path: The source or vault path exactly as the operator supplied it.
+
+    Returns:
+        ``True`` when *path* is a symlink whose target is not a descendant of
+        its own resolved parent directory.
+    """
+    return path.is_symlink() and not resolves_within(
+        path,
+        path.parent.resolve(strict=False),
+    )
+
+
+def _assert_named_path_contained(
+    path: Path,
+    *,
+    console: Console,
+    label: str,
+) -> None:
+    """Refuse a directly-named symlink that escapes its own parent (#1293).
+
+    The write-path half of the contract: ``--apply`` and ``--review`` stop
+    here, before the named path is opened, walked, or used to locate
+    ``<vault>/00-Creek-Meta/creek_config.yaml``. The companion read path
+    (``--scan``) skips instead — see :class:`SymlinkPolicy`.
+
+    The refusal is outright. There is no ``--force``, no environment
+    variable, and no config key, per SEC-003's no-waiver precedent: the
+    security direction here is one-way, and this guard may only ever cause
+    the tool to read and write *less*.
+
+    Only the as-supplied path is named — in the banner and in the log. The
+    resolved target is never disclosed: doing so is the very oracle #1087
+    closes. The log is a ``warning`` rather than an ``exception`` because no
+    exception is being handled at this point; ``logger.exception`` here would
+    append a bogus ``NoneType: None`` traceback to the record.
+
+    Args:
+        path: The source or vault path exactly as the operator supplied it.
+        console: Rich console sink for the error banner.
+        label: Human-readable label for the root in the error message
+            (e.g. ``"source"`` or ``"vault"``).
+
+    Raises:
+        typer.Exit: With code ``1`` when *path* is an escaping symlink.
+    """
+    if not _named_path_escapes(path):
+        return
+    logger.warning(
+        "Refusing to follow symlink that escapes the %s root: %s",
+        label,
+        path,
+    )
+    _error_exit(
+        console,
+        f"Refusing to follow symlink that escapes the {label} root: {path}",
+        code=1,
+    )
 
 
 def _assert_no_escaping_symlinks(
@@ -354,6 +500,11 @@ def run_scan(
 ) -> ScanSummary:
     """Scan *source* for sensitive data and render a report.
 
+    The read path never refuses over containment: a *source* that is itself
+    an escaping symlink is declined and counted in the statistics table
+    (:attr:`SymlinkPolicy.SKIP`), so one bad link cannot disable the whole
+    safety pass.
+
     Args:
         source: File or directory to scan.
         report: When ``True``, render the detailed markdown report.
@@ -368,7 +519,13 @@ def run_scan(
     """
     _require_existing(console, source, "Source path")
     config = load_config(resolve_config_path(vault, None))
-    scanner, summary = _scan_source(source, config)
+    scanner, summary = _scan_source(
+        source,
+        config,
+        console=console,
+        label="source",
+        policy=SymlinkPolicy.SKIP,
+    )
     render_summary(summary, console)
     if verbose:
         render_matches(summary, console)
@@ -409,6 +566,16 @@ def _atomic_write(file_path: Path, content: str) -> None:
     place with :func:`os.replace`. The swap is atomic on POSIX and best
     effort on Windows. If any step fails the temp file is unlinked so
     the original on-disk file is left untouched.
+
+    When *file_path* is a symlink, :func:`os.replace` MATERIALISES it: the
+    link is replaced by a regular file rather than written through. That
+    side effect is deliberate, not incidental. Writing *through* a link is
+    the operation SEC-003 forbids; by the time execution reaches here both
+    ends of any surviving alias are inside the tree the operator named
+    (:func:`_named_path_escapes` for the named leaf,
+    :func:`_assert_no_escaping_symlinks` for descendants), and
+    ``scan_batch`` surfaces the alias's target as a file in its own right,
+    so the target is redacted on its own pass.
 
     Args:
         file_path: Destination path to rewrite.
@@ -469,7 +636,29 @@ def _write_redaction_audit(
     vault_path: Path,
     dry_run: bool,
 ) -> None:
-    """Append one audit entry per touched file under *vault_path*."""
+    """Append one audit entry per touched file under *vault_path*.
+
+    Each entry records ``source_path`` exactly as the pipeline saw it, never
+    resolved. That is truthful without being exhaustive, and the difference
+    matters to anyone reading the trail:
+
+    * for a directly-named path, because no admitted named path resolves
+      outside its own parent (:func:`_named_path_escapes`);
+    * for a descendant, because the walk guard and the scanner's own
+      candidate filter both decline children that escape the root.
+    * Residual: a path reached through a symlinked ANCESTOR component is
+      admitted by that leaf-only policy, and the audit then records the
+      as-supplied path rather than where the write landed.
+
+    Resolving audit paths would not close that residual — it would only
+    start disclosing real intra-tree paths behind ordinary aliases.
+
+    Args:
+        summary: Scan summary whose matches describe what was found.
+        files: Files touched by this run, in report order.
+        vault_path: Vault root owning ``00-Creek-Meta/audit/redact.jsonl``.
+        dry_run: Whether this run previewed rather than committed changes.
+    """
     audit_log = RedactionAuditLog(vault_path)
     grouped = _matches_by_file(summary)
     for file_path in files:
@@ -567,14 +756,37 @@ def run_apply(
         assume_yes: Skip the interactive confirmation prompt.
         console: Rich console sink.
         vault: Vault root for the audit log. Defaults to
-            ``load_config().vault_path``.
+            ``load_config().vault_path``. Contained like *source*: it is
+            both read from and *written to*, so an escaping link here is an
+            out-of-root write even when *source* is innocent.
+
+    Raises:
+        typer.Exit: With code ``1`` when *source* or *vault* is, or
+            contains, a symlink that escapes the tree the operator named.
     """
     _require_existing(console, source, "Source path")
+    # Before ``is_dir()``, which follows the link, and before ``load_config``,
+    # which would otherwise read the config *through* it (#1293).
+    _assert_named_path_contained(source, console=console, label="source")
+    # ``--vault`` is the second path the operator names, and the only one this
+    # mode WRITES to: the audit record lands in
+    # ``<vault>/00-Creek-Meta/audit/redact.jsonl``, creating that directory if
+    # needed. Guarding only ``--source`` would leave the audit trail — the
+    # record of what was touched — landing wherever a link points, with an
+    # entirely innocent source (#1293).
+    if vault is not None:
+        _assert_named_path_contained(vault, console=console, label="vault")
     if source.is_dir():
         _assert_no_escaping_symlinks(source, console=console, label="source")
     config = load_config(resolve_config_path(vault, None))
     vault_path = vault if vault is not None else config.vault_path
-    scanner, summary = _scan_source(source, config)
+    scanner, summary = _scan_source(
+        source,
+        config,
+        console=console,
+        label="source",
+        policy=SymlinkPolicy.REFUSE,
+    )
     render_summary(summary, console)
     if verbose:
         render_matches(summary, console)
@@ -625,12 +837,25 @@ def run_review(
         vault: Vault root (or any directory) to re-scan.
         verbose: When ``True``, also list every individual match.
         console: Rich console sink.
+
+    Raises:
+        typer.Exit: With code ``1`` when *vault* is, or contains, a symlink
+            that escapes the tree the operator named.
     """
     _require_existing(console, vault, "Vault path")
+    # Before ``is_dir()``, which follows the link, and before ``load_config``,
+    # which would otherwise read the config *through* it (#1293).
+    _assert_named_path_contained(vault, console=console, label="vault")
     if vault.is_dir():
         _assert_no_escaping_symlinks(vault, console=console, label="vault")
     config = load_config(resolve_config_path(vault, None))
-    scanner, summary = _scan_source(vault, config)
+    scanner, summary = _scan_source(
+        vault,
+        config,
+        console=console,
+        label="vault",
+        policy=SymlinkPolicy.REFUSE,
+    )
     render_summary(summary, console)
     if verbose:
         render_matches(summary, console)

--- a/creek-tools/creek/redact/scanner.py
+++ b/creek-tools/creek/redact/scanner.py
@@ -787,8 +787,13 @@ def _statistics_lines(summary: ScanSummary) -> list[str]:
     return lines
 
 
-def _resolves_within(child: Path, resolved_root: Path) -> bool:
+def resolves_within(child: Path, resolved_root: Path) -> bool:
     """Report whether *child*'s symlink target stays under *resolved_root*.
+
+    Public because it is now also the named-leaf containment predicate for
+    :mod:`creek.redact.cli_commands` (#1293), so the walked-child surface and
+    the named-path surface cannot drift into two subtly different definitions
+    of "inside".
 
     The failure arm is a deliberate classification, not a swallowed error:
     a loop (``RuntimeError``), an unreadable link (``OSError``), and a
@@ -846,8 +851,13 @@ def _scannable_candidates(dir_path: Path) -> tuple[list[Path], int]:
 
     Known gaps, deliberately out of scope here:
 
-    * #1293 — the SEC-003 write guard is directory-only, so
-      ``creek redact --apply <symlinked-file>`` still writes through the link.
+    * Escaping ANCESTOR components. The directly-named path is now tested
+      for containment by :mod:`creek.redact.cli_commands` before any mode
+      reads through it (#1293), but a path reached *through* a link one
+      level up — ``<root>/linkdir/a.md``, where ``linkdir`` is the escaping
+      link — is still admitted here. That is not an oversight: it is the
+      resolve-the-root / ``lstat``-the-leaf policy documented above, applied
+      consistently on both surfaces.
     * #1294 — the ingestor walks (e.g.
       ``creek.ingest.markdown.MarkdownIngestor._read_directory``) still follow
       symlinks out of the source root.
@@ -866,7 +876,7 @@ def _scannable_candidates(dir_path: Path) -> tuple[list[Path], int]:
     for child in dir_path.rglob("*"):
         if not child.is_file():
             continue
-        if child.is_symlink() and not _resolves_within(child, resolved_root):
+        if child.is_symlink() and not resolves_within(child, resolved_root):
             logger.warning("Skipping symlink that escapes the scan root: %s", child)
             escaped += 1
             continue

--- a/creek-tools/docs/security/threat-model.md
+++ b/creek-tools/docs/security/threat-model.md
@@ -78,13 +78,70 @@ from most to least likely:
   that skip to a hard refusal before it acts on the scan result,
   because `creek.ingest.markdown.MarkdownIngestor` would otherwise
   read the same file again with no symlink guard of its own, turning
-  a silent skip into a silent unredacted ingest. Two gaps remain
-  open: the SEC-003 write guard is directory-only, so naming a
-  symlinked *file* directly to `--apply` bypasses it entirely
-  (#1293); and the ingestor's own directory walks still follow
-  symlinks out of the source root regardless, so the pipeline
-  refusal is a backstop that a vault with `redaction.enabled: false`
-  never reaches (#1294).
+  a silent skip into a silent unredacted ingest. #1293 is now closed
+  for the CLI's named-path surface: `--apply`/`--review` refuse
+  (exit 1) before reading anything through a named symlink —
+  including before loading `<vault>/00-Creek-Meta/creek_config.yaml`,
+  which was previously read through a symlinked vault. Both paths
+  the operator names are contained, not just the scanned one:
+  `--apply` also takes a `--vault`, and that one is *written* to —
+  the audit record lands in
+  `<vault>/00-Creek-Meta/audit/redact.jsonl`, creating the `audit/`
+  directory if absent. An escaping `--vault` was therefore a second
+  out-of-root write, reachable with an entirely innocent `--source`,
+  and it put the record of what was touched wherever the link
+  pointed. `--scan`
+  still skips the named path and counts it under "Files skipped
+  (escaping symlink)" rather than refusing the whole pass, keeping
+  its distinct skip-and-count contract: `--scan` writes nothing, so
+  refusing a whole scan over one bad link would be a denial of
+  service on the safety pass itself. The mechanism that was actually
+  closed is not what the original report claimed: `--apply
+  <symlinked-file>` never "writes through the link" —
+  `_atomic_write` ends in `os.replace`, which replaces the *link*,
+  not its target. The real defect for a named symlinked file was
+  out-of-root read, exfiltration into the tree, and destruction of
+  the operator's link — the target's secrets were enumerated and
+  printed, and the link was replaced by a regular in-tree file
+  holding a redacted copy of out-of-tree content. A named symlinked
+  *directory* was a separate, worse failure — a genuine in-place
+  out-of-root rewrite, because `is_dir()` follows the link and the
+  walk guard then resolved the root to the target, laundering every
+  child as "inside." `run_scan` had no symlink guard of any kind.
+  The fix for a named symlinked directory is leaf-only, not a
+  blanket refusal: it is refused when its target escapes the link's
+  own parent, and admitted — with the resolved target used as the
+  root everywhere thereafter — when the target stays under that
+  parent, so `~/vault -> ~/Dropbox/vault` is still admitted and
+  still redacts under `~/Dropbox/vault`. Three residuals remain.
+  First, a named path reached through an escaping *ancestor*
+  component (e.g. `<root>/linkdir/a.md`, where the leaf is a real
+  file but `linkdir` is the escaping link) is still admitted and
+  rewritten in place — the same resolve-the-root/lstat-the-leaf
+  asymmetry the scanner already documents and relies on to keep a
+  `/tmp` -> `/private/tmp` root scannable. Second,
+  `Pipeline._run_redaction` (`creek/pipeline.py:478`
+  `source_path.rglob("*")` and `:484` `scan_batch`) still traverses
+  a directly-named symlinked directory; it is read-only there and
+  escalates to a hard refusal via the skip counter rather than
+  writing. Third, `--scan`'s own `--vault` is not contained. It is
+  used only to locate `creek_config.yaml`, and `--scan` writes
+  nothing, so this is a read-escape rather than a write: an
+  out-of-tree `creek_config.yaml` is opened, parsed, and used to
+  configure the pass (confirmed by pointing it at malformed YAML,
+  which surfaces as a parse error from outside the named tree). It
+  is deliberately not refused here, because a refusing `--scan` is
+  the denial of service the skip-and-count contract exists to
+  avoid; tracked separately in #1359. One gap remains open: the
+  ingestor's own directory walks
+  still follow symlinks out of the source root regardless, so the
+  pipeline refusal is a backstop that a vault with `redaction.enabled:
+  false` never reaches (#1294). User-visible effect: aliasing an
+  external export tree into the vault (`ln -s /Volumes/Export
+  ~/vault/inbox`) and naming that alias to `--apply`/`--review` is
+  now refused; the workaround is to name the resolved path directly.
+  `--scan` on such an alias now reports 0 files scanned with a skip
+  row instead of scanning the target.
 - **Prompt-injection hardening.** Fragment title and body are
   sanitised before being templated into the LLM classifier prompt;
   responses are strictly validated to reject multi-document YAML and
@@ -167,7 +224,10 @@ The codebase annotates design-trace work with short IDs: `SEC-*`, `INC-*`, `OPS-
 Notable threat-model-adjacent IDs that have shipped or are in flight:
 
 - **SEC-002** — Redaction pattern coverage gaps
-- **SEC-003** — Symlink refusal in redaction (resolved)
+- **SEC-003** — Symlink refusal in redaction: covers both the walked
+  tree and a directly-named path (`--apply`/`--review` refuse before
+  reading; `--scan` skips and counts); the escaping-ancestor-component
+  residual is leaf-only and documented above (resolved)
 - **SEC-004** — Prompt injection hardening (resolved)
 - **SEC-005** — Audit log tamper-evidence
 - **SEC-006** — Privacy-tier enforcement in mine/draft

--- a/creek-tools/tests/test_cli_redact.py
+++ b/creek-tools/tests/test_cli_redact.py
@@ -912,10 +912,20 @@ def test_redact_apply_refuses_a_named_symlinked_directory_before_walking_it(
     walked: list[str] = []
     real_walk = real_os.walk
 
-    def spy_walk(top: object, *args: object, **kwargs: object) -> object:
+    # ``Any`` rather than ``object``: this spy is a transparent passthrough to
+    # ``os.walk``, which typeshed declares as an overload set (str vs bytes
+    # paths). Typing the parameters as ``object`` makes the delegation
+    # untypeable under mypy strict and invites a type suppression, which the
+    # house rules forbid without a tracking issue and which would paper over
+    # the symptom rather than the cause. ``Any`` splats into the overload
+    # cleanly and needs nothing suppressed. Imported here, not at module
+    # scope, to leave the pre-existing import block untouched.
+    from typing import Any
+
+    def spy_walk(top: Any, *args: Any, **kwargs: Any) -> Any:
         """Record each walk root, then delegate to the real ``os.walk``."""
         walked.append(str(top))
-        return real_walk(top, *args, **kwargs)  # type: ignore[arg-type]
+        return real_walk(top, *args, **kwargs)
 
     monkeypatch.setattr(real_os, "walk", spy_walk)
 

--- a/creek-tools/tests/test_cli_redact.py
+++ b/creek-tools/tests/test_cli_redact.py
@@ -865,6 +865,91 @@ def test_redact_apply_refuses_a_named_symlinked_directory_whose_target_escapes(
     )
 
 
+def test_redact_apply_refuses_a_named_symlinked_directory_before_walking_it(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The refusal must land *before* the tree is walked, not merely before a write.
+
+    ``run_apply`` guards ``--source`` in the handler and again at the
+    ``_scan_source`` chokepoint. The chokepoint alone already prevents the
+    out-of-root *write*, so a test that only asserts ``exit_code == 1`` and
+    unchanged victim bytes passes with the handler guard deleted — the two
+    layers are indistinguishable by outcome. Mutation testing found exactly
+    that survivor.
+
+    What the handler guard uniquely buys is ordering, and it is the reason
+    the call sits above ``if source.is_dir():`` with a comment saying so:
+    ``is_dir()`` follows the link, so without the early refusal
+    :func:`_assert_no_escaping_symlinks` runs ``os.walk`` over the *target's*
+    tree. That enumerates directory names outside the tree the operator
+    named — a structure disclosure of the victim directory, and the same
+    class of oracle #1087 closes — before anything refuses. Measured on the
+    unmutated tree the count is zero directories; with the handler guard
+    removed it is the link plus every subdirectory beneath it.
+
+    Spying on ``os.walk`` rather than ``os.scandir`` keeps this stable across
+    3.11-3.13: the guard calls the module-level ``os.walk`` directly, whereas
+    ``scandir`` is a pathlib implementation detail that has moved between
+    versions and could make this test vacuously green.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+        monkeypatch: Pytest monkeypatch fixture, used to install the
+            ``os.walk`` spy.
+    """
+    secrets_dir = tmp_path / "outside" / "secrets"
+    (secrets_dir / "nested").mkdir(parents=True)
+    (secrets_dir / "a.md").write_text(
+        "API_KEY=sk-abcdefghijklmnopqrstuvwx\n",
+        encoding="utf-8",
+    )
+    source = tmp_path / "src"
+    source.mkdir()
+    link = source / "linkdir"
+    link.symlink_to(secrets_dir)
+
+    walked: list[str] = []
+    real_walk = real_os.walk
+
+    def spy_walk(top: object, *args: object, **kwargs: object) -> object:
+        """Record each walk root, then delegate to the real ``os.walk``."""
+        walked.append(str(top))
+        return real_walk(top, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(real_os, "walk", spy_walk)
+
+    result = runner.invoke(
+        app,
+        ["redact", "--apply", "--source", str(link), "--yes"],
+    )
+
+    assert result.exit_code == 1, (
+        "--apply accepted a named escaping symlinked directory.\n\n"
+        f"exit_code={result.exit_code}\n{result.output}"
+    )
+
+    # ``realpath`` on plain strings, not ``Path``: this module imports
+    # ``pathlib.Path`` only under ``TYPE_CHECKING``, so naming it here would
+    # raise ``NameError`` at runtime and turn a genuine regression into a
+    # red-for-the-wrong-reason. Resolving both sides also collapses the
+    # macOS ``/tmp`` -> ``/private/tmp`` alias.
+    secrets_real = real_os.path.realpath(secrets_dir)
+    escaping_walks = [
+        root
+        for root in walked
+        if real_os.path.realpath(root) == secrets_real
+        or real_os.path.realpath(root).startswith(secrets_real + real_os.sep)
+    ]
+    assert not escaping_walks, (
+        "the run walked out of the tree the operator named before refusing. "
+        "The write was still blocked downstream, but the victim directory's "
+        "structure was enumerated on the way there; the guard exists to "
+        "refuse before is_dir() follows the link.\n\n"
+        f"out-of-root walk roots={escaping_walks}\nall walk roots={walked}"
+    )
+
+
 def test_redact_review_refuses_a_named_symlink_whose_target_escapes_its_parent(
     tmp_path: Path,
 ) -> None:

--- a/creek-tools/tests/test_cli_redact.py
+++ b/creek-tools/tests/test_cli_redact.py
@@ -7,6 +7,7 @@ together with the supporting flags (``--report``, ``--dry-run``,
 
 from __future__ import annotations
 
+import logging
 import os as real_os
 from typing import TYPE_CHECKING
 
@@ -657,4 +658,707 @@ def test_redact_scan_omits_the_symlink_skip_row_when_nothing_was_skipped(
     )
     assert "Files scanned" in result.output, (
         f"the statistics table did not render at all.\n\n{result.output}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# #1293: containment for a DIRECTLY NAMED path
+#
+# Both guards above are directory-only — ``if source.is_dir():`` in
+# ``run_apply`` and ``if vault.is_dir():`` in ``run_review`` — and what they
+# guard is a walk of the tree looking for links *inside* it. The path the
+# operator names on the command line is never itself examined, so naming a
+# symlink walks straight past SEC-003 and into the target:
+#
+#   * ``--apply --source <named symlink to a file>`` reads the out-of-tree
+#     file, prints its finding types, and then lands the redacted copy on the
+#     link itself — the operator's link is destroyed and the victim's content
+#     has been disclosed.
+#   * ``--apply --source <named symlink to a directory>`` rewrites files
+#     outside the named tree in place. That is a genuine out-of-root write.
+#   * ``--scan --source <named symlink>`` reads the target and reports it.
+#
+# The two contracts established above stay distinct, and the fix must keep
+# them distinct — this is the whole reason the guard belongs at the
+# ``_scan_source`` chokepoint with a *policy*, rather than being copied a
+# fourth time into a handler:
+#
+#   * the WRITE path (``--apply``, ``--review``) REFUSES: exit 1, before
+#     anything is read through the link.
+#   * the READ path (``--scan``) SKIPS the file, counts it under
+#     ``_SYMLINK_SKIP_LABEL``, and still exits 0 — see the #1087 banner above
+#     for why refusing there would be a denial of service on the safety pass.
+# ---------------------------------------------------------------------------
+
+
+def test_redact_apply_refuses_a_named_symlink_whose_target_escapes_its_parent(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``--apply`` on a named symlink refuses instead of reading the target.
+
+    The primary red for #1293. Four separately observable failures at HEAD,
+    each pinned by its own assertion so that a partial fix cannot pass:
+
+    * the run succeeds (exit 0) rather than refusing;
+    * the out-of-tree target's finding types reach the console, which is
+      disclosure of the content of a file the operator never named;
+    * ``os.replace`` lands the redacted copy on the link, so the named path
+      comes back as an ordinary in-tree regular file and the link is gone;
+    * nothing in the output says "symlink", so the operator has no way to
+      learn any of the above happened.
+
+    Deliberately run without ``--verbose``: the per-match table renders
+    absolute temporary paths that Rich truncates to the console width, which
+    would make any path assertion here an accident of formatting. The
+    "Findings by Type" table names the pattern types on its own.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+        caplog: Pytest log capture — the refusal must not disclose the
+            resolved target through the logs either.
+    """
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    victim = outside / "victim.env"
+    victim.write_text(
+        "API_KEY=sk-abcdefghijklmnopqrstuvwx\nssn: 999-88-7777\n",
+        encoding="utf-8",
+    )
+    original_bytes = victim.read_bytes()
+    source = tmp_path / "src"
+    source.mkdir()
+    link = source / "leak.env"
+    link.symlink_to(victim)
+
+    with caplog.at_level(logging.WARNING):
+        result = runner.invoke(
+            app,
+            ["redact", "--apply", "--source", str(link), "--yes"],
+        )
+
+    assert result.exit_code == 1, (
+        "--apply followed a symlink named directly on the command line; the "
+        "directory-only SEC-003 guard never looked at the named path "
+        "itself.\n\n"
+        f"exit_code={result.exit_code}\n{result.output}"
+    )
+    assert "api_key" not in result.output.lower(), (
+        "the findings-by-type table names a pattern that only exists in the "
+        "out-of-tree target, so the target was opened and read.\n\n"
+        f"{result.output}"
+    )
+    assert "ssn" not in result.output.lower(), (
+        "the findings-by-type table names a pattern that only exists in the "
+        "out-of-tree target, so the target was opened and read.\n\n"
+        f"{result.output}"
+    )
+    assert link.is_symlink(), (
+        "the named symlink is no longer a symlink: the atomic replace wrote "
+        "the redacted copy over the link, silently converting the operator's "
+        "link into a regular file.\n\n"
+        f"exit_code={result.exit_code}\n{result.output}"
+    )
+    assert "symlink" in result.output.lower(), (
+        "the refusal does not say why it refused; an operator cannot act on "
+        f"an unexplained exit 1.\n\nexit_code={result.exit_code}\n"
+        f"{result.output}"
+    )
+
+    disclosing = [
+        record.getMessage()
+        for record in caplog.records
+        if str(victim) in record.getMessage()
+    ]
+    assert not disclosing, (
+        "a log record spells out the resolved out-of-tree target. The "
+        "refusal should name the path the operator typed, not the one it "
+        f"points at.\n\n{disclosing}"
+    )
+    assert victim.name not in result.output, (
+        "the console output names the out-of-tree target file. Asserted on "
+        "the bare filename rather than the absolute path on purpose: Rich "
+        "truncates long paths to the console width, so an assertion on "
+        f"str(victim) would hold no matter what was printed.\n\n"
+        f"{result.output}"
+    )
+
+    # REGRESSION INVARIANT ONLY — this assertion ALREADY PASSES AT HEAD and
+    # is not part of the red. In the named-*file* case HEAD reads the victim
+    # and then writes the redacted copy over the *link*, so the victim's own
+    # bytes survive; it is pinned here so a fix cannot start writing through
+    # the link on its way to refusing. The load-bearing "bytes unchanged"
+    # red is the named-*directory* case in the next test, where HEAD really
+    # does rewrite the out-of-tree file in place.
+    assert victim.read_bytes() == original_bytes, (
+        "the out-of-tree target's bytes changed; a run that refuses must "
+        f"write nothing anywhere.\n\nexit_code={result.exit_code}\n"
+        f"{result.output}"
+    )
+
+
+def test_redact_apply_refuses_a_named_symlinked_directory_whose_target_escapes(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A named symlinked *directory* is the case that writes out of root.
+
+    The issue body describes the named-file case; this is the one that does
+    real damage. ``Path.is_dir()`` follows symlinks, so a link to a directory
+    satisfies ``if source.is_dir():`` and the SEC-003 walk runs — but it
+    walks the *target's* tree, finds no links inside it, and passes. Every
+    file discovered under the link is then a plain regular file, so the
+    atomic replace rewrites it where it lives: outside the tree the operator
+    named.
+
+    The unchanged-bytes assertion here IS load-bearing red (HEAD rewrites
+    the file), unlike its labelled counterpart in the named-file test above.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+        caplog: Pytest log capture, for the same non-disclosure pin.
+    """
+    secrets_dir = tmp_path / "outside" / "secrets"
+    secrets_dir.mkdir(parents=True)
+    victim = secrets_dir / "a.md"
+    victim.write_text(
+        "API_KEY=sk-abcdefghijklmnopqrstuvwx\n",
+        encoding="utf-8",
+    )
+    original_bytes = victim.read_bytes()
+    source = tmp_path / "src"
+    source.mkdir()
+    link = source / "linkdir"
+    link.symlink_to(secrets_dir)
+
+    with caplog.at_level(logging.WARNING):
+        result = runner.invoke(
+            app,
+            ["redact", "--apply", "--source", str(link), "--yes"],
+        )
+
+    assert result.exit_code == 1, (
+        "--apply accepted a symlinked directory named on the command line; "
+        "is_dir() follows the link, so the SEC-003 walk ran over the "
+        "target's tree instead of rejecting the link.\n\n"
+        f"exit_code={result.exit_code}\n{result.output}"
+    )
+    assert "symlink" in result.output.lower(), (
+        "the refusal does not say why it refused.\n\n"
+        f"exit_code={result.exit_code}\n{result.output}"
+    )
+    assert victim.read_bytes() == original_bytes, (
+        "a file outside the named tree was rewritten in place. This is the "
+        "out-of-root WRITE: the operator named one directory and another "
+        f"directory's contents changed.\n\nexit_code={result.exit_code}\n"
+        f"{result.output}"
+    )
+
+    disclosing = [
+        record.getMessage()
+        for record in caplog.records
+        if str(secrets_dir) in record.getMessage()
+    ]
+    assert not disclosing, (
+        "a log record spells out the resolved out-of-tree directory; report "
+        f"the named path, not what it resolves to.\n\n{disclosing}"
+    )
+
+
+def test_redact_review_refuses_a_named_symlink_whose_target_escapes_its_parent(
+    tmp_path: Path,
+) -> None:
+    """``--review`` refuses a named symlink, matching its in-tree contract.
+
+    ``--review`` already refuses an escaping link *found inside* the vault
+    (see the SEC-003 test above, whose message shape this mirrors). Naming
+    that same link as ``--vault`` must not be the way around it: at HEAD
+    ``vault.is_dir()`` is False for a link to a file, the guard is skipped
+    entirely, and the out-of-tree target is scanned and rendered into the
+    review queue.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+    """
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    victim = outside / "victim.env"
+    victim.write_text(
+        "API_KEY=sk-abcdefghijklmnopqrstuvwx\n",
+        encoding="utf-8",
+    )
+    source = tmp_path / "src"
+    source.mkdir()
+    link = source / "linkvault.md"
+    link.symlink_to(victim)
+
+    result = runner.invoke(
+        app,
+        ["redact", "--review", "--vault", str(link)],
+    )
+
+    assert result.exit_code == 1, (
+        "--review followed a symlink named directly as --vault and rendered "
+        "a review queue for a file outside it.\n\n"
+        f"exit_code={result.exit_code}\n{result.output}"
+    )
+    assert "symlink" in result.output.lower(), (
+        "the refusal message does not name the reason, so it does not match "
+        "the message-shape contract the in-tree SEC-003 refusal already "
+        f"holds to.\n\nexit_code={result.exit_code}\n{result.output}"
+    )
+
+
+def test_redact_review_refusal_reads_no_config_through_the_link(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The refusal happens BEFORE anything is read through the link.
+
+    "Refuses before reading anything through the link" is the half of the
+    contract that prose cannot check. A handler that resolves
+    ``<vault>/00-Creek-Meta/creek_config.yaml`` through the symlink, opens
+    it, parses it, applies its privacy and redaction settings — and only
+    then refuses — still exits 1, still says "symlink", and still satisfies
+    every other test in this section. It has nonetheless already read a file
+    from outside the tree the operator named and let it steer the run.
+
+    So the ordering is pinned directly: ``load_config`` is swapped for a
+    recording wrapper and asserted never to have been reached. The wrapper
+    delegates to the real loader rather than raising, because a raising
+    sentinel would be caught by ``CliRunner`` and reported as exit 1 —
+    manufacturing a pass for the exit-code assertion at HEAD.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    from creek.config import load_config as real_load_config
+
+    outside_vault = tmp_path / "outside" / "vault"
+    (outside_vault / "00-Creek-Meta").mkdir(parents=True)
+    (outside_vault / "00-Creek-Meta" / "creek_config.yaml").write_text(
+        "# empty config: parses to {} and validates to the defaults\n",
+        encoding="utf-8",
+    )
+    (outside_vault / "notes.md").write_text(
+        "SSN: 999-88-7777\n",
+        encoding="utf-8",
+    )
+    source = tmp_path / "src"
+    source.mkdir()
+    link = source / "linkvault"
+    link.symlink_to(outside_vault)
+
+    calls: list[Path | None] = []
+
+    def _recording_load_config(config_path=None, **kwargs):
+        """Record the call, then delegate to the real loader."""
+        calls.append(config_path)
+        return real_load_config(config_path, **kwargs)
+
+    monkeypatch.setattr(
+        "creek.redact.cli_commands.load_config",
+        _recording_load_config,
+    )
+
+    result = runner.invoke(
+        app,
+        ["redact", "--review", "--vault", str(link)],
+    )
+
+    assert result.exit_code == 1, (
+        "--review accepted a symlinked directory named as --vault.\n\n"
+        f"exit_code={result.exit_code}\n{result.output}"
+    )
+    assert not calls, (
+        "load_config was called before the refusal, so the run read "
+        "<vault>/00-Creek-Meta/creek_config.yaml through the symlink — a "
+        "file outside the named tree, resolved and parsed, and allowed to "
+        f"configure the run that then refused.\n\ncalls={calls}\n"
+        f"exit_code={result.exit_code}\n{result.output}"
+    )
+
+
+def test_redact_apply_refusal_reads_no_config_through_the_link(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--apply`` refuses before it reads config through the named link.
+
+    The ``--apply`` counterpart to the ``--review`` ordering pin above, and
+    the test that makes ``run_apply``'s own guard load-bearing rather than
+    merely redundant. Without it, deleting the handler guard entirely still
+    left every other test in this section green: the ``_scan_source``
+    chokepoint caught the escape a few lines later and the run still exited
+    1. Defence in depth is the point of having both, but a layer no test can
+    tell the absence of is not a layer.
+
+    What the later catch does not prevent is this: ``run_apply`` takes a
+    ``--vault`` of its own, and ``resolve_config_path`` reads
+    ``<vault>/00-Creek-Meta/creek_config.yaml`` when that file exists. Point
+    both flags at the same escaping link and the chokepoint-only ordering
+    opens, parses, and applies a config file from outside the named tree —
+    letting the target steer the privacy and redaction settings of the run
+    that is about to refuse it. Refusing after being configured by the thing
+    you refused is not refusing.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    from creek.config import load_config as real_load_config
+
+    outside_vault = tmp_path / "outside" / "vault"
+    (outside_vault / "00-Creek-Meta").mkdir(parents=True)
+    (outside_vault / "00-Creek-Meta" / "creek_config.yaml").write_text(
+        "# empty config: parses to {} and validates to the defaults\n",
+        encoding="utf-8",
+    )
+    (outside_vault / "notes.md").write_text(
+        "SSN: 999-88-7777\n",
+        encoding="utf-8",
+    )
+    source = tmp_path / "src"
+    source.mkdir()
+    link = source / "linkvault"
+    link.symlink_to(outside_vault)
+
+    calls: list[Path | None] = []
+
+    def _recording_load_config(config_path=None, **kwargs):
+        """Record the call, then delegate to the real loader."""
+        calls.append(config_path)
+        return real_load_config(config_path, **kwargs)
+
+    monkeypatch.setattr(
+        "creek.redact.cli_commands.load_config",
+        _recording_load_config,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "redact",
+            "--apply",
+            "--source",
+            str(link),
+            "--vault",
+            str(link),
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 1, (
+        "--apply accepted a symlinked directory named on the command "
+        f"line.\n\nexit_code={result.exit_code}\n{result.output}"
+    )
+    assert not calls, (
+        "load_config was called before the refusal, so the run read "
+        "<vault>/00-Creek-Meta/creek_config.yaml through the symlink and "
+        "let a file outside the named tree configure the run that then "
+        f"refused it.\n\ncalls={calls}\nexit_code={result.exit_code}\n"
+        f"{result.output}"
+    )
+
+
+def test_redact_apply_refuses_an_escaping_vault_symlink(tmp_path: Path) -> None:
+    """``--apply --vault <escaping link>`` is an out-of-root WRITE.
+
+    ``--source`` is not the only path an operator names. ``run_apply`` also
+    takes a ``--vault``, and it does two things with it that ``--source``
+    never does: it reads ``<vault>/00-Creek-Meta/creek_config.yaml`` to
+    configure the run, and it *appends the audit record* to
+    ``<vault>/00-Creek-Meta/audit/redact.jsonl``. Point ``--vault`` at a
+    symlink leaving its parent and both happen outside the named tree — the
+    write creating the ``audit/`` directory itself if it does not exist.
+
+    That makes this the second genuine out-of-root write in #1293, and the
+    one the issue body, the guard, and every other test here missed: the
+    source can be entirely innocent. Guarding only the scanned path leaves
+    the audit trail — the thing an operator trusts to say what was touched —
+    landing wherever a link points.
+
+    The assertion is on the filesystem rather than the exit code alone: a
+    refusal that still created the out-of-tree directory would satisfy an
+    exit-code-only test while having already written outside the root.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+    """
+    outside_vault = tmp_path / "outside" / "vault"
+    (outside_vault / "00-Creek-Meta").mkdir(parents=True)
+    (outside_vault / "00-Creek-Meta" / "creek_config.yaml").write_text(
+        "redaction:\n  enabled: true\n",
+        encoding="utf-8",
+    )
+    root = tmp_path / "root"
+    source = root / "src"
+    source.mkdir(parents=True)
+    (source / "leak.env").write_text(
+        "API_KEY=sk-abcdefghijklmnopqrstuvwx\n",
+        encoding="utf-8",
+    )
+    # The link must sit somewhere that does NOT contain the target, or it
+    # does not escape its own parent and there is nothing to refuse.
+    link = root / "linkvault"
+    link.symlink_to(outside_vault)
+
+    result = runner.invoke(
+        app,
+        [
+            "redact",
+            "--apply",
+            "--source",
+            str(source),
+            "--vault",
+            str(link),
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 1, (
+        "--apply accepted an escaping symlink as --vault. The scanned source "
+        "was innocent, so the source guard never fired, and the run went on "
+        f"to write its audit trail through the link.\n\n"
+        f"exit_code={result.exit_code}\n{result.output}"
+    )
+    assert "symlink" in result.output.lower(), (
+        f"the refusal does not say why it refused.\n\n{result.output}"
+    )
+    assert not (outside_vault / "00-Creek-Meta" / "audit").exists(), (
+        "the audit log was written outside the tree the operator named — a "
+        "real out-of-root write, and to the very record that is supposed to "
+        f"say truthfully what this run touched.\n\n{result.output}"
+    )
+
+
+def test_redact_scan_skips_a_named_symlink_whose_target_escapes_its_parent(
+    tmp_path: Path,
+) -> None:
+    """``--scan`` SKIPS a named escaping symlink; it does not refuse.
+
+    The distinct contract, and the reason the fix needs a policy rather than
+    an unconditional guard at the chokepoint. ``--scan`` writes nothing, so
+    refusing an entire scan over one bad link would be a denial of service
+    on the safety pass itself — the operator's only way of finding out what
+    is exposed. That is the #1087 reasoning in the banner above, and naming
+    the link on the command line does not change it: decline the file, keep
+    the exit code at 0, and say so in the statistics.
+
+    At HEAD there is no guard on ``run_scan`` at all, so the target's ``ssn``
+    is read and reported. The skip-label assertion is also the non-vacuity
+    guard here: unlike the #1087 test there is no in-root control file to
+    read (the named source *is* the link), so "reported nothing" would
+    otherwise be indistinguishable from "did nothing".
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+    """
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    victim = outside / "victim.md"
+    victim.write_text(_ESCAPING_TARGET_PII, encoding="utf-8")
+    source = tmp_path / "src"
+    source.mkdir()
+    link = source / "linked.md"
+    link.symlink_to(victim)
+
+    result = runner.invoke(
+        app,
+        ["redact", "--scan", "--source", str(link)],
+    )
+
+    assert result.exit_code == 0, (
+        "--scan refused a named escaping symlink. The read path skips; only "
+        "the write path refuses, or one stray link disables the operator's "
+        f"whole safety pass.\n\nexit_code={result.exit_code}\n{result.output}"
+    )
+    assert "ssn" not in result.output.lower(), (
+        "the scan reported the PII type of a file outside the named path's "
+        f"own parent, so it followed the link and read it.\n\n{result.output}"
+    )
+    assert _SYMLINK_SKIP_LABEL in result.output, (
+        "the statistics table does not report the skip, so the operator "
+        "reads a clean scan of a path whose contents were never "
+        f"examined.\n\n{result.output}"
+    )
+
+
+def test_scan_source_refuses_an_escaping_named_path_under_the_refuse_policy(
+    tmp_path: Path,
+) -> None:
+    """The chokepoint enforces the policy, not each individual handler.
+
+    This is the regression guard for the exact omission that produced #1293.
+    The guard lived in the handlers: ``run_apply`` calls it, ``run_review``
+    calls it, ``run_scan`` does not — and all three then call the same
+    ``_scan_source``. Under that shape a fourth mode, or any new caller of
+    ``_scan_source``, inherits the hole by default and nothing fails until
+    somebody notices.
+
+    Moving the decision onto ``_scan_source`` with a required ``policy``
+    inverts that: a new caller has to state what it wants before it will run
+    at all. This test exercises the chokepoint directly, with no CLI in the
+    way, so it keeps holding whatever the handlers are later refactored into.
+
+    The imports are function-local on purpose. ``SymlinkPolicy`` does not
+    exist yet, and a module-level import of a missing name is a collection
+    error for the whole file — it would take the other tests here down with
+    it and hide the real signal. The ``ImportError`` from this one test is
+    the expected RED until the implementation lands.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+    """
+    import typer
+    from rich.console import Console
+
+    from creek.config import load_config
+    from creek.redact.cli_commands import SymlinkPolicy, _scan_source
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    victim = outside / "victim.env"
+    victim.write_text(
+        "API_KEY=sk-abcdefghijklmnopqrstuvwx\n",
+        encoding="utf-8",
+    )
+    source = tmp_path / "src"
+    source.mkdir()
+    link = source / "leak.env"
+    link.symlink_to(victim)
+
+    console = Console()
+    config = load_config(None)
+
+    with pytest.raises(typer.Exit) as excinfo:
+        _scan_source(
+            link,
+            config,
+            console=console,
+            label="source",
+            policy=SymlinkPolicy.REFUSE,
+        )
+
+    assert excinfo.value.exit_code == 1, (
+        "the chokepoint aborted with the wrong code: 1 is the SEC-003 "
+        "refusal, 2 is the generic 'bad usage' exit that a missing path "
+        f"produces.\n\nexit_code={excinfo.value.exit_code}"
+    )
+
+
+def test_redact_apply_admits_a_named_intra_tree_symlink(tmp_path: Path) -> None:
+    """A named symlink pointing inside its own parent still works.
+
+    The over-breadth guard. "Refuse any named symlink" would pass every
+    other test in this section while breaking the ordinary case of an alias
+    beside the file it aliases — the same case ``--source <dir>`` has always
+    allowed (see ``test_redact_apply_allows_internal_symlink``). Containment
+    is about the target escaping, not about the link existing.
+
+    Asserted through the named path rather than through ``real.md``, so the
+    test holds whether the fix writes through the link or replaces it.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+    """
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "real.md").write_text(
+        "SSN: 123-45-6789\n",
+        encoding="utf-8",
+    )
+    alias = source / "alias.md"
+    alias.symlink_to(source / "real.md")
+
+    result = runner.invoke(
+        app,
+        ["redact", "--apply", "--source", str(alias), "--yes"],
+    )
+
+    assert result.exit_code == 0, (
+        "a named symlink whose target sits under its own parent was "
+        "refused; the fix is over-broad and now rejects ordinary "
+        f"aliases.\n\nexit_code={result.exit_code}\n{result.output}"
+    )
+    redacted = alias.read_text(encoding="utf-8")
+    assert "123-45-6789" not in redacted, (
+        "the run exited 0 without redacting anything, so the exit code "
+        f"above proves nothing.\n\n{redacted!r}\n\n{result.output}"
+    )
+    assert "[REDACTED" in redacted, (
+        "the sensitive value is gone but no redaction marker replaced it; "
+        f"the file was truncated or rewritten wholesale.\n\n{redacted!r}"
+    )
+
+
+def test_redact_apply_on_a_dangling_named_symlink_exits_two(tmp_path: Path) -> None:
+    """ORDERING PIN THAT PASSES AT HEAD: existence is checked first.
+
+    ``_require_existing`` gates on ``Path.exists()``, which follows the link
+    and returns False when the target is missing, so a dangling link is a
+    "not found" (exit 2) and never reaches the symlink guard at all. Pinned
+    because the obvious way to implement #1293 — hoisting a symlink check
+    above the existence check — would silently reclassify every broken link
+    as a containment refusal and change an exit code operators script
+    against.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+    """
+    source = tmp_path / "src"
+    source.mkdir()
+    dangling = source / "dangling.md"
+    dangling.symlink_to(tmp_path / "outside" / "gone.md")
+
+    result = runner.invoke(
+        app,
+        ["redact", "--apply", "--source", str(dangling), "--yes"],
+    )
+
+    assert result.exit_code == 2, (
+        "a dangling link no longer exits 2; the existence check has been "
+        "reordered behind the symlink guard.\n\n"
+        f"exit_code={result.exit_code}\n{result.output}"
+    )
+    assert "not found" in result.output.lower(), (
+        "a broken link should be reported as a missing path, not as a "
+        f"containment failure.\n\n{result.output}"
+    )
+
+
+def test_redact_apply_on_a_looping_named_symlink_exits_two(tmp_path: Path) -> None:
+    """ORDERING PIN THAT PASSES AT HEAD: a link loop is also "not found".
+
+    ``a → b → a`` raises ``OSError(ELOOP)`` on resolution, and
+    ``Path.exists()`` swallows that and returns False — so, exactly as with
+    a dangling link, ``_require_existing`` reports "not found" and exits 2
+    before any symlink logic runs. Written to that fact rather than to the
+    tempting "exit 1 with a symlink message", which is not what the code
+    does and would be a permanently red test dressed up as a requirement.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+    """
+    source = tmp_path / "src"
+    source.mkdir()
+    a = source / "a.md"
+    b = source / "b.md"
+    a.symlink_to(b)
+    b.symlink_to(a)
+
+    result = runner.invoke(
+        app,
+        ["redact", "--apply", "--source", str(a), "--yes"],
+    )
+
+    assert result.exit_code == 2, (
+        "a looping link no longer exits 2; ELOOP is being handled somewhere "
+        "other than the existence check, which is where Python's False "
+        f"return puts it.\n\nexit_code={result.exit_code}\n{result.output}"
+    )
+    assert "not found" in result.output.lower(), (
+        "the loop was reported as something other than a missing path.\n\n"
+        f"{result.output}"
     )


### PR DESCRIPTION
## Summary

SEC-003's symlink guard was **directory-only**. It walked a tree looking for
escaping links *inside* it, and never examined the path the operator **named**
on the command line. Naming a symlink walked straight past it.

**The issue body's mechanism is wrong, and I did not implement it.** It claims
`creek redact --apply <symlinked-file>` "writes through the link" and asks for a
red-first test asserting the victim's bytes are unchanged. `_atomic_write` ends
in `os.replace` (`cli_commands.py`), and **`os.replace` onto a symlink path
replaces the link — it does not follow it**. I ran the real CLI at the base
commit: victim md5 `5859146984a98cc174eaa129a0fa1745` before *and* after. That
acceptance criterion is already green at HEAD, so writing it to spec would have
shipped a fake red. A premise correction is recorded on the issue.

### What was actually broken (all verified by running the CLI, exit 0, no refusal)

1. **Named symlinked FILE** — out-of-root **read** + **exfiltration into the
   tree** + **link destruction**. The target's secrets were enumerated and
   printed (`api_key`, `env_secret`, `high_entropy_string`, `ssn`), then
   `os.replace` destroyed the link, leaving a regular in-tree file holding a
   redacted copy of out-of-tree content.
2. **Named symlinked DIRECTORY** — a genuine in-place **out-of-root write**, and
   the case the issue body omits entirely. `is_dir()` follows the link, so the
   walk guard ran with `resolved_root = root.resolve()` = the *target*,
   laundering every child as "inside". Verified: out-of-tree `a.md` md5
   `06832860b4ed54631d892598f5743380` → `2c8ab87896ad93d35109d353dccc493a`.
3. **`run_scan`** — a third `_scan_source` caller the body never names, with **no
   symlink guard of any kind**.
4. **`--apply --vault <escaping link>`** — found at self-review, not in the issue
   or the plan. `run_apply` takes a `--vault` of its own and **writes** to it:
   the audit record lands in `<vault>/00-Creek-Meta/audit/redact.jsonl`,
   *creating* `audit/` if absent. So a second out-of-root write, reachable with
   an entirely innocent `--source`, putting the record of what was touched
   wherever a link pointed. Verified live, then fixed.

## The fix

- `scanner._resolves_within` → public **`resolves_within`**, so the walked-child
  and named-path surfaces share one definition of "inside" instead of drifting
  into two.
- **`_named_path_escapes(path)`** — `path.is_symlink() and not
  resolves_within(path, path.parent.resolve(strict=False))`.
- **`_assert_named_path_contained(...)`** — exit 1, the exact existing SEC-003
  message shape, naming **only the as-supplied path**. `logger.warning`, not
  `logger.exception` (no exception is being handled there; `.exception` would
  append a bogus `NoneType: None`).
- **`SymlinkPolicy`** enum on `_scan_source`, as a **required, non-defaulted**
  kwarg. That absence is the point: mypy strict now makes it a build error to
  add a fourth redaction mode without stating a symlink policy — the exact
  omission that left `run_scan` unguarded and produced this issue.
- Handler guards in `run_apply`/`run_review` placed after `_require_existing`
  but **before** `is_dir()` (which follows the link) and **before**
  `load_config` (which would otherwise read `creek_config.yaml` *through* it).
  The shipped `_assert_no_escaping_symlinks` walk guard was left exactly where
  it is.

### The two contracts stay distinct

`--apply`/`--review` **refuse** (exit 1). `--scan` **skips and counts** and still
exits 0. `--scan` writes nothing, so refusing a whole scan over one bad link
would be a denial of service on the safety pass itself — a regression wearing a
fix's clothes. This is why the policy is a parameter rather than an
unconditional guard at the shared chokepoint. `tests/test_cli_redact.py:545-553`
and `:576-628` pass unmodified.

### Decision: refused outright, no waiver

No `--force`, no environment variable, no config key, per SEC-003's no-waiver
precedent. The security direction here is one-way: this guard may only ever
cause the tool to read and write *less*. Recorded in the guard's docstring.

### Named symlinked directory — stated accurately

The predicate is **leaf-only**, so the honest statement is: a named symlinked
directory is **refused when its target escapes the link's own parent**, and
**admitted — with the resolved target as the root thereafter — when it does
not**. `~/vault -> ~/Dropbox/vault` is still admitted and still redacts under
`~/Dropbox/vault`. It would have been easy to write "refused uniformly" over
code that does no such thing; that would have put a false claim in the threat
model.

## User-visible behaviour change

Aliasing an external export tree into the vault and naming the alias is now
refused:

```
ln -s /Volumes/Export ~/vault/inbox
creek redact --apply --source ~/vault/inbox     # now exits 1
```

Workaround: name the resolved path. And `--scan` on such an alias now reports 0
files scanned with a skip row instead of scanning the target. This is the
correct ratchet direction, but it is a change and is recorded in the threat
model rather than left to be discovered.

## Residuals — deliberately open, not hidden

1. **Leaf-only predicate.** `<root>/linkdir/a.md` (real file leaf, escaping
   *ancestor* component) is still admitted and rewritten in place. Same
   resolve-the-root / lstat-the-leaf asymmetry the scanner already relies on to
   keep a `/tmp` → `/private/tmp` root scannable.
2. **`Pipeline._run_redaction`** (`pipeline.py:478`/`:484`) still traverses a
   directly-named symlinked directory — read-only, escalating to a refusal via
   the skip counter.
3. **`--scan --vault <escaping link>`** still reads and parses an out-of-tree
   `creek_config.yaml`. Read-escape, not a write. Confirmed by pointing it at
   malformed YAML and watching the parse error surface from outside the tree.
   Deliberately not refused here, because a refusing `--scan` is the very DoS
   the skip-and-count contract exists to avoid — that trade deserves its own
   decision. Filed as **#1359 (P2)**.

**#1294 is NOT touched by this PR** and must not be treated as closed or
half-closed. Its sentence in the threat model is preserved verbatim.

## Test plan

Gate 1 RED proven **before** any source change, on behavioural assertions:

```
FAILED test_redact_apply_refuses_a_named_symlink_whose_target_escapes_its_parent
  AssertionError: --apply followed a symlink named directly on the command line;
  the directory-only SEC-003 guard never looked at the named path itself.
  exit_code=0
  │ api_key             │ critical │ 1 │
  │ env_secret          │ high     │ 1 │
  │ high_entropy_string │ medium   │ 1 │
  │ ssn                 │ critical │ 1 │
  Applied redactions to 1 file(s).
  assert 0 == 1
FAILED test_redact_apply_refuses_a_named_symlinked_directory_whose_target_escapes
FAILED test_redact_review_refuses_a_named_symlink_whose_target_escapes_its_parent
FAILED test_redact_review_refusal_reads_no_config_through_the_link
FAILED test_redact_scan_skips_a_named_symlink_whose_target_escapes_its_parent
FAILED test_scan_source_refuses_an_escaping_named_path_under_the_refuse_policy
  ImportError: cannot import name 'SymlinkPolicy'   (expected until GREEN)
6 failed, 3 passed
```

The 3 that passed at HEAD are labelled **ordering pins**, not reds: dangling and
looping named links exit 2 via `_require_existing`'s `path.exists()` (False for
both — Python swallows ELOOP), and an intra-tree alias is admitted. They exist so
a later guard reshuffle cannot silently reclassify a broken link as a
containment refusal.

Two reds rest on **out-of-tree bytes unchanged**; only one legitimately can. In
the named-FILE test that assertion already passes at HEAD, so it is labelled
regression-only in an inline comment. It is load-bearing in the named-DIRECTORY
test, where HEAD really does rewrite in place.

**Disclosure** is asserted via `caplog` records plus the bare filename — never
`str(victim) not in output`, which is vacuous: Rich truncates the Matches table
to the console width (`/var/folders/vg/73pzvjkj3p9dy38k1cf…`). No new test
passes `--verbose`.

### Mutation battery — 6 mutants, 0 survivors

Each guard reverted alone; exactly the intended tests go red.

| Mutant | Result |
|---|---|
| Remove `run_apply` source guard | kills the `--apply` config-ordering pin |
| Remove `run_review` vault guard | kills the `--review` config-ordering pin |
| Disable `_scan_source` chokepoint | kills the scan-skip test + the chokepoint unit test |
| SKIP arm → REFUSE | kills the scan skip-and-count test (DoS regression caught) |
| Predicate → bare `is_symlink()` | kills the intra-tree admit test (over-breadth caught) |
| Remove the new `--vault` guard | kills the escaping-vault write test |

The first mutant **survived the initial battery** — the chokepoint caught it a
few lines later, so removing the handler guard changed nothing observable. A
layer no test can detect the absence of is not a layer, so I added
`test_redact_apply_refusal_reads_no_config_through_the_link`, which pins the
real property: with `--source` and `--vault` both naming the same escaping link,
chokepoint-only ordering parses an out-of-tree config and lets it steer the run
that then refuses. Refusing after being configured by the thing you refused is
not refusing.

### Not weakened

`tests/test_cli_redact.py` lines 1-660 are **byte-identical** to the base commit
(diffed), plus one added `import logging`. Everything else is appended. All six
protected SEC-003/#1087 tests pass unmodified. No test deleted, no assertion
relaxed, no threshold changed, no `# noqa` / `# type: ignore` / skip marker.

### Gates

- `./scripts/check-all.sh` → **exit 0**
- 468 tests pass across `test_cli_redact.py`, `test_redact.py`, `test_cli.py`
- Gate 2.5 `code-review-orchestrator` found the `--vault` write escape above; it
  is fixed here, with its own RED-first test, rather than deferred.
- crawdad's separate gate is not implicated — no caller of these entrypoints
  under `crawdad/crawdad/`. `creek_mcp/tools/redact.py` is out of blast radius
  (already gated by `resolve_within_vault` upstream).

Closes #1293
