### PR TITLE
fix(ingest): a fragment's id must not depend on the host that ingested it

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -60,6 +60,7 @@ if TYPE_CHECKING:
     from creek.generate.mining import MiningRunReport
     from creek.ingest.base import Ingestor
     from creek.ingest.discord_dispatch import DiscordMode
+    from creek.ingest.pin_ids import PinResult
     from creek.link.link_engine import LinkSummary
     from creek.models import CompileTargetKind, Frequency, Mode, Phase
     from creek.purge import PurgeEngine, PurgeResult
@@ -1233,6 +1234,26 @@ def ingest(
         "-y",
         help="Skip the consent prompt for first-time sources (logged).",
     ),
+    pin_source_ids: bool = typer.Option(
+        False,
+        "--pin-source-ids",
+        help=(
+            "One-time migration: back-fill the ingest ledger with each existing "
+            "fragment's existing id, so no id moves under the #1329 "
+            "id-derivation fix. Operators MUST run this once after upgrading — "
+            "without it the next ingest mints a new id for every markdown "
+            "fragment already on disk and leaves the original behind as a "
+            "duplicate. Idempotent. --type / --input are ignored."
+        ),
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help=(
+            "With --pin-source-ids: print the plan and write nothing "
+            "(no ledger records, no frontmatter changes)."
+        ),
+    ),
     refresh_dates: bool = typer.Option(
         False,
         "--refresh-dates",
@@ -1285,18 +1306,25 @@ def ingest(
     input is idempotent: deterministic fragment IDs ensure existing
     files are recognised and skipped.
 
+    ``--pin-source-ids`` is a one-shot migration: it walks ``--vault``
+    (or the configured vault) and records each existing fragment's
+    **existing** id against its source in the ingest ledger, so the
+    #1329 id-derivation fix can never move an id already on disk.
+    ``--dry-run`` plans it without writing.
+
     ``--refresh-dates`` is a one-shot backfill: it walks
     ``--vault`` (or the configured vault), re-runs the per-format
     authored-date extraction chain against each fragment's source
     file, and rewrites the frontmatter in place. ``--type`` /
     ``--input`` are ignored in refresh mode.
     """
-    if refresh_dates:
-        _run_refresh_dates(vault)
-        return
-
-    if refresh_ai_chat:
-        _run_refresh_ai_chat(vault)
+    if _dispatch_ingest_migration(
+        vault,
+        pin_source_ids=pin_source_ids,
+        dry_run=dry_run,
+        refresh_dates=refresh_dates,
+        refresh_ai_chat=refresh_ai_chat,
+    ):
         return
 
     if type is None or input is None:
@@ -1343,6 +1371,143 @@ def ingest(
         source_type=type,
         strict=strict,
     )
+
+
+def _dispatch_ingest_migration(
+    vault: Path | None,
+    *,
+    pin_source_ids: bool,
+    dry_run: bool,
+    refresh_dates: bool,
+    refresh_ai_chat: bool,
+) -> bool:
+    """Run whichever one-shot migration ``creek ingest`` was asked for.
+
+    ``--pin-source-ids`` is checked before every other mode, including the two
+    refresh migrations: a vault that still needs pinning must not fall through
+    into a normal ingest, because that run is precisely the one that derives
+    fresh ids and duplicates it (#1329).
+
+    Args:
+        vault: ``--vault``, or ``None`` to use the configured vault.
+        pin_source_ids: Whether ``--pin-source-ids`` was given.
+        dry_run: Whether ``--dry-run`` was given.
+        refresh_dates: Whether ``--refresh-dates`` was given.
+        refresh_ai_chat: Whether ``--refresh-ai-chat`` was given.
+
+    Returns:
+        ``True`` when a migration ran and the caller should return
+        immediately; ``False`` to proceed with a normal ingest.
+
+    Raises:
+        typer.BadParameter: If ``--dry-run`` is combined with a migration that
+            does not support it.
+    """
+    if pin_source_ids:
+        _run_pin_source_ids(vault, dry_run=dry_run)
+        return True
+    if dry_run:
+        # Refusing beats ignoring. --dry-run is new to `creek ingest` and
+        # scoped to --pin-source-ids; silently running a different migration
+        # for real while the operator believes they asked for a preview is the
+        # worst possible reading of the flag.
+        msg = "--dry-run is only supported with --pin-source-ids."
+        raise typer.BadParameter(msg)
+    if refresh_dates:
+        _run_refresh_dates(vault)
+        return True
+    if refresh_ai_chat:
+        _run_refresh_ai_chat(vault)
+        return True
+    return False
+
+
+def _print_pin_findings(label: str, lines: list[str]) -> None:
+    """Print every finding under *label*, one per line, or nothing if there are none.
+
+    Findings are listed in full rather than counted. Each line names a
+    fragment the migration deliberately left unpinned, and an unpinned
+    fragment is one the next ingest can still orphan — a bare count would tell
+    the operator that a problem exists without telling them which file to fix.
+    Each line is markup-escaped because it carries a filesystem path, and a
+    path containing ``[`` would otherwise be swallowed as Rich markup or raise
+    ``MarkupError`` over the top of the message (#1310).
+
+    ``soft_wrap=True`` is load-bearing for the same reason: Rich's default
+    word-wrap breaks a long absolute path across lines mid-token, which is
+    exactly the string the operator needs to copy-paste into their next
+    command. Letting the terminal wrap it keeps the path intact.
+
+    Args:
+        label: Heading for this class of finding, e.g. ``"Conflicts"``.
+        lines: Human-readable finding lines from :class:`PinResult`.
+    """
+    if not lines:
+        return
+    console.print(f"[yellow]{label}: {len(lines)}[/yellow]")
+    for line in lines:
+        console.print(f"  [dim]{escape(line)}[/dim]", soft_wrap=True)
+
+
+def _render_pin_summary(result: PinResult, *, dry_run: bool) -> None:
+    """Render the one-screen summary of a ``--pin-source-ids`` run.
+
+    Args:
+        result: What the migration did, or would have done under *dry_run*.
+        dry_run: Whether this was a plan; when ``True`` nothing was written.
+    """
+    verb = "Would pin" if dry_run else "Pinned"
+    console.print(
+        f"[bold green]{verb} {result.pinned} existing fragment id(s) into the "
+        "ingest ledger.[/bold green]"
+    )
+    console.print(f"  already pinned: {result.already_pinned}")
+    console.print(f"  examined: {result.examined}")
+    if result.repaired:
+        # Surfaced rather than folded into "already pinned": a non-zero count
+        # is evidence that an earlier run did not finish, which the operator
+        # would otherwise have no way to learn.
+        console.print(
+            f"[yellow]  repaired {result.repaired} half-pinned fragment(s) left "
+            "by an interrupted earlier run.[/yellow]"
+        )
+    # Advisory only, and labelled as such on screen: a fragment that does not
+    # re-derive its own id is not a failure — its id was minted by the very
+    # build this migration exists to correct. Nothing is gated on this number,
+    # so nothing about the run should read as if a low one meant trouble.
+    console.print(
+        f"  re-derive their own id: {result.reproduced} "
+        "(advisory diagnostic only; nothing is gated on it)"
+    )
+    if dry_run:
+        console.print("[yellow]Dry run: nothing was written.[/yellow]")
+    _print_pin_findings("Conflicts (pinned none of these)", result.conflicts)
+    _print_pin_findings("Unpinnable", result.unpinnable)
+
+
+def _run_pin_source_ids(vault: Path | None, *, dry_run: bool) -> None:
+    """Execute the #1329 ``--pin-source-ids`` ledger back-fill.
+
+    Resolves the vault path (CLI flag → configured default), invokes
+    :func:`creek.ingest.pin_ids.pin_source_ids`, and renders a one-screen
+    summary. Exit codes mirror the rest of the CLI: 0 on success (regardless
+    of how many fragments were pinned, conflicted or were unpinnable), 1 if
+    the vault path is unusable.
+
+    Args:
+        vault: ``--vault``, or ``None`` to use the configured vault.
+        dry_run: ``--dry-run``; when ``True`` the plan is printed and neither
+            the ledger nor any frontmatter is written.
+    """
+    from creek.ingest.pin_ids import pin_source_ids
+
+    config = _load_config_for_vault(vault)
+    vault_path = vault or config.vault_path
+    if not vault_path.exists():
+        console.print(f"[red]Vault path does not exist: {vault_path}[/red]")
+        raise typer.Exit(code=1)
+
+    _render_pin_summary(pin_source_ids(vault_path, dry_run=dry_run), dry_run=dry_run)
 
 
 def _run_refresh_dates(vault: Path | None) -> None:

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -379,6 +379,31 @@ def _parse_since_arg(text: str) -> datetime:
     return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
 
 
+def _print_ingest_warning(message: str) -> None:
+    """Show one ingest advisory to the operator, as it is detected (#1329).
+
+    Warnings go to the same stdout console as every other ``creek ingest``
+    advisory (``_warn_if_discovered_but_empty``, ``_print_pin_findings``)
+    rather than to stderr: this command's output is human prose, not data on a
+    pipe, and an advisory routed to a stream none of its neighbours use is one
+    an operator can lose.
+
+    The exit code is deliberately left alone. A warning reports vault state
+    that will cause trouble later, not a failure of this run — and
+    ``creek sync`` shares this path, so escalating would turn every scheduled
+    pass over an un-migrated vault into a hard failure.
+
+    ``escape`` and ``soft_wrap=True`` are load-bearing for the same reasons as
+    in :func:`_print_pin_findings`: the text carries a shell command the
+    operator is meant to copy, and rich would otherwise be free to wrap it
+    across lines (or read a bracketed path as markup).
+
+    Args:
+        message: The advisory text from the ingest pipeline.
+    """
+    console.print(f"[yellow]{escape(message)}[/yellow]", soft_wrap=True)
+
+
 def _run_ingest(
     *,
     ingestor_cls: type[Ingestor],
@@ -413,6 +438,12 @@ def _run_ingest(
         list of human-readable strings prefixed with ``[<source_type>]`` and
         ``discovered`` is how many inputs the ingestor's ``discover()`` found.
 
+        Operator advisories are **not** in this tuple. They are printed by
+        :func:`_print_ingest_warning` the moment the pipeline detects them, so
+        every caller of this helper surfaces them without having to remember
+        to — which is what went wrong when the un-pinned-vault advisory was
+        left to a return value nobody read (#1329).
+
     Raises:
         typer.Exit: With code ``1`` when the vault cannot be opened.
     """
@@ -427,6 +458,7 @@ def _run_ingest(
             reclassify_threshold=reclassify_threshold,
             since=since,
             incremental=incremental,
+            on_warning=_print_ingest_warning,
         )
     except FileNotFoundError as exc:
         console.print(f"[red]Vault unavailable: {exc}[/red]")

--- a/creek-tools/creek/ingest/base.py
+++ b/creek-tools/creek/ingest/base.py
@@ -454,8 +454,43 @@ def assemble_ingested_fragment(parsed: ParsedFragment) -> IngestedFragment:
 def file_modified_time(path: Path) -> datetime:
     """Return *path*'s modification time as a timezone-aware UTC datetime.
 
-    Centralised so file-based ingestors share a single conversion
-    rule and do not drift apart over time.
+    This is the **identity anchor** for every file-based ingestor that has
+    no embedded date to fall back on. :func:`generate_fragment_id` hashes
+    the timestamp it returns, so the conversion must be a *pure function of
+    the epoch float*: invariant under the host's ``TZ`` environment
+    variable, its installed tzdata, its DST state, and its operating
+    system. ``datetime.fromtimestamp(st_mtime, tz=UTC)`` is exactly that.
+
+    Two ways of getting it wrong were live until #1329, and both are worth
+    naming because both look like simplifications:
+
+    * ``datetime.fromtimestamp(st_mtime)`` with no ``tz=`` renders the epoch
+      in the *host's* local zone. One file then mints a different
+      ``frag-<sha>`` in every timezone it is ingested from.
+    * ``getattr(stat, "st_birthtime", stat.st_mtime)`` reads a field that
+      exists on macOS/BSD and not on Linux. One file then mints a different
+      id on a developer's laptop than in CI. Birth time is *not* available
+      here for that reason; mtime is the only field every supported
+      platform agrees on.
+
+    Rendering in a fixed non-UTC zone (say LA) would also be
+    host-independent, but it bakes a ``-07:00``/``-08:00`` offset that
+    flips with DST into the hashed input. UTC is the rule for markdown,
+    documents, generic, substack, spreadsheets, presentations and images.
+    :mod:`creek.ingest.code` renders LA instead — a deliberate, equally
+    host-independent divergence left alone by #1329 because re-minting it
+    would orphan every code fragment, and code sources change too
+    continuously for any reproduction-based migration to recover them. That
+    last divergence is tracked by #1364.
+
+    Note that this value answers "which file is this?", not "when was this
+    written?". Authorship is ``authored_at``'s job (FEAT-031).
+
+    Args:
+        path: The file to stat.
+
+    Returns:
+        The file's mtime as a timezone-aware UTC datetime.
     """
     return datetime.fromtimestamp(path.stat().st_mtime, tz=UTC)
 

--- a/creek-tools/creek/ingest/documents.py
+++ b/creek-tools/creek/ingest/documents.py
@@ -36,6 +36,7 @@ from creek.ingest.base import (
     Ingestor,
     ParsedFragment,
     RawDocument,
+    file_modified_time,
     normalize_encoding,
     normalize_timestamp,
     parse_authored_at,
@@ -810,12 +811,31 @@ class DocumentIngestor(Ingestor):
         Checks metadata for created_date first, then falls back to
         the file's modification time.
 
+        **This value is an identity anchor, not an authorship claim.**
+        :func:`creek.ingest.base.generate_fragment_id` hashes it, so the
+        fallback must be a pure function of the file's epoch mtime —
+        invariant under the host's ``TZ`` env var, its tzdata, its DST
+        state, and its operating system (#1329). That is exactly what
+        :func:`~creek.ingest.base.file_modified_time` guarantees, and it is
+        why this must never be "simplified" back to a bare
+        ``datetime.fromtimestamp(mtime)``, which renders the epoch in the
+        host's local zone and so mints one id per timezone.
+
+        Documents are more exposed to this than markdown, not less:
+        :func:`creek.ingest.pipeline.ledger_for_source` leaves them
+        unledgered, so there is no recorded id to fall back on and a
+        drifting derivation is an unconditional second write rather than a
+        merely possible one. Widening the ledger to documents is blocked on
+        a bare-filename collision in ``derive_source_key`` and is tracked by
+        #1363; this fix removes the timezone-driven churn, not the
+        mtime-driven churn.
+
         Args:
             metadata: Fragment metadata dict.
             file_path: Path to the source file.
 
         Returns:
-            A timezone-aware datetime.
+            A timezone-aware datetime; UTC when it comes from the filesystem.
         """
         created = metadata.get("created_date")
         if created is not None:
@@ -824,10 +844,7 @@ class DocumentIngestor(Ingestor):
             except ValueError:
                 logger.warning("Invalid metadata timestamp: %s", created)
 
-        # Fall back to file modification time
-        mtime = file_path.stat().st_mtime
-        ts_string = datetime.fromtimestamp(mtime).isoformat()
-        return normalize_timestamp(ts_string, None)
+        return file_modified_time(file_path)
 
     def convert_to_markdown(self, fragment: ParsedFragment) -> str:
         """Return the fragment content as markdown.

--- a/creek-tools/creek/ingest/images.py
+++ b/creek-tools/creek/ingest/images.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import logging
 import shutil
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
@@ -38,6 +38,7 @@ from creek.ingest.base import (
     Ingestor,
     ParsedFragment,
     RawDocument,
+    file_modified_time,
     parse_authored_at,
 )
 from creek.models import SourcePlatform
@@ -603,8 +604,13 @@ class ImageIngestor(Ingestor):
 
 
 def _modified_time(path: Path) -> datetime:
-    """Return the file's mtime as a timezone-aware UTC datetime."""
-    return datetime.fromtimestamp(path.stat().st_mtime, tz=UTC)
+    """Return the file's mtime as a timezone-aware UTC datetime.
+
+    Delegates to :func:`creek.ingest.base.file_modified_time` so the
+    id-anchoring conversion rule lives in exactly one place (#1329); the
+    semantics are byte-identical to the expression this replaced.
+    """
+    return file_modified_time(path)
 
 
 # EXIF tag IDs — magic numbers chosen by the standard, not by us. Hard-coded

--- a/creek-tools/creek/ingest/markdown.py
+++ b/creek-tools/creek/ingest/markdown.py
@@ -16,9 +16,8 @@ from __future__ import annotations
 
 import logging
 import re
-from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import frontmatter
 
@@ -26,11 +25,15 @@ from creek.ingest.base import (
     Ingestor,
     ParsedFragment,
     RawDocument,
+    file_modified_time,
     normalize_encoding,
     normalize_timestamp,
     parse_authored_at,
 )
 from creek.models import SourcePlatform
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 logger = logging.getLogger(__name__)
 
@@ -261,25 +264,6 @@ def _extract_authored_at_from_frontmatter(fm_data: dict[str, Any]) -> datetime |
     return None
 
 
-def _get_file_creation_timestamp(path: Path) -> datetime:
-    """Get the file creation timestamp from filesystem metadata.
-
-    Falls back to modification time if creation time is not available.
-    Returns a timezone-aware datetime in America/Los_Angeles.
-
-    Args:
-        path: The file path to inspect.
-
-    Returns:
-        A timezone-aware datetime from the file's metadata.
-    """
-    stat = path.stat()
-    # Use birth time on macOS, fall back to mtime
-    ctime = getattr(stat, "st_birthtime", stat.st_mtime)
-    ts_string = datetime.fromtimestamp(ctime).isoformat()
-    return normalize_timestamp(ts_string, None)
-
-
 # ---- MarkdownIngestor ----
 
 
@@ -420,14 +404,28 @@ class MarkdownIngestor(Ingestor):
         """Resolve a timestamp from frontmatter or filesystem metadata.
 
         Checks frontmatter fields first (date, created, created_at),
-        then falls back to the file's creation/modification time.
+        then falls back to the file's modification time.
+
+        **This value is an identity anchor, not an authorship claim.**
+        :func:`creek.ingest.base.generate_fragment_id` hashes it, so the
+        fallback must be a pure function of the file's epoch mtime —
+        invariant under the host's ``TZ`` env var, its tzdata, its DST
+        state, and its operating system (#1329). That is exactly what
+        :func:`~creek.ingest.base.file_modified_time` guarantees, and it is
+        why this must never be "simplified" back to a bare
+        ``datetime.fromtimestamp(mtime)`` (host-local, so one file mints one
+        id per timezone) or to ``st_birthtime`` (present on macOS/BSD,
+        absent on Linux, so one file mints one id per operating system).
+
+        Authorship is ``authored_at``'s job (FEAT-031), which has its own
+        frontmatter fields and its own backfill.
 
         Args:
             fm_data: Parsed frontmatter dictionary.
             file_path: Path to the source file.
 
         Returns:
-            A timezone-aware datetime.
+            A timezone-aware datetime; UTC when it comes from the filesystem.
         """
         fm_ts = _extract_timestamp_from_frontmatter(fm_data)
         if fm_ts is not None:
@@ -436,7 +434,7 @@ class MarkdownIngestor(Ingestor):
             except ValueError:
                 logger.warning("Invalid frontmatter timestamp: %s", fm_ts)
 
-        return _get_file_creation_timestamp(file_path)
+        return file_modified_time(file_path)
 
     def convert_to_markdown(self, fragment: ParsedFragment) -> str:
         """Return the fragment content as-is (already markdown).

--- a/creek-tools/creek/ingest/pin_ids.py
+++ b/creek-tools/creek/ingest/pin_ids.py
@@ -1,0 +1,523 @@
+"""Pin existing markdown fragment ids to their source units (#1329 migration).
+
+``MarkdownIngestor`` and ``DocumentIngestor`` used to derive a fragment's
+timestamp from a timezone-**naive** ``datetime.fromtimestamp(mtime)``.
+:func:`~creek.ingest.base.generate_fragment_id` hashes that timestamp, so the
+*same* file minted a *different* ``frag-…`` id depending on the host ``TZ``
+environment variable. The fix replaces both fallbacks with
+:func:`~creek.ingest.base.file_modified_time`, which is a pure function of the
+epoch float and therefore host-independent — but it also **changes id
+derivation**. Left alone, the next ``creek ingest`` over an existing vault
+would fail to recognise every markdown fragment already on disk, mint a new id
+for it, and leave the original behind as an orphaned duplicate.
+
+The answer here is deliberately *not* to re-mint ids. It is to **pin** them:
+back-fill the ingest ledger so each existing fragment's **existing** id is
+recorded against its ``source_key``. From then on
+``write_fragment_idempotent`` reuses ``record.fragment_id`` and no id ever
+moves — whatever the new derivation would have produced is simply never
+consulted for a unit the ledger already knows.
+
+What this migration touches, and what it refuses to touch:
+
+* **Ledger** — one appended :class:`~creek.ingest.ledger.LedgerRecord` per
+  markdown-sourced fragment, carrying the id read off disk. Never a
+  recomputed id.
+* **Frontmatter** — exactly one added key, ``source.origin_key``. The ``id``,
+  the ``created`` timestamp, the body and the filename are preserved
+  byte-for-byte. Nothing is renamed and nothing is re-minted.
+* **Duplicated vaults** — a ``source_key`` claimed by more than one live
+  fragment is pinned for *neither*. Choosing arbitrarily would bless the wrong
+  fragment forever, and pinning both is not expressible in a
+  one-record-per-key ledger. The operator is pointed at ``creek clean
+  duplicates`` instead. This conflict guard is the migration's primary safety
+  property.
+
+Only the markdown source is in scope: it is the one ledger-wired source
+(:func:`creek.ingest.pipeline.ledger_for_source`), and append-only event
+sources (Discord/chat exports) keep their content-hashed ids and never consult
+the ledger at all.
+
+The run is idempotent — a ``source_key`` already present in the ledger is not
+re-pinned — and ``dry_run=True`` writes nothing while still returning a fully
+populated :class:`PinResult` so a caller can print the plan.
+
+It is also **resumable**. Pinning one fragment is two durable writes that
+cannot be made atomic with respect to each other, so an interrupted run (an
+``OSError`` partway through an N-fragment pass, not just a ``kill -9``) can
+leave a fragment with a ledger record but no stamp. :func:`_pin_one` detects
+and repairs exactly that state rather than skipping the candidate because its
+key is already present — see its docstring for why the record is nonetheless
+written first.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path  # runtime use: suffix/existence checks on source paths
+
+import frontmatter
+
+from creek.ingest.base import generate_fragment_id
+from creek.ingest.ledger import SourceLedger
+from creek.ingest.pipeline import derive_source_key
+from creek.vault.authors import OTHER_AUTHORS_DIR
+from creek.vault.reader import iter_vault_fragments
+
+# Importing these three from the writer rather than retyping them is
+# deliberate. ``_atomic_write_text`` is the vault's one crash-safe rewrite
+# (tempfile + ``os.replace``); the two relpart constants are the writer's
+# single source of truth for where fragments live, kept that way so the
+# scaffold drift guard can *derive* the directories ``creek init`` ships
+# (#1025). Re-typing a destination is how the scaffold and the writer drifted
+# apart in the first place. ``creek.ingest.refresh`` sets the precedent for
+# reaching across a module boundary for a private helper.
+from creek.vault.writer import (
+    _FRAGMENTS_RELPART,
+    _ORPHANED_RELPARTS,
+    _atomic_write_text,
+)
+
+logger = logging.getLogger(__name__)
+
+_LEDGER_SOURCE: str = "markdown"
+"""Ledger name to back-fill.
+
+Must match the source type :func:`creek.ingest.pipeline.ledger_for_source`
+ledgers, or the records written here would land in a file no ingest ever
+reads.
+"""
+
+_MARKDOWN_SUFFIX: str = ".md"
+"""The only source extension this migration pins.
+
+``MarkdownIngestor.discover`` globs ``*.md`` exclusively, so a fragment whose
+``original_file`` carries any other extension was produced by a different
+ingestor and does not belong in the markdown ledger.
+"""
+
+_FRAGMENT_ROOTS: tuple[tuple[str, ...], ...] = (
+    (_FRAGMENTS_RELPART,),
+    (OTHER_AUTHORS_DIR,),
+    _ORPHANED_RELPARTS,
+)
+"""Vault-relative roots holding fragment files, as ``joinpath`` part tuples.
+
+Borrowed content under ``11-Other-Authors/`` and soft-tombed content under
+``10-Liminal/Orphaned/`` are as ledger-eligible as a native fragment: a tombed
+unit whose source re-appears is *restored* under its preserved id, which only
+works if that id is pinned.
+"""
+
+
+@dataclass(frozen=True)
+class PinResult:
+    """Summary of a :func:`pin_source_ids` run.
+
+    Attributes:
+        pinned: Fragments whose existing id was newly recorded against its
+            ``source_key`` (the count a ``dry_run`` *would* write).
+        already_pinned: Fragments whose ``source_key`` was already in the
+            ledger and were therefore not re-pinned.
+        repaired: Of *already_pinned*, how many were half-pinned by an earlier
+            interrupted run — ledger record present, ``source.origin_key``
+            missing — and had the missing stamp restored by this one. A
+            non-zero count means a previous run did not complete; it is not an
+            error, but it is worth an operator's attention.
+        conflicts: One human-readable line per ``source_key`` claimed by more
+            than one live fragment, naming every claimant's path. None of
+            those fragments were pinned.
+        unpinnable: One human-readable line per fragment that could not be
+            resolved to a live markdown source, naming the fragment path and
+            the reason.
+        reproduced: Advisory diagnostic — how many candidates re-derive their
+            own id from their own stored frontmatter and body. See
+            :func:`_reproduces_own_id`; this gates nothing.
+        examined: Fragment files inspected, i.e. candidates (pinnable or
+            conflicted) plus ``unpinnable``.
+    """
+
+    pinned: int
+    already_pinned: int
+    repaired: int
+    conflicts: list[str]
+    unpinnable: list[str]
+    reproduced: int
+    examined: int
+
+
+@dataclass(frozen=True)
+class _Candidate:
+    """One on-disk fragment resolved to the source unit that produced it.
+
+    Attributes:
+        md_file: Path to the fragment file in the vault.
+        fragment_id: The id as read from the fragment's frontmatter — the
+            value that gets pinned, never a recomputed one.
+        source_path: ``source.original_file`` verbatim; this exact string was
+            hashed into ``fragment_id`` at first ingest.
+        source_key: Ledger key derived from *source_path*.
+        body: The fragment's stored markdown body (``post.content``).
+        created: ``created`` as it appears in the raw frontmatter, or ``None``
+            when absent/unparseable. Only used by the advisory diagnostic.
+        has_origin_key: Whether ``source.origin_key`` is already present on
+            disk. Drives the torn-pin repair in :func:`_pin_one`.
+    """
+
+    md_file: Path
+    fragment_id: str
+    source_path: str
+    source_key: str
+    body: str
+    created: datetime | None
+    has_origin_key: bool
+
+
+def _raw_created(metadata: dict[str, object]) -> datetime | None:
+    """Read ``created`` from *metadata* exactly as the file records it.
+
+    The raw frontmatter value is used rather than ``Fragment.created``:
+    :meth:`creek.models.Fragment._normalise_timestamp` anchors a naive
+    timestamp to America/Los_Angeles at validation time, so the model's value
+    is not necessarily the one that was hashed into the id.
+
+    YAML delivers the key either already parsed into a :class:`datetime` (bare
+    scalar) or as a string (the usual case — the writer serialises the
+    timestamp with ``model_dump(mode="json")``, and PyYAML quotes a string
+    that would otherwise implicitly resolve to a timestamp).
+
+    Args:
+        metadata: The fragment's raw frontmatter mapping.
+
+    Returns:
+        The parsed timestamp, or ``None`` when the key is missing, is a plain
+        date, or does not parse as ISO-8601.
+    """
+    value = metadata.get("created")
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError:
+            logger.debug("Unparseable 'created' frontmatter value: %r", value)
+            return None
+    return None
+
+
+def _unpinnable_reason(source_path_str: str) -> str | None:
+    """Return why *source_path_str* cannot be pinned, or ``None`` if it can.
+
+    Three dispositions are refused, each for its own reason:
+
+    * an empty ``original_file`` gives nothing to key a ledger record on;
+    * a non-``.md`` source came from a different ingestor and does not belong
+      in the markdown ledger;
+    * a source that no longer exists on disk cannot be re-ingested, so pinning
+      it would only add a record no future run will ever match — and, worse,
+      could shadow a *different* file that later takes that path.
+
+    Args:
+        source_path_str: The fragment's ``source.original_file``, verbatim.
+
+    Returns:
+        A human-readable reason, or ``None`` when the source is pinnable.
+    """
+    if not source_path_str:
+        return "fragment records no source.original_file"
+    source_path = Path(source_path_str)
+    if source_path.suffix.lower() != _MARKDOWN_SUFFIX:
+        return f"source {source_path_str!r} is not a {_MARKDOWN_SUFFIX} file"
+    if not source_path.exists():
+        return f"source {source_path_str!r} no longer exists on disk"
+    return None
+
+
+def _collect_candidates(vault_path: Path) -> tuple[list[_Candidate], list[str]]:
+    """Walk the vault's fragment roots and resolve each fragment to its source.
+
+    Args:
+        vault_path: Vault root.
+
+    Returns:
+        ``(candidates, unpinnable)`` — the fragments that resolve to a live
+        markdown source, and one ``"<path>: <reason>"`` line for each that
+        does not.
+    """
+    candidates: list[_Candidate] = []
+    unpinnable: list[str] = []
+    for relparts in _FRAGMENT_ROOTS:
+        for md_file, fragment, body, raw in iter_vault_fragments(
+            vault_path.joinpath(*relparts),
+        ):
+            source_path_str = fragment.source.original_file or ""
+            reason = _unpinnable_reason(source_path_str)
+            if reason is not None:
+                unpinnable.append(f"{md_file}: {reason}")
+                continue
+            candidates.append(
+                _Candidate(
+                    md_file=md_file,
+                    fragment_id=fragment.id,
+                    source_path=source_path_str,
+                    source_key=derive_source_key(source_path_str, vault_path),
+                    body=body,
+                    created=_raw_created(raw),
+                    has_origin_key=bool(fragment.source.origin_key),
+                ),
+            )
+    return candidates, unpinnable
+
+
+def _index_by_source_key(
+    candidates: list[_Candidate],
+) -> dict[str, list[_Candidate]]:
+    """Group *candidates* by ``source_key``, preserving discovery order.
+
+    Built in full **before** anything is pinned: a key with more than one
+    claimant is the already-duplicated-vault case, and it can only be detected
+    by looking at the whole population first.
+
+    Args:
+        candidates: Every fragment that resolved to a live markdown source.
+
+    Returns:
+        Mapping of ``source_key`` to the fragments claiming it.
+    """
+    index: dict[str, list[_Candidate]] = {}
+    for candidate in candidates:
+        index.setdefault(candidate.source_key, []).append(candidate)
+    return index
+
+
+def _conflict_line(source_key: str, claimants: list[_Candidate]) -> str:
+    """Render the operator-facing message for a contested ``source_key``.
+
+    Args:
+        source_key: The contested ledger key.
+        claimants: The two-or-more fragments claiming it.
+
+    Returns:
+        A single line naming every claimant's path and the remedy.
+    """
+    paths = ", ".join(str(candidate.md_file) for candidate in claimants)
+    return (
+        f"{source_key}: claimed by {len(claimants)} fragments ({paths}); "
+        "pinned none — run `creek clean duplicates`, resolve them, then re-run."
+    )
+
+
+def _reproduces_own_id(candidate: _Candidate) -> bool:
+    """Return whether *candidate* re-derives its own id from its own contents.
+
+    Purely a diagnostic. It is **not** a gate, and pinning must never be made
+    conditional on it: the id being pinned was minted by a build whose
+    timestamp handling this issue exists to correct, and by an ingest whose
+    ``created`` may have come from the source's own frontmatter rather than
+    from ``parsed.timestamp`` at all. A migration gated on reproduction would
+    match a fraction of the vault and therefore *do nothing* for the rest —
+    which is precisely the population that gets orphaned.
+
+    The real safety properties live elsewhere: the conflict guard in
+    :func:`_index_by_source_key` / :func:`pin_source_ids`, and the
+    source-exists check in :func:`_unpinnable_reason`. This number is reported
+    so an operator can see how much of the vault independently corroborates
+    its own pinning, and nothing more.
+
+    Args:
+        candidate: The fragment to check.
+
+    Returns:
+        ``True`` when the recomputed id equals the id on disk.
+    """
+    if candidate.created is None:
+        return False
+    recomputed = generate_fragment_id(
+        candidate.source_path,
+        candidate.created,
+        candidate.body,
+    )
+    return recomputed == candidate.fragment_id
+
+
+def _stored_body_hash(body: str) -> str:
+    """Hash the fragment's **stored** body for the ledger's ``content_hash``.
+
+    Hashing the vault-side body rather than re-reading the current source file
+    is load-bearing twice over:
+
+    * It is faithful. ``MarkdownIngestor.convert_to_markdown`` is the identity
+      function and the body is written verbatim below the frontmatter, so the
+      stored body *is* the parsed source content — the same string a fresh
+      ingest hashes.
+    * It keeps a post-ingest edit visible. If the source was edited after its
+      original ingest, recording the hash of the **current** source would file
+      the new hash against the **old** stored body. The next ``creek ingest``
+      would compute that same hash, take the unchanged branch, and the edit
+      would be silently swallowed — permanently, since nothing ever revisits
+      an unchanged unit. Recording the stored body's hash instead makes that
+      run correctly report ``updated`` and apply the edit in place, under the
+      pinned id.
+
+    Args:
+        body: The fragment's stored markdown body (``post.content``).
+
+    Returns:
+        The ledger's SHA-256 hex digest of *body*.
+    """
+    return SourceLedger.content_hash(body)
+
+
+def _stamp_origin_key(md_file: Path, source_key: str) -> None:
+    """Add ``source.origin_key`` to *md_file*'s frontmatter, atomically.
+
+    This stamp is mandatory, not cosmetic. The RTBF purge sweep resolves a
+    fragment's purge target from its **on-disk** frontmatter via
+    :func:`creek.purge.engine._extract_source_origin_key` and skips any
+    fragment without the key; and ``VaultWriter.update_fragment`` reloads and
+    *preserves* the on-disk frontmatter rather than merging fresh ``source``
+    fields into it (see :mod:`creek.vault.writer`). So a fragment that lacks
+    ``origin_key`` at migration time never gains one on any later ingest —
+    omitting the stamp here would permanently strand RTBF coverage for exactly
+    the population this migration exists to protect.
+
+    The write goes through the vault's atomic helper rather than
+    ``Path.write_text`` (which is what
+    :func:`creek.ingest.refresh._rewrite_frontmatter` uses): this migration
+    rewrites N live fragment files in one pass, and a plain write truncates
+    its target before repopulating it, so a kill mid-run would destroy a
+    fragment's content outright.
+
+    Only the one key is added — ``id``, ``created``, every other frontmatter
+    field, and the body are round-tripped unchanged. The rendered text carries
+    no trailing newline beyond what ``frontmatter.dumps`` emits, matching
+    :meth:`~creek.vault.writer.VaultWriter.update_fragment`, the vault's own
+    in-place fragment rewrite.
+
+    Args:
+        md_file: The fragment file to stamp.
+        source_key: The ledger key to record on ``source.origin_key``.
+    """
+    post = frontmatter.load(str(md_file))
+    existing = post.metadata.get("source")
+    # A validated fragment always carries a mapping here; the guard keeps the
+    # helper total for a hand-edited file rather than raising mid-migration.
+    source: dict[str, object] = dict(existing) if isinstance(existing, dict) else {}
+    source["origin_key"] = source_key
+    post.metadata["source"] = source
+    _atomic_write_text(md_file, frontmatter.dumps(post))
+
+
+def _pin_one(
+    candidate: _Candidate,
+    ledger: SourceLedger,
+    *,
+    dry_run: bool,
+) -> tuple[bool, bool]:
+    """Pin one uncontested *candidate*, or repair a previously torn pin.
+
+    Pinning is two durable writes — a ledger record and a frontmatter stamp —
+    and they cannot be made atomic with respect to each other. Whichever runs
+    second can fail on its own (a disk-full or permission-denied
+    ``OSError`` partway through an N-fragment pass is far more likely than a
+    ``kill -9``), leaving the fragment half-pinned.
+
+    The ledger record is written **first**, deliberately. It is the write that
+    protects *identity*: while a record exists, ``write_fragment_idempotent``
+    reuses ``record.fragment_id`` and the fragment cannot be duplicated by a
+    re-ingest, whether or not the stamp landed. Writing the stamp first would
+    invert that, leaving a window in which the fragment is RTBF-visible but
+    its identity is unpinned — trading a recoverable gap for an unrecoverable
+    one, since a duplicate cannot be un-minted.
+
+    That ordering is only safe because the already-ledgered path below is
+    **self-healing**: a fragment whose record exists but whose stamp is
+    missing gets the stamp on the next run. Without that, the presence of the
+    record would make the retry skip the candidate entirely and the fragment
+    would stay RTBF-invisible forever — the purge sweep resolves its target
+    from on-disk frontmatter and skips fragments lacking the key, and
+    ``update_fragment`` never merges fresh ``source`` fields, so nothing
+    downstream would ever repair it.
+
+    Args:
+        candidate: The fragment to pin.
+        ledger: The markdown ledger, already loaded.
+        dry_run: When ``True``, decide but write nothing.
+
+    Returns:
+        ``(pinned, repaired)``. *pinned* is ``True`` when this call pinned the
+        candidate (or would have, under *dry_run*). *repaired* is ``True``
+        when the candidate was already ledgered but needed its missing stamp
+        restored.
+    """
+    if candidate.source_key in ledger:
+        if candidate.has_origin_key:
+            return False, False
+        if not dry_run:
+            _stamp_origin_key(candidate.md_file, candidate.source_key)
+        return False, True
+    if not dry_run:
+        ledger.record(
+            candidate.source_key,
+            candidate.fragment_id,
+            _stored_body_hash(candidate.body),
+        )
+        _stamp_origin_key(candidate.md_file, candidate.source_key)
+    return True, False
+
+
+def pin_source_ids(vault_path: Path, *, dry_run: bool = False) -> PinResult:
+    """Back-fill the markdown ingest ledger with existing fragment ids (#1329).
+
+    Walks the vault's fragment roots, resolves each fragment to the markdown
+    source that produced it, and records the fragment's **existing** id
+    against that source's ledger key — so the id-derivation change that
+    motivated this migration can never move an id that is already on disk.
+    Each pinned fragment also gains ``source.origin_key`` in its frontmatter,
+    written atomically.
+
+    A ``source_key`` claimed by more than one live fragment is pinned for
+    neither and reported as a conflict; see :func:`_index_by_source_key`.
+
+    Idempotent: a key already present in the ledger is counted as
+    ``already_pinned`` and left alone, so a second run reports ``pinned == 0``
+    and writes nothing.
+
+    Args:
+        vault_path: Vault root (the directory containing ``01-Fragments/``).
+        dry_run: When ``True``, nothing is written — no ledger append and no
+            frontmatter stamp — but the returned result is fully populated so
+            a caller can print the plan.
+
+    Returns:
+        A :class:`PinResult` summarising what was (or would be) pinned.
+    """
+    candidates, unpinnable = _collect_candidates(vault_path)
+    ledger = SourceLedger.load(vault_path, source=_LEDGER_SOURCE)
+
+    conflicts: list[str] = []
+    pinned = 0
+    already_pinned = 0
+    repaired = 0
+    for source_key, claimants in _index_by_source_key(candidates).items():
+        if len(claimants) > 1:
+            conflicts.append(_conflict_line(source_key, claimants))
+            continue
+        was_pinned, was_repaired = _pin_one(claimants[0], ledger, dry_run=dry_run)
+        if was_pinned:
+            pinned += 1
+        else:
+            already_pinned += 1
+            repaired += int(was_repaired)
+
+    return PinResult(
+        pinned=pinned,
+        already_pinned=already_pinned,
+        repaired=repaired,
+        conflicts=conflicts,
+        unpinnable=unpinnable,
+        reproduced=sum(1 for candidate in candidates if _reproduces_own_id(candidate)),
+        examined=len(candidates) + len(unpinnable),
+    )

--- a/creek-tools/creek/ingest/pin_ids.py
+++ b/creek-tools/creek/ingest/pin_ids.py
@@ -62,7 +62,7 @@ import frontmatter
 
 from creek.ingest.base import generate_fragment_id
 from creek.ingest.ledger import SourceLedger
-from creek.ingest.pipeline import derive_source_key
+from creek.ingest.pipeline import LEDGERED_SOURCE_TYPE, derive_source_key
 from creek.vault.authors import OTHER_AUTHORS_DIR
 from creek.vault.reader import iter_vault_fragments
 
@@ -82,12 +82,14 @@ from creek.vault.writer import (
 
 logger = logging.getLogger(__name__)
 
-_LEDGER_SOURCE: str = "markdown"
+_LEDGER_SOURCE: str = LEDGERED_SOURCE_TYPE
 """Ledger name to back-fill.
 
-Must match the source type :func:`creek.ingest.pipeline.ledger_for_source`
-ledgers, or the records written here would land in a file no ingest ever
-reads.
+Imported rather than retyped: this has to be the same ledger
+:func:`creek.ingest.pipeline.ledger_for_source` loads and
+:func:`creek.ingest.pipeline.unpinned_vault_warning` judges, or the records
+written here land in a file no ingest ever reads and the advisory that sends
+operators to this migration never notices it ran.
 """
 
 _MARKDOWN_SUFFIX: str = ".md"

--- a/creek-tools/creek/ingest/pin_ids.py
+++ b/creek-tools/creek/ingest/pin_ids.py
@@ -56,13 +56,17 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from datetime import datetime
-from pathlib import Path  # runtime use: suffix/existence checks on source paths
+from typing import TYPE_CHECKING
 
 import frontmatter
 
 from creek.ingest.base import generate_fragment_id
 from creek.ingest.ledger import SourceLedger
-from creek.ingest.pipeline import LEDGERED_SOURCE_TYPE, derive_source_key
+from creek.ingest.pipeline import (
+    LEDGERED_SOURCE_TYPE,
+    derive_source_key,
+    resolve_recorded_source,
+)
 from creek.vault.authors import OTHER_AUTHORS_DIR
 from creek.vault.reader import iter_vault_fragments
 
@@ -79,6 +83,9 @@ from creek.vault.writer import (
     _ORPHANED_RELPARTS,
     _atomic_write_text,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -209,7 +216,7 @@ def _raw_created(metadata: dict[str, object]) -> datetime | None:
     return None
 
 
-def _unpinnable_reason(source_path_str: str) -> str | None:
+def _unpinnable_reason(source_path_str: str, vault_path: Path) -> str | None:
     """Return why *source_path_str* cannot be pinned, or ``None`` if it can.
 
     Three dispositions are refused, each for its own reason:
@@ -221,15 +228,26 @@ def _unpinnable_reason(source_path_str: str) -> str | None:
       it would only add a record no future run will ever match — and, worse,
       could shadow a *different* file that later takes that path.
 
+    The existence question is asked of :func:`~creek.ingest.pipeline.
+    resolve_recorded_source`, the same resolution
+    :func:`~creek.ingest.pipeline.derive_source_key` keys on, so this predicate
+    and the key written for whatever it admits can never disagree about where a
+    recorded path points. Asking it of a bare ``Path`` instead anchored a
+    relative record to the *current directory*, so running this one-shot
+    migration from anywhere but the original ingest's directory reported live
+    in-vault sources as deleted and silently skipped exactly the fragments the
+    migration exists to protect.
+
     Args:
         source_path_str: The fragment's ``source.original_file``, verbatim.
+        vault_path: Vault root, used to anchor a relative record.
 
     Returns:
         A human-readable reason, or ``None`` when the source is pinnable.
     """
     if not source_path_str:
         return "fragment records no source.original_file"
-    source_path = Path(source_path_str)
+    source_path = resolve_recorded_source(source_path_str, vault_path)
     if source_path.suffix.lower() != _MARKDOWN_SUFFIX:
         return f"source {source_path_str!r} is not a {_MARKDOWN_SUFFIX} file"
     if not source_path.exists():
@@ -255,7 +273,7 @@ def _collect_candidates(vault_path: Path) -> tuple[list[_Candidate], list[str]]:
             vault_path.joinpath(*relparts),
         ):
             source_path_str = fragment.source.original_file or ""
-            reason = _unpinnable_reason(source_path_str)
+            reason = _unpinnable_reason(source_path_str, vault_path)
             if reason is not None:
                 unpinnable.append(f"{md_file}: {reason}")
                 continue

--- a/creek-tools/creek/ingest/pipeline.py
+++ b/creek-tools/creek/ingest/pipeline.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
+from pathlib import Path  # runtime use: resolving recorded source paths
 from typing import TYPE_CHECKING, Final
 
 from creek.ingest.base import assemble_ingested_fragment
@@ -26,7 +27,6 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from collections.abc import Callable
     from datetime import datetime
-    from pathlib import Path
 
     from creek.ingest.base import Ingestor, ParsedFragment
     from creek.ingest.ledger import LedgerRecord, SourceLedger
@@ -62,16 +62,64 @@ class IngestRunResult:
     warnings: list[str] = field(default_factory=list)
 
 
+def resolve_recorded_source(source_path: str, vault_path: Path) -> Path:
+    """Interpret a recorded ``source.original_file`` string as a path on disk.
+
+    ``source.original_file`` is stored **verbatim** as whatever path the ingest
+    run was handed — ``MarkdownIngestor.parse`` records ``str(raw.path)`` and
+    the CLI does not resolve ``--source`` — so a vault ingested with ``creek
+    ingest --source 00-Inbox`` from the vault root holds *relative* recorded
+    paths. A bare :class:`Path` of such a string is anchored to the current
+    working directory, which makes every later reader of that record answer a
+    different question depending on where it was invoked from.
+
+    Anchoring to the vault is the recovery: the vault root is a stable anchor
+    the reader already holds as an argument, and it is the directory a
+    vault-relative record was almost certainly written against.
+
+    The current directory still wins when it resolves, so a run made from the
+    original ingest's directory behaves exactly as before; the vault is
+    consulted only for a relative path that names nothing where it stands.
+    When neither locates a file the string is returned unchanged, so a caller
+    asking whether the source still exists gets the same honest ``no`` — this
+    widens what *resolves*, never what is assumed to exist.
+
+    Args:
+        source_path: The recorded ``source.original_file``, verbatim.
+        vault_path: Vault root, used to anchor a relative record.
+
+    Returns:
+        The best on-disk interpretation of *source_path*.
+    """
+    candidate = Path(source_path)
+    # The ``is_absolute`` arm states intent and saves a stat; it is not a
+    # behavioural branch. ``vault_path / <absolute>`` is that absolute path
+    # again, so an absolute record takes the same value either way — dropping
+    # this clause is an equivalent mutation, and no test can kill it.
+    if candidate.is_absolute() or candidate.exists():
+        return candidate
+    vault_anchored = vault_path / candidate
+    if vault_anchored.exists():
+        return vault_anchored
+    return candidate
+
+
 def derive_source_key(source_path: str, vault_path: Path) -> str:
     """Return a stable vault-relative ``source_key`` for a source file (#672).
 
     Prefers the path relative to the vault root (the stable identity a
     re-ingested edit is matched on); falls back to the bare filename when the
     source lives outside the vault.
-    """
-    from pathlib import Path as _Path
 
-    candidate = _Path(source_path)
+    The recorded string is interpreted by :func:`resolve_recorded_source`
+    rather than being anchored to the current directory, so a relative record
+    keys the same way whichever directory the caller runs from. Sharing that
+    one resolution with the ``pin_ids`` migration is deliberate: two functions
+    disagreeing about where the same recorded path points is how the migration
+    came to call a live in-vault source deleted while this function happily
+    derived a key for it.
+    """
+    candidate = resolve_recorded_source(source_path, vault_path)
     try:
         return candidate.resolve().relative_to(vault_path.resolve()).as_posix()
     except ValueError:

--- a/creek-tools/creek/ingest/pipeline.py
+++ b/creek-tools/creek/ingest/pipeline.py
@@ -24,6 +24,7 @@ from creek.ingest.base import assemble_ingested_fragment
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from datetime import datetime
     from pathlib import Path
 
@@ -423,6 +424,7 @@ def run_ingest(
     incremental: bool = False,
     ledger_source: str | None = None,
     privacy_tier: PrivacyTier | None = None,
+    on_warning: Callable[[str], None] | None = None,
 ) -> IngestRunResult:
     """Run one ingestor and persist its output idempotently to the vault.
 
@@ -451,6 +453,14 @@ def run_ingest(
             Merged onto each fragment with
             :func:`creek.classify.privacy_pass.escalate`, so it can only
             raise the tier, never lower one the source already declared.
+        on_warning: Called with each operator advisory **at the moment it is
+            detected**, which for the un-pinned-vault advisory is before the
+            first fragment is written (#1329). Surfaces still get every warning
+            on :attr:`IngestRunResult.warnings`; this exists because an
+            advisory whose whole purpose is "stop before this run hurts you"
+            is worthless delivered after the run finished. Keeping it a plain
+            ``str`` callback leaves this module UI-agnostic — the caller
+            decides what printing means.
 
     Returns:
         An :class:`IngestRunResult` with the write tallies and any errors.
@@ -464,13 +474,25 @@ def run_ingest(
     filtering = since is not None or incremental
 
     warnings: list[str] = []
+
+    def warn(message: str) -> None:
+        """Record an advisory and hand it to the caller in the same breath.
+
+        The single way a warning enters this run. Appending to the list
+        without notifying *on_warning* is how an advisory becomes invisible,
+        so the two are not separable here.
+        """
+        warnings.append(message)
+        logger.warning("%s", message)
+        if on_warning is not None:
+            on_warning(message)
+
     # Checked BEFORE the write loop: once the loop has recorded its first
     # ledger entry the vault no longer looks un-pinned, and the advisory would
     # never fire for the very run it needed to warn about.
     unpinned = unpinned_vault_warning(ledger, vault_path)
     if unpinned is not None:
-        warnings.append(unpinned)
-        logger.warning("%s", unpinned)
+        warn(unpinned)
 
     errors: list[str] = [f"[{source_type}] {err}" for err in ingest_result.errors]
     written = 0

--- a/creek-tools/creek/ingest/pipeline.py
+++ b/creek-tools/creek/ingest/pipeline.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 from creek.ingest.base import assemble_ingested_fragment
 
@@ -78,7 +78,19 @@ def derive_source_key(source_path: str, vault_path: Path) -> str:
         return candidate.name
 
 
-TOMBING_SOURCES: frozenset[str] = frozenset({"markdown"})
+LEDGERED_SOURCE_TYPE: Final[str] = "markdown"
+"""The one source type whose identity is ledger-backed by default (#672).
+
+Three places have to agree on this name: :func:`ledger_for_source`, which
+loads that ledger; :func:`unpinned_vault_warning`, whose whole subject is
+that ledger; and the ``creek.ingest.pin_ids`` migration, which back-fills
+it. They agree by importing this constant rather than by each spelling
+``"markdown"`` and a comment promising to stay in step — a promise is not
+an enforcement, and the review that produced this constant found the
+advisory already consulting a different ledger than the migration wrote.
+"""
+
+TOMBING_SOURCES: frozenset[str] = frozenset({LEDGERED_SOURCE_TYPE})
 """Source types whose directory ingest may soft-tomb units it no longer sees.
 
 Deliberately *narrower* than "has a ledger", and separate from it (#1329).
@@ -98,7 +110,7 @@ def ledger_for_source(source_type: str, vault_path: Path) -> SourceLedger | None
     Only the markdown (journal) source is ledger-wired; append-only event
     sources keep their content-hashed ids untouched.
     """
-    if source_type != "markdown":
+    if source_type != LEDGERED_SOURCE_TYPE:
         return None
     from creek.ingest.ledger import SourceLedger
 
@@ -381,29 +393,49 @@ _UNPINNED_VAULT_WARNING = (
 
 
 def unpinned_vault_warning(
-    ledger: SourceLedger | None,
+    source_type: str,
     vault_path: Path,
 ) -> str | None:
     """Return the un-pinned-vault advisory, or ``None`` when it does not apply.
 
-    A vault that already holds markdown fragments but whose ledger is empty
-    predates the pin migration. The next ingest of those same sources will
-    derive ids under the corrected rule, fail to match anything, and write
-    duplicates — so the operator is told once, before that happens.
+    A vault that already holds markdown fragments but whose **markdown**
+    ledger is empty predates the pin migration. The next ingest of those same
+    sources will derive ids under the corrected rule, fail to match anything,
+    and write duplicates — so the operator is told once, before that happens.
 
-    The ledger's own emptiness *is* the marker; deriving the signal from it
+    That ledger's own emptiness *is* the marker; deriving the signal from it
     rather than from a version stamp in ``00-Creek-Meta/State/`` keeps this to
     one piece of state. A second marker is a second thing that can be wrong.
 
+    **This deliberately does not accept a ledger.** It used to take whichever
+    ledger the run had resolved, and a run with a ``ledger_source`` override —
+    which the ``creek.upload`` MCP tool always passes, including for an
+    uploaded ``.md`` — therefore weighed an unrelated ledger's emptiness. That
+    produced a spurious warning on an already-migrated vault, and, worse, went
+    permanently silent on a genuinely un-pinned one as soon as the borrowed
+    ledger gained any record. The subject of this advisory is fixed by what
+    the advisory *says*, so it is looked up here from :data:`LEDGERED_SOURCE_TYPE`
+    and cannot be substituted by anything a caller overrides.
+
+    The run's *source_type* still gates it, because #1329 moved markdown id
+    derivation only: a document or image run has nothing to be warned about,
+    and a warning delivered on a run it does not apply to is trained-away
+    noise. Unlike the resolved ledger, ``source_type`` names the identity
+    scheme this run writes under and no override can move it.
+
     Args:
-        ledger: The ledger resolved for this run, or ``None`` when unledgered.
+        source_type: Registry key of the ingestor being run, verbatim.
         vault_path: Vault root.
 
     Returns:
-        The advisory text, or ``None`` when the vault is fresh, already
-        pinned, or this run is unledgered.
+        The advisory text, or ``None`` when this run writes under some other
+        source type's identity, or the vault is fresh or already pinned.
     """
-    if ledger is None or len(ledger) > 0:
+    if source_type != LEDGERED_SOURCE_TYPE:
+        return None
+    from creek.ingest.ledger import SourceLedger
+
+    if len(SourceLedger.load(vault_path, source=LEDGERED_SOURCE_TYPE)) > 0:
         return None
     fragments_root = vault_path / "01-Fragments"
     if not fragments_root.is_dir():
@@ -490,7 +522,7 @@ def run_ingest(
     # Checked BEFORE the write loop: once the loop has recorded its first
     # ledger entry the vault no longer looks un-pinned, and the advisory would
     # never fire for the very run it needed to warn about.
-    unpinned = unpinned_vault_warning(ledger, vault_path)
+    unpinned = unpinned_vault_warning(source_type, vault_path)
     if unpinned is not None:
         warn(unpinned)
 

--- a/creek-tools/creek/ingest/pipeline.py
+++ b/creek-tools/creek/ingest/pipeline.py
@@ -15,10 +15,13 @@ any surface can drive it.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import logging
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from creek.ingest.base import assemble_ingested_fragment
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -42,6 +45,9 @@ class IngestRunResult:
         tombed: Ledgered units soft-tombed because a full-source pass no longer
             saw them.
         skipped: Units skipped by incremental/``since`` filtering.
+        warnings: Non-fatal operator advisories. Unlike *errors*, these do not
+            mean anything failed — they mean the run detected a vault state
+            that will cause trouble if left alone (#1329).
     """
 
     written: int
@@ -52,6 +58,7 @@ class IngestRunResult:
     unchanged: int
     tombed: int
     skipped: int
+    warnings: list[str] = field(default_factory=list)
 
 
 def derive_source_key(source_path: str, vault_path: Path) -> str:
@@ -68,6 +75,20 @@ def derive_source_key(source_path: str, vault_path: Path) -> str:
         return candidate.resolve().relative_to(vault_path.resolve()).as_posix()
     except ValueError:
         return candidate.name
+
+
+TOMBING_SOURCES: frozenset[str] = frozenset({"markdown"})
+"""Source types whose directory ingest may soft-tomb units it no longer sees.
+
+Deliberately *narrower* than "has a ledger", and separate from it (#1329).
+:func:`resolve_ledger` lets a caller opt a non-markdown source type into
+ledger-backed *identity* via ``ledger_source``, and until this split that same
+opt-in silently armed :func:`tomb_missing_units` as well — so a directory
+ingest under a borrowed ledger would tomb every previously-recorded unit it
+did not happen to see. Identity and tombing are different questions; only a
+source whose directory listing is genuinely the full, authoritative set of
+live units belongs here.
+"""
 
 
 def ledger_for_source(source_type: str, vault_path: Path) -> SourceLedger | None:
@@ -226,12 +247,22 @@ def write_fragment_idempotent(
 ) -> str:
     """Write or update the fragment; return ``"created"``/``"updated"``/``"unchanged"``.
 
-    When the ledger already maps this source unit to a fragment and the
-    content has *changed*, reuse that fragment id and rewrite it in place
-    (preserving classifications/links, flagging re-classification on a material
-    change per *reclassify_threshold*). Unchanged content falls through to the
-    normal write, where the deterministic id makes it an idempotent no-op. A
-    new unit (no prior ledger record) is written fresh and reported as created.
+    When the ledger already maps this source unit to a fragment, **the
+    ledger's recorded id wins on every branch** — changed, unchanged, or
+    tombed. That assignment is hoisted above the branches deliberately
+    (#1329): it used to happen only on the changed and tombed paths, leaving
+    the unchanged path to write whatever id the ingestor had just *derived*.
+    Any drift in id derivation — a timezone bug, a new hash input, a
+    refactor — therefore turned every unchanged ledgered unit into a silent
+    duplicate, because the writer's dedup keys on the id alone. Identity for
+    a mutable file source is ledger-backed by design (#672 SPEC R1); the
+    derivation is only how a *new* unit gets its first id.
+
+    Beyond identity: changed content is rewritten in place (preserving
+    classifications/links, flagging re-classification on a material change
+    per *reclassify_threshold*); unchanged content falls through to a write
+    the id makes a no-op; a new unit with no prior record is written fresh
+    and reported as created.
     """
     record = ledger_record(ledger, fragment)
     # `record is not None` guarantees `ledger is not None` (ledger_record
@@ -239,6 +270,9 @@ def write_fragment_idempotent(
     if record is None or ledger is None:
         writer.write_fragment(fragment, body=body)
         return "created"
+    # The ledger is the authority on this unit's identity, on every branch
+    # below. Do not push this back down into the branches (#1329).
+    fragment.id = record.fragment_id
     new_hash = ledger.content_hash(parsed.content)
     if record.tombed:
         restored = restore_tombed(
@@ -249,7 +283,6 @@ def write_fragment_idempotent(
             writer.write_fragment(fragment, body=body)
         return "updated"
     if record.content_hash != new_hash:
-        fragment.id = record.fragment_id
         updated = writer.update_fragment(
             fragment, body, reclassify_threshold=reclassify_threshold
         )
@@ -257,9 +290,11 @@ def write_fragment_idempotent(
             # File gone out of band: recreate under the preserved id.
             writer.write_fragment(fragment, body=body)
         return "updated"
-    # Known unit, content unchanged: idempotent no-op (the deterministic id
-    # dedups the write). Reported as unchanged so it never inflates the
-    # updated counter in the ingest summary.
+    # Known unit, content unchanged: idempotent no-op. The write resolves to
+    # the existing file because `fragment.id` is now the *ledgered* id and the
+    # writer's per-directory id index matches on it — the guarantee comes from
+    # the ledger, not from trusting the derivation to reproduce (#1329).
+    # Reported as unchanged so it never inflates the updated counter.
     writer.write_fragment(fragment, body=body)
     return "unchanged"
 
@@ -278,11 +313,19 @@ def tomb_missing_units(
     input never tombs — that guards the incremental epic from tombing every
     other unit when re-ingesting one file.
 
+    Tombing is additionally gated on *source_type* being in
+    :data:`TOMBING_SOURCES` (#1329). Holding a ledger is not sufficient: a
+    caller can borrow one via ``ledger_source`` purely to pin identity, and
+    that must not arm the tomb sweep for a source type whose directory
+    listing is not the authoritative set of live units.
+
     A tomb that fails on I/O is collected into *errors* and the unit is left
     live in the ledger so the next full-source pass retries it, rather than
     crashing the whole run. Returns the number of units actually tombed.
     """
     if ledger is None or not input_path.is_dir():
+        return 0
+    if source_type not in TOMBING_SOURCES:
         return 0
     tombed = 0
     for source_key in sorted(ledger.live_keys() - seen_keys):
@@ -324,6 +367,49 @@ def should_skip_unit(
     record = ledger_record(ledger, fragment)
     content_hash = ledger.content_hash(parsed.content) if ledger is not None else ""
     return not unit_is_changed(parsed.timestamp, content_hash, record, since)
+
+
+_UNPINNED_VAULT_WARNING = (
+    "This vault has markdown fragments but an empty ingest ledger, so it has "
+    "not been migrated for the #1329 id-derivation fix. Re-ingesting these "
+    "sources will mint new ids and leave the existing fragments behind as "
+    "duplicates. Run `creek ingest --pin-source-ids --vault <vault>` once "
+    "first (use --dry-run to preview)."
+)
+"""Advisory shown when a populated vault has no ledger records yet (#1329)."""
+
+
+def unpinned_vault_warning(
+    ledger: SourceLedger | None,
+    vault_path: Path,
+) -> str | None:
+    """Return the un-pinned-vault advisory, or ``None`` when it does not apply.
+
+    A vault that already holds markdown fragments but whose ledger is empty
+    predates the pin migration. The next ingest of those same sources will
+    derive ids under the corrected rule, fail to match anything, and write
+    duplicates — so the operator is told once, before that happens.
+
+    The ledger's own emptiness *is* the marker; deriving the signal from it
+    rather than from a version stamp in ``00-Creek-Meta/State/`` keeps this to
+    one piece of state. A second marker is a second thing that can be wrong.
+
+    Args:
+        ledger: The ledger resolved for this run, or ``None`` when unledgered.
+        vault_path: Vault root.
+
+    Returns:
+        The advisory text, or ``None`` when the vault is fresh, already
+        pinned, or this run is unledgered.
+    """
+    if ledger is None or len(ledger) > 0:
+        return None
+    fragments_root = vault_path / "01-Fragments"
+    if not fragments_root.is_dir():
+        return None
+    if not any(fragments_root.rglob("*.md")):
+        return None
+    return _UNPINNED_VAULT_WARNING
 
 
 def run_ingest(
@@ -376,6 +462,15 @@ def run_ingest(
     ingest_result = ingestor_cls().ingest(input_path)
     ledger = resolve_ledger(source_type, vault_path, ledger_source)
     filtering = since is not None or incremental
+
+    warnings: list[str] = []
+    # Checked BEFORE the write loop: once the loop has recorded its first
+    # ledger entry the vault no longer looks un-pinned, and the advisory would
+    # never fire for the very run it needed to warn about.
+    unpinned = unpinned_vault_warning(ledger, vault_path)
+    if unpinned is not None:
+        warnings.append(unpinned)
+        logger.warning("%s", unpinned)
 
     errors: list[str] = [f"[{source_type}] {err}" for err in ingest_result.errors]
     written = 0
@@ -437,4 +532,5 @@ def run_ingest(
         unchanged=counts.get("unchanged", 0),
         tombed=tombed,
         skipped=skipped,
+        warnings=warnings,
     )

--- a/creek-tools/creek_mcp/tools/upload.py
+++ b/creek-tools/creek_mcp/tools/upload.py
@@ -125,13 +125,21 @@ def _stage_upload(
 ) -> Path:
     """Write *raw* to its stable staged path and return it, skipping no-op writes.
 
-    The identical-bytes short-circuit is **not** an optimisation. Every
-    ingestor without an embedded date derives its parse timestamp from the
-    file's ``st_mtime``, and :func:`creek.ingest.base.generate_fragment_id`
-    hashes that timestamp — while ``write_fragment_idempotent``'s *unchanged*
-    branch never reassigns ``fragment.id``. Re-writing identical bytes would
-    therefore bump the mtime, mint a new id, and leave a duplicate fragment
-    behind on every idempotent re-send.
+    The identical-bytes short-circuit avoids a pointless write on an
+    idempotent re-send: an ingestor without an embedded date derives its parse
+    timestamp from the file's ``st_mtime``, and
+    :func:`creek.ingest.base.generate_fragment_id` hashes that timestamp, so
+    rewriting the same bytes would bump the mtime and derive a different id.
+
+    It is no longer load-bearing against *duplication*, and this docstring
+    should not be read as claiming otherwise. Uploads run under a borrowed
+    ledger (``UPLOAD_LEDGER_SOURCE``), and since #1329
+    ``write_fragment_idempotent`` assigns ``fragment.id = record.fragment_id``
+    on **every** branch — including the unchanged one, which previously wrote
+    whatever id had just been derived. A shifted derivation is therefore
+    absorbed by the ledger rather than turning into an orphan. Keeping the
+    short-circuit is still worth it; keeping a comment that asserts a hazard
+    the ledger now closes is how the hazard gets reopened.
 
     Args:
         vault_path: Vault root.

--- a/creek-tools/docs/idempotent-ingest.md
+++ b/creek-tools/docs/idempotent-ingest.md
@@ -87,6 +87,13 @@ The migration **pins**; it does not re-mint. Existing ids never move.
 
 It is idempotent (a second run pins nothing) and `--dry-run` writes nothing.
 
+Run it from wherever you like. `source.original_file` is recorded verbatim, so
+a vault ingested with a relative `--source` holds relative paths; a relative
+record that names nothing in the current directory is resolved against the
+vault root before it is called missing. Without that, running this one-shot
+migration from a different directory than the original ingest reported live
+sources as deleted and skipped exactly the fragments it exists to protect.
+
 An un-migrated vault is detected on the next ingest — an empty **markdown**
 ledger over a vault that already holds fragments is the marker — and the
 advisory naming the remedy is printed **before that run's write pass begins**,

--- a/creek-tools/docs/idempotent-ingest.md
+++ b/creek-tools/docs/idempotent-ingest.md
@@ -26,6 +26,85 @@ tracked in a per-source **ledger**:
 Today the markdown (journal) source is ledger-wired; append-only event sources
 keep their content-hash ids untouched.
 
+**The ledger is the authority on a known unit's identity.** Once a
+`source_key` has a record, every branch below reuses `record.fragment_id` —
+including the *unchanged* branch, which until #1329 wrote whatever id the
+ingestor had just derived. That distinction matters more than it sounds: it
+means a change to *how* ids are derived can never silently duplicate a
+fragment the ledger already knows about. Derivation is only how a **new** unit
+gets its first id.
+
+## One-time migration: `creek ingest --pin-source-ids`
+
+**If you have a vault created before this release, run this once:**
+
+```bash
+creek ingest --pin-source-ids --vault <vault>          # add --dry-run to preview
+```
+
+### Why
+
+`generate_fragment_id` hashes the fragment's timestamp, and for a file with no
+embedded date that timestamp came from the filesystem. Two host-dependent
+inputs leaked into it (#1329):
+
+- `datetime.fromtimestamp(mtime)` with no `tz=` rendered the epoch in the
+  *host's local zone*, so one file minted a different id in every timezone —
+  move a laptop, or run CI in UTC while working in Los Angeles, and the next
+  ingest saw a "new" fragment.
+- `st_birthtime` exists on macOS/BSD and not on Linux, so the same file minted
+  a different id on a developer's Mac than in Linux CI.
+
+Both are fixed: markdown, documents and images now derive that fallback
+through `creek.ingest.base.file_modified_time`, a pure function of the file's
+epoch mtime in UTC. But fixing the derivation **changes** it, so without the
+migration the next `creek ingest` over an existing vault would fail to
+recognise its own fragments and write duplicates.
+
+### What it does — and what it refuses to do
+
+The migration **pins**; it does not re-mint. Existing ids never move.
+
+- **Ledger** — one record per markdown-sourced fragment, carrying the id read
+  off disk. Never a recomputed one. That is what makes the whole re-mapping
+  problem (renaming files, rewriting the id index, children, resonance edges,
+  the embedding cache, thread membership, provenance) *vacuous* rather than
+  merely skipped: none of those references move, so none of them need
+  rewriting.
+- **Frontmatter** — exactly one key is added, `source.origin_key`. `id`,
+  `created`, the body and the filename are byte-identical afterwards. The
+  stamp is mandatory rather than cosmetic: the RTBF purge sweep resolves its
+  target by reading that field off disk and skips fragments without it, and
+  `update_fragment` preserves on-disk frontmatter rather than merging fresh
+  `source` fields — so a fragment lacking the key at migration time would
+  never gain one on any later ingest. Writes are atomic.
+- **Already-duplicated vaults** — a `source_key` claimed by more than one live
+  fragment is pinned for *neither*, and both paths are printed. Blessing one
+  would orphan the other forever. Resolve with `creek clean duplicates`, then
+  re-run.
+- **Unresolvable sources** — a fragment whose source has been deleted, or that
+  records no source file, is listed and skipped rather than guessed at.
+
+It is idempotent (a second run pins nothing) and `--dry-run` writes nothing.
+An un-migrated vault is detected on the next `creek ingest` and warned about
+before it is duplicated.
+
+### Two behaviour changes worth knowing about
+
+1. **On macOS, a markdown fragment's `created` now reports modification time,
+   not birth time.** That is the price of an id that does not depend on which
+   operating system ingested the file, and the trade is deliberate. Because
+   the writer builds a fragment's filename from `created`, a **newly ingested**
+   fragment's date prefix may differ from what the old code would have chosen.
+   No existing file is renamed — the migration never touches `created`.
+   Authorship remains `authored_at`'s job (FEAT-031), which has its own
+   frontmatter fields and its own backfill (`creek ingest --refresh-dates`).
+2. **Documents remain unledgered.** The derivation fix alone stops their
+   *timezone*-driven duplication, but a document whose mtime moves still
+   re-derives its id with no ledger record to pin it. Widening the ledger to
+   documents is blocked on a real defect in `derive_source_key` and is tracked
+   separately (#1363).
+
 ## What happens on ingest
 
 For each source unit, the ledger drives an **unchanged / changed / gone**
@@ -33,7 +112,7 @@ decision:
 
 | Case | Detection | Behaviour |
 |------|-----------|-----------|
-| **unchanged** | content hash matches the ledger | idempotent no-op (deterministic id dedups the write) |
+| **unchanged** | content hash matches the ledger | idempotent no-op (the write resolves to the existing fragment under the **ledgered** id) |
 | **changed** | same `source_key`, new content hash | **update in place** — the existing fragment is rewritten under its preserved id, keeping classifications and resonance links |
 | **gone** | a ledgered `source_key` is absent from a full-source pass | **soft-tomb** — the fragment moves to `10-Liminal/Orphaned/` and is marked `lifecycle: orphaned` (never hard-deleted) |
 | **re-added** | a tombed `source_key` reappears | **restore** — the tombed fragment is moved back and un-marked under its preserved id |

--- a/creek-tools/docs/idempotent-ingest.md
+++ b/creek-tools/docs/idempotent-ingest.md
@@ -86,8 +86,19 @@ The migration **pins**; it does not re-mint. Existing ids never move.
   records no source file, is listed and skipped rather than guessed at.
 
 It is idempotent (a second run pins nothing) and `--dry-run` writes nothing.
-An un-migrated vault is detected on the next `creek ingest` and warned about
-before it is duplicated.
+
+An un-migrated vault is detected on the next ingest — the empty ledger is the
+marker — and the advisory naming the remedy is printed **before that run's
+write pass begins**, so an operator watching it can still abort with nothing
+yet duplicated. This covers every ingest driven through the CLI, `creek sync`
+included.
+
+It is an advisory, not a gate: the run continues and the exit code is
+unchanged. A warning describes vault state that will cause trouble, not a
+failure of the run in front of it, and making it fatal would hard-fail every
+scheduled `creek sync` over a vault that has not been migrated yet. So an
+*unattended* ingest over an un-migrated vault will still duplicate it. Pin
+first.
 
 ### Two behaviour changes worth knowing about
 

--- a/creek-tools/docs/idempotent-ingest.md
+++ b/creek-tools/docs/idempotent-ingest.md
@@ -87,11 +87,21 @@ The migration **pins**; it does not re-mint. Existing ids never move.
 
 It is idempotent (a second run pins nothing) and `--dry-run` writes nothing.
 
-An un-migrated vault is detected on the next ingest — the empty ledger is the
-marker — and the advisory naming the remedy is printed **before that run's
-write pass begins**, so an operator watching it can still abort with nothing
-yet duplicated. This covers every ingest driven through the CLI, `creek sync`
-included.
+An un-migrated vault is detected on the next ingest — an empty **markdown**
+ledger over a vault that already holds fragments is the marker — and the
+advisory naming the remedy is printed **before that run's write pass begins**,
+so an operator watching it can still abort with nothing yet duplicated. This
+covers every ingest driven through the CLI, `creek sync` included.
+
+The ledger it weighs is always the markdown one, never whichever ledger the
+current run resolved. A run may borrow another ledger for identity
+(`run_ingest(ledger_source=…)`, as the `creek.upload` MCP tool always does),
+and judging that borrowed ledger's emptiness would both warn about vaults
+already migrated and — the worse half — go permanently quiet about vaults that
+are not, as soon as the borrowed ledger gained its first record. The advisory
+is scoped by the run's `source_type` instead: `#1329` moved *markdown* id
+derivation only, so a document or image run is never warned, and no
+`ledger_source` override can change what a run's `source_type` is.
 
 It is an advisory, not a gate: the run continues and the exit code is
 unchanged. A warning describes vault state that will cause trouble, not a

--- a/creek-tools/tests/test_ingest_id_host_independence.py
+++ b/creek-tools/tests/test_ingest_id_host_independence.py
@@ -1,0 +1,265 @@
+"""A fragment's id must not depend on the host it was ingested on (#1329).
+
+``generate_fragment_id`` hashes the fragment's timestamp
+(``creek/ingest/base.py``: ``f"{source}:{timestamp.isoformat()}:{content}"``),
+so any host-dependent input to that timestamp leaks straight into the
+fragment's identity. Two such leaks existed:
+
+1. **The host ``TZ`` env var.** ``datetime.fromtimestamp(mtime)`` with no
+   ``tz=`` renders the epoch in the *host's* local zone, and
+   ``normalize_timestamp`` then re-interpreted that naive wall-clock as UTC
+   before shifting it to LA — a double shift. One file, four ids.
+2. **The host operating system.** ``getattr(stat, "st_birthtime", st_mtime)``
+   reads a field that exists on macOS/BSD but not on Linux, so the same file
+   minted one id on a developer's Mac and a different one in Linux CI.
+
+Both are pinned here. The assertions are on the **fragment id**, not merely on
+``created``: the timestamp's UTC-offset *string* is inside the hashed input, so
+a change that fixed the instant but re-rendered the offset would slip past a
+``created``-only check.
+
+Nothing in this module uses ``--incremental``/``since``. ``should_skip_unit``
+short-circuits the write for an unchanged ledgered unit, so an incremental-mode
+test is green while the bug is live.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from creek.ingest.base import assemble_ingested_fragment
+from creek.ingest.documents import DocumentIngestor
+from creek.ingest.markdown import MarkdownIngestor
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+ZONES = ("UTC", "America/Los_Angeles", "Europe/Berlin", "Australia/Sydney")
+"""Host timezones the derivation must be invariant under.
+
+Chosen to straddle the epoch instant: 2024-03-15T09:00:00Z is the *previous*
+calendar day in Los Angeles and the *same* day in Sydney, so a naive
+derivation cannot accidentally agree.
+"""
+
+PINNED_MTIME = 1710493200.0
+"""2024-03-15T09:00:00+00:00 — the fixed mtime every case in this module uses."""
+
+EXPECTED_INSTANT = datetime(2024, 3, 15, 9, 0, tzinfo=UTC)
+"""The UTC instant ``PINNED_MTIME`` denotes."""
+
+MARKDOWN_ID = "frag-b145fde4406d"
+"""``generate_fragment_id("note.md", 2024-03-15T09:00:00+00:00, "body text")``.
+
+Pinned as a literal rather than asserted only as ``len(ids) == 1`` because a
+future "simplification" that made all four zones agree on some *other*
+derivation would slip past a set-size check.
+"""
+
+DOCUMENT_ID = "frag-e71aebc3ad98"
+"""``generate_fragment_id("note.txt", 2024-03-15T09:00:00+00:00, "# body text")``.
+
+``DocumentIngestor`` renders a ``.txt`` body through the markdown converter,
+which promotes the first line to a heading — hence ``"# body text"``.
+"""
+
+
+@pytest.fixture
+def restore_host_tz() -> Iterator[None]:
+    """Restore the process timezone after a test perturbs ``TZ``.
+
+    ``time.tzset()`` mutates *process-global* state that ``monkeypatch.setenv``
+    alone cannot undo, so a leaked ``TZ`` would poison every later test in the
+    session.
+
+    Yields:
+        ``None``; the restoration happens on teardown.
+    """
+    original = os.environ.get("TZ")
+    try:
+        yield
+    finally:
+        if original is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = original
+        time.tzset()
+
+
+def _write_source(name: str, body: str = "body text\n") -> Path:
+    """Create *name* in the CWD with its mtime pinned to ``PINNED_MTIME``.
+
+    The path is deliberately **relative**. ``assemble_ingested_fragment``
+    hashes ``parsed.source_path``, and the file ingestors set that to
+    ``str(raw.path)``, so discovering the file through an absolute
+    ``tmp_path`` would put the per-run pytest temp directory inside the hash
+    and make the pinned literals above unreproducible between runs.
+
+    Args:
+        name: Relative filename to create.
+        body: File contents.
+
+    Returns:
+        The relative :class:`~pathlib.Path` to the created file.
+    """
+    path = Path(name)
+    path.write_text(body, encoding="utf-8")
+    os.utime(path, (PINNED_MTIME, PINNED_MTIME))
+    return path
+
+
+def _ids_across_zones(
+    ingestor_cls: type[MarkdownIngestor] | type[DocumentIngestor],
+    source: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[set[str], list[datetime]]:
+    """Ingest *source* once per zone in :data:`ZONES` and collect the results.
+
+    Args:
+        ingestor_cls: The concrete ingestor to drive.
+        source: Relative path to the source file.
+        monkeypatch: Pytest fixture used to set ``TZ``.
+
+    Returns:
+        A ``(set of fragment ids, list of created datetimes)`` pair. A set with
+        more than one member *is* the bug.
+    """
+    ids: set[str] = set()
+    createds: list[datetime] = []
+    for tz_name in ZONES:
+        monkeypatch.setenv("TZ", tz_name)
+        time.tzset()
+        parsed = ingestor_cls().ingest(source).fragments[0]
+        fragment = assemble_ingested_fragment(parsed).fragment
+        ids.add(fragment.id)
+        createds.append(fragment.created)
+    return ids, createds
+
+
+@pytest.mark.usefixtures("restore_host_tz")
+def test_markdown_fragment_id_is_identical_across_host_timezones(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One markdown file mints one id, whatever ``TZ`` the host is set to.
+
+    Pre-fix this set had four members (frag-c8bfc3e67c4d, frag-aa53901eaffa,
+    frag-fe2989a00f9b, frag-5ebe48b2ce65) — one per zone.
+    """
+    monkeypatch.chdir(tmp_path)
+    source = _write_source("note.md")
+
+    ids, createds = _ids_across_zones(MarkdownIngestor, source, monkeypatch)
+
+    assert ids == {MARKDOWN_ID}
+    assert [c.astimezone(UTC) for c in createds] == [EXPECTED_INSTANT] * len(ZONES)
+
+
+@pytest.mark.usefixtures("restore_host_tz")
+def test_document_fragment_id_is_identical_across_host_timezones(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One document mints one id, whatever ``TZ`` the host is set to.
+
+    ``DocumentIngestor`` has the same naive fallback as ``MarkdownIngestor``
+    and is *strictly worse off*: it is unledgered by default, so a shifted id
+    is an unconditional ``created`` rather than a merely possible duplicate.
+
+    Pre-fix this set had four members (frag-dd49a01f5539, frag-7286deeb5d27,
+    frag-430e7de61929, frag-936750c2ef1f).
+    """
+    monkeypatch.chdir(tmp_path)
+    source = _write_source("note.txt")
+
+    ids, createds = _ids_across_zones(DocumentIngestor, source, monkeypatch)
+
+    assert ids == {DOCUMENT_ID}
+    assert [c.astimezone(UTC) for c in createds] == [EXPECTED_INSTANT] * len(ZONES)
+
+
+class _FakeStat:
+    """A minimal ``os.stat_result`` stand-in exposing chosen fields only.
+
+    Real ``os.stat_result`` instances cannot be constructed with
+    ``st_birthtime`` selectively absent, and a filesystem-based test is no
+    substitute: on APFS, backdating a file's mtime with ``os.utime`` also
+    clamps its ``st_birthtime``, so the two agree by accident and the test
+    proves nothing.
+    """
+
+    def __init__(self, *, st_mtime: float, st_birthtime: float | None = None) -> None:
+        """Store the stat fields this fake exposes.
+
+        Args:
+            st_mtime: Modification time, always present.
+            st_birthtime: Creation time; omitted entirely when ``None``, which
+                is the Linux shape.
+        """
+        self.st_mtime = st_mtime
+        self.st_size = 9
+        self.st_mode = 0o100644
+        if st_birthtime is not None:
+            self.st_birthtime = st_birthtime
+
+
+def _id_with_stat(
+    fake: _FakeStat,
+    source: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> str:
+    """Ingest *source* with ``Path.stat`` faked for that one path.
+
+    The ingest chain stats more than once (discovery, read), and it stats
+    other paths too, so the patch delegates to the real ``stat`` for
+    everything except the target file.
+
+    Args:
+        fake: The stat stand-in to return for *source*.
+        source: Relative path whose ``stat()`` is faked.
+        monkeypatch: Pytest fixture used to patch ``Path.stat``.
+
+    Returns:
+        The resulting fragment id.
+    """
+    real_stat = Path.stat
+    target = str(source)
+
+    def _patched(self: Path, **kwargs: Any) -> Any:
+        if str(self) == target:
+            return fake
+        return real_stat(self, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", _patched)
+    parsed = MarkdownIngestor().ingest(source).fragments[0]
+    return assemble_ingested_fragment(parsed).fragment.id
+
+
+def test_markdown_id_ignores_st_birthtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A macOS host and a Linux host mint the SAME id for the same file.
+
+    ``st_birthtime`` exists on macOS/BSD and not on Linux. Reading it through
+    ``getattr(stat, "st_birthtime", stat.st_mtime)`` therefore made a
+    fragment's identity a function of the ingesting machine's operating
+    system, independently of ``TZ`` — an axis the issue never mentioned. The
+    derivation must read ``st_mtime`` unconditionally.
+    """
+    monkeypatch.chdir(tmp_path)
+    source = _write_source("note.md")
+
+    linux_shape = _FakeStat(st_mtime=PINNED_MTIME)
+    macos_shape = _FakeStat(st_mtime=PINNED_MTIME, st_birthtime=PINNED_MTIME - 86400)
+
+    linux_id = _id_with_stat(linux_shape, source, monkeypatch)
+    macos_id = _id_with_stat(macos_shape, source, monkeypatch)
+
+    assert linux_id == macos_id == MARKDOWN_ID

--- a/creek-tools/tests/test_ingest_tz_duplicate_e2e.py
+++ b/creek-tools/tests/test_ingest_tz_duplicate_e2e.py
@@ -1,0 +1,355 @@
+"""Re-ingesting an untouched file from a differently-configured host (#1329).
+
+The unit-level proof that a fragment id is host-dependent lives in
+``tests/test_ingest_id_host_independence.py``. This module proves the
+*consequence* end-to-end through the real shared pipeline: an operator who
+moves a laptop across a timezone — or whose CI runs in UTC while they work in
+Los Angeles — re-ingests the same unmodified files and silently doubles their
+vault.
+
+Three properties are pinned here, and each one is a separate failure mode:
+
+* **Markdown** is ledger-wired, and the ledger still did not save it: the
+  *unchanged* branch of ``write_fragment_idempotent`` wrote the fragment under
+  its freshly-*derived* id rather than the ledger's recorded one.
+* **Documents** are unledgered by default (``ledger_for_source`` returns
+  ``None`` for every source type but ``markdown``), so nothing but a stable
+  derivation stands between them and an unconditional second write.
+* The ledger must be the **authority on identity** even if some future
+  derivation change drifts again — the forcing-function test at the bottom
+  pins that independently of any timezone.
+
+Every case drives the **default, non-incremental** path. ``should_skip_unit``
+returns early for an unchanged ledgered unit under ``--incremental``/``since``,
+so an incremental-mode test would be green while the bug was live.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import TYPE_CHECKING
+
+import frontmatter
+import pytest
+
+from creek.ingest import pipeline as ingest_pipeline
+from creek.ingest.documents import DocumentIngestor
+from creek.ingest.ledger import SourceLedger
+from creek.ingest.markdown import MarkdownIngestor
+from creek.ingest.pipeline import run_ingest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+    from creek.ingest.base import IngestedFragment, ParsedFragment
+    from creek.ingest.pipeline import IngestRunResult
+
+PINNED_MTIME = 1710493200.0
+"""2024-03-15T09:00:00+00:00 — the mtime every source file here is pinned to."""
+
+FIRST_ZONE = "UTC"
+"""The zone the vault is first populated under."""
+
+SECOND_ZONE = "Australia/Sydney"
+"""The zone the *identical, untouched* tree is re-ingested under.
+
+Sydney is +11 from UTC in March, so a naive derivation lands the fragment on a
+different wall-clock hour (and, for other zones in the matrix, a different
+calendar day) — guaranteeing a different hashed timestamp and hence a
+different id.
+"""
+
+_BODY = "An untouched note.\n"
+
+
+@pytest.fixture
+def restore_host_tz() -> Iterator[None]:
+    """Restore the process timezone after a test perturbs ``TZ``.
+
+    ``time.tzset()`` mutates process-global state that ``monkeypatch.setenv``
+    cannot undo on its own.
+
+    Yields:
+        ``None``; restoration happens on teardown.
+    """
+    original = os.environ.get("TZ")
+    try:
+        yield
+    finally:
+        if original is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = original
+        time.tzset()
+
+
+def _make_vault(tmp_path: Path) -> Path:
+    """Scaffold the minimal vault tree :class:`VaultWriter` needs.
+
+    Args:
+        tmp_path: Pytest temp directory.
+
+    Returns:
+        The vault root.
+    """
+    vault = tmp_path / "vault"
+    for directory in ("00-Creek-Meta/Processing-Log", "01-Fragments/Unsorted"):
+        (vault / directory).mkdir(parents=True, exist_ok=True)
+    return vault
+
+
+def _make_source_dir(tmp_path: Path, filename: str) -> Path:
+    """Write a single pinned-mtime source file into a directory outside the vault.
+
+    Args:
+        tmp_path: Pytest temp directory.
+        filename: Name of the single file to create.
+
+    Returns:
+        The containing directory, suitable as ``input_path``.
+    """
+    src = tmp_path / "src"
+    src.mkdir(parents=True, exist_ok=True)
+    note = src / filename
+    note.write_text(_BODY, encoding="utf-8")
+    os.utime(note, (PINNED_MTIME, PINNED_MTIME))
+    return src
+
+
+def _fragment_files(vault: Path) -> list[Path]:
+    """Return every fragment markdown file written under ``01-Fragments``.
+
+    Args:
+        vault: Vault root.
+
+    Returns:
+        Sorted list of fragment file paths.
+    """
+    return sorted((vault / "01-Fragments").rglob("*.md"))
+
+
+def _ingest_under(
+    tz_name: str,
+    *,
+    ingestor_cls: type[MarkdownIngestor] | type[DocumentIngestor],
+    source_type: str,
+    src: Path,
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> IngestRunResult:
+    """Run one full ingest with the host timezone set to *tz_name*.
+
+    Deliberately passes neither ``incremental`` nor ``since``: the default
+    path is the only one that exercises the write.
+
+    Args:
+        tz_name: IANA zone to set as the host ``TZ``.
+        ingestor_cls: Concrete ingestor to drive.
+        source_type: Registry key for the ingestor.
+        src: Input directory.
+        vault: Vault root.
+        monkeypatch: Pytest fixture used to set ``TZ``.
+
+    Returns:
+        The pipeline's structured result.
+    """
+    monkeypatch.setenv("TZ", tz_name)
+    time.tzset()
+    return run_ingest(
+        ingestor_cls=ingestor_cls,
+        source_type=source_type,
+        input_path=src,
+        vault_path=vault,
+    )
+
+
+@pytest.mark.usefixtures("restore_host_tz")
+def test_markdown_reingest_under_a_different_timezone_does_not_duplicate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An untouched markdown tree re-ingested from another zone stays one fragment.
+
+    Pre-fix the second pass took ``write_fragment_idempotent``'s *unchanged*
+    branch — correctly identifying the unit as known and unmodified — and then
+    wrote it anyway under a newly-derived id, leaving two files and one
+    orphan.
+    """
+    vault = _make_vault(tmp_path)
+    src = _make_source_dir(tmp_path, "note.md")
+
+    first = _ingest_under(
+        FIRST_ZONE,
+        ingestor_cls=MarkdownIngestor,
+        source_type="markdown",
+        src=src,
+        vault=vault,
+        monkeypatch=monkeypatch,
+    )
+    assert first.errors == []
+    assert first.created == 1
+    assert len(_fragment_files(vault)) == 1
+    original_id = str(frontmatter.load(str(_fragment_files(vault)[0]))["id"])
+
+    second = _ingest_under(
+        SECOND_ZONE,
+        ingestor_cls=MarkdownIngestor,
+        source_type="markdown",
+        src=src,
+        vault=vault,
+        monkeypatch=monkeypatch,
+    )
+
+    assert second.errors == []
+    assert second.unchanged == 1
+    assert second.created == 0
+    files = _fragment_files(vault)
+    assert len(files) == 1
+    assert str(frontmatter.load(str(files[0]))["id"]) == original_id
+
+    ledger = SourceLedger.load(vault, source="markdown")
+    assert len(ledger.live_keys()) == 1
+
+
+@pytest.mark.usefixtures("restore_host_tz")
+def test_document_reingest_under_a_different_timezone_does_not_duplicate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An untouched document re-ingested from another zone stays one fragment.
+
+    Documents are the harder case: ``ledger_for_source`` returns ``None`` for
+    them, so there is no record to fall back on and no ``origin_key`` to match.
+    The *only* thing holding the vault at one file is the derived id staying
+    stable, which lets the writer's per-directory id index recognise the
+    second write as the same model. This case therefore asserts the file count
+    but deliberately does **not** assert a ledger record.
+    """
+    vault = _make_vault(tmp_path)
+    src = _make_source_dir(tmp_path, "note.txt")
+
+    first = _ingest_under(
+        FIRST_ZONE,
+        ingestor_cls=DocumentIngestor,
+        source_type="documents",
+        src=src,
+        vault=vault,
+        monkeypatch=monkeypatch,
+    )
+    assert first.errors == []
+    assert len(_fragment_files(vault)) == 1
+    original_id = str(frontmatter.load(str(_fragment_files(vault)[0]))["id"])
+
+    second = _ingest_under(
+        SECOND_ZONE,
+        ingestor_cls=DocumentIngestor,
+        source_type="documents",
+        src=src,
+        vault=vault,
+        monkeypatch=monkeypatch,
+    )
+
+    assert second.errors == []
+    files = _fragment_files(vault)
+    assert len(files) == 1
+    assert str(frontmatter.load(str(files[0]))["id"]) == original_id
+
+
+def test_borrowing_a_ledger_for_identity_does_not_arm_the_tomb_sweep(
+    tmp_path: Path,
+) -> None:
+    """``ledger_source`` opts a source into pinned identity, not into tombing.
+
+    ``resolve_ledger`` lets a non-markdown caller borrow a ledger purely to get
+    ledger-backed identity — that is how an uploaded document earns its
+    ``origin_key`` and therefore its RTBF purge coverage. Until the
+    ``TOMBING_SOURCES`` split, that same opt-in also armed
+    ``tomb_missing_units`` for any *directory* input, so one directory ingest
+    under a borrowed ledger would soft-tomb every previously-recorded unit it
+    did not happen to see. Identity and tombing are separate questions and are
+    now gated separately.
+
+    No behaviour changes for markdown, which remains the one tombing source.
+    """
+    vault = _make_vault(tmp_path)
+    src = _make_source_dir(tmp_path, "note.txt")
+
+    first = run_ingest(
+        ingestor_cls=DocumentIngestor,
+        source_type="documents",
+        input_path=src,
+        vault_path=vault,
+        ledger_source="uploads",
+    )
+    assert first.errors == []
+    assert first.created == 1
+
+    # A second directory pass that no longer sees the first unit at all.
+    other = tmp_path / "other"
+    other.mkdir()
+    later = other / "later.txt"
+    later.write_text("A different note.\n", encoding="utf-8")
+    os.utime(later, (PINNED_MTIME, PINNED_MTIME))
+
+    second = run_ingest(
+        ingestor_cls=DocumentIngestor,
+        source_type="documents",
+        input_path=other,
+        vault_path=vault,
+        ledger_source="uploads",
+    )
+
+    assert second.errors == []
+    assert second.tombed == 0
+    assert len(_fragment_files(vault)) == 2
+
+
+def test_unchanged_branch_reuses_the_ledgered_id_not_the_derived_one(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The ledger, not the derivation, is the authority on a known unit's id.
+
+    This is the forcing function, and it is independent of #1329's timezone
+    cause. Even after the derivation is made host-independent, *any* future
+    change to how an id is derived would silently duplicate every ledgered
+    fragment as long as the unchanged branch writes the derived id. Here the
+    derivation is perturbed directly — as a future refactor might perturb it
+    accidentally — and the pipeline must still write under the recorded id.
+    """
+    vault = _make_vault(tmp_path)
+    src = _make_source_dir(tmp_path, "note.md")
+
+    first = run_ingest(
+        ingestor_cls=MarkdownIngestor,
+        source_type="markdown",
+        input_path=src,
+        vault_path=vault,
+    )
+    assert first.created == 1
+    ledgered_id = str(frontmatter.load(str(_fragment_files(vault)[0]))["id"])
+
+    real_assemble = ingest_pipeline.assemble_ingested_fragment
+
+    def _drifted(parsed: ParsedFragment) -> IngestedFragment:
+        """Assemble normally, then perturb the derived id as a drift would."""
+        assembled = real_assemble(parsed)
+        assembled.fragment.id = "frag-ffffffffffff"
+        return assembled
+
+    monkeypatch.setattr(ingest_pipeline, "assemble_ingested_fragment", _drifted)
+
+    second = run_ingest(
+        ingestor_cls=MarkdownIngestor,
+        source_type="markdown",
+        input_path=src,
+        vault_path=vault,
+    )
+
+    assert second.errors == []
+    assert second.unchanged == 1
+    files = _fragment_files(vault)
+    assert len(files) == 1
+    assert str(frontmatter.load(str(files[0]))["id"]) == ledgered_id

--- a/creek-tools/tests/test_pin_source_ids.py
+++ b/creek-tools/tests/test_pin_source_ids.py
@@ -196,13 +196,16 @@ def test_a_bare_reingest_of_an_unpinned_vault_duplicates(tmp_path: Path) -> None
     assert len(_fragment_files(vault)) == 2
 
 
-def test_an_unpinned_vault_is_warned_about_before_it_is_duplicated(
+def test_an_unpinned_vault_advisory_is_recorded_in_the_run_result(
     tmp_path: Path,
 ) -> None:
-    """The operator is told the vault needs migrating, on the run that would hurt.
+    """The advisory reaches the structured result on the run that would hurt.
 
     Derived from the ledger's own emptiness rather than a separate version
-    marker, so there is only one piece of state that can be wrong.
+    marker, so there is only one piece of state that can be wrong. This asserts
+    the *result object* only; whether a human ever sees it is a separate
+    property, covered by
+    :func:`test_cli_ingest_prints_the_unpinned_vault_advisory_before_it_writes`.
     """
     vault = _make_vault(tmp_path)
     source = _make_source(tmp_path)
@@ -713,6 +716,78 @@ def test_cli_pin_source_ids_exits_one_on_a_missing_vault(tmp_path: Path) -> None
     )
 
     assert code == 1
+
+
+def _ingest_via_cli(vault: Path, src_dir: Path) -> tuple[int, str]:
+    """Run a bare ``creek ingest`` the way an operator does, through the CLI.
+
+    Every other un-pinned-vault assertion in this module calls
+    :func:`~creek.ingest.pipeline.run_ingest` directly, which is precisely how
+    the advisory could be produced, stored, and still never reach a human.
+
+    Args:
+        vault: Vault root.
+        src_dir: Directory holding the source files.
+
+    Returns:
+        ``(exit_code, output)`` with ANSI styling removed.
+    """
+    return _run_cli(
+        "ingest",
+        "--type",
+        "markdown",
+        "--input",
+        str(src_dir),
+        "--vault",
+        str(vault),
+        "--yes",
+    )
+
+
+def test_cli_ingest_prints_the_unpinned_vault_advisory_before_it_writes(
+    tmp_path: Path,
+) -> None:
+    """A plain ``creek ingest`` shows the advisory, ahead of its own write pass.
+
+    This is the whole safety mechanism: an advisory the operator never sees is
+    not an advisory. It is asserted on rendered output rather than on
+    ``IngestRunResult.warnings`` because the gap being guarded is exactly the
+    step between the two.
+
+    Ordering is part of the contract, not incidental. The advisory is emitted
+    at detection time — before the first fragment is written — so the operator
+    who is watching can still abort with nothing yet duplicated. Printed after
+    the run it would only ever be an explanation of damage already done.
+
+    The remedy command is asserted whole: it is meant to be copy-pasted, and a
+    line-wrap through the middle of it is a broken instruction.
+    """
+    vault = _make_vault(tmp_path)
+    source = _make_source(tmp_path)
+    _seed_pre_fix_fragment(vault, source)
+
+    code, output = _ingest_via_cli(vault, source.parent)
+
+    assert code == 0, output
+    assert "creek ingest --pin-source-ids --vault <vault>" in output
+    assert output.index("--pin-source-ids") < output.index("Ingest summary:")
+
+
+def test_cli_ingest_stays_quiet_about_a_pinned_vault(tmp_path: Path) -> None:
+    """A migrated vault gets no advisory, so the warning keeps its meaning.
+
+    Without this, printing the advisory unconditionally would pass the
+    companion test while training the operator to ignore it.
+    """
+    vault = _make_vault(tmp_path)
+    source = _make_source(tmp_path)
+    _seed_pre_fix_fragment(vault, source)
+    pin_source_ids(vault)
+
+    code, output = _ingest_via_cli(vault, source.parent)
+
+    assert code == 0, output
+    assert "--pin-source-ids" not in output
 
 
 def test_the_reproduction_diagnostic_counts_a_reproducing_fragment(

--- a/creek-tools/tests/test_pin_source_ids.py
+++ b/creek-tools/tests/test_pin_source_ids.py
@@ -1,0 +1,752 @@
+"""The #1329 pin migration: existing ids must survive the derivation change.
+
+``creek/ingest/pin_ids.py`` back-fills the markdown ingest ledger with each
+existing fragment's **existing** id, so the corrected (host-independent)
+derivation never moves an id that is already on disk.
+
+The load-bearing test in this module is
+:func:`test_a_bare_reingest_of_an_unpinned_vault_duplicates` — it demonstrates
+the failure the migration prevents. Without it, every other assertion here
+could hold while the migration was doing nothing useful, and a reader would
+have no way to tell.
+
+Vaults are seeded the way a real pre-fix vault looks: fragments written through
+the real :class:`~creek.vault.writer.VaultWriter` under ids minted by the
+**old naive derivation**, ``source.original_file`` populated,
+``source.origin_key`` absent, and an empty ledger.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import frontmatter
+import pytest
+from typer.testing import CliRunner
+
+from creek.cli import app
+from creek.ingest import pin_ids
+from creek.ingest.base import generate_fragment_id
+from creek.ingest.ledger import SourceLedger
+from creek.ingest.markdown import MarkdownIngestor
+from creek.ingest.pin_ids import pin_source_ids
+from creek.ingest.pipeline import (
+    IngestRunResult,
+    run_ingest,
+    unpinned_vault_warning,
+)
+from creek.models import Fragment, FragmentSource, SourcePlatform
+from creek.vault.writer import VaultWriter
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+PINNED_MTIME = 1710493200.0
+"""2024-03-15T09:00:00+00:00."""
+
+_BODY = "An untouched note.\n"
+
+_PRE_FIX_ID = "frag-0ldc0ffee123"
+"""A stand-in for an id minted by the pre-fix derivation.
+
+Its exact value does not matter and it deliberately is **not** reproducible
+from the fragment's contents: the whole point of pinning is that the migration
+records the id it *finds*, never one it recomputes. A literal that happened to
+reproduce would let a broken implementation pass.
+"""
+
+
+def _make_vault(tmp_path: Path) -> Path:
+    """Scaffold the minimal vault tree the writer needs.
+
+    Args:
+        tmp_path: Pytest temp directory.
+
+    Returns:
+        The vault root.
+    """
+    vault = tmp_path / "vault"
+    for directory in ("00-Creek-Meta/Processing-Log", "01-Fragments/Unsorted"):
+        (vault / directory).mkdir(parents=True, exist_ok=True)
+    return vault
+
+
+def _make_source(tmp_path: Path, name: str = "note.md", body: str = _BODY) -> Path:
+    """Write a pinned-mtime markdown source file outside the vault.
+
+    Args:
+        tmp_path: Pytest temp directory.
+        name: Filename to create.
+        body: File contents.
+
+    Returns:
+        The source file path.
+    """
+    src = tmp_path / "src"
+    src.mkdir(parents=True, exist_ok=True)
+    note = src / name
+    note.write_text(body, encoding="utf-8")
+    os.utime(note, (PINNED_MTIME, PINNED_MTIME))
+    return note
+
+
+def _seed_pre_fix_fragment(
+    vault: Path,
+    source: Path,
+    *,
+    fragment_id: str = _PRE_FIX_ID,
+    body: str = _BODY,
+) -> Path:
+    """Write one fragment as a pre-fix vault would hold it.
+
+    ``source.origin_key`` is deliberately left unset — that is the state the
+    migration has to repair, and the state
+    :meth:`~creek.vault.writer.VaultWriter.update_fragment` can never repair
+    on its own because it preserves on-disk frontmatter rather than merging
+    fresh ``source`` fields into it.
+
+    Args:
+        vault: Vault root.
+        source: The markdown source this fragment came from.
+        fragment_id: The id to write, standing in for a pre-fix derivation.
+        body: The stored fragment body.
+
+    Returns:
+        The written fragment's path.
+    """
+    fragment = Fragment(
+        id=fragment_id,
+        title=source.stem,
+        created=datetime(2024, 3, 14, 19, 0, tzinfo=UTC),
+        source=FragmentSource(
+            platform=SourcePlatform.MARKDOWN,
+            original_file=str(source),
+        ),
+    )
+    return VaultWriter(vault_path=vault).write_fragment(fragment, body=body)
+
+
+def _fragment_files(vault: Path) -> list[Path]:
+    """Return every fragment markdown file under ``01-Fragments``.
+
+    Args:
+        vault: Vault root.
+
+    Returns:
+        Sorted fragment paths.
+    """
+    return sorted((vault / "01-Fragments").rglob("*.md"))
+
+
+def _origin_key(md_file: Path) -> str | None:
+    """Read ``source.origin_key`` straight off disk, as the purge sweep does.
+
+    Args:
+        md_file: The fragment file.
+
+    Returns:
+        The recorded origin key, or ``None`` when absent.
+    """
+    source = frontmatter.load(str(md_file)).metadata.get("source")
+    if not isinstance(source, dict):
+        return None
+    value = source.get("origin_key")
+    return str(value) if value is not None else None
+
+
+def _reingest(vault: Path, src_dir: Path) -> IngestRunResult:
+    """Run a bare, non-incremental markdown ingest over *src_dir*.
+
+    Args:
+        vault: Vault root.
+        src_dir: Directory holding the source files.
+
+    Returns:
+        The pipeline's structured result.
+    """
+    return run_ingest(
+        ingestor_cls=MarkdownIngestor,
+        source_type="markdown",
+        input_path=src_dir,
+        vault_path=vault,
+    )
+
+
+# ---- (a) the failure being prevented ----
+
+
+def test_a_bare_reingest_of_an_unpinned_vault_duplicates(tmp_path: Path) -> None:
+    """Without the migration, re-ingesting a pre-fix vault orphans its fragment.
+
+    This is what makes the migration load-bearing rather than ceremonial: the
+    corrected derivation mints an id the vault has never seen, the empty
+    ledger offers nothing to match on, and the pre-fix fragment is left behind.
+    """
+    vault = _make_vault(tmp_path)
+    source = _make_source(tmp_path)
+    _seed_pre_fix_fragment(vault, source)
+    assert len(_fragment_files(vault)) == 1
+
+    result = _reingest(vault, source.parent)
+
+    assert result.created == 1
+    assert len(_fragment_files(vault)) == 2
+
+
+def test_an_unpinned_vault_is_warned_about_before_it_is_duplicated(
+    tmp_path: Path,
+) -> None:
+    """The operator is told the vault needs migrating, on the run that would hurt.
+
+    Derived from the ledger's own emptiness rather than a separate version
+    marker, so there is only one piece of state that can be wrong.
+    """
+    vault = _make_vault(tmp_path)
+    source = _make_source(tmp_path)
+    _seed_pre_fix_fragment(vault, source)
+
+    result = _reingest(vault, source.parent)
+
+    assert any("--pin-source-ids" in warning for warning in result.warnings)
+
+
+def test_a_fresh_vault_is_not_warned_about(tmp_path: Path) -> None:
+    """An empty vault has nothing to strand, so the advisory stays quiet."""
+    vault = _make_vault(tmp_path)
+    ledger = SourceLedger.load(vault, source="markdown")
+
+    assert unpinned_vault_warning(ledger, vault) is None
+
+
+def test_a_pinned_vault_is_not_warned_about(tmp_path: Path) -> None:
+    """Once the ledger has records the advisory stops firing."""
+    vault = _make_vault(tmp_path)
+    source = _make_source(tmp_path)
+    _seed_pre_fix_fragment(vault, source)
+    pin_source_ids(vault)
+
+    ledger = SourceLedger.load(vault, source="markdown")
+    assert unpinned_vault_warning(ledger, vault) is None
+
+
+# ---- (b) + (c) the migration's core promise ----
+
+
+def test_pinning_makes_the_next_reingest_a_no_op_under_the_original_id(
+    tmp_path: Path,
+) -> None:
+    """After the migration the same re-ingest reports ``unchanged`` and moves nothing.
+
+    The id assertion is the point. A migration that merely stopped the
+    duplicate by re-minting would satisfy the file count and still break every
+    resonance edge, embedding-cache row and child id that references the old
+    value.
+    """
+    vault = _make_vault(tmp_path)
+    source = _make_source(tmp_path)
+    _seed_pre_fix_fragment(vault, source)
+
+    result = pin_source_ids(vault)
+    assert result.pinned == 1
+    assert result.conflicts == []
+    assert result.unpinnable == []
+
+    reingested = _reingest(vault, source.parent)
+
+    assert reingested.unchanged == 1
+    assert reingested.created == 0
+    files = _fragment_files(vault)
+    assert len(files) == 1
+    assert str(frontmatter.load(str(files[0]))["id"]) == _PRE_FIX_ID
+
+
+def test_pinning_changes_nothing_but_the_origin_key(tmp_path: Path) -> None:
+    """``id``, ``created``, the body and the filename are all preserved exactly.
+
+    Pinning is not a rewrite. ``created`` in particular feeds the fragment's
+    filename through the writer's date prefix, so moving it would rename files
+    — the migration must not.
+    """
+    vault = _make_vault(tmp_path)
+    source = _make_source(tmp_path)
+    md_file = _seed_pre_fix_fragment(vault, source)
+
+    before = frontmatter.load(str(md_file))
+    assert _origin_key(md_file) is None
+
+    pin_source_ids(vault)
+
+    after_files = _fragment_files(vault)
+    assert after_files == [md_file]
+    after = frontmatter.load(str(md_file))
+
+    # Whole-frontmatter equality, not a handful of spot checks: the claim is
+    # that *nothing* moves except one nested key, so the test states exactly
+    # that and would catch a field the round-trip silently dropped or coerced.
+    expected_source = dict(before.metadata["source"])
+    expected_source["origin_key"] = _origin_key(md_file)
+    assert after.metadata == {**before.metadata, "source": expected_source}
+    assert after.content == before.content
+
+
+# ---- (d) the RTBF criterion ----
+
+
+def test_pinning_stamps_the_origin_key_the_purge_sweep_keys_on(
+    tmp_path: Path,
+) -> None:
+    """A pinned fragment gains ``source.origin_key`` in its on-disk frontmatter.
+
+    The RTBF purge sweep resolves its target by reading that field off disk and
+    skips any fragment without it, and ``update_fragment`` preserves on-disk
+    frontmatter rather than merging fresh ``source`` fields — so a fragment
+    that lacks the key at migration time would never gain one on any later
+    ingest. Omitting this stamp would permanently strand purge coverage for
+    exactly the population the migration protects.
+    """
+    vault = _make_vault(tmp_path)
+    source = _make_source(tmp_path)
+    md_file = _seed_pre_fix_fragment(vault, source)
+
+    pin_source_ids(vault)
+
+    stamped = _origin_key(md_file)
+    assert stamped is not None
+    ledger = SourceLedger.load(vault, source="markdown")
+    record = ledger.get(stamped)
+    assert record is not None
+    assert record.fragment_id == _PRE_FIX_ID
+
+
+# ---- (e) + (f) dry-run and idempotency ----
+
+
+def test_dry_run_reports_the_plan_and_writes_nothing(tmp_path: Path) -> None:
+    """``--dry-run`` is a preview: no ledger append, no frontmatter stamp."""
+    vault = _make_vault(tmp_path)
+    source = _make_source(tmp_path)
+    md_file = _seed_pre_fix_fragment(vault, source)
+    before = md_file.read_bytes()
+
+    result = pin_source_ids(vault, dry_run=True)
+
+    assert result.pinned == 1
+    assert md_file.read_bytes() == before
+    assert _origin_key(md_file) is None
+    assert len(SourceLedger.load(vault, source="markdown")) == 0
+
+
+def test_an_interrupted_run_is_repaired_by_the_next_one(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A half-pinned fragment gets its missing ``origin_key`` on the retry.
+
+    Pinning is two durable writes — a ledger record and a frontmatter stamp —
+    and they cannot be atomic with respect to each other. A failure between
+    them (a disk-full or permission ``OSError`` partway through an
+    N-fragment pass is far likelier than a ``kill -9``) leaves the record
+    present and the stamp missing.
+
+    Without the repair path that state is **permanent and silent**: the retry
+    sees the key in the ledger, reports the fragment as already pinned, and
+    never stamps it — so the RTBF purge sweep, which resolves its target from
+    on-disk frontmatter and skips fragments lacking the key, can never see
+    that fragment again. ``update_fragment`` does not merge fresh ``source``
+    fields either, so no later ingest repairs it.
+
+    The failure is injected on the *second* of three fragments so the test
+    also pins that the pass is resumable in the middle, not just at its edges.
+    """
+    vault = _make_vault(tmp_path)
+    fragments = []
+    for index in range(3):
+        source = _make_source(tmp_path, name=f"n{index}.md", body=f"Body {index}.\n")
+        fragments.append(
+            _seed_pre_fix_fragment(
+                vault,
+                source,
+                fragment_id=f"frag-00000000000{index}",
+                body=f"Body {index}.",
+            )
+        )
+
+    real_stamp = pin_ids._stamp_origin_key
+    calls = {"n": 0}
+
+    def flaky_stamp(md_file: Path, source_key: str) -> None:
+        """Fail on the second stamp, as a full disk would."""
+        calls["n"] += 1
+        if calls["n"] == 2:
+            msg = "simulated disk full"
+            raise OSError(msg)
+        real_stamp(md_file, source_key)
+
+    monkeypatch.setattr(pin_ids, "_stamp_origin_key", flaky_stamp)
+    with pytest.raises(OSError, match="simulated disk full"):
+        pin_source_ids(vault)
+    monkeypatch.undo()
+
+    # The failure aborted the pass, so the vault now holds three distinct
+    # states: fragment 0 fully pinned, fragment 1 HALF-pinned (record written,
+    # stamp lost — the dangerous one), fragment 2 never reached at all.
+    ledger_after_tear = SourceLedger.load(vault, source="markdown")
+    assert _origin_key(fragments[0]) is not None
+    assert _origin_key(fragments[1]) is None
+    assert len(ledger_after_tear) == 2, "fragment 1's record must have landed"
+
+    result = pin_source_ids(vault)
+
+    # Exactly one fragment was half-pinned and therefore repaired; the
+    # untouched third is a normal fresh pin, not a repair.
+    assert result.repaired == 1
+    assert result.pinned == 1
+    assert result.already_pinned == 2
+    assert all(_origin_key(path) is not None for path in fragments)
+    # And the repair is not a re-pin: no id moved and no record was replaced.
+    ledger = SourceLedger.load(vault, source="markdown")
+    for index, path in enumerate(fragments):
+        assert str(frontmatter.load(str(path))["id"]) == f"frag-00000000000{index}"
+    assert len(ledger) == len(fragments)
+
+
+def test_a_repaired_run_reports_zero_repairs_the_third_time(
+    tmp_path: Path,
+) -> None:
+    """Once repaired, the fragment stops being reported — the repair converges."""
+    vault = _make_vault(tmp_path)
+    source = _make_source(tmp_path)
+    _seed_pre_fix_fragment(vault, source)
+    pin_source_ids(vault)
+
+    result = pin_source_ids(vault)
+
+    assert result.repaired == 0
+    assert result.already_pinned == 1
+
+
+def test_a_second_run_pins_nothing(tmp_path: Path) -> None:
+    """The migration is idempotent, so running it twice is safe."""
+    vault = _make_vault(tmp_path)
+    source = _make_source(tmp_path)
+    _seed_pre_fix_fragment(vault, source)
+
+    first = pin_source_ids(vault)
+    second = pin_source_ids(vault)
+
+    assert first.pinned == 1
+    assert second.pinned == 0
+    assert second.already_pinned == 1
+
+
+# ---- (g) an already-duplicated vault ----
+
+
+def test_a_contested_source_key_pins_neither_fragment(tmp_path: Path) -> None:
+    """Two fragments claiming one source are reported, not silently arbitrated.
+
+    This is the vault that already got duplicated — by a timezone change, or a
+    laptop move — before the operator upgraded. The ledger holds one record per
+    key, so blessing one fragment would orphan the other forever. Refusing, and
+    naming both paths, is the only honest answer.
+    """
+    vault = _make_vault(tmp_path)
+    source = _make_source(tmp_path)
+    _seed_pre_fix_fragment(vault, source, fragment_id="frag-aaaaaaaaaaaa")
+    _seed_pre_fix_fragment(vault, source, fragment_id="frag-bbbbbbbbbbbb")
+    assert len(_fragment_files(vault)) == 2
+
+    result = pin_source_ids(vault)
+
+    assert result.pinned == 0
+    assert len(result.conflicts) == 1
+    assert "frag-aaaaaaaaaaaa" not in str(
+        SourceLedger.load(vault, source="markdown").live_keys()
+    )
+    assert len(SourceLedger.load(vault, source="markdown")) == 0
+    assert len(_fragment_files(vault)) == 2
+
+
+# ---- (h) the stored-body hash correction ----
+
+
+def test_a_source_edited_after_ingest_reports_updated_not_unchanged(
+    tmp_path: Path,
+) -> None:
+    """The backfill hashes the STORED BODY, so a post-ingest edit still applies.
+
+    If the migration recorded the hash of the *current source file* instead,
+    it would file the new hash against the old stored body. The next ingest
+    would compute that same hash, take the unchanged branch, and the operator's
+    edit would be swallowed permanently — nothing ever revisits an unchanged
+    unit. Hashing the stored body makes the run correctly report ``updated``
+    and apply the edit in place, under the pinned id.
+    """
+    vault = _make_vault(tmp_path)
+    source = _make_source(tmp_path)
+    _seed_pre_fix_fragment(vault, source)
+
+    pin_source_ids(vault)
+
+    edited = "An untouched note.\n\nA sentence added after ingest.\n"
+    source.write_text(edited, encoding="utf-8")
+    os.utime(source, (PINNED_MTIME, PINNED_MTIME))
+
+    result = _reingest(vault, source.parent)
+
+    assert result.updated == 1
+    assert result.created == 0
+    files = _fragment_files(vault)
+    assert len(files) == 1
+    written = frontmatter.load(str(files[0]))
+    assert str(written["id"]) == _PRE_FIX_ID
+    assert "added after ingest" in written.content
+
+
+def test_an_edit_made_before_the_migration_is_not_swallowed(tmp_path: Path) -> None:
+    """A source edited *between* its ingest and the migration still applies later.
+
+    This is the precise hazard the stored-body hash exists for, and it is a
+    different scenario from an edit made *after* pinning. Here the vault holds
+    the old body while the source on disk already holds the new one. A
+    migration that hashed the **current source** would file the new hash
+    against the old stored body; the next ``creek ingest`` would compute that
+    same hash, take the unchanged branch, and the operator's edit would be
+    lost permanently — nothing ever revisits an unchanged unit.
+
+    Hashing the stored body records what the vault actually contains, so the
+    divergence is still visible and the next run reports ``updated``.
+    """
+    vault = _make_vault(tmp_path)
+    source = _make_source(tmp_path)
+    _seed_pre_fix_fragment(vault, source)
+
+    # The edit lands BEFORE the migration runs. Written with no trailing
+    # newline on purpose: ``frontmatter`` strips one on the way in, so a file
+    # that ends in "\n" would hash differently from its own parsed content and
+    # a source-hashing implementation would look correct here by accident.
+    edited = "An untouched note.\n\nEdited before the migration ran."
+    source.write_text(edited, encoding="utf-8")
+    os.utime(source, (PINNED_MTIME, PINNED_MTIME))
+
+    assert pin_source_ids(vault).pinned == 1
+
+    result = _reingest(vault, source.parent)
+
+    assert result.updated == 1
+    assert result.unchanged == 0
+    assert result.created == 0
+    files = _fragment_files(vault)
+    assert len(files) == 1
+    written = frontmatter.load(str(files[0]))
+    assert str(written["id"]) == _PRE_FIX_ID
+    assert "Edited before the migration ran." in written.content
+
+
+# ---- (i) sources that cannot be pinned ----
+
+
+@pytest.mark.parametrize(
+    ("original_file", "fragment_marker"),
+    [
+        pytest.param("", "no-source", id="no-original-file"),
+        pytest.param("/nowhere/gone.md", "vanished", id="source-deleted"),
+    ],
+)
+def test_an_unresolvable_source_is_reported_and_not_pinned(
+    tmp_path: Path,
+    original_file: str,
+    fragment_marker: str,
+) -> None:
+    """A fragment with no live markdown source is counted and named, not guessed at.
+
+    Pinning a vanished source would file a record no future run can match and,
+    worse, could shadow a different file that later takes that path.
+
+    Args:
+        tmp_path: Pytest temp directory.
+        original_file: The ``source.original_file`` to seed.
+        fragment_marker: Distinguishes the parametrised fragment titles.
+    """
+    vault = _make_vault(tmp_path)
+    fragment = Fragment(
+        id=f"frag-{fragment_marker[:4]}00000000",
+        title=fragment_marker,
+        created=datetime(2024, 3, 14, 19, 0, tzinfo=UTC),
+        source=FragmentSource(
+            platform=SourcePlatform.MARKDOWN,
+            original_file=original_file or None,
+        ),
+    )
+    md_file = VaultWriter(vault_path=vault).write_fragment(fragment, body=_BODY)
+
+    result = pin_source_ids(vault)
+
+    assert result.pinned == 0
+    assert len(result.unpinnable) == 1
+    assert str(md_file) in result.unpinnable[0]
+    assert len(SourceLedger.load(vault, source="markdown")) == 0
+    assert _origin_key(md_file) is None
+
+
+def test_a_non_markdown_source_is_left_to_its_own_ingestor(tmp_path: Path) -> None:
+    """A ``.pdf``-sourced fragment does not belong in the markdown ledger."""
+    vault = _make_vault(tmp_path)
+    pdf = tmp_path / "src" / "report.pdf"
+    pdf.parent.mkdir(parents=True, exist_ok=True)
+    pdf.write_bytes(b"%PDF-1.4\n")
+    fragment = Fragment(
+        id="frag-cccccccccccc",
+        title="report",
+        created=datetime(2024, 3, 14, 19, 0, tzinfo=UTC),
+        source=FragmentSource(
+            platform=SourcePlatform.DOCUMENT,
+            original_file=str(pdf),
+        ),
+    )
+    VaultWriter(vault_path=vault).write_fragment(fragment, body=_BODY)
+
+    result = pin_source_ids(vault)
+
+    assert result.pinned == 0
+    assert len(result.unpinnable) == 1
+    assert ".md" in result.unpinnable[0]
+
+
+# ---- CLI surface ----
+
+
+def _run_cli(*argv: str) -> tuple[int, str]:
+    """Invoke the ``creek`` CLI and return its exit code and plain-text output.
+
+    SGR escapes are stripped so substring assertions are not defeated by
+    rich's colouring if a future console gains a forced-colour mode.
+
+    Args:
+        *argv: Command-line arguments.
+
+    Returns:
+        ``(exit_code, output)`` with ANSI styling removed from *output*.
+    """
+    result = CliRunner().invoke(app, list(argv))
+    return result.exit_code, re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+
+
+def test_cli_pin_source_ids_runs_the_migration(tmp_path: Path) -> None:
+    """``creek ingest --pin-source-ids`` pins the vault and reports what it did."""
+    vault = _make_vault(tmp_path)
+    source = _make_source(tmp_path)
+    md_file = _seed_pre_fix_fragment(vault, source)
+
+    code, output = _run_cli("ingest", "--pin-source-ids", "--vault", str(vault))
+
+    assert code == 0, output
+    assert "Pinned 1" in output
+    assert _origin_key(md_file) is not None
+    assert len(SourceLedger.load(vault, source="markdown")) == 1
+
+
+def test_cli_pin_source_ids_dry_run_writes_nothing(tmp_path: Path) -> None:
+    """``--dry-run`` says so on screen and leaves the vault untouched."""
+    vault = _make_vault(tmp_path)
+    source = _make_source(tmp_path)
+    md_file = _seed_pre_fix_fragment(vault, source)
+    before = md_file.read_bytes()
+
+    code, output = _run_cli(
+        "ingest", "--pin-source-ids", "--dry-run", "--vault", str(vault)
+    )
+
+    assert code == 0, output
+    assert "Would pin 1" in output
+    assert "nothing was written" in output
+    assert md_file.read_bytes() == before
+    assert len(SourceLedger.load(vault, source="markdown")) == 0
+
+
+def test_cli_pin_source_ids_prints_every_action_item_in_full(
+    tmp_path: Path,
+) -> None:
+    """Conflicts and unpinnable fragments are listed, never reduced to a count.
+
+    These lines are the operator's to-do list — a summary count would tell
+    them something is wrong without telling them which fragment.
+    """
+    vault = _make_vault(tmp_path)
+    source = _make_source(tmp_path)
+    _seed_pre_fix_fragment(vault, source, fragment_id="frag-aaaaaaaaaaaa")
+    _seed_pre_fix_fragment(vault, source, fragment_id="frag-bbbbbbbbbbbb")
+
+    code, output = _run_cli("ingest", "--pin-source-ids", "--vault", str(vault))
+
+    assert code == 0, output
+    assert "Conflicts" in output
+    assert "claimed by 2 fragments" in output
+
+
+def test_cli_dry_run_is_refused_rather_than_ignored_by_other_migrations(
+    tmp_path: Path,
+) -> None:
+    """``--dry-run --refresh-dates`` is rejected, not silently run for real.
+
+    ``--dry-run`` is new to ``creek ingest`` and is scoped to
+    ``--pin-source-ids``. Quietly running a *different* migration for real
+    while the operator believes they asked for a preview is the worst
+    available reading of the flag, so the combination is refused.
+    """
+    vault = _make_vault(tmp_path)
+
+    code, _output = _run_cli(
+        "ingest", "--dry-run", "--refresh-dates", "--vault", str(vault)
+    )
+
+    assert code != 0
+
+
+def test_cli_pin_source_ids_exits_one_on_a_missing_vault(tmp_path: Path) -> None:
+    """A vault path that does not exist is an error, not a silent no-op."""
+    code, _output = _run_cli(
+        "ingest", "--pin-source-ids", "--vault", str(tmp_path / "absent")
+    )
+
+    assert code == 1
+
+
+def test_the_reproduction_diagnostic_counts_a_reproducing_fragment(
+    tmp_path: Path,
+) -> None:
+    """A fragment that re-derives its own id is counted, and pinned regardless.
+
+    The diagnostic is advisory. It is reported so an operator can see how much
+    of the vault independently corroborates its own pinning, and it gates
+    nothing — a migration conditioned on reproduction would skip exactly the
+    fragments most at risk.
+    """
+    vault = _make_vault(tmp_path)
+    source = _make_source(tmp_path)
+    created = datetime(2024, 3, 15, 9, 0, tzinfo=UTC)
+    # The body the diagnostic re-hashes is the one the vault *stores*, and
+    # ``frontmatter`` strips the trailing newline on the round-trip. Hashing
+    # the pre-write string would silently never reproduce, which is exactly
+    # the accident this test exists to rule out.
+    stored_body = _BODY.rstrip("\n")
+    reproducing_id = generate_fragment_id(str(source), created, stored_body)
+    fragment = Fragment(
+        id=reproducing_id,
+        title=source.stem,
+        created=created,
+        source=FragmentSource(
+            platform=SourcePlatform.MARKDOWN,
+            original_file=str(source),
+        ),
+    )
+    VaultWriter(vault_path=vault).write_fragment(fragment, body=stored_body)
+
+    result = pin_source_ids(vault)
+
+    assert result.reproduced == 1
+    assert result.pinned == 1
+    assert result.examined == 1

--- a/creek-tools/tests/test_pin_source_ids.py
+++ b/creek-tools/tests/test_pin_source_ids.py
@@ -723,6 +723,179 @@ def test_a_non_markdown_source_is_left_to_its_own_ingestor(tmp_path: Path) -> No
     assert ".md" in result.unpinnable[0]
 
 
+# ---- (j) a relatively-pathed source, migrated from a different directory ----
+#
+# ``source.original_file`` is stored verbatim as whatever path the ingest run
+# was handed (``MarkdownIngestor.parse`` records ``str(raw.path)`` and the CLI
+# does not resolve ``--source``), so an operator who ran ``creek ingest
+# --source 00-Inbox`` from the vault root has a vault full of *relative*
+# recorded paths. The one-time migration is a separate invocation and there is
+# nothing to make an operator run it from the same directory.
+
+
+def _make_in_vault_source(vault: Path, relpath: str = "00-Inbox/note.md") -> Path:
+    """Write a pinned-mtime markdown source *inside* the vault.
+
+    The in-vault case is what a relatively-pathed record is normally about:
+    journals kept in the vault and ingested from the vault root.
+
+    Args:
+        vault: Vault root.
+        relpath: Vault-relative location for the source file.
+
+    Returns:
+        The absolute path to the created source file.
+    """
+    src = vault / relpath
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.write_text(_BODY, encoding="utf-8")
+    os.utime(src, (PINNED_MTIME, PINNED_MTIME))
+    return src
+
+
+def test_a_relatively_pathed_source_is_pinned_from_any_working_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A live fragment is protected even when the migration runs from elsewhere.
+
+    Resolving the recorded path against the *current* directory rather than
+    against the vault it was recorded relative to made this fragment look
+    deleted, so the migration skipped it — leaving the one population the
+    migration exists to protect exposed to the re-minting duplication. The
+    report line said so, but an operator who runs a one-shot migration, sees a
+    few sources called unpinnable and moves on has not been protected.
+
+    Args:
+        tmp_path: Pytest temp directory.
+        monkeypatch: Used to run the migration from an unrelated directory.
+    """
+    vault = _make_vault(tmp_path)
+    source = _make_in_vault_source(vault)
+    md_file = _seed_pre_fix_fragment(vault, source.relative_to(vault))
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    result = pin_source_ids(vault)
+
+    assert result.unpinnable == []
+    assert result.pinned == 1
+    assert _origin_key(md_file) == "00-Inbox/note.md"
+
+    # The outcome that matters: the pin actually holds against the re-ingest.
+    reingested = _reingest(vault, source.parent)
+
+    assert reingested.unchanged == 1
+    assert reingested.created == 0
+    files = _fragment_files(vault)
+    assert len(files) == 1
+    assert str(frontmatter.load(str(files[0]))["id"]) == _PRE_FIX_ID
+
+
+def test_a_relatively_pathed_source_pins_the_same_key_from_either_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The recorded ``source_key`` does not depend on where the migration ran.
+
+    Two identical vaults, two different working directories, one key. A key
+    that varied with the operator's shell would file the pin under a name the
+    next ingest does not look up, which re-mints just as surely as skipping the
+    fragment does.
+
+    Args:
+        tmp_path: Pytest temp directory.
+        monkeypatch: Used to switch working directory between the two runs.
+    """
+    keys: list[str | None] = []
+    for index, cwd_name in enumerate(("inside", "elsewhere")):
+        vault = _make_vault(tmp_path / f"case{index}")
+        source = _make_in_vault_source(vault)
+        md_file = _seed_pre_fix_fragment(vault, source.relative_to(vault))
+        cwd = vault if cwd_name == "inside" else tmp_path / f"case{index}-cwd"
+        cwd.mkdir(parents=True, exist_ok=True)
+        monkeypatch.chdir(cwd)
+
+        assert pin_source_ids(vault).pinned == 1
+        keys.append(_origin_key(md_file))
+
+    assert keys == ["00-Inbox/note.md", "00-Inbox/note.md"]
+
+
+def test_a_relative_source_resolving_where_it_stands_still_wins(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The vault is the fallback anchor, not the preferred one.
+
+    A migration run from the original ingest's own directory must key exactly
+    as it did before this anchoring existed, or the fix would quietly re-point
+    already-correct records at a same-named file that happens to sit in the
+    vault. Here the recorded path resolves *both* ways: the real source is
+    outside the vault under the working directory, and a decoy of the same
+    vault-relative name sits inside. The working directory wins, so the key is
+    the outside-the-vault bare-name form.
+
+    Args:
+        tmp_path: Pytest temp directory.
+        monkeypatch: Used to run the migration from the ingest's directory.
+    """
+    vault = _make_vault(tmp_path)
+    _make_in_vault_source(vault)  # the decoy, same vault-relative name
+    work = tmp_path / "work"
+    real = work / "00-Inbox" / "note.md"
+    real.parent.mkdir(parents=True, exist_ok=True)
+    real.write_text(_BODY, encoding="utf-8")
+    md_file = _seed_pre_fix_fragment(vault, real.relative_to(work))
+    monkeypatch.chdir(work)
+
+    result = pin_source_ids(vault)
+
+    assert result.pinned == 1
+    assert _origin_key(md_file) == "note.md"
+
+
+def test_a_relative_source_that_exists_nowhere_is_still_unpinnable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Anchoring to the vault widens what resolves — it does not pin blindly.
+
+    The refusal in :func:`~creek.ingest.pin_ids._unpinnable_reason` is a real
+    safety property: a record filed against a path holding no file can shadow a
+    different file that later takes that path. A relative path that names
+    nothing under the vault *or* the working directory is still a vanished
+    source.
+
+    Args:
+        tmp_path: Pytest temp directory.
+        monkeypatch: Used to run the migration from an unrelated directory.
+    """
+    vault = _make_vault(tmp_path)
+    fragment = Fragment(
+        id="frag-deadbeef0000",
+        title="ghost",
+        created=datetime(2024, 3, 14, 19, 0, tzinfo=UTC),
+        source=FragmentSource(
+            platform=SourcePlatform.MARKDOWN,
+            original_file="00-Inbox/never-existed.md",
+        ),
+    )
+    md_file = VaultWriter(vault_path=vault).write_fragment(fragment, body=_BODY)
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    result = pin_source_ids(vault)
+
+    assert result.pinned == 0
+    assert len(result.unpinnable) == 1
+    assert str(md_file) in result.unpinnable[0]
+    assert len(SourceLedger.load(vault, source="markdown")) == 0
+    assert _origin_key(md_file) is None
+
+
 # ---- CLI surface ----
 
 

--- a/creek-tools/tests/test_pin_source_ids.py
+++ b/creek-tools/tests/test_pin_source_ids.py
@@ -30,6 +30,7 @@ from typer.testing import CliRunner
 from creek.cli import app
 from creek.ingest import pin_ids
 from creek.ingest.base import generate_fragment_id
+from creek.ingest.journal_staging import UPLOAD_LEDGER_SOURCE
 from creek.ingest.ledger import SourceLedger
 from creek.ingest.markdown import MarkdownIngestor
 from creek.ingest.pin_ids import pin_source_ids
@@ -219,9 +220,8 @@ def test_an_unpinned_vault_advisory_is_recorded_in_the_run_result(
 def test_a_fresh_vault_is_not_warned_about(tmp_path: Path) -> None:
     """An empty vault has nothing to strand, so the advisory stays quiet."""
     vault = _make_vault(tmp_path)
-    ledger = SourceLedger.load(vault, source="markdown")
 
-    assert unpinned_vault_warning(ledger, vault) is None
+    assert unpinned_vault_warning("markdown", vault) is None
 
 
 def test_a_pinned_vault_is_not_warned_about(tmp_path: Path) -> None:
@@ -231,8 +231,112 @@ def test_a_pinned_vault_is_not_warned_about(tmp_path: Path) -> None:
     _seed_pre_fix_fragment(vault, source)
     pin_source_ids(vault)
 
-    ledger = SourceLedger.load(vault, source="markdown")
-    assert unpinned_vault_warning(ledger, vault) is None
+    assert unpinned_vault_warning("markdown", vault) is None
+
+
+# ---- (a2) the advisory's subject is the markdown ledger, always ----
+
+
+def _upload_style_ingest(vault: Path, staged: Path) -> list[str]:
+    """Ingest one markdown file the way ``creek.upload`` does, and collect its
+    advisories from the emission channel operators actually see.
+
+    ``creek_mcp.tools.upload`` always passes
+    ``ledger_source=UPLOAD_LEDGER_SOURCE``, including for an uploaded ``.md``
+    (``route_to_ingestor`` maps ``.md`` to the *markdown* ingestor), so this is
+    the exact shape of a real upload: markdown identity written under a
+    borrowed ledger. A single file is passed, not a directory, because that is
+    what the upload tool passes — and because a directory pass under a borrowed
+    ledger is the separate tombing hazard :data:`TOMBING_SOURCES` guards.
+
+    Advisories are read off the ``on_warning`` callback rather than
+    :attr:`IngestRunResult.warnings`: the callback is the channel a surface
+    prints from, so asserting on it tests the advisory as *emitted* rather than
+    as an internal tally.
+
+    Args:
+        vault: Vault root.
+        staged: The single markdown file standing in for a staged upload.
+
+    Returns:
+        Every advisory emitted during the run, in emission order.
+    """
+    emitted: list[str] = []
+    run_ingest(
+        ingestor_cls=MarkdownIngestor,
+        source_type="markdown",
+        input_path=staged,
+        vault_path=vault,
+        ledger_source=UPLOAD_LEDGER_SOURCE,
+        on_warning=emitted.append,
+    )
+    return emitted
+
+
+def test_a_pinned_vault_is_not_warned_about_through_a_borrowed_ledger(
+    tmp_path: Path,
+) -> None:
+    """An already-pinned vault stays quiet even when the run borrows a ledger.
+
+    The false-positive half of the ``ledger_source`` defect. This vault *is*
+    migrated — its markdown ledger holds the pinned record — but the first
+    upload finds the ``upload`` ledger empty, and an advisory that reads
+    whichever ledger the run happened to resolve would tell the operator to
+    re-run a migration they have already run. An advisory that fires on a vault
+    in good order is how operators learn to ignore advisories.
+    """
+    vault = _make_vault(tmp_path)
+    source = _make_source(tmp_path)
+    _seed_pre_fix_fragment(vault, source)
+    pin_source_ids(vault)
+
+    emitted = _upload_style_ingest(vault, source)
+
+    assert [msg for msg in emitted if "--pin-source-ids" in msg] == []
+
+
+def test_an_unpinned_vault_is_warned_about_through_a_borrowed_ledger(
+    tmp_path: Path,
+) -> None:
+    """An un-pinned vault is still warned about once an unrelated ledger fills.
+
+    The false-negative half, and the serious one: the markdown ledger is empty
+    — the vault genuinely will duplicate on its next markdown re-ingest — but a
+    previous upload has put a record in the ``upload`` ledger. Reading the
+    resolved ledger's emptiness silences the advisory through this path
+    permanently, on exactly the vault that needs it. The advisory's subject is
+    the markdown ledger; nothing a run overrides may substitute another.
+    """
+    vault = _make_vault(tmp_path)
+    source = _make_source(tmp_path)
+    _seed_pre_fix_fragment(vault, source)
+    SourceLedger.load(vault, source=UPLOAD_LEDGER_SOURCE).record(
+        "00-Creek-Meta/Staging/uploads/earlier.pdf",
+        "frag-unrelated-upload",
+        SourceLedger.content_hash("earlier"),
+    )
+
+    emitted = _upload_style_ingest(vault, source)
+
+    assert [msg for msg in emitted if "--pin-source-ids" in msg] != []
+
+
+def test_a_non_markdown_source_type_is_never_warned_about(tmp_path: Path) -> None:
+    """The advisory is scoped to the source type whose ids the fix moved.
+
+    Companion invariant to the two above, and the boundary that keeps the
+    subject-fix from over-correcting into noise: #1329 changed *markdown* id
+    derivation, so a document or image run — even on an un-pinned vault, even
+    under a borrowed ledger — has nothing this advisory can warn it about. The
+    gate is the run's own ``source_type``, which no ``ledger_source`` override
+    can move.
+    """
+    vault = _make_vault(tmp_path)
+    source = _make_source(tmp_path)
+    _seed_pre_fix_fragment(vault, source)
+
+    assert unpinned_vault_warning("document", vault) is None
+    assert unpinned_vault_warning("discord", vault) is None
 
 
 # ---- (b) + (c) the migration's core promise ----

--- a/creek-tools/tests/test_timestamp_derivation_guard.py
+++ b/creek-tools/tests/test_timestamp_derivation_guard.py
@@ -1,0 +1,253 @@
+"""A source-scanning guard against reintroducing host-dependent timestamps (#1329).
+
+:func:`creek.ingest.base.generate_fragment_id` hashes a fragment's timestamp,
+so any host-dependent input to that timestamp becomes part of the fragment's
+identity. Two such inputs shipped for a long time and both *looked like*
+simplifications, which is exactly why a docstring is not sufficient protection:
+
+* ``datetime.fromtimestamp(mtime)`` with no ``tz=`` renders the epoch in the
+  host's local zone, so one file minted a different id in every timezone.
+* ``getattr(stat, "st_birthtime", stat.st_mtime)`` reads a field present on
+  macOS/BSD and absent on Linux, so one file minted a different id per
+  operating system.
+
+The behavioural regression tests in ``test_ingest_id_host_independence.py``
+pin the two ingestors that had the bug. This module is the *tree-wide* net: it
+walks the AST of every module under ``creek/`` and ``creek_mcp/`` so a new
+ingestor cannot quietly reintroduce either pattern somewhere the behavioural
+tests do not look. Precedent for source-scanning tests in this repo:
+``test_dependency_pins.py``, ``test_config_contract.py``,
+``test_ruff_cache_poisoning.py``.
+
+**A third rule was considered and deliberately rejected**: "no ``.st_mtime``
+attribute read under ``creek/ingest/`` outside ``file_modified_time``". It is
+red on ``creek/ingest/gdrive.py`` (``GoogleDriveDownloader._is_up_to_date``),
+which compares a local file's mtime against Drive's to decide whether a
+re-download is needed. That is a staleness comparison, not a fragment-timestamp
+derivation, and it is correct as written. A guard that fails the build on
+correct code teaches people to disable guards.
+
+The scan is deliberately syntactic. It reads *code*, not prose — docstrings and
+comments discussing the forbidden patterns (this module is full of them, and so
+are the fixed call sites) are invisible to it, because they parse to string
+constants and comments rather than to calls and attribute reads.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+PACKAGE_ROOTS = ("creek", "creek_mcp")
+"""Package directories scanned by every rule in this module."""
+
+
+def _repo_source_root() -> Path:
+    """Return the ``creek-tools/`` directory holding the scanned packages.
+
+    Returns:
+        The directory containing ``creek/`` and ``creek_mcp/``.
+    """
+    return Path(__file__).resolve().parent.parent
+
+
+def _python_files() -> list[Path]:
+    """Return every ``.py`` file under the scanned package roots.
+
+    Returns:
+        A sorted list of module paths. Non-empty by construction; the
+        emptiness check lives in its own test so a broken glob cannot make
+        every other rule pass vacuously.
+    """
+    root = _repo_source_root()
+    files: list[Path] = []
+    for package in PACKAGE_ROOTS:
+        files.extend((root / package).rglob("*.py"))
+    return sorted(files)
+
+
+def _parse(path: Path) -> ast.Module:
+    """Parse *path* into an AST module.
+
+    Args:
+        path: The Python file to parse.
+
+    Returns:
+        The parsed module.
+    """
+    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+
+def _call_name(node: ast.Call) -> str:
+    """Return the dotted-ish name of *node*'s callee for matching.
+
+    Args:
+        node: The call node.
+
+    Returns:
+        The attribute name for ``a.b()``, the bare name for ``b()``, or the
+        empty string for anything more exotic (a call on a subscript, say).
+    """
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    if isinstance(func, ast.Name):
+        return func.id
+    return ""
+
+
+def _relative(path: Path) -> str:
+    """Render *path* relative to the source root for readable assertions.
+
+    Args:
+        path: An absolute module path.
+
+    Returns:
+        The path relative to ``creek-tools/``, as a POSIX string.
+    """
+    return path.relative_to(_repo_source_root()).as_posix()
+
+
+def _naive_fromtimestamp_sites() -> list[str]:
+    """Find every ``fromtimestamp(...)`` call that omits a ``tz`` keyword.
+
+    Returns:
+        ``"<file>:<line>"`` for each offending call site.
+    """
+    offenders: list[str] = []
+    for path in _python_files():
+        for node in ast.walk(_parse(path)):
+            if not isinstance(node, ast.Call):
+                continue
+            if _call_name(node) != "fromtimestamp":
+                continue
+            if any(keyword.arg == "tz" for keyword in node.keywords):
+                continue
+            offenders.append(f"{_relative(path)}:{node.lineno}")
+    return offenders
+
+
+def _birthtime_sites() -> list[str]:
+    """Find every reference to ``st_birthtime`` in executable code.
+
+    Catches both spellings that matter: a direct ``stat.st_birthtime``
+    attribute read, and the ``getattr(stat, "st_birthtime", ...)`` form the
+    bug actually shipped as — which hides the field name inside a string
+    constant where an attribute-only scan would miss it.
+
+    Returns:
+        ``"<file>:<line>"`` for each offending reference.
+    """
+    offenders: list[str] = []
+    for path in _python_files():
+        for node in ast.walk(_parse(path)):
+            if (isinstance(node, ast.Attribute) and node.attr == "st_birthtime") or (
+                isinstance(node, ast.Call)
+                and _call_name(node) == "getattr"
+                and any(
+                    isinstance(arg, ast.Constant) and arg.value == "st_birthtime"
+                    for arg in node.args
+                )
+            ):
+                offenders.append(f"{_relative(path)}:{node.lineno}")
+    return offenders
+
+
+def test_the_scan_actually_reaches_the_source_tree() -> None:
+    """The file glob finds modules, so the rules below cannot pass vacuously.
+
+    A guard that scans nothing is green forever. This pins the scan's own
+    precondition, and asserts the two packages the rules claim to cover are
+    both really in the set.
+    """
+    files = _python_files()
+    assert len(files) > 100
+    scanned = {_relative(path).split("/")[0] for path in files}
+    assert scanned == set(PACKAGE_ROOTS)
+    assert "creek/ingest/base.py" in {_relative(path) for path in files}
+
+
+def test_every_fromtimestamp_call_specifies_a_timezone() -> None:
+    """No naive ``datetime.fromtimestamp`` survives anywhere in the packages.
+
+    Naive conversion renders the epoch in the *host's* local zone. When the
+    result reaches ``generate_fragment_id`` the host's ``TZ`` env var ends up
+    inside the fragment's identity — the #1329 bug. Passing ``tz=`` makes the
+    conversion a pure function of the epoch float instead.
+    """
+    assert _naive_fromtimestamp_sites() == []
+
+
+def test_no_code_reads_st_birthtime() -> None:
+    """File *creation* time is never consulted, because Linux does not have it.
+
+    ``st_birthtime`` is populated on macOS/BSD and missing on Linux, so a
+    derivation that reads it makes a fragment's id a function of the
+    ingesting machine's operating system. ``st_mtime`` is the only stat field
+    every supported platform agrees on.
+    """
+    assert _birthtime_sites() == []
+
+
+@pytest.mark.parametrize(
+    ("snippet", "finder", "expected_line"),
+    [
+        pytest.param(
+            "import datetime\nx = datetime.datetime.fromtimestamp(1.0)\n",
+            _naive_fromtimestamp_sites,
+            2,
+            id="naive-fromtimestamp",
+        ),
+        pytest.param(
+            "def f(stat):\n    return stat.st_birthtime\n",
+            _birthtime_sites,
+            2,
+            id="birthtime-attribute",
+        ),
+        pytest.param(
+            'def f(stat):\n    return getattr(stat, "st_birthtime", stat.st_mtime)\n',
+            _birthtime_sites,
+            2,
+            id="birthtime-getattr",
+        ),
+    ],
+)
+def test_each_rule_bites_when_the_pattern_is_reintroduced(
+    snippet: str,
+    finder: object,
+    expected_line: int,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Each rule really detects its pattern, rather than being green by luck.
+
+    A guard is only worth its runtime if it fails when the thing it guards
+    against comes back. Rather than mutating the real tree, each rule is
+    pointed at a one-file scratch package containing exactly the pattern it
+    forbids, in the precise syntactic form the bug shipped as.
+
+    Args:
+        snippet: Source text reintroducing one forbidden pattern.
+        finder: The rule's finder function.
+        expected_line: Line within *snippet* the finder must report.
+        monkeypatch: Used to redirect the scan at the scratch package.
+        tmp_path: Pytest temp directory holding the scratch package.
+    """
+    package = tmp_path / "creek"
+    package.mkdir()
+    offender = package / "offender.py"
+    offender.write_text(snippet, encoding="utf-8")
+
+    monkeypatch.setattr(
+        "tests.test_timestamp_derivation_guard._repo_source_root",
+        lambda: tmp_path,
+    )
+    monkeypatch.setattr(
+        "tests.test_timestamp_derivation_guard.PACKAGE_ROOTS",
+        ("creek",),
+    )
+
+    assert callable(finder)
+    assert finder() == [f"creek/offender.py:{expected_line}"]


### PR DESCRIPTION
## Summary

A fragment's id was a function of the machine that ingested it.

`generate_fragment_id` hashes the fragment's timestamp — `f"{source}:{timestamp.isoformat()}:{content}"` — and for a file with no embedded date that timestamp came from the filesystem. Two host-dependent inputs leaked in:

1. **The host `TZ` env var.** `datetime.fromtimestamp(mtime)` with no `tz=` renders the epoch in the host's *local* zone, and `normalize_timestamp` then re-read that naive wall-clock as UTC before shifting to LA — a double shift. Reproduced digit-for-digit at HEAD, one file, mtime pinned to `1710493200.0`:

   | `TZ` | markdown | documents |
   |---|---|---|
   | `UTC` | `frag-c8bfc3e67c4d` | `frag-dd49a01f5539` |
   | `America/Los_Angeles` | `frag-aa53901eaffa` | `frag-7286deeb5d27` |
   | `Europe/Berlin` | `frag-fe2989a00f9b` | `frag-430e7de61929` |
   | `Australia/Sydney` | `frag-5ebe48b2ce65` | `frag-936750c2ef1f` |

2. **The host operating system — an axis the issue never mentions.** `markdown.py` read `getattr(stat, "st_birthtime", stat.st_mtime)`. `st_birthtime` exists on macOS/BSD and *not* on Linux, where the `getattr` silently falls back to mtime. So the same file already minted one id on a developer's Mac and a different one in Linux CI, independently of `TZ`. **A fix that only passed `tz=` would have left the id host-dependent.** Dropping birthtime is the deliberate trade; see "Behaviour changes" below.

Both fallbacks now go through `creek.ingest.base.file_modified_time` — `datetime.fromtimestamp(st_mtime, tz=UTC)`, a pure function of the epoch float. All four rows collapse to one: `frag-b145fde4406d` (markdown) and `frag-e71aebc3ad98` (documents), `created` `2024-03-15T09:00:00+00:00`.

---

## ⚠️ Read this first: this PR PINS ids, it does not RE-MINT them

**The issue's acceptance criteria mandate a re-minting migration** — an old→new id map, in-place file renames, and a lockstep remap of the per-directory id index, the ledger, `parent_id`/`child_ids` and every `generate_child_fragment_id` descendant, resonance edges, the embedding cache, thread/eddy membership and provenance, plus an RTBF alias, crash-resumability, and a duplicate-merge rule.

**This PR inverts that.** Existing ids never move, which makes that entire apparatus **vacuous rather than skipped**. There is nothing to remap because nothing moves.

The justification is in-tree, not invented here. `write_fragment_idempotent` already overrode the derived id with `record.fragment_id` on the changed branch and the tombed branch: **ledger-backed identity is the designed invariant for mutable file sources** (#672 SPEC R1), and the vault already tolerates `id != derived(id)` for every edited journal entry. The derivation is only how a *new* unit gets its *first* id. So the correct response to a derivation change is to make sure the ledger knows about the fragments that predate it — not to chase the derivation across eight referencing surfaces.

A reviewer holding the AC as a checklist will read roughly eight criteria as unmet. They are listed explicitly at the bottom of this description rather than glossed.

### Proof that no existing id moves

Built a 5-fragment vault using the **pre-fix derivation** (called directly, so the worktree was never edited), then migrated, then re-ingested under a *different* host timezone:

```
seeded 5 fragments with PRE-FIX ids
new derivation would mint 5/5 ids NOT present in the vault -> 5 orphans without the migration
pin: pinned=5 conflicts=0 unpinnable=0 reproduced=5/5
reingest: created=0 updated=0 unchanged=5 tombed=0 errors=[]
files before=5 after=5
IDS IDENTICAL: True
FILENAMES IDENTICAL: True
MOVED/ORPHANED: none
```

---

## What changed

**The derivation** — `creek/ingest/markdown.py`, `creek/ingest/documents.py`, `creek/ingest/images.py`, `creek/ingest/base.py`. Both `_resolve_timestamp` fallbacks delegate to `file_modified_time`; the birthtime-reading `_get_file_creation_timestamp` is deleted outright (only two references tree-wide, both removed); `images._modified_time` folds into the same helper. `file_modified_time`'s docstring stops claiming a "single conversion rule" it did not have, and names both failure modes so the next reader cannot reintroduce them by simplifying.

**Identity is the ledger's job** — `creek/ingest/pipeline.py`. `fragment.id = record.fragment_id` is **hoisted above every branch** of `write_fragment_idempotent`. It previously ran only on the changed and tombed paths, leaving the *unchanged* path to write whatever id had just been derived — which is the precise mechanism that turned a derivation drift into a silent duplicate, and which `creek_mcp/tools/upload.py` already documented as a live hazard worked around by hand. That comment is now corrected rather than left asserting a closed hazard. This is a forcing function: it is tested independently of timezones, by perturbing the derivation directly.

**`TOMBING_SOURCES`** — `creek/ingest/pipeline.py`. Unfuses "has a ledger" from "may tomb". `resolve_ledger` lets a caller borrow a ledger purely to pin identity (that is how an uploaded document earns its `origin_key` and therefore its RTBF coverage), and that opt-in also armed `tomb_missing_units` for any directory input. Two lines, no behaviour change today, footgun removed before anyone widens.

**The migration** — new `creek/ingest/pin_ids.py` + `creek ingest --pin-source-ids [--dry-run]`. Back-fills the ledger with each fragment's **existing** id. Notable decisions:
- **Conflict guard first.** A `source_key` claimed by 2+ live fragments is pinned for *neither*, and both paths are printed. This is the already-duplicated vault; blessing one claimant would orphan the other forever, and the ledger holds one record per key so pinning both is not expressible. This is the primary safety property.
- **Hashes the fragment's STORED BODY, not a re-read of the current source.** If the source was edited after its original ingest, hashing the current source would file the new hash against the old stored body; the next ingest would read `unchanged` and **the edit would be swallowed permanently**, because nothing revisits an unchanged unit. Covered by a dedicated test that edits the source *before* the migration runs.
- **Stamps `source.origin_key` atomically.** Mandatory, not cosmetic: the RTBF purge sweep resolves its target from on-disk frontmatter and skips fragments without the key, while `update_fragment` preserves on-disk frontmatter without merging new `source` fields — so a fragment lacking it at migration time would never gain one, ever. The write uses the vault's atomic helper rather than `refresh._rewrite_frontmatter`'s plain `write_text`, which would truncate a live fragment on a mid-run kill.
- **Reproduction rate is advisory, never a gate.** A migration gated on reproduction matches a fraction of the vault and therefore does nothing for the rest — which is exactly the population that gets orphaned.

**Un-migrated vaults are detected**, from the ledger's own emptiness rather than a second version marker, and warned about *before* the run that would duplicate them.

**An AST guard** — new `tests/test_timestamp_derivation_guard.py`. No naive `fromtimestamp` and no `st_birthtime` anywhere in `creek/` or `creek_mcp/`. A third proposed rule (no `.st_mtime` read outside `file_modified_time`) was **rejected and the rejection recorded**: it is red on `gdrive.py`'s legitimate local-vs-Drive staleness comparison, and a guard that fails on correct code teaches people to disable guards.

## Deliberately NOT done

**`ledger_for_source` is not widened to documents**, against the AC's preference — because it ships data loss. `derive_source_key` returns the **bare filename** for any source outside the vault, which is the normal case for `creek ingest --type documents --input ~/Documents`. So `~/Documents/a/report.pdf` and `~/Documents/b/report.pdf` share the key `report.pdf`; the second hits the `content_hash != new_hash` branch, adopts the first's `fragment_id`, and `update_fragment` **overwrites the first fragment's body**. Documents get the derivation fix (which alone kills their TZ duplicate) plus follow-up #1363, which the AC explicitly permits.

**`code.py:430` keeps its LA rendering.** Already host-independent; re-minting would orphan every code fragment, and code is unledgered with continuously-changing sources so no reproduction-based migration could recover them. Follow-up #1364.

## Behaviour changes worth knowing about

1. **On macOS a markdown fragment's `created` now reports modification time, not birth time.** That is the price of an id that does not depend on the ingesting OS. Because the writer builds a filename from `created`, a **newly ingested** fragment's date prefix may shift. **No existing file is renamed** — the migration never touches `created`. Authorship remains `authored_at`'s job (FEAT-031).
2. **Documents remain unledgered**, so an mtime move still re-derives their id with nothing to pin it (#1363).

## Test plan

**Gate 1 — RED first, on behavioural assertions.** All six new tests failed before the fix, each on the behaviour rather than a symbol:
- id sets had four members (the tables above); birthtime shape vs Linux shape gave `frag-aa53901eaffa` vs `frag-1f63caef932d`; every e2e case failed `assert 2 == 1` on the duplicate file.
- The RED uses a **relative source path** via `monkeypatch.chdir` — load-bearing. `assemble_ingested_fragment` hashes `parsed.source_path`, so an absolute `tmp_path` discovery would put the per-run temp dir inside the hash and make the pinned literals unreproducible between runs.
- **No test uses `--incremental`.** `should_skip_unit` skips an unchanged ledgered unit before the write, so an incremental-mode test is green while the bug is live.

**Mutation battery — 11 reverts, zero survivors.** Each guard was reverted alone and the suite re-run: naive markdown derivation (4 fail), naive documents derivation (3), un-hoisting `fragment.id` (2), removing the `TOMBING_SOURCES` gate (1), dropping the unpinned-vault warning (1), dropping the `origin_key` stamp (2), hashing the current source instead of the stored body (2), conflict guard picking a claimant (2), `dry_run` writing anyway (2), removing the idempotency check (1), removing the torn-pin repair (1). Each AST guard rule was also proved to bite against a scratch package containing the exact forbidden syntax.

The battery found a real gap: the first version of the edited-source test edited *after* pinning and did **not** discriminate the stored-body correction — and a trailing newline was masking the mutation. Added `test_an_edit_made_before_the_migration_is_not_swallowed`, which edits *before* the migration with an exact-round-tripping body; it now fails with `updated == 0` under the mutation, i.e. the edit is silently swallowed exactly as predicted.

**Gate 2.5 — self-review found a real blocker, reproduced and fixed.** A `code-review-orchestrator` pass over the diff returned FIX_REQUIRED on one issue, which I then reproduced by execution before fixing:

> `_pin_one` wrote the ledger record before stamping `source.origin_key`. If the second write failed — a disk-full or permission `OSError` partway through an N-fragment pass, far likelier than a `kill -9` — the record's presence made the *retry* report the fragment as `already_pinned` and never stamp it. The fragment would be RTBF-invisible forever, silently.

Reproduced by injecting an `OSError` on the second of three fragments: after the retry, `2024-03-14-n1.md` was still unstamped.

I did **not** take the suggested fix (swap the two writes). Swapping trades an unrecoverable loss for a different unrecoverable loss: with the stamp first, a crash leaves the fragment RTBF-visible but *identity-unpinned*, and a re-ingest in that window mints a duplicate — which cannot be un-minted, whereas a missing stamp can be restored. Instead the ledger record stays first (it is the write that protects identity) and the already-ledgered path is made **self-healing**: a fragment with a record but no stamp gets the stamp on the next run, reported as `repaired`. Both failure modes now converge. Covered by `test_an_interrupted_run_is_repaired_by_the_next_one`, which fails with `assert 0 == 1` if the repair is removed.

Two further findings addressed: `--dry-run` combined with `--refresh-dates`/`--refresh-ai-chat` now raises `BadParameter` instead of silently running that migration for real; and the "nothing changes but one key" claim is now a whole-frontmatter equality assertion rather than four spot checks. One finding — a partially-pinned vault stops emitting the migration advisory, so an *unresolved conflict* can still mint a third duplicate — is triaged to **#1367** rather than expanded into this PR, because closing it properly needs a cheap per-ingest signal and the obvious implementation is a full vault scan on the hot path.

I also fixed an unreported usability defect found by eyeballing the output: rich word-wrapped long absolute paths mid-token, making the operator's copy-pasteable action items unusable. Those lines now print with `soft_wrap=True`.

**Gate 2 — `./scripts/check-all.sh` exit code 0.** 12 checks passed, 0 failed. Aggregate branch coverage 94.40%; per-file gate clean (257 files ≥ 80%, including the new `pin_ids.py`); mypy strict clean; xenon clean; ruff clean. Integration lane 356 passed, e2e lane 14 passed. Full unit suite 9238 passed with no pre-existing test modified or deleted.

**No bypasses.** No `# noqa`, `# type: ignore`, `# pylint: disable`, `@pytest.mark.skip`, no threshold change, no deleted test. Three `# type: ignore`s that crept into draft tests were removed by fixing the types properly.

**Test literals:** the dossier's claim that all 60 `frag-` literals in `tests/` are synthetic held — no existing literal needed re-baselining, and none failed.

## Acceptance criteria the inversion leaves formally unmet

Listed explicitly, not glossed. Each is unmet **because ids do not move**, which makes the requirement vacuous:

- *"A MIGRATION EXISTS ... recomputes each affected fragment's id from the corrected derivation and UPDATES IN PLACE"* — a migration exists and is CLI-reachable, but it records the existing id rather than recomputing one. Nothing is renamed and `created` is never rewritten.
- *"remaps every id-referencing artefact in lockstep ... An old→new id map is emitted"* — no artefact is remapped and no map is emitted, because no id changes. The id index, children/`generate_child_fragment_id` descendants, resonance edges, the embedding cache, thread/eddy membership and provenance are all untouched **by construction**.
- *"RTBF/purge coverage survives ... a purge issued against a pre-migration id still resolves — via the emitted id map or a recorded alias"* — no alias exists; a pre-migration id still resolves because it is still the id. `origin_key` is additionally *stamped*, which closes a purge gap the AC did not identify.
- *"crash-safe or resumable"* — the ledger is append-only JSONL and the only fragment write is a single atomic key stamp, so there is no torn state to resume from. Resumability is a property here, not a feature.
- *"DETECTS AND REPAIRS an already-duplicated vault ... Define and implement the merge/keep rule"* — detected and reported, **not repaired**. Deliberate: the ledger holds one record per key, so any automatic keep-rule permanently orphans the loser. The operator is routed to `creek clean duplicates`.
- *"Every existing test that transitively pins a `frag-<sha>` derived from a file mtime is re-baselined"* — none needed it; all 60 literals are synthetic.
- *"Documents' unledgered status is either fixed or explicitly recorded as accepted risk with a follow-up issue"* — met via the accepted-risk arm (#1363), not the fix arm.
- *"code.py alignment"* — deferred to #1364 with the reason stated.

Closes #1329
Refs #1363, #1364, #1367, #672
