### PR TITLE
fix(api): build the /v1 header merge so Vary cannot be overridden (#1128)

### DIFF
--- a/creek-tools/creek_mcp/httpapi/errors.py
+++ b/creek-tools/creek_mcp/httpapi/errors.py
@@ -19,11 +19,42 @@ caller's ceiling-filtered response to another. Authentication sits *above* the
 ceiling gate, so there is no single middleware every response passes through on
 the way out with the ceiling in scope. There is, however, exactly one builder:
 :func:`json_response`. Routing every response through it is what makes the
-header unconditional.
+header unconditional — and, since #1128, unforgeable. The builder used to lay
+this header *under* the caller's, so any call site handing in a ``Vary`` of its
+own silently deleted the ceiling token; the merge now runs the other way. Note
+the narrowness of that claim: ``Vary`` is the only header this builder stamps
+and so the only one protected. Everything else a call site passes still rides
+through untouched, which is what a ``401`` needs — see :func:`_challenge_for`.
+
+It absorbs the colliding value rather than discarding it, and that is the
+load-bearing half of the policy. Dropping a caller's ``Vary`` would close this
+hole and open its mirror image — a response whose body really does turn on
+``Accept-Encoding`` but that claims to turn only on the ceiling invites a cache
+to key on less than the truth, which is this same defect pointed the other way.
+Union is also the only direction that is *monotone*: RFC 9111 §4.1 makes reuse
+a conjunction over the nominated field names, so adding a token can only ever
+shrink the set of requests an entry may be served to, never widen it.
+
+So the values union: the ceiling token first, then the caller's in the order
+supplied. The order is fixed rather than incidental because the rendered value
+is asserted byte-for-byte by
+``tests/test_v1_api_admission.py::test_a_caller_echoing_the_standing_token_does_not_double_it``,
+and because a header whose bytes depended on set iteration would differ between
+two worker processes answering the same request.
+
+Names are matched case-folded, because ``Vary`` and ``vary`` are one header on
+the wire and two keys in a dict — Starlette lowercases each key independently
+and never deduplicates, so an unfolded merge emits two ``vary`` lines and leaves
+it to the intermediary to decide which one keys the cache. Caller tokens outside
+RFC 9110's ``tchar`` set are dropped whole rather than repaired, and only ``OWS``
+— the space and the horizontal tab — is trimmed before that test, so a token
+cannot be *whitespace-stripped* back into legality either. A repaired token is
+still a token the caller chose, and this header's contents decide a cache key.
 """
 
 from __future__ import annotations
 
+import string
 from typing import TYPE_CHECKING, Any, Final
 
 from starlette.responses import JSONResponse
@@ -37,7 +68,7 @@ from creek_mcp.api.models import (
 from creek_mcp.api.routes import CEILING_HEADER
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Iterable, Mapping
 
     from starlette.responses import Response
 
@@ -45,6 +76,34 @@ if TYPE_CHECKING:
 
 VARY_HEADER: Final[str] = "Vary"
 """The response header naming which request headers the body depends on."""
+
+_TCHAR: Final[frozenset[str]] = frozenset(
+    string.ascii_letters + string.digits + "!#$%&'*+-.^_`|~"
+)
+"""RFC 9110's ``tchar`` — every character a bare field name may contain.
+
+This is the entire admission test for a caller-supplied ``Vary`` token, so it is
+spelled out rather than approximated by a "no control characters" check: the
+things it excludes include the space, the colon and the carriage return, each of
+which turns one header value into something other than one header value.
+
+``*`` is a member and therefore survives, which is the right outcome even though
+it reads like a wildcard. RFC 9111 §4.1 tests for ``*`` by *membership* in the
+stored ``Vary`` value, not only as the whole value, and a stored response
+carrying it never matches — so an entry that would otherwise have been reusable
+becomes uncacheable. Dropping ``*`` would be the harmful direction: it would
+turn a response its author declared uncacheable into one a cache may serve on
+the ceiling alone. The token degrades closed, so it is kept.
+"""
+
+_OWS: Final[str] = " \t"
+"""RFC 9110's ``OWS`` — the only whitespace that may pad a list element.
+
+Trimmed before the :data:`_TCHAR` test, and deliberately narrower than
+:meth:`str.strip`'s default. A bare ``strip()`` also eats ``\\r`` and ``\\n``,
+which would quietly convert ``Cookie,\\r\\nAccept`` into the perfectly legal
+token ``Accept`` — repairing exactly the input this module refuses to repair.
+"""
 
 WWW_AUTHENTICATE_HEADER: Final[str] = "WWW-Authenticate"
 """The challenge header a ``401`` is obliged to send."""
@@ -59,6 +118,96 @@ unauthenticated caller is guaranteed to see.
 
 HTTP_OK: Final[int] = 200
 """The one success status ``/v1`` returns; readiness lives in the body."""
+
+
+def _is_vary(name: str) -> bool:
+    """Return whether *name* is the ``Vary`` header under any spelling.
+
+    Args:
+        name: A header name as some call site chose to capitalise it.
+
+    Returns:
+        ``True`` for ``Vary``, ``vary``, ``VARY`` and the rest. Folding here is
+        not politeness about style: an unfolded comparison lets a second
+        spelling through as a separate dict key, and Starlette renders that as
+        a second ``vary`` line rather than merging it.
+    """
+    return name.casefold() == VARY_HEADER.casefold()
+
+
+def _is_token(candidate: str) -> bool:
+    """Return whether *candidate* is a whole, well-formed field name.
+
+    Args:
+        candidate: One comma-separated piece of a caller ``Vary``, already
+            stripped of surrounding ``OWS``.
+
+    Returns:
+        ``True`` only when it is non-empty and made entirely of :data:`_TCHAR`.
+        The empty pieces a doubled or trailing comma leaves behind fall out here
+        for free, and so does anything carrying a space, a colon or a line break
+        — which matters, because Starlette writes a header value out verbatim,
+        and a value that ends its own line describes a second header the
+        application never wrote. An allowlist rather than a CR/LF blocklist:
+        the set of characters that are legal in a field name is small, closed
+        and written down, and the set that is dangerous is neither.
+    """
+    return bool(candidate) and all(char in _TCHAR for char in candidate)
+
+
+def _vary_tokens(supplied: Iterable[str]) -> list[str]:
+    """Return the merged ``Vary`` tokens, the standing one first.
+
+    Args:
+        supplied: The value of every caller header whose name folds to
+            ``Vary``. Usually empty; a dict can hold more than one of them
+            only because ``Vary`` and ``vary`` are distinct keys, which is the
+            case this exists to collapse.
+
+    Returns:
+        :data:`~creek_mcp.api.routes.CEILING_HEADER`, then each well-formed
+        caller token in the order it was supplied, deduplicated case-folded
+        because field names are case-insensitive on the wire. Malformed tokens
+        are absent rather than corrected: only ``OWS`` is trimmed, so a piece
+        whose whitespace is a line break stays malformed and is dropped instead
+        of being tidied into a legal token. The order is fixed rather than
+        incidental — the rendered value is asserted byte-for-byte by
+        ``test_a_caller_echoing_the_standing_token_does_not_double_it``.
+    """
+    tokens = [CEILING_HEADER]
+    seen = {CEILING_HEADER.casefold()}
+    for value in supplied:
+        for piece in value.split(","):
+            token = piece.strip(_OWS)
+            if _is_token(token) and token.casefold() not in seen:
+                seen.add(token.casefold())
+                tokens.append(token)
+    return tokens
+
+
+def _merged_headers(headers: Mapping[str, str] | None) -> dict[str, str]:
+    """Return *headers* with the standing ``Vary`` merged in over the top.
+
+    Args:
+        headers: The caller's extra headers for this response, or ``None``. It
+            may hold more than one spelling of ``Vary`` — ``Vary`` and ``vary``
+            are one header on the wire but two keys in a dict — and every one
+            of them is collected, which is why the collection is a list.
+
+    Returns:
+        Every non-colliding caller header unchanged and unexamined — the bearer
+        challenge has to reach the caller or a ``401`` is a protocol violation —
+        plus exactly one ``Vary`` carrying the ceiling token and whatever the
+        caller asked to add to it. ``Vary`` is placed first so that a response
+        with no colliding header renders byte-for-byte as it did before this
+        merge existed.
+    """
+    supplied = headers or {}
+    caller_vary = [value for name, value in supplied.items() if _is_vary(name)]
+    passthrough = {
+        name: value for name, value in supplied.items() if not _is_vary(name)
+    }
+    return {VARY_HEADER: ", ".join(_vary_tokens(caller_vary))} | passthrough
 
 
 def json_response(
@@ -80,13 +229,17 @@ def json_response(
             function never has to know which model it is rendering.
         status: The HTTP status line.
         headers: Extra headers for this particular response, such as the
-            bearer challenge.
+            bearer challenge. The standing ``Vary`` wins — it is the only
+            header this builder stamps and so the only one protected. A name
+            that collides with it — case-folded, so ``vary`` is the same name —
+            neither replaces the standing value nor is dropped, but has its
+            well-formed tokens folded in after the ceiling token. Every other
+            name passes through unexamined.
 
     Returns:
         The response, ready to be awaited as an ASGI application.
     """
-    merged = {VARY_HEADER: CEILING_HEADER, **(headers or {})}
-    return JSONResponse(payload, status_code=status, headers=merged)
+    return JSONResponse(payload, status_code=status, headers=_merged_headers(headers))
 
 
 def _challenge_for(code: ErrorCode) -> Mapping[str, str]:

--- a/creek-tools/tests/test_v1_api_admission.py
+++ b/creek-tools/tests/test_v1_api_admission.py
@@ -44,13 +44,22 @@ from creek_mcp import policy
 from creek_mcp.api.models import ERROR_MESSAGES, ErrorCode
 from creek_mcp.httpapi import capabilities as capabilities_module
 from creek_mcp.httpapi import handlers as handlers_module
+from creek_mcp.httpapi.errors import (
+    BEARER_CHALLENGE,
+    HTTP_OK,
+    VARY_HEADER,
+    WWW_AUTHENTICATE_HEADER,
+    json_response,
+)
 from creek_mcp.tier_ceiling import TierCeiling
 from tests.v1_api_support import (
     CEILING_HEADER,
     CONSUMER,
+    HEALTH_BODY,
     HEALTH_PATH,
     MOUNTED,
     MOUNTED_IDS,
+    OP_HEALTH,
     OTHER_CONSUMER,
     OTHER_TOKEN,
     STRONG_TOKEN,
@@ -109,6 +118,61 @@ _BODIES: Final[dict[str, dict[str, Any]]] = {
     "PUT": VALID_JOURNAL_BODY,
     "POST": VALID_REFLECTION_BODY,
 }
+
+_LOWERCASE_VARY: Final[str] = "vary"
+"""``Vary`` as an intermediary writes it: field names are case-insensitive."""
+
+_CALLER_VARY_TOKEN: Final[str] = "Accept-Encoding"
+"""A token a caller has every right to add, and no right to lose."""
+
+_HOSTILE_VARY: Final[str] = "Cookie\r\nX-Creek-Injected: 1"
+"""A caller ``Vary`` carrying CRLF — one header value, two rendered lines."""
+
+_MALFORMED_VARY_CASES: Final[tuple[tuple[str, str], ...]] = (
+    (_HOSTILE_VARY, "crlf"),
+    ("Bad Token", "space"),
+    ("Accept:Encoding", "colon"),
+    ("Accépt", "non-latin-1"),
+)
+"""Caller ``Vary`` values that are not tokens, and the reason each one is not.
+
+Four cases rather than one because the guard is an allowlist, and a single CRLF
+case can only ever exercise a blocklist's worth of it: ``"\\r" not in value``
+would pass that case while admitting both the space and the colon.
+"""
+
+_ECHOED_CEILING_SPELLINGS: Final[tuple[str, ...]] = (
+    CEILING_HEADER,
+    CEILING_HEADER.lower(),
+    CEILING_HEADER.upper(),
+)
+"""The three ways a call site might spell the ceiling header back at us.
+
+Field names are case-insensitive, so all three are the same token and none may
+be emitted a second time alongside the standing one.
+"""
+
+_ECHOED_CEILING_SPELLING_IDS: Final[tuple[str, ...]] = (
+    "canonical",
+    "lower",
+    "upper",
+)
+"""Stable parametrize ids for :data:`_ECHOED_CEILING_SPELLINGS`, in that order.
+
+Spelled out because the three values fold to one string, so any id derived from
+the value itself would collide and pytest would number them instead.
+"""
+
+_STRIPPABLE_VARY: Final[str] = "Cookie,\r\nAccept"
+"""A caller ``Vary`` whose second element is malformed *only at its edges*.
+
+The one input that tells :meth:`str.strip` and ``strip(OWS)`` apart. Splitting
+on the comma yields ``"\\r\\nAccept"``; a bare strip trims the line break and
+hands back the perfectly legal token ``Accept``, repairing precisely the input
+the builder refuses to repair. ``Cookie`` is well-formed and must survive
+either way, which is what keeps the assertion about the repair and not about
+the drop.
+"""
 
 
 @pytest.fixture
@@ -537,6 +601,351 @@ def test_vary_is_set_on_every_response(
         response = test_client.request(method, path, headers=request_headers, json=body)
     assert response.status_code == expected
     assert CEILING_HEADER.lower() in response.headers.get("vary", "").lower()
+
+
+def _rendered_vary(response: Response) -> list[str]:
+    """Return every ``vary`` header line *response* has rendered.
+
+    Read off ``raw_headers`` rather than ``response.headers[...]`` on purpose.
+    Starlette's mapping answers with the *first* match, so a response carrying
+    two ``vary`` lines is indistinguishable through it from one carrying the
+    right single line — and a duplicated ``vary`` is one of the defects these
+    tests exist to catch.
+
+    Args:
+        response: The built response, before anything sends it.
+
+    Returns:
+        One decoded entry per rendered ``vary`` header line, in render order.
+    """
+    return [
+        value.decode("latin-1")
+        for name, value in response.raw_headers
+        if name.decode("latin-1").lower() == _LOWERCASE_VARY
+    ]
+
+
+def _serialised_header_block(response: Response) -> bytes:
+    """Return *response*'s headers as the byte block a server would emit.
+
+    ``raw_headers`` holds one tuple per dict key, so a name smuggled inside a
+    *value* can never show up as a name there — an assertion that only searches
+    the names of that list passes against the injection it claims to rule out.
+    Joining the pairs back into field lines is what makes the smuggled name
+    findable, because that concatenation is precisely what a ``\\r\\n`` in a
+    value would have forged.
+
+    Args:
+        response: The built response, before anything sends it.
+
+    Returns:
+        The header block, lowercased, as ``name: value`` lines.
+    """
+    lines = [name + b": " + value for name, value in response.raw_headers]
+    return b"\r\n".join(lines).lower()
+
+
+def _vary_token_set(value: str) -> set[str]:
+    """Return the comparable token set of a single ``Vary`` header *value*.
+
+    ``Vary`` is a comma-separated list of case-insensitive field names, so the
+    set — not the string — is what a cache keys on. Named apart from the
+    production ``_vary_tokens`` it checks, which returns an ordered list: a test
+    helper sharing a name with its subject invites the two to be read as one.
+
+    Args:
+        value: One rendered ``Vary`` header value.
+
+    Returns:
+        Its tokens, stripped and folded to lower case.
+    """
+    return {token.strip().lower() for token in value.split(",")}
+
+
+def test_a_caller_cannot_replace_the_standing_vary() -> None:
+    """A caller's ``Vary`` may add to the standing one; it may never displace it.
+
+    The ceiling token is not decoration: it is the only thing stopping a shared
+    cache from serving an ``open`` caller the response computed for a
+    ``personal`` one. No production call site passes a ``Vary`` today — the sole
+    caller handing this builder extra headers is ``_challenge_for``, and it
+    passes only ``WWW-Authenticate`` — so nothing is broken in the field. That
+    is the argument for pinning it now rather than the argument against: the
+    first call site that does pass one would have deleted the protection
+    silently, and a plain dict merge is what let it.
+
+    Weaker by design than the union test below, which subsumes this assertion.
+    It is kept separate because it is the issue's own acceptance criterion, and
+    a named test for the property under repair is what a later reader looks for.
+    """
+    response = json_response({}, HTTP_OK, headers={VARY_HEADER: _CALLER_VARY_TOKEN})
+    lines = _rendered_vary(response)
+    assert len(lines) == 1
+    assert CEILING_HEADER.lower() in lines[0].lower()
+
+
+def test_a_caller_added_vary_token_is_not_discarded() -> None:
+    """The caller's token survives too: the standing header wins by *union*.
+
+    Simply discarding a colliding caller ``Vary`` would fix the disclosure and
+    introduce its twin. A response whose body genuinely depends on
+    ``Accept-Encoding`` but that says it depends only on the ceiling invites a
+    cache to serve the gzipped body to a client that cannot read it — the same
+    class of bug, a cache key that is narrower than the truth. So the assertion
+    is on the whole token set, which pins union as the policy and rules out
+    both discard and replace.
+    """
+    response = json_response({}, HTTP_OK, headers={VARY_HEADER: _CALLER_VARY_TOKEN})
+    lines = _rendered_vary(response)
+    assert len(lines) == 1
+    assert _vary_token_set(lines[0]) == {
+        CEILING_HEADER.lower(),
+        _CALLER_VARY_TOKEN.lower(),
+    }
+
+
+def test_the_standing_vary_token_is_written_first() -> None:
+    """The order is fixed so the rendered value is a function of the input alone.
+
+    A merge that joined the tokens in set order would satisfy every assertion
+    about *which* tokens are present and still render different bytes in two
+    worker processes answering the same request, because the iteration order of
+    a set of strings turns on the hash seed. That is not a disclosure, but it
+    makes the header irreproducible, and the byte-exact assertion in
+    :func:`test_a_caller_echoing_the_standing_token_does_not_double_it` would
+    become the flake that reports it.
+
+    Standing-token-first is also the honest reading order: the token the server
+    insists on, then whatever the call site asked to add.
+    """
+    response = json_response({}, HTTP_OK, headers={VARY_HEADER: _CALLER_VARY_TOKEN})
+    lines = _rendered_vary(response)
+    assert len(lines) == 1
+    assert lines[0].startswith(CEILING_HEADER)
+
+
+def test_a_lowercase_vary_cannot_smuggle_a_second_header_line() -> None:
+    """Field names are case-insensitive on the wire but not in a Python dict.
+
+    ``{"Vary": ..., "vary": ...}`` is two dict keys and therefore two rendered
+    header lines, and RFC 9110 leaves a recipient free to combine them in
+    either order — so which ceiling the cache keys on becomes the intermediary's
+    choice rather than the server's. Note that reversing the merge order alone
+    does not fix this: the fix has to fold the header *name* before comparing,
+    which is why this case is tested separately from the exact-case one above.
+    """
+    response = json_response({}, HTTP_OK, headers={_LOWERCASE_VARY: "Cookie"})
+    lines = _rendered_vary(response)
+    assert len(lines) == 1
+    assert _vary_token_set(lines[0]) == {CEILING_HEADER.lower(), "cookie"}
+
+
+def test_both_spellings_of_vary_are_collected_into_the_one_value() -> None:
+    """Two colliding keys at once, which is the case the merge is a *list* for.
+
+    ``{"Vary": ..., "vary": ...}`` is the pathological dict: two keys, one wire
+    header. Collapsing it correctly requires collecting *every* colliding value
+    rather than the first or the last one found, and a merge that took either
+    end would pass every other test in this section. It is asserted byte-exact
+    because it pins three properties at once — both values survive, the standing
+    token still leads, and the whole thing still renders as one header line.
+    """
+    response = json_response(
+        {},
+        HTTP_OK,
+        headers={VARY_HEADER: _CALLER_VARY_TOKEN, _LOWERCASE_VARY: "Cookie"},
+    )
+    assert _rendered_vary(response) == [
+        f"{CEILING_HEADER}, {_CALLER_VARY_TOKEN}, Cookie"
+    ]
+
+
+@pytest.mark.parametrize(
+    "spelling", _ECHOED_CEILING_SPELLINGS, ids=_ECHOED_CEILING_SPELLING_IDS
+)
+def test_a_caller_echoing_the_standing_token_does_not_double_it(
+    spelling: str,
+) -> None:
+    """Union deduplicates by field name, and the server's spelling is the one kept.
+
+    A call site that has read the contract and dutifully names the ceiling in
+    its own ``Vary`` is the likeliest collision there is, and it will spell the
+    field name however it happens to spell it. Emitting the token twice would be
+    legal but is a rendering nobody wrote, and a dedupe that compared spellings
+    literally would emit it twice for any caller who did not match the constant
+    character for character.
+
+    All three spellings, because a single lower-case case is not enough to pin
+    the rule: a half-folded dedupe that seeds its ``seen`` set case-folded but
+    then tests the raw token passes the lower-case echo by coincidence and
+    doubles the upper-case one. The whole rendered value is asserted rather than
+    the token set, because a set cannot see a repetition at all.
+
+    Args:
+        spelling: How the caller happens to capitalise the ceiling header.
+    """
+    response = json_response(
+        {},
+        HTTP_OK,
+        headers={VARY_HEADER: f"{spelling}, Cookie"},
+    )
+    assert _rendered_vary(response) == [f"{CEILING_HEADER}, Cookie"]
+
+
+def test_an_empty_vary_token_leaves_no_trailing_separator() -> None:
+    """A doubled comma contributes nothing, not an empty list element.
+
+    ``all()`` is vacuously true on the empty string, so a token test written as
+    the character check alone admits ``""`` and renders ``..., Cookie, `` — a
+    value whose last element is absent. It is legal enough that most caches will
+    shrug, and it is exactly the sort of rendering that makes a byte-comparison
+    somewhere else fail for a reason nobody can find.
+    """
+    response = json_response({}, HTTP_OK, headers={VARY_HEADER: "Cookie,,"})
+    assert _rendered_vary(response) == [f"{CEILING_HEADER}, Cookie"]
+
+
+def test_the_uncacheable_wildcard_token_survives_the_filter() -> None:
+    """``*`` is a ``tchar``, and dropping it would be the unsafe direction.
+
+    It reads like a wildcard to filter out, which is the trap. RFC 9111 §4.1
+    tests for ``*`` by membership in the stored ``Vary``, so a response carrying
+    it never matches a stored entry — a call site that adds it is declaring the
+    response uncacheable. Filtering it would convert that declaration into a
+    response a cache may serve on the ceiling alone, which is the whole hazard
+    this module exists to close, arrived at from the opposite side.
+    """
+    response = json_response({}, HTTP_OK, headers={VARY_HEADER: "*"})
+    assert _rendered_vary(response) == [f"{CEILING_HEADER}, *"]
+
+
+@pytest.mark.parametrize(
+    ("malformed", "why"),
+    _MALFORMED_VARY_CASES,
+    ids=[why for _, why in _MALFORMED_VARY_CASES],
+)
+def test_a_malformed_vary_token_never_reaches_the_header_value(
+    malformed: str, why: str
+) -> None:
+    """Admission is an allowlist of ``tchar``, not a blocklist of line breaks.
+
+    CRLF is the memorable hazard — Starlette encodes a header value verbatim, so
+    a value that ends its own line describes a second header the application
+    never wrote — but it is not the only one, and a guard written as
+    ``"\\r" not in value`` would pass the CRLF case while admitting the space and
+    the colon, each of which also turns one header value into something other
+    than one header value. Parametrised precisely so no single case can stand in
+    for the rule.
+
+    Args:
+        malformed: A caller ``Vary`` value that is not a well-formed token.
+        why: What is wrong with it; supplies the parametrize id.
+    """
+    response = json_response({}, HTTP_OK, headers={VARY_HEADER: malformed})
+    assert _rendered_vary(response) == [CEILING_HEADER], why
+
+
+def test_a_malformed_token_is_not_whitespace_stripped_into_a_legal_one() -> None:
+    """Only ``OWS`` is trimmed, so a line break cannot be tidied out of the way.
+
+    ``str.strip()`` with no argument eats ``\\r`` and ``\\n`` along with the
+    space, which turns the list element ``"\\r\\nAccept"`` into the well-formed
+    token ``Accept`` — a token the caller never wrote in a form the caller could
+    have used, admitted by the very step meant to normalise whitespace. The
+    well-formed ``Cookie`` in the same value must still survive, so this is a
+    test about repair rather than about rejection.
+    """
+    response = json_response({}, HTTP_OK, headers={VARY_HEADER: _STRIPPABLE_VARY})
+    assert _rendered_vary(response) == [f"{CEILING_HEADER}, Cookie"]
+
+
+def test_a_hostile_vary_cannot_forge_a_second_header() -> None:
+    """The smuggled field name is absent from the block a server would write.
+
+    Asserted over the serialised header block rather than over ``raw_headers``'
+    *names*: those come one per dict key, so an injected name could only ever
+    live inside a value and searching the names alone passes even against the
+    pre-fix builder. Joining the pairs back into field lines reproduces the
+    concatenation a ``\\r\\n`` in a value would have exploited, which is what
+    makes the forgery findable.
+
+    Uvicorn and h11 would both reject such a value before it left the process,
+    so the realistic consequence of *not* filtering here is a fault answering a
+    request rather than a response split at a cache. That is a better outcome
+    than an injection and still not the contract's: this builder is the layer
+    that must not construct the value in the first place.
+    """
+    response = json_response({}, HTTP_OK, headers={VARY_HEADER: _HOSTILE_VARY})
+    block = _serialised_header_block(response)
+    assert b"x-creek-injected" not in block
+    assert b"\r" not in block.replace(b"\r\n", b"")
+    assert b"\n" not in block.replace(b"\r\n", b"")
+    assert _rendered_vary(response) == [CEILING_HEADER]
+
+
+def test_a_non_colliding_caller_header_still_rides() -> None:
+    """The bearer challenge is untouched by the ``Vary`` merge.
+
+    Green before the fix and green after it — a deliberate non-regression pin,
+    not a failed RED. ``_challenge_for`` is the one production caller that hands
+    :func:`~creek_mcp.httpapi.errors.json_response` extra headers, and a merge
+    written to make the standing headers win could just as easily be written to
+    make them the *only* headers. A ``401`` without its ``WWW-Authenticate`` is
+    a protocol violation, so the header that does not collide must still ride.
+    """
+    response = json_response(
+        {}, HTTP_OK, headers={WWW_AUTHENTICATE_HEADER: BEARER_CHALLENGE}
+    )
+    challenge = (
+        WWW_AUTHENTICATE_HEADER.lower().encode("latin-1"),
+        BEARER_CHALLENGE.encode("latin-1"),
+    )
+    assert challenge in response.raw_headers
+    assert _rendered_vary(response) == [CEILING_HEADER]
+
+
+async def _vary_overriding_health(_request: Request) -> Response:
+    """Answer health with a colliding, lowercased caller ``Vary``.
+
+    Args:
+        _request: Ignored, exactly as the real health handler ignores it.
+
+    Returns:
+        The health body, plus the caller ``Vary`` the builder must absorb.
+    """
+    return json_response(HEALTH_BODY, HTTP_OK, headers={_LOWERCASE_VARY: "Cookie"})
+
+
+def test_a_handler_cannot_override_the_standing_vary_through_the_stack(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The guarantee survives a real handler and all seven middleware layers.
+
+    The unit tests above read a response object the moment it is built; this one
+    reads what an HTTP client is handed after the whole stack has run, which is
+    the closest the suite gets to what a cache would see — ``TestClient`` never
+    opens a socket, so "past every middleware" is the honest claim, not "on the
+    wire". Health is the right probe because it is exempt from the
+    contract-version gate and its real handler is a bare
+    ``json_response(HEALTH_BODY, HTTP_OK)``, so the substitution changes exactly
+    one thing — the colliding header — and any difference in the answer is
+    attributable to it. A ceiling-refused path would prove nothing, since it
+    never reaches a handler at all.
+
+    ``get_list`` rather than ``headers["vary"]``: httpx joins duplicate lines
+    with ``", "``, so the substring assertions below hold just as well against
+    two lines as against the one correct line, and the length assertion is the
+    only one of the three that can see the difference.
+
+    Args:
+        vault: A seeded vault.
+        monkeypatch: Substitutes the health handler for one that collides.
+    """
+    monkeypatch.setitem(handlers_module.HANDLERS, OP_HEALTH, _vary_overriding_health)
+    with client(vault_path=vault) as test_client:
+        response = test_client.get(HEALTH_PATH, headers=headers())
+    assert response.status_code == 200
+    assert response.headers.get_list("vary") == [f"{CEILING_HEADER}, Cookie"]
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

`creek_mcp/httpapi/errors.py:88` built the response header block as
`{VARY_HEADER: CEILING_HEADER, **(headers or {})}`, so a caller-supplied `headers` dict
silently overrode the standing `Vary: X-Creek-Tier-Ceiling`. `json_response` is the single
builder every `/v1` response passes through, and that header is the only thing stopping a
shared cache from serving one caller's ceiling-filtered body to a caller at another ceiling.

**No production call site passes a `Vary` today** — the only caller handing this builder extra
headers is `_challenge_for`, and it passes only `WWW-Authenticate` — so nothing was broken in
the field. That is the argument for pinning it now rather than the argument against: the first
call site that did pass one would have deleted the protection silently.

The fix is deliberately larger than the one-line merge reversal the issue proposed, because the
one-liner leaves two of the three defects in place. Verified: reversal alone still fails 10 of
the new assertions (mutant M1 below).

### The merge policy, and why each part

1. **The standing `Vary` wins**, by explicitly partitioning colliding caller keys out rather
   than by dict-literal ordering.
2. **Names are matched case-folded.** `{"vary": ...}` is a distinct dict key, and Starlette's
   `Response.init_headers` lowercases each key independently and never deduplicates — so an
   unfolded merge emits **two** `vary` lines and leaves the intermediary to choose which one
   keys the cache. Confirmed empirically at the pre-fix HEAD: `headers={"vary": "Cookie"}`
   rendered `Headers([('vary', 'X-Creek-Tier-Ceiling'), ('vary', 'Cookie'), ...])`.
   **A merge that does not fold case has moved the bug, not fixed it.**
3. **`Vary` values UNION rather than replace.** Discarding a colliding caller token would close
   this hole and open its mirror image: a response whose body really does turn on
   `Accept-Encoding` but that claims to turn only on the ceiling invites a cache to key on
   *less* than the truth — the same defect pointed the other way. Union is also the only
   monotone direction: RFC 9111 §4.1 makes reuse a conjunction over the nominated field names,
   so adding a token can only shrink the set of requests an entry may be served to, never widen
   it. Standing token first, caller tokens in supplied order, deduplicated case-folded.
4. **Caller tokens outside RFC 9110 `tchar` are dropped whole, not repaired**, and only `OWS`
   (space and horizontal tab) is trimmed before that test — a bare `.strip()` would tidy
   `"Cookie,\r\nAccept"` into the perfectly legal token `Accept`, repairing exactly the input
   the builder refuses to repair. This is the first path here that parses and reassembles
   caller-shaped text into a header value, and Starlette encodes header values latin-1 verbatim
   with no CRLF validation. An allowlist rather than a CRLF blocklist because the set of legal
   field-name characters is small, closed and written down, and the dangerous set is none of
   those. `*` is a `tchar` and is deliberately kept: RFC 9111 §4.1 tests for it by membership,
   so a response carrying it never matches a stored entry — filtering it would convert an
   author's "do not cache this" into a response servable on the ceiling alone.

### Not changed, deliberately

- `creek_mcp/api/openapi.py` `DOCUMENT_DESCRIPTION` — feeds a byte-pinned committed OpenAPI
  golden file, and its claim "Every response carries Vary: X-Creek-Tier-Ceiling" stays true
  under union. Same for `docs/api.md`. No ADR: this is a defect inside an existing decision.
- **No `STANDING_HEADERS` mapping.** `Vary` needs a union rule and #1129's `Cache-Control:
  no-store` needs replacement, so one `Mapping[str, str]` with one merge rule is already the
  wrong type for two members — and #1129's header is conditional on authentication, which a
  constant cannot express. What #1129 gets instead is a named seam: `_merged_headers`, whose
  docstring states the policy, and `_vary_tokens`, which seeds from a single standing token
  that #1129 turns into a tuple to add `Authorization` (its issue text asks for exactly that).
- **Passthrough header names and values are still unvalidated.** Only the `Vary` value is
  parsed. Acceptable today because `_challenge_for` is the sole caller and returns module
  constants, and uvicorn and h11 both reject CR/LF downstream. Recorded here as a scope
  boundary rather than filed, since there is no reachable defect to fix.

## Test plan

`tests/test_v1_api_admission.py`, appended to its existing
`# Vary — the cache cannot cross-serve two ceilings` section. 12 test functions, 18 cases with
parametrisation. Every assertion is on **rendered** headers — `raw_headers` for the builder
tests (Starlette's `Headers.__getitem__` returns only the first match and would hide a
duplicate `vary`, which is one of the defects under test) and httpx's `get_list` for the
end-to-end one.

**Gate 1 RED — 16 of 18 red at the pre-fix HEAD.** The two green by construction are stated as
such in their own docstrings: `test_a_non_colliding_caller_header_still_rides` is a deliberate
non-regression pin that `_challenge_for`'s output survives the new merge, and the `canonical`
case of the echo test is one HEAD happens to render correctly. Sample actual pre-fix output:
`headers={"Vary": "Accept-Encoding"}` rendered `vary: Accept-Encoding` — the ceiling token
gone; the hostile value reached the header block as raw `b'Cookie\r\nX-Creek-Injected: 1'`.

**Mutation battery — 12 mutants, each patching only `errors.py`, zero survivors:**

| Mutant | Tests red |
|---|---|
| M0 full revert to HEAD | 16 |
| M1 naive merge reversal (the issue's own proposed fix) | 10 |
| M2 discard caller `Vary` instead of union | 10 |
| M3 name comparison no longer folds case | 3 |
| M4 `tchar` allowlist downgraded to a CRLF blocklist | 3 |
| M5 standing token written last instead of first | 9 |
| M6 dedupe made case-sensitive | 2 |
| M7 non-colliding caller headers dropped | 2 (one a pre-existing auth test) |
| M8 only the *first* colliding `Vary` spelling collected | 1 |
| M9 empty token admitted (`bool(candidate)` dropped) | 1 |
| M10 `*` removed from `_TCHAR` | 1 |
| M11 bare `.strip()` repairs a CRLF-padded token | 1 |

Control after restore: 211 passed. M6 survived a first pass — the echo test used only the
lower-case spelling, which a half-folded dedupe passes by coincidence — so it is now
parametrised over all three spellings, and M6 dies.

**Gate 2:** `./scripts/check-all.sh` exit code 0, 12/12 checks. `errors.py` per-file coverage
93.10% (misses only the `TYPE_CHECKING` block).

**Gate 2.5:** `code-review-orchestrator` across the security, test, implementation and
documentation dimensions. It returned FIX_REQUIRED with no defect in the production logic and
five findings against the *evidence and the prose*: a load-bearing justification for the token
order cited to a test that provably cannot enforce it (`header_items` is a frozenset compared
within one process, and no `401` supplies a caller `Vary` at all — verified, and the citation
is now the byte-exact echo test); an overstated RED count; four surviving mutants; a vacuous
`assert b"x-creek-injected" not in [names]` that passes against the pre-fix builder because
`raw_headers` holds one tuple per dict key (now asserted over the serialised header block); and
three docstrings claiming a socket the `TestClient` never opens. All fixed. One nit declined:
the review asked to delete `test_a_caller_cannot_replace_the_standing_vary` as subsumed by the
union test — it is kept, with the subsumption stated in its docstring, because it is the
issue's own acceptance criterion and a named test for the property under repair is what a later
reader looks for.

Confirmed the #1127/#1351 `500` path still carries the correct `Vary`:
`test_a_non_routing_http_exception_echoes_no_detail` asserts `response.headers["vary"] ==
CEILING_HEADER` and stays green verbatim, as does the 56-probe byte-identity sweep in
`tests/test_v1_api_auth.py`.

Closes #1128
Refs #1129
