### PR TITLE
fix(author): police every corpus subtree with the HARD privacy leak gate

### DIFF
--- a/creek-tools/creek/author/agents.py
+++ b/creek-tools/creek/author/agents.py
@@ -45,7 +45,7 @@ from creek.models import (
     PrivacyTier,
     VoiceRegister,
 )
-from creek.vault.reader import iter_vault_fragments
+from creek.vault.reader import CORPUS_SUBDIRS, iter_vault_fragments
 
 if TYPE_CHECKING:
     from enum import StrEnum
@@ -56,9 +56,6 @@ if TYPE_CHECKING:
     from creek.models import Fragment
 
 _DimT = TypeVar("_DimT", bound="StrEnum")
-
-#: Vault subtrees the specialists draw evidence from.
-_CORPUS_SUBDIRS: tuple[str, ...] = ("01-Fragments", "09-Reference", "11-Other-Authors")
 
 #: Obsidian wikilink target, ignoring any ``|alias`` or ``#heading`` suffix.
 _WIKILINK = re.compile(r"\[\[([^\]|#]+)")
@@ -110,7 +107,7 @@ def _load_corpus(
     ``override`` of ``None`` defaults to ``OPEN`` (the most restrictive).
     """
     records: list[tuple[Fragment, str]] = []
-    for sub in _CORPUS_SUBDIRS:
+    for sub in CORPUS_SUBDIRS:
         for _path, fragment, body, _meta in iter_vault_fragments(vault / sub):
             if tier_within_override(fragment.privacy_tier, override):
                 records.append((fragment, body))
@@ -126,6 +123,20 @@ def fragment_tier_map(
     Built from the same override-filtered corpus the specialists gather from, so
     the desk can derive a run's *content tier* (the most-sensitive tier actually
     in the evidence) and route the voice call accordingly.
+
+    This is the **admitted** view of the corpus, and it diverges from the leak
+    gate's on purpose. Here an id seen twice resolves last-wins in
+    :data:`~creek.vault.reader.CORPUS_SUBDIRS` order over records that already
+    passed ``tier_within_override``, because the question is "what is in the
+    evidence this run may use". The HARD gate at
+    :func:`creek.author.checks._resolve_cited_tiers` reads the *unfiltered*
+    corpus and resolves most-restrictive-wins, because its question is "what is
+    the true tier of the text this draft reproduces" — a gate that only saw the
+    admitted view would be blind to exactly the content it exists to catch.
+    The divergence is deliberate, and pinned by
+    ``test_leak_gate_reads_the_true_tier_while_the_router_reads_the_admitted_one``
+    in ``tests/test_reflection.py``, so a future "make these agree" cleanup has
+    to argue with a named assertion rather than a silent assumption.
 
     Args:
         vault: Vault root.

--- a/creek-tools/creek/author/checks.py
+++ b/creek-tools/creek/author/checks.py
@@ -7,15 +7,20 @@ records. The checks are *deterministic* — no LLM — so the mutation tests in
 produces. Citation completeness and privacy compliance are HARD gates for the
 research medium; the rest are softer rubric divergences.
 
-The privacy check reuses the vault fragment loader
-(:func:`creek.vault.reader.iter_vault_fragments`) to resolve each cited
-fragment's :class:`~creek.models.PrivacyTier`; the voice check reuses the
-FEAT-040.x AI-style scanner (:func:`creek.generate.ai_style.scanner.scan`).
+The privacy check resolves each cited fragment's
+:class:`~creek.models.PrivacyTier` with
+:func:`creek.vault.reader.try_load_fragment`, walking the corpus subtrees
+file by file rather than through :func:`~creek.vault.reader.iter_vault_fragments`
+(or the desk's own ``_load_corpus``), both of which materialise every fragment
+in the vault into a list before the caller sees the first record. The voice
+check reuses the FEAT-040.x AI-style scanner
+(:func:`creek.generate.ai_style.scanner.scan`).
 """
 
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import yaml
@@ -34,7 +39,7 @@ from creek.models import (
     PHASE_LEGACY_ALIASES,
     PrivacyTier,
 )
-from creek.vault.reader import try_load_fragment
+from creek.vault.reader import CORPUS_SUBDIRS, try_load_fragment
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -185,32 +190,118 @@ def check_biographical_grounding(
     ]
 
 
-def _resolve_cited_tiers(
-    evidence: EvidenceBundle,
-    vault: Path,
-) -> dict[str, tuple[PrivacyTier, str]]:
-    """Map each cited fragment id to its ``(privacy_tier, body)`` from *vault*.
+def _as_tier(value: PrivacyTier) -> PrivacyTier:
+    """Coerce a tier loaded from a fragment back into the enum.
+
+    :class:`~creek.models.Fragment` is configured with ``use_enum_values=True``,
+    so Pydantic hands back the plain ``str`` behind the member even though the
+    annotation says ``PrivacyTier``. Left as a ``str`` it misses every
+    :data:`_TIER_RANK` lookup — the gate would then fail closed at the most
+    restrictive rank for *every* cited fragment — and rendering the finding
+    would raise on the missing ``.value``.
 
     Args:
-        evidence: The evidence whose cited fragment ids are resolved.
-        vault: The vault root to load fragments from.
+        value: A ``privacy_tier`` as loaded from a fragment's frontmatter.
 
     Returns:
-        A mapping of cited fragment id to its tier and stored body. Fragments
-        not found in the vault are omitted.
-
-    The walk is lazy — ``rglob`` is iterated directly (not materialised) and
-    exits as soon as every cited fragment is resolved, so a draft citing a
-    handful of fragments stops early instead of parsing the whole vault on every
-    ``review`` call inside the retry loop. Iteration order is therefore the
-    filesystem's; that is irrelevant here since results are keyed by fragment id.
+        The corresponding :class:`~creek.models.PrivacyTier` member.
     """
-    cited = set(evidence.all_source_fragments())
-    resolved: dict[str, tuple[PrivacyTier, str]] = {}
-    fragments_root = vault / "01-Fragments"
-    if not cited or not fragments_root.is_dir():
-        return resolved
-    for md_file in fragments_root.rglob("*.md"):
+    return PrivacyTier(value)
+
+
+def _fragment_rank(tier: PrivacyTier) -> int:
+    """Return the restrictiveness rank of a cited *fragment's* tier.
+
+    :data:`_TIER_RANK` is read at call time rather than captured, so a test can
+    shrink the table to stand in for a future tier nobody has ranked yet; such a
+    tier fails closed at :data:`_MOST_RESTRICTIVE_RANK` (#509).
+
+    Args:
+        tier: The fragment's privacy tier.
+
+    Returns:
+        The tier's rank; higher is more restrictive.
+    """
+    return _TIER_RANK.get(tier, _MOST_RESTRICTIVE_RANK)
+
+
+@dataclass(frozen=True, slots=True)
+class _CitedFragment:
+    """One cited fragment id's resolved tier and every body stored under it.
+
+    A vault id is not unique: the same id can sit in more than one corpus
+    subtree (an import, a copy, a re-export), and those records can disagree
+    about both tier and body. This type folds the sightings together for the
+    leak gate (#1341).
+
+    The fold is **monotone** — the tier never becomes less restrictive and no
+    body is ever dropped — and **commutative**, since rank-max and
+    append-if-absent both are. Walk order therefore cannot change the verdict,
+    which is what lets the resolver widen from one subtree to three without
+    acquiring a tie-break rule to argue about.
+
+    Its accepted cost: a genuinely ``open`` body is refused when a same-id
+    record above the ceiling exists, because the tier is treated as a property
+    of the *id*. That trade is a false-positive revise round in exchange for
+    never shipping a leak — the safe direction for a one-way ratchet.
+
+    Attributes:
+        tier: The most restrictive tier seen for this id.
+        bodies: Every distinct body seen for this id, at *every* tier rather
+            than only the winning one. Dropping the below-winner bodies would
+            reopen the hole one rank down: a draft could reproduce the ``open``
+            twin of an id that resolved ``intimate``.
+    """
+
+    tier: PrivacyTier
+    bodies: tuple[str, ...]
+
+    def merged_with(self, tier: PrivacyTier, body: str) -> _CitedFragment:
+        """Return a new record with one more sighting of this id folded in.
+
+        Args:
+            tier: The sighted record's privacy tier (coerced via
+                :func:`_as_tier`, since it arrives as a plain ``str``).
+            body: The sighted record's stored body.
+
+        Returns:
+            A new frozen record carrying the more restrictive of the two tiers
+            and every body of both. ``self`` is left untouched.
+        """
+        sighted = _as_tier(tier)
+        stricter = (
+            sighted
+            if _fragment_rank(sighted) > _fragment_rank(self.tier)
+            else self.tier
+        )
+        bodies = self.bodies if body in self.bodies else (*self.bodies, body)
+        return _CitedFragment(tier=stricter, bodies=bodies)
+
+
+def _scan_subtree_for_cited(
+    root: Path,
+    cited: set[str],
+    resolved: dict[str, _CitedFragment],
+) -> None:
+    """Fold every cited fragment found under *root* into *resolved*, in place.
+
+    The walk is sorted, mirroring :func:`~creek.vault.reader.iter_vault_fragments`,
+    so a run is reproducible across hosts. Correctness does not depend on it —
+    :class:`_CitedFragment`'s fold is order-independent — but a host-dependent
+    walk order in a HARD gate is a debugging trap worth not setting.
+
+    Unreadable files and markdown that is not a Creek fragment are skipped with
+    exactly the tolerance :func:`~creek.vault.reader.try_load_fragment` callers
+    already use. That parity is load-bearing now that the walk reaches beyond
+    ``01-Fragments``: the reference notes and the ``_author.md`` manifests
+    living in the other two subtrees must skip, not raise.
+
+    Args:
+        root: An existing corpus subtree to walk.
+        cited: The fragment ids the draft cites.
+        resolved: Accumulator mapping cited id to its folded record; mutated.
+    """
+    for md_file in sorted(root.rglob("*.md")):
         try:
             record = try_load_fragment(md_file)
         except (OSError, ValueError, yaml.YAMLError):
@@ -218,10 +309,73 @@ def _resolve_cited_tiers(
         if record is None:
             continue
         fragment, body, _raw = record
-        if fragment.id in cited:
-            resolved[fragment.id] = (fragment.privacy_tier, body)
-            if len(resolved) == len(cited):
-                break  # every cited fragment found — stop scanning the vault
+        if fragment.id not in cited:
+            continue
+        # No `tier_within_override` here, deliberately. The admission ceiling
+        # decides what the specialists may *gather*; this gate must read the
+        # fragment's TRUE tier, or it goes blind to exactly the content it
+        # exists to catch. Filtering here is the single most tempting wrong
+        # edit in this file.
+        seen = resolved.get(fragment.id)
+        resolved[fragment.id] = (
+            seen.merged_with(fragment.privacy_tier, body)
+            if seen is not None
+            else _CitedFragment(tier=_as_tier(fragment.privacy_tier), bodies=(body,))
+        )
+
+
+def _resolve_cited_tiers(
+    evidence: EvidenceBundle,
+    vault: Path,
+) -> dict[str, _CitedFragment]:
+    """Resolve each cited fragment id against every corpus subtree in *vault*.
+
+    Searches all of :data:`~creek.vault.reader.CORPUS_SUBDIRS` —
+    ``01-Fragments``, ``09-Reference`` and ``11-Other-Authors`` — which is the
+    same tuple the desk's specialists gather evidence from. Sharing the object
+    is the point: while the gate kept its own one-entry list it policed a
+    subtree the specialists had long since outgrown, and an over-tier fragment
+    cited out of either other subtree resolved to nothing at all (#1341). An
+    absent subtree is skipped on its own; the absence of one never disables the
+    others.
+
+    Records sharing an id are folded by :class:`_CitedFragment`: most
+    restrictive tier wins and every body is kept, an order-independent merge.
+    The fragment's own tier is read — never
+    :func:`~creek.classify.privacy_filter.tier_within_override`'s admitted view.
+
+    No containment check is applied to symlinked or otherwise out-of-tree files,
+    and none is wanted. Under a monotone fold an extra record can only raise a
+    tier or add a body, so a planted shadow cannot downgrade or mask anything;
+    adding a skip path would introduce the one genuinely unsafe move available
+    here — dropping a body, and with it a leak.
+
+    Honest cost: worst case this parses all three subtrees once per ``review``
+    call, and the conductor may call ``review`` once per round up to
+    ``max_author_rounds`` (default 3, capped at 10). The common miss — an LLM
+    inventing a fragment id — is now always exhaustive, where the old
+    single-root walk could exit early. No memo is kept on purpose: a cache with
+    wrong invalidation on a HARD leak gate is worse than a slow gate.
+
+    Args:
+        evidence: The evidence whose cited fragment ids are resolved.
+        vault: The vault root to load fragments from.
+
+    Returns:
+        A mapping of cited fragment id to its folded :class:`_CitedFragment`.
+        Ids with no matching file anywhere in the corpus are omitted.
+    """
+    cited = set(evidence.all_source_fragments())
+    resolved: dict[str, _CitedFragment] = {}
+    if not cited:
+        return resolved
+    for sub in CORPUS_SUBDIRS:
+        subtree = vault / sub
+        # Per-root, never global: bailing on the whole walk because the first
+        # root is missing left a vault whose corpus lives under `09-Reference`
+        # with no privacy gate at all.
+        if subtree.is_dir():
+            _scan_subtree_for_cited(subtree, cited, resolved)
     return resolved
 
 
@@ -285,6 +439,23 @@ def _is_verbatim_leak(protected: str, body: str) -> bool:
     return re.search(pattern, normalized_body) is not None
 
 
+def _leaks_any_body(cited: _CitedFragment, body: str) -> bool:
+    """Return whether the draft reproduces any text stored under a cited id.
+
+    Every stored body counts, not only the one on the record that won the tier
+    fold: the tier is a property of the *id*, so once that id resolves above the
+    ceiling its lower-tier twin's text is protected too (#1341).
+
+    Args:
+        cited: The resolved record for one cited fragment id.
+        body: The drafted prose under review.
+
+    Returns:
+        ``True`` when at least one stored body appears verbatim in the draft.
+    """
+    return any(_is_verbatim_leak(stored.strip(), body) for stored in cited.bodies)
+
+
 def check_privacy_compliance(
     body: str,
     evidence: EvidenceBundle,
@@ -326,21 +497,21 @@ def check_privacy_compliance(
     )
     ceiling = _TIER_RANK.get(ceiling_tier, _LEAST_RESTRICTIVE_RANK)
     findings: list[ReflectionFinding] = []
-    for frag_id, (raw_tier, frag_body) in _resolve_cited_tiers(evidence, vault).items():
-        tier = PrivacyTier(raw_tier)
-        protected = frag_body.strip()
+    # Sorted by fragment id so a draft leaking several fragments always reports
+    # them in the same order, whichever subtree resolved each one first.
+    for frag_id, cited in sorted(_resolve_cited_tiers(evidence, vault).items()):
         # Deterministic scope: this catches substantive verbatim leakage of the
         # protected body (see :func:`_is_verbatim_leak`). A paraphrase of
         # over-tier content — or a snippet too short to be a reliable signal —
         # is NOT caught here; that needs the semantic LLM judge (#474).
-        rank = _TIER_RANK.get(tier, _MOST_RESTRICTIVE_RANK)
-        if rank > ceiling and _is_verbatim_leak(protected, body):
+        rank = _fragment_rank(cited.tier)
+        if rank > ceiling and _leaks_any_body(cited, body):
             findings.append(
                 ReflectionFinding(
                     dimension="privacy_compliance",
                     severity="HIGH",
                     message=(
-                        f"Cited fragment {frag_id!r} is {tier.value!r} "
+                        f"Cited fragment {frag_id!r} is {cited.tier.value!r} "
                         f"(above the {ceiling_tier.value!r} "
                         "default) yet its protected text appears in the draft."
                     ),

--- a/creek-tools/creek/vault/__init__.py
+++ b/creek-tools/creek/vault/__init__.py
@@ -4,10 +4,15 @@ from creek.vault.authors import (
     load_author_manifest,
     load_author_manifest_or_default,
 )
-from creek.vault.reader import iter_vault_fragments, try_load_fragment
+from creek.vault.reader import (
+    CORPUS_SUBDIRS,
+    iter_vault_fragments,
+    try_load_fragment,
+)
 from creek.vault.writer import VaultWriter
 
 __all__ = [
+    "CORPUS_SUBDIRS",
     "VaultWriter",
     "iter_vault_fragments",
     "load_author_manifest",

--- a/creek-tools/creek/vault/reader.py
+++ b/creek-tools/creek/vault/reader.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path  # noqa: TC003  # no issue: runtime use in type hints
+from typing import Final
 
 import frontmatter
 import yaml
@@ -32,6 +33,33 @@ from pydantic import ValidationError
 from creek.models import Fragment
 
 logger = logging.getLogger(__name__)
+
+CORPUS_SUBDIRS: Final[tuple[str, ...]] = (
+    "01-Fragments",
+    "09-Reference",
+    "11-Other-Authors",
+)
+"""The vault subtrees that hold Creek fragments, in walk order.
+
+One definition with two consumers that must never disagree:
+
+* the Writing Desk specialists gather their evidence from these subtrees
+  (:func:`creek.author.agents._load_corpus`), and
+* the HARD ``privacy_compliance`` leak gate resolves each cited fragment's tier
+  by walking exactly the same ones
+  (:func:`creek.author.checks._resolve_cited_tiers`).
+
+While those were two separate literals the gate fell a subtree behind the
+specialists it polices, and a draft could reproduce the protected body of an
+``intimate`` fragment filed under ``09-Reference`` or ``11-Other-Authors`` and
+still review as ``PASS`` (#1341). Anything that reads part of the corpus reads
+this tuple; a second list is a second thing to forget to update.
+
+Index 2 is the folder :data:`creek.vault.authors.OTHER_AUTHORS_DIR` already
+names. That module is deliberately *not* imported here — the dependency inside
+:mod:`creek.vault` runs toward the reader, not away from it — so the equality is
+pinned by ``tests/test_vault_reader.py`` rather than by an import.
+"""
 
 
 def try_load_fragment(

--- a/creek-tools/docs/writing-desk.md
+++ b/creek-tools/docs/writing-desk.md
@@ -90,6 +90,15 @@ The reflection node scores a draft across six rubric dimensions:
 - `paradox_preservation`
 - `attribution_correctness`
 
+`privacy_compliance` is a HARD gate, and it polices **every** subtree the
+specialists draw evidence from — `01-Fragments`, `09-Reference` and
+`11-Other-Authors`. Both sides read one definition of that list
+(`creek.vault.reader.CORPUS_SUBDIRS`), so the gate cannot fall behind the
+specialists it polices. A cited fragment id present in more than one subtree
+resolves to its **most restrictive** tier, and every body stored under that id
+is checked against the draft — the lower-tier twins' bodies included, because
+the tier is a property of the id rather than of the file that happened to win.
+
 A clean draft returns `PASS`. One or more findings return `REVISE`, which the
 conductor retries within the round budget. A draft that cannot be authored at
 all — or that never clears `REVISE` before the budget is exhausted — returns

--- a/creek-tools/tests/test_cli_author.py
+++ b/creek-tools/tests/test_cli_author.py
@@ -496,6 +496,78 @@ def test_author_withholds_intimate_text_leaked_by_the_deterministic_render(
     assert result.exit_code != 0, plain
 
 
+@pytest.mark.parametrize(
+    "subdir",
+    [
+        pytest.param("09-Reference/External-Sources", id="09-Reference"),
+        pytest.param("11-Other-Authors/quoted-friend", id="11-Other-Authors"),
+    ],
+)
+def test_author_withholds_intimate_text_leaked_from_a_non_fragments_subtree(
+    tmp_path: Path,
+    subdir: str,
+) -> None:
+    """The same refusal must hold for the other two corpus subtrees (#1341).
+
+    The twin of
+    :func:`test_author_withholds_intimate_text_leaked_by_the_deterministic_render`
+    with one thing changed: where the fragment lives. The desk's specialists
+    gather from ``01-Fragments``, ``09-Reference`` and ``11-Other-Authors``
+    alike (``creek/author/agents.py``), so all three can put protected text in
+    a draft — but ``check_privacy_compliance`` resolves cited tiers out of
+    ``01-Fragments`` only, and an unresolvable id is skipped rather than
+    guessed. The result is a leak the HARD gate cannot see.
+
+    ``title == body`` for the same reason as the original: the deterministic
+    renderer emits fragment *titles* as claims while ``_is_verbatim_leak``
+    matches *bodies*, so a differing title renders nothing leakable and the
+    test would pass vacuously.
+
+    The fragment stays self-authored with no ``author_slug`` in both cases —
+    including under ``11-Other-Authors`` — so ``privacy_compliance`` remains
+    the only dimension this corpus can raise. Adding a slug would add an
+    ``attribution_correctness`` finding and muddy which gate produced the
+    refusal, and the loader keys on the folder, not on the slug.
+
+    Measured today: stdout carries the protected sentence verbatim under
+    ``verdict=PASS`` with exit code ``0``.
+
+    Args:
+        tmp_path: Root for the synthetic vault.
+        subdir: The corpus subtree (and leaf) the fragment is seeded into.
+    """
+    vault = _vault(tmp_path)
+    write_raw_fragment_file(
+        vault,
+        subdir,
+        "frag-int",
+        _INTIMATE_SENTENCE,
+        body=_INTIMATE_SENTENCE,
+        privacy_tier="intimate",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "author",
+            "--medium",
+            "research",
+            "--query",
+            "father",
+            "--vault",
+            str(vault),
+            "--include-tier",
+            "intimate",
+        ],
+    )
+
+    plain = _collapse(result.output)
+    assert _collapse(_INTIMATE_SENTENCE) not in plain, plain
+    assert "verdict=ESCALATE" in plain, plain
+    assert "privacy_compliance" in plain, plain
+    assert result.exit_code != 0, plain
+
+
 def test_author_withholds_intimate_text_leaked_by_the_live_voice_client(
     tmp_path: Path,
 ) -> None:

--- a/creek-tools/tests/test_reflection.py
+++ b/creek-tools/tests/test_reflection.py
@@ -40,8 +40,6 @@ from creek.models import MediumContract, PrivacyTier
 if TYPE_CHECKING:
     from pathlib import Path
 
-    import pytest
-
 
 def _grounded() -> EvidenceBundle:
     """Return a single grounded, attributed-free, paradox-free evidence bundle."""
@@ -54,14 +52,38 @@ def _seed_fragment(
     vault: Path,
     frag_id: str,
     body: str,
-    tier: PrivacyTier = PrivacyTier.OPEN,
+    tier: PrivacyTier | None = PrivacyTier.OPEN,
+    *,
+    subtree: str = "01-Fragments",
+    title: str = "t",
 ) -> None:
-    """Write a minimal fragment file with *body* and *tier* into the vault."""
-    folder = vault / "01-Fragments" / "Notes"
+    """Write a minimal fragment file with *body* and *tier* into the vault.
+
+    The defaults reproduce the pre-#1341 shape exactly — an ``open`` fragment
+    under ``01-Fragments/Notes`` — so every existing caller is untouched.
+
+    Args:
+        vault: Vault root to seed under.
+        frag_id: Fragment id; also the file stem. Two records sharing an id
+            must therefore be seeded into two different ``subtree`` values.
+        body: Markdown body written below the frontmatter.
+        tier: Tier to stamp, or ``None`` to omit the ``privacy_tier`` key
+            entirely — the legacy / hand-edited shape, which
+            :class:`~creek.models.Fragment` loads as
+            :attr:`~creek.models.PrivacyTier.UNCLASSIFIED` (``creek/models.py``
+            field default).
+        subtree: Top-level vault folder to seed under. The desk's specialists
+            gather from ``01-Fragments``, ``09-Reference`` and
+            ``11-Other-Authors``; the ``Notes`` leaf is kept under whichever
+            one is named.
+        title: Fragment title.
+    """
+    folder = vault / subtree / "Notes"
     folder.mkdir(parents=True, exist_ok=True)
+    tier_line = "" if tier is None else f"privacy_tier: {tier.value}\n"
     (folder / f"{frag_id}.md").write_text(
-        f'---\ntype: fragment\nid: {frag_id}\ntitle: "t"\n'
-        f"privacy_tier: {tier.value}\n"
+        f'---\ntype: fragment\nid: {frag_id}\ntitle: "{title}"\n'
+        f"{tier_line}"
         f"source:\n  platform: journal\n  author: self\n---\n{body}\n",
         encoding="utf-8",
     )
@@ -836,6 +858,369 @@ def test_privacy_missing_contract_gates_at_the_strictest_ceiling(
     ]
     assert "frag-a" in findings[0].message
     assert "intimate" in findings[0].message
+
+
+# ---------------------------------------------------------------------------
+# #1341 — the HARD leak gate must police every corpus subtree
+#
+# ``_resolve_cited_tiers`` walks ``<vault>/01-Fragments`` alone, while the desk
+# specialists gather evidence from ``01-Fragments``, ``09-Reference`` **and**
+# ``11-Other-Authors`` (``creek/author/agents.py``'s ``_CORPUS_SUBDIRS``, used
+# by ``_load_corpus``). A cited fragment living in either of the other two
+# subtrees resolves to nothing, so the gate never learns its tier and the draft
+# ships its protected text with ``verdict=PASS``.
+# ---------------------------------------------------------------------------
+
+_LEAK_SECRET = "the confession I never wanted written down"
+"""A seven-word protected snippet — comfortably over ``_MIN_PROTECTED_LEAK_WORDS``.
+
+Anything under five words cannot trip the gate at all, so a shorter snippet
+would make every test below pass vacuously. Deliberately plain English: no
+legacy taxonomy alias (``origins``, ``solo``, ``pitch``, …) and no bespoke
+ontology term, so ``privacy_compliance`` is the only dimension it can raise.
+"""
+
+_DECOY_BODY = "a plainly publishable paragraph about tide charts"
+"""The twin body a duplicate-id record carries, never reproduced in a draft.
+
+Its job is to be the record the resolver *prefers* — by tier, by walk order, or
+by both — so that preferring it is observable as a missing finding.
+"""
+
+
+def _draft_reproducing(secret: str) -> str:
+    """Return a longer reviewed body that reproduces *secret* verbatim.
+
+    Args:
+        secret: The protected snippet to embed word for word.
+
+    Returns:
+        Innocuous prose with *secret* inside it — the realistic hazard shape,
+        where nothing but the protected text itself gives the leak away.
+    """
+    return (
+        "The piece opens on an ordinary morning and then reproduces its "
+        f"source word for word: {secret} — and it keeps going after that."
+    )
+
+
+_SUBTREE_TIER_CASES = [
+    pytest.param(subtree, tier, expected, id=f"{subtree}-{label}")
+    for subtree in ("09-Reference", "11-Other-Authors")
+    for tier, expected, label in (
+        (PrivacyTier.INTIMATE, "intimate", "intimate"),
+        (PrivacyTier.PERSONAL, "personal", "personal"),
+        (None, "unclassified", "absent-privacy-tier-key"),
+    )
+]
+"""The cross product of the two unwalked corpus subtrees and three over-tier shapes.
+
+``PERSONAL`` is included because it is *also* above an ``open`` ceiling — the
+gate is not an intimate-only gate — and the key-absent shape because a legacy
+or hand-edited fragment is exactly the content nobody has vouched for.
+"""
+
+
+@pytest.mark.parametrize(("subtree", "tier", "expected_tier"), _SUBTREE_TIER_CASES)
+def test_privacy_gate_sees_over_tier_fragment_in_every_corpus_subtree(
+    tmp_path: Path,
+    subtree: str,
+    tier: PrivacyTier | None,
+    expected_tier: str,
+) -> None:
+    """An over-tier fragment leaks identically from any corpus subtree (#1341).
+
+    One cited fragment, seeded outside ``01-Fragments``, whose protected body is
+    reproduced verbatim in the draft under an ``open`` medium contract. The
+    fragment's location in the vault is not a privacy property, so the finding
+    must be the same one ``01-Fragments`` already produces: a single ``HIGH``
+    ``privacy_compliance`` finding naming the fragment and its tier.
+
+    The key-absent case asserts ``'unclassified'`` because
+    :class:`~creek.models.Fragment` defaults ``privacy_tier`` to
+    :attr:`~creek.models.PrivacyTier.UNCLASSIFIED` (verified in
+    ``creek/models.py``), and the leak gate's ``_TIER_RANK`` puts
+    ``UNCLASSIFIED`` at the *top* of the restrictiveness order — an untiered
+    fragment is over every ceiling.
+
+    Measured today: the resolver returns ``{}`` for both subtrees, so this
+    reviews as ``PASS`` with zero findings.
+
+    Args:
+        tmp_path: Vault root for this case.
+        subtree: The corpus subtree the fragment is seeded into.
+        tier: The stamped tier, or ``None`` to omit the key entirely.
+        expected_tier: The tier string the finding's message must name.
+    """
+    _seed_fragment(tmp_path, "frag-b", _LEAK_SECRET, tier, subtree=subtree)
+    evidence = EvidenceBundle(
+        claims=[EvidenceClaim(claim="a claim", source_fragments=["frag-b"])]
+    )
+    contract = MediumContract(medium="research", default_privacy_tier=PrivacyTier.OPEN)
+
+    result = ReflectionNode().review(
+        _draft_reproducing(_LEAK_SECRET),
+        evidence,
+        contract=contract,
+        vault=tmp_path,
+    )
+
+    assert result.decision == "REVISE", result.findings
+    leaks = [f for f in result.findings if f.dimension == "privacy_compliance"]
+    assert len(leaks) == 1, result.findings
+    assert leaks[0].severity == "HIGH"
+    assert "'frag-b'" in leaks[0].message
+    assert f"'{expected_tier}'" in leaks[0].message
+
+
+@pytest.mark.parametrize(
+    ("strict_subtree", "lax_subtree"),
+    [
+        pytest.param("09-Reference", "01-Fragments", id="strict-last"),
+        pytest.param("01-Fragments", "09-Reference", id="strict-first"),
+    ],
+)
+def test_duplicate_cited_id_resolves_to_the_most_restrictive_tier(
+    tmp_path: Path,
+    strict_subtree: str,
+    lax_subtree: str,
+) -> None:
+    """Two vault records share an id — the gate must read the stricter tier (#1341).
+
+    Fragment ids are not unique across a real vault: the same id can land in
+    ``01-Fragments`` and in ``09-Reference`` (an import, a copy, a re-export).
+    Once the resolver walks more than one subtree it will see both records, and
+    "last write wins" would let the ``open`` twin overwrite the ``intimate``
+    one and silently disarm the HARD gate. Resolution must fail closed to the
+    most restrictive tier found for that id.
+
+    Both walk orders are exercised, and the second one is the whole point.
+    The walk runs in ``CORPUS_SUBDIRS`` order, so with the strict record in
+    ``09-Reference`` it is simply seen *last* — and last-wins happens to give
+    the right answer, for the wrong reason. Only ``strict-first`` — the
+    ``intimate`` record in ``01-Fragments``, its ``open`` twin behind it —
+    separates a real rank-max from that coincidence. Measured against a
+    last-wins merge: ``strict-last`` still reports the leak while
+    ``strict-first`` reports **nothing at all**, with the protected body
+    sitting verbatim in the draft.
+
+    Only the intimate body is reproduced in the draft, so a correct gate has
+    both halves of the evidence it needs: the strict tier and the leaked text.
+
+    Args:
+        tmp_path: Vault root for this case.
+        strict_subtree: Where the ``intimate`` record carrying the secret goes.
+        lax_subtree: Where its harmless ``open`` twin goes.
+    """
+    _seed_fragment(
+        tmp_path, "frag-d", _DECOY_BODY, PrivacyTier.OPEN, subtree=lax_subtree
+    )
+    _seed_fragment(
+        tmp_path,
+        "frag-d",
+        _LEAK_SECRET,
+        PrivacyTier.INTIMATE,
+        subtree=strict_subtree,
+    )
+    evidence = EvidenceBundle(
+        claims=[EvidenceClaim(claim="a claim", source_fragments=["frag-d"])]
+    )
+    contract = MediumContract(medium="research", default_privacy_tier=PrivacyTier.OPEN)
+
+    result = ReflectionNode().review(
+        _draft_reproducing(_LEAK_SECRET),
+        evidence,
+        contract=contract,
+        vault=tmp_path,
+    )
+
+    leaks = [f for f in result.findings if f.dimension == "privacy_compliance"]
+    assert len(leaks) == 1, result.findings
+    assert leaks[0].severity == "HIGH"
+    assert "'frag-d'" in leaks[0].message
+    assert "'intimate'" in leaks[0].message
+
+
+@pytest.mark.parametrize(
+    ("decoy_subtree", "leaker_subtree"),
+    [
+        pytest.param("01-Fragments", "11-Other-Authors", id="decoy-first"),
+        pytest.param("11-Other-Authors", "01-Fragments", id="decoy-second"),
+    ],
+)
+def test_duplicate_cited_id_at_equal_tier_cannot_mask_the_leaking_body(
+    tmp_path: Path,
+    decoy_subtree: str,
+    leaker_subtree: str,
+) -> None:
+    """Same id, same tier, two bodies — walk order must not decide the verdict (#1341).
+
+    Tier alone cannot break this tie: both records are ``intimate``, so a
+    resolver that keeps one ``(tier, body)`` pair per id keeps whichever body it
+    happened to see last. Sorting the walk makes that deterministic but not
+    *correct* — it just fixes which of the two draws. The subtree name decides
+    the sort (``01-Fragments`` < ``09-Reference`` < ``11-Other-Authors``), so
+    the two cases here put the harmless twin on either side of the leaker and
+    demand the same finding from both. Keeping **every** body stored under a
+    cited id is the only implementation that satisfies both cases at once.
+
+    Args:
+        tmp_path: Vault root for this case.
+        decoy_subtree: Where the harmless twin is seeded.
+        leaker_subtree: Where the twin carrying the protected text is seeded.
+    """
+    _seed_fragment(
+        tmp_path, "frag-e", _DECOY_BODY, PrivacyTier.INTIMATE, subtree=decoy_subtree
+    )
+    _seed_fragment(
+        tmp_path, "frag-e", _LEAK_SECRET, PrivacyTier.INTIMATE, subtree=leaker_subtree
+    )
+    evidence = EvidenceBundle(
+        claims=[EvidenceClaim(claim="a claim", source_fragments=["frag-e"])]
+    )
+    contract = MediumContract(medium="research", default_privacy_tier=PrivacyTier.OPEN)
+
+    result = ReflectionNode().review(
+        _draft_reproducing(_LEAK_SECRET),
+        evidence,
+        contract=contract,
+        vault=tmp_path,
+    )
+
+    leaks = [f for f in result.findings if f.dimension == "privacy_compliance"]
+    assert len(leaks) == 1, result.findings
+    assert "'frag-e'" in leaks[0].message
+    assert "'intimate'" in leaks[0].message
+
+
+def test_duplicate_cited_id_below_the_winner_is_still_body_checked(
+    tmp_path: Path,
+) -> None:
+    """The loser record's body is protected too, because the *id* resolved intimate.
+
+    An implementation that fails closed on the tier but keeps only the winning
+    record's body still leaks: here the draft reproduces the ``open`` twin's
+    body while the id resolves to ``intimate``, and the gate must flag it. The
+    tier is a property of the cited id, and every body stored under that id is
+    text the draft may not reproduce — pinning keep-ALL-bodies against a
+    keep-only-the-winner's-body shortcut (#1341).
+    """
+    _seed_fragment(
+        tmp_path,
+        "frag-f",
+        _LEAK_SECRET,
+        PrivacyTier.INTIMATE,
+        subtree="09-Reference",
+    )
+    second_body = "the quieter half of the same note, filed openly"
+    _seed_fragment(tmp_path, "frag-f", second_body, PrivacyTier.OPEN)
+    evidence = EvidenceBundle(
+        claims=[EvidenceClaim(claim="a claim", source_fragments=["frag-f"])]
+    )
+    contract = MediumContract(medium="research", default_privacy_tier=PrivacyTier.OPEN)
+
+    result = ReflectionNode().review(
+        _draft_reproducing(second_body),
+        evidence,
+        contract=contract,
+        vault=tmp_path,
+    )
+
+    leaks = [f for f in result.findings if f.dimension == "privacy_compliance"]
+    assert len(leaks) == 1, result.findings
+    assert "'frag-f'" in leaks[0].message
+    assert "'intimate'" in leaks[0].message
+
+
+def test_privacy_gate_polices_a_vault_with_no_01_fragments_dir(
+    tmp_path: Path,
+) -> None:
+    """A vault with no ``01-Fragments`` folder is still policed (#1341).
+
+    The resolver bails on the whole walk when ``<vault>/01-Fragments`` is not a
+    directory, so a corpus held entirely under ``09-Reference`` — a
+    reference-only vault, or one mid-migration — gets no privacy gate at all,
+    not even a degraded one. The absence of one subtree must never disable the
+    others.
+
+    Measured today: zero findings, ``PASS``.
+    """
+    _seed_fragment(
+        tmp_path,
+        "frag-g",
+        _LEAK_SECRET,
+        PrivacyTier.INTIMATE,
+        subtree="09-Reference",
+    )
+    assert not (tmp_path / "01-Fragments").exists()  # the precondition under test
+    evidence = EvidenceBundle(
+        claims=[EvidenceClaim(claim="a claim", source_fragments=["frag-g"])]
+    )
+    contract = MediumContract(medium="research", default_privacy_tier=PrivacyTier.OPEN)
+
+    findings = check_privacy_compliance(
+        _draft_reproducing(_LEAK_SECRET), evidence, tmp_path, contract
+    )
+
+    assert [(f.dimension, f.severity) for f in findings] == [
+        ("privacy_compliance", "HIGH")
+    ]
+    assert "'frag-g'" in findings[0].message
+    assert "'intimate'" in findings[0].message
+
+
+def test_leak_gate_reads_the_true_tier_while_the_router_reads_the_admitted_one(
+    tmp_path: Path,
+) -> None:
+    """The gate and the router see the same id at two different tiers — on purpose.
+
+    Two records share ``frag-d``: an ``open`` one in ``01-Fragments`` and an
+    ``intimate`` one in ``09-Reference``.
+
+    * The **router** (``creek.author.agents.fragment_tier_map``) reads the
+      *admitted* view. ``_load_corpus`` filters with ``tier_within_override``,
+      so at an ``open`` ceiling the intimate copy never enters the evidence and
+      the map reports ``open``. That half passes today; it is a pin, not a fix.
+    * The **leak gate** reads the *true* tier, unfiltered and fail-closed. It
+      exists to answer "is protected text in this draft?", and a gate that only
+      looked at what the ceiling admitted would be blind to exactly the content
+      it is there to catch. It must report ``intimate``.
+
+    The divergence is therefore deliberate, and this test states it so a future
+    "make these agree" cleanup has to argue with a named assertion rather than a
+    silent assumption. The gate half is asserted through the public
+    :func:`~creek.author.checks.check_privacy_compliance` message rather than
+    the private resolver, whose return shape #1341 changes.
+    """
+    from creek.author.agents import fragment_tier_map
+    from creek.classify.privacy_filter import PrivacyTierOverride
+
+    _seed_fragment(tmp_path, "frag-d", _DECOY_BODY, PrivacyTier.OPEN)
+    _seed_fragment(
+        tmp_path,
+        "frag-d",
+        _LEAK_SECRET,
+        PrivacyTier.INTIMATE,
+        subtree="09-Reference",
+    )
+    evidence = EvidenceBundle(
+        claims=[EvidenceClaim(claim="a claim", source_fragments=["frag-d"])]
+    )
+    contract = MediumContract(medium="research", default_privacy_tier=PrivacyTier.OPEN)
+
+    findings = check_privacy_compliance(
+        _draft_reproducing(_LEAK_SECRET), evidence, tmp_path, contract
+    )
+
+    # Gate half — the true tier, above the ceiling, so the leak is caught.
+    assert [(f.dimension, f.severity) for f in findings] == [
+        ("privacy_compliance", "HIGH")
+    ]
+    assert "'intimate'" in findings[0].message
+    # Router half — the admitted view at the same ceiling, unchanged.
+    assert fragment_tier_map(tmp_path, PrivacyTierOverride.OPEN) == {
+        "frag-d": PrivacyTier.OPEN
+    }
 
 
 def test_privacy_without_a_vault_still_skips(tmp_path: Path) -> None:

--- a/creek-tools/tests/test_vault_reader.py
+++ b/creek-tools/tests/test_vault_reader.py
@@ -2,17 +2,20 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import ast
+from pathlib import Path
 from zoneinfo import ZoneInfo
 
 import pytest
 
+from creek import author as author_pkg
+from creek.author import agents as author_agents
+from creek.author import checks as author_checks
 from creek.models import Fragment, FragmentSource, SourcePlatform
+from creek.vault import authors as vault_authors
+from creek.vault import reader as vault_reader
 from creek.vault.reader import iter_vault_fragments, try_load_fragment
 from tests.helpers import write_fragment_file
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 def test_try_load_fragment_returns_triple(tmp_path: Path) -> None:
@@ -213,3 +216,123 @@ def test_try_load_fragment_round_trips_hierarchy_fields(tmp_path: Path) -> None:
     assert raw["child_ids"] == ["frag-hier-kidaa", "frag-hier-kidbb"]
     assert raw["level"] == "section"
     assert raw["structural_path"] == ["Essay", "Part 2"]
+
+
+# ---------------------------------------------------------------------------
+# #1341 — one definition of "the corpus", or the leak gate goes blind again
+#
+# ``creek/author/agents.py`` listed the three subtrees the desk reads;
+# ``creek/author/checks.py`` hardcoded ``01-Fragments`` and read one. The two
+# lists disagreeing is the whole defect, so the fix is not "add two strings to
+# the gate" — it is "there is only one list, and it lives under ``creek.vault``
+# with the rest of the vault-layout knowledge."
+# ---------------------------------------------------------------------------
+
+_CORPUS_ROOTS = ("01-Fragments", "09-Reference", "11-Other-Authors")
+"""The three vault subtrees the Writing Desk draws evidence from.
+
+Spelled out here rather than imported so the AST sweep below fails on what it
+is meant to find — a hardcoded root in a desk module — instead of on an import
+error. Drift between this literal and the shipped constant is what
+:func:`test_the_leak_gate_and_the_specialists_read_one_corpus_definition`
+catches.
+"""
+
+
+def _author_package_root() -> Path:
+    """Return the on-disk directory holding the ``creek.author`` package.
+
+    Derived from the imported package rather than a repository-relative path so
+    the sweep follows the installed package wherever the test runs from.
+
+    Returns:
+        The directory containing ``creek/author/__init__.py``.
+    """
+    origin = author_pkg.__file__
+    assert origin is not None  # a regular package always has a file origin
+    return Path(origin).parent
+
+
+def _non_docstring_strings(tree: ast.Module) -> list[str]:
+    """Return every string constant in *tree* that is not in a docstring position.
+
+    A docstring — module, class, function, or the PEP-257-style *attribute*
+    docstring this repo writes after an assignment — is a bare expression
+    statement whose value is a string constant. That is a superset of what
+    :func:`ast.get_docstring` reports (which covers only ``Module`` /
+    ``ClassDef`` / ``FunctionDef`` / ``AsyncFunctionDef``), so skipping bare
+    ``Expr(Constant(str))`` statements excludes every kind at once. Prose is
+    allowed to name a vault folder; *code* is not.
+
+    Args:
+        tree: A parsed module.
+
+    Returns:
+        The remaining string constants, in walk order.
+    """
+    docstring_positions = {
+        id(node.value)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant)
+    }
+    return [
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and id(node) not in docstring_positions
+    ]
+
+
+def test_the_leak_gate_and_the_specialists_read_one_corpus_definition() -> None:
+    """The gate and the specialists must share one corpus-subtree object (#1341).
+
+    Asserted by **identity**, not equality: two hardcoded lists that happen to
+    match today would satisfy ``==`` and then drift apart on the next edit —
+    which is precisely how ``check_privacy_compliance`` came to police one
+    subtree while ``_load_corpus`` gathered from three. ``is`` can only be
+    satisfied by both modules reading the same object.
+
+    The definition belongs beside the rest of the vault-layout knowledge in
+    :mod:`creek.vault.reader`, and its ``11-Other-Authors`` entry must be the
+    already-canonical :data:`creek.vault.authors.OTHER_AUTHORS_DIR` rather than
+    a fourth copy of that string.
+
+    Today this fails with ``AttributeError`` — the constant does not exist yet.
+    """
+    assert tuple(vault_reader.CORPUS_SUBDIRS) == _CORPUS_ROOTS
+    assert author_checks.CORPUS_SUBDIRS is vault_reader.CORPUS_SUBDIRS
+    assert author_agents.CORPUS_SUBDIRS is vault_reader.CORPUS_SUBDIRS
+    assert vault_reader.CORPUS_SUBDIRS[2] == vault_authors.OTHER_AUTHORS_DIR
+
+
+def test_no_desk_module_hardcodes_a_corpus_root() -> None:
+    """No module under ``creek/author/`` may spell a corpus root in code (#1341).
+
+    The forcing function for the constant above: an AST sweep of every desk
+    module for a string constant — outside any docstring — containing one of
+    the three corpus roots. A second literal is a second source of truth, and
+    the first one that fell out of step is what made the HARD privacy gate
+    blind to ``09-Reference`` and ``11-Other-Authors``.
+
+    Only the three exact root strings are matched. A shape-based rule such as
+    ``^\\d{2}-[A-Za-z]`` would reject ``creek/author/contracts.py``'s
+    legitimate ``("00-Creek-Meta", "Skills", "mediums")`` tuple, which names a
+    *different* part of the vault and is not the constant under discussion.
+
+    Today this fails naming two offenders: ``agents.py``'s ``_CORPUS_SUBDIRS``
+    tuple and ``checks.py``'s ``vault / "01-Fragments"``.
+    """
+    offenders: list[str] = []
+    for module_path in sorted(_author_package_root().rglob("*.py")):
+        tree = ast.parse(module_path.read_text(encoding="utf-8"))
+        offenders.extend(
+            f"{module_path.name}: {text!r}"
+            for text in _non_docstring_strings(tree)
+            if any(root in text for root in _CORPUS_ROOTS)
+        )
+
+    assert offenders == [], (
+        "Desk modules must import the corpus subtrees from creek.vault.reader "
+        f"instead of spelling them: {offenders}"
+    )


### PR DESCRIPTION
## Summary

The HARD `privacy_compliance` leak gate resolved cited fragment tiers out of `01-Fragments` **only**, while the Writing Desk specialists gather evidence from three subtrees. A cited over-tier fragment living in `09-Reference` or `11-Other-Authors` resolved to nothing, so the gate never learned its tier and a draft could reproduce its protected body verbatim under `verdict=PASS`.

Reproduced by execution before the fix — same INTIMATE fragment, same id, same body reproduced verbatim in the draft, `MediumContract(medium="research", default_privacy_tier=OPEN)`; only the subtree differs:

| subtree | `_resolve_cited_tiers` | findings |
|---|---|---|
| `01-Fragments` | `['frag-b']` | `['privacy_compliance']` |
| `09-Reference` | `[]` | `[]` |
| `11-Other-Authors` | `[]` | `[]` |

The corroborating inconsistency, also measured: `fragment_tier_map(v, INTIMATE)` returned `{'frag-r': 'intimate', 'frag-o': 'intimate'}` for the very two fragments the gate returned `[]` for — the #661 router and the leak gate genuinely disagreed about the same vault.

### What changed

- **One corpus definition.** `CORPUS_SUBDIRS` now lives in `creek/vault/reader.py`; `checks.py` and `agents.py` both import that object. While they were two literals the gate fell a subtree behind the specialists it polices.
- **The walk covers all three roots**, with a **per-root** `is_dir()` skip. The old global `if not fragments_root.is_dir(): return resolved` became an outright bug with three roots — a vault with no `01-Fragments` but a populated `09-Reference` had no privacy gate at all.
- **Duplicate ids fold through a frozen `_CitedFragment`**: most-restrictive tier wins, and **every** body is kept at every rank. The fold is monotone and commutative, so walk order provably cannot change the verdict. Keeping only the winning rank's body would reopen the hole one rank down.
- **The first-hit `break` is gone** — you cannot stop at the first match and also take the most restrictive.
- Docstring corrections: the module docstring claimed the check uses `iter_vault_fragments` (it uses `try_load_fragment`), and the resolver's docstring sold an early exit the code no longer has. `docs/writing-desk.md` now states which subtrees the gate polices.

### Behaviour change an operator will notice

This makes the gate see **more**, and on this base (#1352, #1361, both merged) a seen finding actually withholds: `creek author` withholds the body and exits non-zero, and the MCP `creek.author` verb answers `status: "refused"`. **So drafts that previously shipped can now be refused.** That is the intended direction, but it is user-visible.

A draft is newly refused only when all of these hold: it cites id X; X resolves from `09-Reference` or `11-Other-Authors` (or is duplicated across subtrees with an above-ceiling twin); X's true tier ranks above the contract ceiling (`open` in every shipped medium template); and the draft reproduces >= 4 words of one of X's stored bodies verbatim. Reaching it also requires an elevated `--include-tier personal|intimate|all`, since the default OPEN admission keeps above-OPEN content out of the evidence to begin with.

**Measured, on the only corpus available: zero.** The full suite is 8902 passed / 5 skipped, so no previously-passing draft flipped. 63 fixture sites across the other suites seed those two subtrees, and every one relies on `write_raw_fragment_file`'s `privacy_tier="open"` default (no explicit override on any of them), so none is above the ceiling.

**I cannot give a number for a real operator vault** — no vault exists on this host (no `01-Fragments` / `09-Reference` / `11-Other-Authors` tree anywhere under the repo). The count is a property of vault content, not of the code. To get the upper bound on your own vault — the population of newly gate-visible fragments, of which only the *cited and verbatim-reproduced* ones can refuse a draft:

```python
from creek.vault.reader import CORPUS_SUBDIRS, iter_vault_fragments
from creek.models import PrivacyTier
RANK = {PrivacyTier.OPEN: 0, PrivacyTier.PERSONAL: 1,
        PrivacyTier.INTIMATE: 2, PrivacyTier.UNCLASSIFIED: 3}
vault = pathlib.Path("<your vault>")
newly = [f.id for sub in CORPUS_SUBDIRS if sub != "01-Fragments"
         for _p, f, _b, _m in iter_vault_fragments(vault / sub)
         if RANK.get(PrivacyTier(f.privacy_tier), 3) > 0]
print(len(newly), newly[:20])
```
(Verified against a synthetic vault with a known answer: 7 fragments in corpus, 3 newly visible — exact match.)

### Deliberately left alone

- The `if vault is None:` guard, the `_NO_CONTRACT_CEILING` branch, and the `check_privacy_compliance` docstring paragraph — all shipped by #1352. The issue body's "Task 2" was already delivered there; rewriting it would re-introduce a merged privacy hole.
- `fragment_tier_map`'s last-wins duplicate rule. It feeds `conductor.py::_content_tier` and therefore the ModelRouter's Intimate-never-cloud decision. The divergence from the gate's most-restrictive rule is now documented in its docstring and pinned by a named test rather than left as a silent assumption.
- `_PRIVACY_DIMENSION`, duplicated privately in `creek/cli.py` and `creek_mcp/tools/author.py` — that cleanup is #1362.
- **No symlink-containment predicate**, on purpose: under a monotone fold an extra record can only raise a tier or add a body, never lower or remove one, so a planted out-of-tree shadow cannot downgrade or mask anything. Adding a skip path would introduce the only genuinely unsafe move available — dropping a body, and with it a leak. Residual: out-of-tree content reachable by symlink can cause a false-*positive* refusal, which is the safe direction.
- **No cache**, on purpose. The walk widened from one subtree to three and the early exit is gone, so the common miss path — an LLM inventing a fragment id — is now always exhaustive, once per `review` call up to `max_author_rounds` (default 3, capped at 10). A cache with wrong invalidation on a HARD leak gate is worse than a slow gate; if it bites, that is a measured follow-up.

## Test plan

**Proved RED before the fix** (the repo's standing rule). 15 node ids, 14 failing on a behavioural assertion and 1 on the deliberately-absent constant:

```
tests/test_reflection.py::test_privacy_gate_sees_over_tier_fragment_in_every_corpus_subtree[09-Reference-intimate]
tests/test_reflection.py::test_privacy_gate_sees_over_tier_fragment_in_every_corpus_subtree[09-Reference-personal]
tests/test_reflection.py::test_privacy_gate_sees_over_tier_fragment_in_every_corpus_subtree[09-Reference-absent-privacy-tier-key]
tests/test_reflection.py::test_privacy_gate_sees_over_tier_fragment_in_every_corpus_subtree[11-Other-Authors-intimate]
tests/test_reflection.py::test_privacy_gate_sees_over_tier_fragment_in_every_corpus_subtree[11-Other-Authors-personal]
tests/test_reflection.py::test_privacy_gate_sees_over_tier_fragment_in_every_corpus_subtree[11-Other-Authors-absent-privacy-tier-key]
tests/test_reflection.py::test_duplicate_cited_id_resolves_to_the_most_restrictive_tier[strict-last]
tests/test_reflection.py::test_duplicate_cited_id_at_equal_tier_cannot_mask_the_leaking_body[decoy-first]
tests/test_reflection.py::test_duplicate_cited_id_below_the_winner_is_still_body_checked
tests/test_reflection.py::test_privacy_gate_polices_a_vault_with_no_01_fragments_dir
tests/test_reflection.py::test_leak_gate_reads_the_true_tier_while_the_router_reads_the_admitted_one
tests/test_vault_reader.py::test_the_leak_gate_and_the_specialists_read_one_corpus_definition   (AttributeError — the shared constant does not exist yet)
tests/test_vault_reader.py::test_no_desk_module_hardcodes_a_corpus_root
tests/test_cli_author.py::test_author_withholds_intimate_text_leaked_from_a_non_fragments_subtree[09-Reference]
tests/test_cli_author.py::test_author_withholds_intimate_text_leaked_from_a_non_fragments_subtree[11-Other-Authors]
```

The two CLI cases are the reachability proof through a real surface — `creek author --medium research --include-tier intimate` via Typer's `CliRunner`. Pre-fix stdout read `verdict=PASS rounds=1` with the intimate sentence verbatim and exit code 0.

**Coverage is not intimate-only:** the matrix crosses both subtrees with INTIMATE, PERSONAL, and an absent `privacy_tier` key — the last ranks UNCLASSIFIED, which this gate's table puts at the *top* of the restrictiveness order, so an untiered fragment is over every ceiling.

**Mutation battery — 8 mutants, each guard reverted alone. 7 killed:**

| mutant | killed by |
|---|---|
| M1 walk `01-Fragments` only (the original defect) | 13 tests |
| M2 global early-return when `01-Fragments` absent | 9 tests |
| M3 tier merge last-wins instead of most-restrictive | 1 — `…most_restrictive_tier[strict-first]` |
| M4 keep only the last body seen | 3 tests |
| M5 drop bodies below the winning rank | 1 — `…below_the_winner_is_still_body_checked` |
| M7 gate applies `tier_within_override` (blinds itself) | 29 tests |
| M8 `checks.py` re-forks its own corpus literal | 2 — both forcing functions |

M3 initially **survived**, and closing it found a real gap: every duplicate-id fixture put the strict record in the later-walked subtree, so last-wins gave the right answer for the wrong reason. Measured under the mutant, with the INTIMATE record in `01-Fragments` and its OPEN twin behind it: **zero findings**, with the protected body sitting verbatim in the draft. Fixed by parameterising the test `[strict-last]` / `[strict-first]`.

**One survivor, by design: M6 (unsorted walk), 0 tests fail.** The `_CitedFragment` fold is monotone and commutative, so walk order provably cannot change the verdict — the `sorted()` is reproducibility and debugging defence-in-depth, not a correctness guard, and no behavioural test can kill it without asserting on filesystem order. Determinism is carried by the type, which is the stronger guarantee.

**Router/gate agreement, proven by execution** on a 3-fragment corpus spanning all three subtrees (deliberately more than one element, so no assertion is vacuous):

```
checks.CORPUS_SUBDIRS is reader.CORPUS_SUBDIRS : True
agents.CORPUS_SUBDIRS is reader.CORPUS_SUBDIRS : True
router (#661 fragment_tier_map): {'frag-b': 'intimate', 'frag-o': 'intimate', 'frag-r': 'intimate'}
gate   (_resolve_cited_tiers)  : {'frag-b': 'intimate', 'frag-o': 'intimate', 'frag-r': 'intimate'}
AGREE on id set: True    AGREE on every tier: True
```

**Gate 2: `./scripts/check-all.sh` exit code 0.** 8902 passed, 5 skipped, branch coverage 94.40%, per-file gate passed (256 files >= 80%), 12/12 checks. Complexity *improved*: `_resolve_cited_tiers` B(8) → A(4), nothing in the file above B, module average A(4.73) → A(3.82). Docstring coverage 100% on both changed modules.

No bypasses were added anywhere, including in tests — `tests/` sits outside mypy's scope (#1366), so that sweep was done by hand as well as by the gate.

**Gate 2.5** (`code-review-orchestrator` over the diff): **CLEAN, no blockers.** Its three non-blocking notes were engagement with the three questions I put to it — it agreed M6 is by-design and could not construct an input where two walk orderings differ; it agreed the symlink argument holds *for this gate*; and it agreed the no-cache trade is correctly called. It also caught a stale citation of mine: `use_enum_values=True` for the `Fragment` model is `creek/models.py:762` (the `:518` I first grepped is `MediumContract`), with the `privacy_tier` default at `:801` — the docstring claim itself is correct.

Its one genuinely new observation is filed as **#1373** (P3): `agents.py::_load_corpus` has the same absence of symlink containment, but unlike the gate it feeds evidence *into the rendered draft*, so there the direction is unsafe rather than safe. Pre-existing and out of scope here.

Closes #1341
