### PR TITLE
fix(api): refuse to let a cache keep, or misfile, a /v1 answer

### DIFF
--- a/creek-tools/creek_mcp/api/openapi.py
+++ b/creek-tools/creek_mcp/api/openapi.py
@@ -39,6 +39,7 @@ from creek_mcp.api.models import (
     ErrorCode,
 )
 from creek_mcp.api.routes import (
+    AUTHORIZATION_HEADER,
     CEILING_HEADER,
     CONTRACT_VERSION_HEADER,
     IMPLEMENTED_CAPABILITIES,
@@ -67,11 +68,25 @@ DOCUMENT_TITLE: Final[str] = "Creek Adepthood /v1 application API"
 
 DOCUMENT_DESCRIPTION: Final[str] = (
     "Authenticated HTTP/JSON access to Creek's Adepthood-facing capabilities. "
-    f"Every response carries Vary: {CEILING_HEADER}, every error is the "
-    "ErrorEnvelope, and retryability is the static retry-policy.json table "
-    "keyed on the error code alone."
+    f"Every response this application builds carries Vary: {CEILING_HEADER}, "
+    f"{AUTHORIZATION_HEADER} and Cache-Control: no-store — do not enable "
+    "caching for /v1 on an intermediary. Every error is the ErrorEnvelope, and "
+    "retryability is the static retry-policy.json table keyed on the error "
+    "code alone."
 )
-"""``info.description``. Prose only; it states no fact about any vault."""
+"""``info.description``. Prose only; it states no fact about any vault.
+
+Interpolated from the header constants rather than spelled out, so the sentence
+a consumer reads and the header the server stamps cannot drift — the same
+reason :func:`_parameters` publishes the parameter names from constants.
+
+The caching half of it changed with #1129 and is a *description* change only:
+no operation, parameter, schema or status moved, so the byte-pinned component
+schemas under ``docs/contracts/adepthood-v1/schemas/`` are untouched and the
+contract minor does not advance. It documents a response header, which OpenAPI
+3.1 has no required place for on a document-wide basis, so prose is where it
+goes until the per-response ``headers`` objects are worth generating.
+"""
 
 _DEFS_KEY: Final[str] = "$defs"
 """The key Pydantic hoists nested definitions under, and OpenAPI does not."""

--- a/creek-tools/creek_mcp/api/routes.py
+++ b/creek-tools/creek_mcp/api/routes.py
@@ -52,8 +52,28 @@ without it, and those two must name the same header.
 CEILING_HEADER: Final[str] = "X-Creek-Tier-Ceiling"
 """Header carrying the caller's declared tier ceiling.
 
-Also the value of every response's ``Vary``, so an intermediary cache can never
-serve one caller's ceiling-filtered response to another.
+Also one of the two standing ``Vary`` tokens, so an intermediary cache can never
+serve one caller's ceiling-filtered response to another. The other is
+:data:`AUTHORIZATION_HEADER`.
+"""
+
+AUTHORIZATION_HEADER: Final[str] = "Authorization"
+"""The header a consumer presents its bearer token in.
+
+Declared in this framework-free module, rather than beside the middleware that
+reads it, because two modules now have to agree on the string and one of them
+cannot import the other. :mod:`creek_mcp.httpapi.auth` *reads* this header to
+authenticate; :mod:`creek_mcp.httpapi.errors` *names* it in every response's
+``Vary`` so a cache keys on the credential (#1129). Those two must be the same
+header or the ``Vary`` declares a dependency on something no request carries —
+and ``auth`` already imports ``errors``, so the constant cannot live there
+without a cycle.
+
+Unlike its two neighbours it is **not** published in the OpenAPI document: that
+document declares no ``securitySchemes`` and no bearer requirement at all,
+despite every route sitting behind the gate. That gap is tracked separately; it
+is a reason this constant will gain a third reader, not a reason to file it
+somewhere else.
 """
 
 OP_CAPABILITIES: Final[str] = "getCapabilities"

--- a/creek-tools/creek_mcp/httpapi/auth.py
+++ b/creek-tools/creek_mcp/httpapi/auth.py
@@ -37,6 +37,7 @@ from typing import TYPE_CHECKING, Final
 from starlette.datastructures import Headers
 
 from creek_mcp.api.models import ErrorCode
+from creek_mcp.api.routes import AUTHORIZATION_HEADER
 from creek_mcp.httpapi.context import HTTP_SCOPE, context_of, pass_through
 from creek_mcp.httpapi.errors import error_response
 from creek_mcp.remote_auth import (
@@ -49,9 +50,6 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
 
     from starlette.types import ASGIApp, Receive, Scope, Send
-
-AUTHORIZATION_HEADER: Final[str] = "Authorization"
-"""The header a consumer presents its bearer token in."""
 
 BEARER_SCHEME: Final[str] = "Bearer"
 """The one accepted scheme spelling. Compared exactly, never case-folded."""

--- a/creek-tools/creek_mcp/httpapi/errors.py
+++ b/creek-tools/creek_mcp/httpapi/errors.py
@@ -1,7 +1,9 @@
 """The one place ``/v1`` builds a response, error or otherwise (#1074).
 
 Two invariants live here, and both are structural rather than behavioural —
-which is why they are worth concentrating in one small module.
+which is why they are worth concentrating in one small module. The second one
+carries most of the prose: the bold headings beneath it are the arguments for
+its shape, not a third and fourth invariant.
 
 **One error-envelope construction site.**
 :class:`~creek_mcp.api.models.ErrorEnvelope` is ``extra="forbid"`` with three
@@ -12,44 +14,111 @@ caller-derived ``message`` eventually appears, and a refusal that varies with
 its input is an existence-and-rank oracle. ``tests/test_v1_api_structure.py``
 AST-counts the construction sites across the package and pins the total at one.
 
-**One ``Vary`` stamp.** Every response — the ``200``, the ``501``, the routing
-``404``, and the ``401`` that never reaches the ceiling middleware at all —
-must carry ``Vary: X-Creek-Tier-Ceiling``, or a shared cache could serve one
-caller's ceiling-filtered response to another. Authentication sits *above* the
-ceiling gate, so there is no single middleware every response passes through on
-the way out with the ceiling in scope. There is, however, exactly one builder:
-:func:`json_response`. Routing every response through it is what makes the
-header unconditional — and, since #1128, unforgeable. The builder used to lay
-this header *under* the caller's, so any call site handing in a ``Vary`` of its
-own silently deleted the ceiling token; the merge now runs the other way. Note
-the narrowness of that claim: ``Vary`` is the only header this builder stamps
-and so the only one protected. Everything else a call site passes still rides
-through untouched, which is what a ``401`` needs — see :func:`_challenge_for`.
+**Two standing headers, two merge rules.** Every response this builder
+constructs — the ``200``, the ``501``, the routing ``404``, and the ``401``
+that never reaches the ceiling middleware at all — carries
+``Vary: X-Creek-Tier-Ceiling, Authorization`` and ``Cache-Control: no-store``.
+Authentication sits *above* the ceiling gate, so there is no single middleware
+every response passes through on the way out with the ceiling in scope. There
+is, however, exactly one builder: :func:`json_response`. Routing every response
+through it is what makes both headers unconditional — and, since #1128,
+unforgeable. They are also the only two headers this builder stamps and so the
+only two protected: everything else a call site passes rides through untouched,
+which is what a ``401`` needs — see :func:`_challenge_for`.
 
-It absorbs the colliding value rather than discarding it, and that is the
-load-bearing half of the policy. Dropping a caller's ``Vary`` would close this
-hole and open its mirror image — a response whose body really does turn on
-``Accept-Encoding`` but that claims to turn only on the ceiling invites a cache
-to key on less than the truth, which is this same defect pointed the other way.
-Union is also the only direction that is *monotone*: RFC 9111 §4.1 makes reuse
-a conjunction over the nominated field names, so adding a token can only ever
-shrink the set of requests an entry may be served to, never widen it.
+Scope that claim to what it covers — *every response this builder constructs*,
+which is not the same as every ``/v1`` response. Two paths reach a client
+without passing through here: Starlette's router answers a trailing-slash
+request with its own ``307`` before any handler runs, and Starlette's
+``ServerErrorMiddleware`` renders a ``text/plain`` ``500`` if a fault escapes
+the access-log layer's own ``try``. Both are filed separately and neither is
+closable from inside this module. A security docstring that overstates its
+reach is worse than one that says nothing, because the next reader stops
+looking where the hole actually is.
 
-So the values union: the ceiling token first, then the caller's in the order
-supplied. The order is fixed rather than incidental because the rendered value
-is asserted byte-for-byte by
+**Why unconditional, rather than conditional on authentication.** The ask was
+for these headers on *authenticated* responses; stamping them on every response
+is the only implementable reading of it. :func:`json_response` takes no
+:class:`~creek_mcp.httpapi.context.RequestContext`, so conditioning on
+``context.consumer`` means threading a context through the one builder and all
+six of its call sites, destroying the context-freedom that lets the builder be
+unit-tested as a pure function of its arguments. The cheap alternative —
+stamping in :func:`error_response` alone — covers every refusal and no ``200``,
+the exact inverse of what was asked. And the condition would have nothing to
+decide: :class:`~creek_mcp.httpapi.auth.BearerAuthMiddleware` is item 5 of the
+seven-layer stack, *above* the router, so all five routes are authenticated by
+construction. Where it *would* have an effect is on a route that does not exist
+yet — one mounted above the gate would silently stop being stamped, because
+such a condition is keyed on the stack's order rather than on anything the
+builder can see. The unconditional form cannot fail that way.
+
+**What the exposure actually is.** Intersect the published status set —
+``{200, 401, 403, 404, 409, 422, 500, 501, 503}`` — with the statuses RFC 9110
+§15.1 enumerates as heuristically cacheable — ``{200, 203, 204, 206, 300, 301,
+404, 405, 410, 414, 501}`` — and the whole of it is ``{200, 404, 501}``. Lead
+with the ``404``: it is reachable today on every unrouted ``/v1`` path, it
+carries no explicit freshness information, and a *conforming* shared cache may
+therefore store it and reuse it on heuristic freshness alone. That is the one
+case here where this is not merely prophylactic. Do not rest the argument on a
+cached ``401`` instead: that status is not on the heuristic list, so the story
+needs an intermediary already violating the specification, and an argument that
+only holds against a broken cache is one a reviewer can wave away.
+
+**The two headers are independent mechanisms, not one doubled.** The hazard is
+a *misconfigured* intermediary — precisely the one that may ignore
+``no-store``. For that cache the remedy is not a louder instruction but a
+correct cache *key*, and naming ``Authorization`` in ``Vary`` is that key:
+RFC 9111 §4.1 makes reuse a conjunction over the nominated field names, so
+adding a token is monotone — it can only ever shrink the set of requests a
+stored entry may be served to, never widen it. Neither header subsumes the
+other. Drop ``no-store`` and a compliant cache is free to store; drop the token
+and a non-compliant one is free to mismatch. Both, or neither is worth having.
+
+**``Vary`` unions.** It absorbs a colliding caller value rather than discarding
+it, and that is the load-bearing half of the policy. Dropping a caller's
+``Vary`` would close this hole and open its mirror image — a response whose
+body really does turn on ``Accept-Encoding`` but that claims to turn only on
+the standing tokens invites a cache to key on less than the truth, which is
+this same defect pointed the other way. Union is also the only direction that
+is monotone, by the paragraph above.
+
+So the values union: the standing tokens first, in their own fixed order, then
+the caller's in the order supplied. That order is fixed rather than incidental
+because the rendered value is asserted byte-for-byte by
 ``tests/test_v1_api_admission.py::test_a_caller_echoing_the_standing_token_does_not_double_it``,
 and because a header whose bytes depended on set iteration would differ between
 two worker processes answering the same request.
 
-Names are matched case-folded, because ``Vary`` and ``vary`` are one header on
-the wire and two keys in a dict — Starlette lowercases each key independently
-and never deduplicates, so an unfolded merge emits two ``vary`` lines and leaves
-it to the intermediary to decide which one keys the cache. Caller tokens outside
-RFC 9110's ``tchar`` set are dropped whole rather than repaired, and only ``OWS``
-— the space and the horizontal tab — is trimmed before that test, so a token
-cannot be *whitespace-stripped* back into legality either. A repaired token is
-still a token the caller chose, and this header's contents decide a cache key.
+**``Cache-Control`` replaces.** A caller's value is dropped whole, under any
+spelling. Be honest about the cost: this is *not* directive-wise monotone.
+``private`` and ``no-cache`` are subsumed by ``no-store``, but ``no-transform``
+and ``must-understand`` are not — a response nothing may store can still be
+transformed in flight — so a call site passing ``no-store, no-transform`` loses
+a restriction. It is chosen anyway. Preserving it means parsing a header whose
+members take ``=``-valued arguments and then ruling on whether ``max-age=600``
+contradicts ``no-store``, and a directive parser with a contradiction policy is
+a larger thing to get wrong than the single directive it would rescue. Nothing
+pays for it today either: no production call site passes a ``Cache-Control`` at
+all — :func:`_challenge_for`, the only caller handing this builder extra
+headers, passes only ``WWW-Authenticate`` — so the first call site that
+genuinely needs ``no-transform`` should teach this builder about it rather than
+smuggle it through an argument documented to discard it. *Prepending* the
+standing directive was rejected on the same evidence rather than on taste:
+``no-store, max-age=600`` is self-contradictory, RFC 9111 does not say which
+half wins, and real caches resolve it inconsistently — so the response's
+meaning would become the intermediary's choice rather than the server's.
+
+The two rules share a mechanism and nothing else. :func:`_folds_to` matches a
+header name case-folded, for both of them; the policies stay two named
+constants and two named rules. Folding is not politeness about style: ``Vary``
+and ``vary`` are one header on the wire and two keys in a dict — Starlette
+lowercases each key independently and never deduplicates, so an unfolded merge
+emits two ``vary`` lines and leaves it to the intermediary to decide which one
+keys the cache. Caller ``Vary`` tokens outside RFC 9110's ``tchar`` set are
+dropped whole rather than repaired, and only ``OWS`` — the space and the
+horizontal tab — is trimmed before that test, so a token cannot be
+*whitespace-stripped* back into legality either. A repaired token is still a
+token the caller chose, and this header's contents decide a cache key.
 """
 
 from __future__ import annotations
@@ -65,7 +134,7 @@ from creek_mcp.api.models import (
     ErrorCode,
     ErrorEnvelope,
 )
-from creek_mcp.api.routes import CEILING_HEADER
+from creek_mcp.api.routes import AUTHORIZATION_HEADER, CEILING_HEADER
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
@@ -76,6 +145,23 @@ if TYPE_CHECKING:
 
 VARY_HEADER: Final[str] = "Vary"
 """The response header naming which request headers the body depends on."""
+
+_STANDING_VARY_TOKENS: Final[tuple[str, ...]] = (CEILING_HEADER, AUTHORIZATION_HEADER)
+"""Every field name a response declares its body depends on, in wire order.
+
+Two since #1129, and load-bearing for the same reason from two directions: a
+``/v1`` body is a function of the declared ceiling *and* of the authenticated
+consumer, so an entry keyed on either alone may be served to a caller the other
+would have told apart. :data:`~creek_mcp.api.routes.AUTHORIZATION_HEADER` is
+the header the credential actually arrives in —
+:mod:`creek_mcp.httpapi.auth` reads that same constant to authenticate — because
+a ``Vary`` naming a header no request carries varies on nothing at all.
+
+A tuple rather than a set, and iterated rather than indexed: the order is part
+of the rendered value and is asserted byte-for-byte, and a merge that seeded
+itself from ``[0]`` alone would emit the second token twice the moment a caller
+echoed it. Adding a third standing token is therefore a one-line change here.
+"""
 
 _TCHAR: Final[frozenset[str]] = frozenset(
     string.ascii_letters + string.digits + "!#$%&'*+-.^_`|~"
@@ -105,6 +191,35 @@ which would quietly convert ``Cookie,\\r\\nAccept`` into the perfectly legal
 token ``Accept`` — repairing exactly the input this module refuses to repair.
 """
 
+CACHE_CONTROL_HEADER: Final[str] = "Cache-Control"
+"""The response header saying whether this answer may be stored at all.
+
+The second header this builder owns, and the one whose merge rule is
+*replacement* rather than union. ``Vary`` can only get safer as tokens are
+added; this header cannot, because ``public`` and ``max-age`` are each strictly
+more permissive than what the server insists on, and a value carrying both
+theirs and ours would be self-contradictory rather than merely wrong.
+"""
+
+NO_STORE: Final[str] = "no-store"
+"""The whole directive, and deliberately nothing else.
+
+The strongest thing RFC 9111 lets a response say: no cache of any kind may keep
+any part of it. That is the right claim for a body computed from one caller's
+credential under one caller's ceiling. Three plausible neighbours were
+considered and rejected rather than overlooked:
+
+* ``private`` — subsumed. It scopes storage to a single-user cache instead of
+  forbidding storage, so it says less than ``no-store`` already says.
+* ``no-cache, max-age=0`` — strictly weaker. It permits storage and merely
+  demands revalidation before reuse, so a copy of the body still lands on the
+  intermediary's disk, which is the outcome being refused.
+* ``Pragma: no-cache`` — deprecated by RFC 9111 §5.4, and a *request*
+  directive besides. Sending it is cargo cult here: ``/v1``'s clients are
+  contract-versioned JSON consumers, not the HTTP/1.0 browsers the habit was
+  formed for, and an extra header nobody reads is one more thing to keep true.
+"""
+
 WWW_AUTHENTICATE_HEADER: Final[str] = "WWW-Authenticate"
 """The challenge header a ``401`` is obliged to send."""
 
@@ -120,19 +235,47 @@ HTTP_OK: Final[int] = 200
 """The one success status ``/v1`` returns; readiness lives in the body."""
 
 
-def _is_vary(name: str) -> bool:
-    """Return whether *name* is the ``Vary`` header under any spelling.
+def _folds_to(name: str, standing: str) -> bool:
+    """Return whether *name* is the *standing* header under any spelling.
+
+    The shared half of the two policies, and deliberately the only shared half.
+    A ``STANDING_HEADERS`` mapping driving one merge loop over both headers was
+    declined: ``Vary`` unions and ``Cache-Control`` replaces, so the mapping
+    would have to carry the rule as well as the name —
+    ``Mapping[str, MergeRule]``, a strictly more complex type than two named
+    constants and two named rules — and two members is not enough repetition to
+    buy an abstraction. Written down so the next reader need not re-derive it.
 
     Args:
         name: A header name as some call site chose to capitalise it.
+        standing: The canonical spelling of a header this builder stamps:
+            :data:`VARY_HEADER` or :data:`CACHE_CONTROL_HEADER`.
 
     Returns:
-        ``True`` for ``Vary``, ``vary``, ``VARY`` and the rest. Folding here is
-        not politeness about style: an unfolded comparison lets a second
-        spelling through as a separate dict key, and Starlette renders that as
-        a second ``vary`` line rather than merging it.
+        ``True`` when the two are one field name — ``Vary``, ``vary``, ``VARY``
+        and the rest all fold together. Folding here is not politeness about
+        style: an unfolded comparison lets a second spelling through as a
+        separate dict key, and Starlette renders that as a second header line
+        rather than merging it, leaving an intermediary to decide which line
+        governs.
     """
-    return name.casefold() == VARY_HEADER.casefold()
+    return name.casefold() == standing.casefold()
+
+
+def _is_standing(name: str) -> bool:
+    """Return whether this builder stamps *name* itself.
+
+    Args:
+        name: A caller header name, however capitalised.
+
+    Returns:
+        ``True`` for ``Vary`` and ``Cache-Control`` under any spelling — the two
+        headers whose value the builder decides, and therefore the two a caller
+        may not have written out beside it. Named rather than inlined into the
+        passthrough filter so that filter reads as the single idea it is: what
+        rides through is every header this module holds no opinion about.
+    """
+    return _folds_to(name, VARY_HEADER) or _folds_to(name, CACHE_CONTROL_HEADER)
 
 
 def _is_token(candidate: str) -> bool:
@@ -156,7 +299,7 @@ def _is_token(candidate: str) -> bool:
 
 
 def _vary_tokens(supplied: Iterable[str]) -> list[str]:
-    """Return the merged ``Vary`` tokens, the standing one first.
+    """Return the merged ``Vary`` tokens, the standing ones first.
 
     Args:
         supplied: The value of every caller header whose name folds to
@@ -165,17 +308,23 @@ def _vary_tokens(supplied: Iterable[str]) -> list[str]:
             case this exists to collapse.
 
     Returns:
-        :data:`~creek_mcp.api.routes.CEILING_HEADER`, then each well-formed
-        caller token in the order it was supplied, deduplicated case-folded
-        because field names are case-insensitive on the wire. Malformed tokens
-        are absent rather than corrected: only ``OWS`` is trimmed, so a piece
-        whose whitespace is a line break stays malformed and is dropped instead
-        of being tidied into a legal token. The order is fixed rather than
-        incidental — the rendered value is asserted byte-for-byte by
+        Every member of :data:`_STANDING_VARY_TOKENS` in its declared order,
+        then each well-formed caller token in the order it was supplied,
+        deduplicated case-folded because field names are case-insensitive on
+        the wire. Both the seed list and the ``seen`` set are built from the
+        whole tuple: seeding the list from one element would drop a standing
+        token, and seeding ``seen`` from one would emit the other twice as soon
+        as a call site echoed it — which, now that ``Authorization`` is
+        published as part of the contract, is the likeliest collision there is.
+        Malformed tokens are absent rather than corrected: only ``OWS`` is
+        trimmed, so a piece whose whitespace is a line break stays malformed and
+        is dropped instead of being tidied into a legal token. The order is
+        fixed rather than incidental — the rendered value is asserted
+        byte-for-byte by
         ``test_a_caller_echoing_the_standing_token_does_not_double_it``.
     """
-    tokens = [CEILING_HEADER]
-    seen = {CEILING_HEADER.casefold()}
+    tokens = list(_STANDING_VARY_TOKENS)
+    seen = {token.casefold() for token in _STANDING_VARY_TOKENS}
     for value in supplied:
         for piece in value.split(","):
             token = piece.strip(_OWS)
@@ -186,28 +335,41 @@ def _vary_tokens(supplied: Iterable[str]) -> list[str]:
 
 
 def _merged_headers(headers: Mapping[str, str] | None) -> dict[str, str]:
-    """Return *headers* with the standing ``Vary`` merged in over the top.
+    """Return *headers* with the two standing headers laid over the top.
 
     Args:
         headers: The caller's extra headers for this response, or ``None``. It
-            may hold more than one spelling of ``Vary`` — ``Vary`` and ``vary``
-            are one header on the wire but two keys in a dict — and every one
-            of them is collected, which is why the collection is a list.
+            may hold more than one spelling of either standing header —
+            ``Vary`` and ``vary`` are one header on the wire but two keys in a
+            dict, and so are ``Cache-Control`` and ``cache-control`` — so every
+            colliding ``Vary`` is collected, which is why that collection is a
+            list, and every colliding ``Cache-Control`` is discarded, which is
+            why that one is not collected at all.
 
     Returns:
-        Every non-colliding caller header unchanged and unexamined — the bearer
-        challenge has to reach the caller or a ``401`` is a protocol violation —
-        plus exactly one ``Vary`` carrying the ceiling token and whatever the
-        caller asked to add to it. ``Vary`` is placed first so that a response
-        with no colliding header renders byte-for-byte as it did before this
-        merge existed.
+        Three groups, in this order: exactly one ``Vary`` carrying both
+        standing tokens and whatever the caller asked to add to them; exactly
+        one ``Cache-Control``, always :data:`NO_STORE`, whatever the caller
+        asked for; and then every caller header that folds to neither,
+        unchanged and unexamined — the bearer challenge has to reach the caller
+        or a ``401`` is a protocol violation. The order is a decision rather
+        than an accident, for the reason the module docstring gives about token
+        order: a header block whose bytes depended on which key a dict happened
+        to yield first would differ between two worker processes answering the
+        same request, and the byte-exact assertions over it would then report a
+        flake instead of a fault.
     """
     supplied = headers or {}
-    caller_vary = [value for name, value in supplied.items() if _is_vary(name)]
+    caller_vary = [
+        value for name, value in supplied.items() if _folds_to(name, VARY_HEADER)
+    ]
     passthrough = {
-        name: value for name, value in supplied.items() if not _is_vary(name)
+        name: value for name, value in supplied.items() if not _is_standing(name)
     }
-    return {VARY_HEADER: ", ".join(_vary_tokens(caller_vary))} | passthrough
+    return {
+        VARY_HEADER: ", ".join(_vary_tokens(caller_vary)),
+        CACHE_CONTROL_HEADER: NO_STORE,
+    } | passthrough
 
 
 def json_response(
@@ -216,12 +378,15 @@ def json_response(
     *,
     headers: Mapping[str, str] | None = None,
 ) -> Response:
-    """Return *payload* as JSON, stamped with the standing ``Vary``.
+    """Return *payload* as JSON, stamped with both standing headers.
 
-    The single builder. Every ``/v1`` response — success, refusal, and the two
-    produced by exception handlers — is constructed here, which is what makes
-    ``Vary: X-Creek-Tier-Ceiling`` unconditional rather than something each
-    call site has to remember.
+    The single builder. Every ``/v1`` response constructed by this application
+    — success, refusal, and the two produced by exception handlers — is built
+    here, which is what makes ``Vary: X-Creek-Tier-Ceiling, Authorization`` and
+    ``Cache-Control: no-store`` unconditional rather than something each call
+    site has to remember. The module docstring names the two paths that reach a
+    client without being constructed here; the guarantee is over this builder's
+    output, not over every byte the process emits.
 
     Args:
         payload: The already-serialised body. Callers hand in
@@ -229,12 +394,13 @@ def json_response(
             function never has to know which model it is rendering.
         status: The HTTP status line.
         headers: Extra headers for this particular response, such as the
-            bearer challenge. The standing ``Vary`` wins — it is the only
-            header this builder stamps and so the only one protected. A name
-            that collides with it — case-folded, so ``vary`` is the same name —
-            neither replaces the standing value nor is dropped, but has its
-            well-formed tokens folded in after the ceiling token. Every other
-            name passes through unexamined.
+            bearer challenge. The two standing headers win, and they are the
+            only two this builder stamps. A name that folds to ``Vary`` —
+            case-folded, so ``vary`` is the same name — is neither honoured nor
+            dropped, but has its well-formed tokens merged in after the
+            standing ones; a name that folds to ``Cache-Control`` is dropped
+            whole, value and all, because that header replaces rather than
+            unions. Every other name passes through unexamined.
 
     Returns:
         The response, ready to be awaited as an ASGI application.

--- a/creek-tools/docs/api.md
+++ b/creek-tools/docs/api.md
@@ -183,12 +183,49 @@ not encryption at rest, not attestation, and not key custody, and it does not
 satisfy an intimate-transit contract. That is entirely
 [#757](https://github.com/Geoffe-Ga/Creek-Vault/issues/757)'s.
 
+## Caching
+
+Every response `creek-tools-api` builds carries both of these, on every status:
+
+```
+Vary: X-Creek-Tier-Ceiling, Authorization
+Cache-Control: no-store
+```
+
+Every `/v1` body is computed from two things a cache cannot see in the URL: the
+**declared tier ceiling** and the **authenticated consumer**. An entry keyed on
+neither — or on only one of them — may be handed to a caller the server would
+have answered differently. `Cache-Control: no-store` says do not keep it;
+`Vary` says that if you keep it anyway, these are the headers that decide
+whether it matches. The two answer different failure modes and neither replaces
+the other: drop the directive and a compliant cache is free to store, drop the
+tokens and a non-compliant one is free to mismatch.
+
+**These are unconditional, not "on authenticated responses".** Bearer
+authentication sits above the router, so all five routes are authenticated
+anyway; and refusals need the treatment as much as successes. A stored `404`
+is the concrete case — it is the one status this surface returns that both is
+reachable on any unrouted path and is *heuristically cacheable* under RFC 9110
+§15.1, so a conforming shared cache may store and reuse it with no freshness
+information at all.
+
+**Scope.** This is a promise about responses the application builds. Two paths
+answer a client without passing through that builder: a trailing slash is
+answered by the router's own `307`
+([#1369](https://github.com/Geoffe-Ga/Creek-Vault/issues/1369)), and a fault in
+the outermost middleware escapes as a bare `text/plain` `500`
+([#1370](https://github.com/Geoffe-Ga/Creek-Vault/issues/1370)). Neither
+carries these headers.
+
+**If you front this server with a reverse proxy, do not enable caching on
+`/v1`.** The [access-log scope note](#request-logging) applies here too: a proxy
+that ignores `no-store` is outside this process and nothing here can stop it.
+
 ## Privacy tiers
 
 The ceiling arrives on `X-Creek-Tier-Ceiling` and defaults to `open` when absent
-— fail closed. Every response carries `Vary: X-Creek-Tier-Ceiling`, so an
-intermediary cache cannot serve one caller's ceiling-filtered response to
-another.
+— fail closed. See [Caching](#caching) for the two response headers that stop an
+intermediary serving one caller's ceiling-filtered response to another.
 
 **`intimate` and `all` are refused at the edge, before any handler runs and
 before any vault read is attempted.** `/v1` is remote by construction, so every

--- a/creek-tools/tests/test_v1_api_admission.py
+++ b/creek-tools/tests/test_v1_api_admission.py
@@ -42,11 +42,14 @@ import pytest
 
 from creek_mcp import policy
 from creek_mcp.api.models import ERROR_MESSAGES, ErrorCode
+from creek_mcp.api.routes import AUTHORIZATION_HEADER
 from creek_mcp.httpapi import capabilities as capabilities_module
 from creek_mcp.httpapi import handlers as handlers_module
 from creek_mcp.httpapi.errors import (
     BEARER_CHALLENGE,
+    CACHE_CONTROL_HEADER,
     HTTP_OK,
+    NO_STORE,
     VARY_HEADER,
     WWW_AUTHENTICATE_HEADER,
     json_response,
@@ -172,6 +175,104 @@ hands back the perfectly legal token ``Accept``, repairing precisely the input
 the builder refuses to repair. ``Cookie`` is well-formed and must survive
 either way, which is what keeps the assertion about the repair and not about
 the drop.
+"""
+
+_STANDING_VARY: Final[str] = f"{CEILING_HEADER}, {AUTHORIZATION_HEADER}"
+"""The whole ``Vary`` value a response with no caller ``Vary`` must render.
+
+Two tokens since #1129, in this order, and written once here so that a third
+standing token is a one-line change rather than a sweep through a dozen
+byte-exact assertions — the sweep is how one of them would be missed, and a
+missed one is a ``Vary`` that under-declares what the response turns on.
+
+The order is part of the value, not an artefact of it: every assertion below
+that compares whole rendered lines would go red on a reordering, and that is
+deliberate. A header whose bytes depended on set iteration would differ between
+two worker processes answering the same request.
+"""
+
+_LOWERCASE_CACHE_CONTROL: Final[str] = "cache-control"
+"""``Cache-Control`` as the wire spells it, and as ``raw_headers`` renders it."""
+
+_MAX_AGE_DIRECTIVE: Final[str] = "max-age=600"
+"""A caller directive that is *strictly more cacheable* than ``no-store``.
+
+The one to search a rendered header block for. ``no-store, max-age=600`` is the
+plausible-looking union a merge would produce, and it is the outcome the
+replacement policy exists to rule out: RFC 9111 reads the pair as
+self-contradictory, so which half an intermediary honours is its choice rather
+than the server's.
+"""
+
+_PUBLIC_CACHE_DIRECTIVE: Final[str] = "public, max-age=600"
+"""What a well-meaning handler writes when it thinks its answer is public."""
+
+_WEAKENING_DIRECTIVES: Final[tuple[str, ...]] = (
+    _MAX_AGE_DIRECTIVE,
+    "public, max-age=31536000",
+    NO_STORE,
+)
+"""Caller ``Cache-Control`` values the builder must overwrite, not negotiate.
+
+Three rather than one because they fail differently. The first is the ordinary
+freshness lifetime; the second adds ``public``, which invites a *shared* cache
+to store a response computed under one caller's ceiling and credential; the
+third is the caller agreeing with the policy, which must still render as one
+line rather than two — a builder that appended when the values matched would
+emit ``no-store, no-store`` and pass any assertion written as a substring test.
+"""
+
+_WEAKENING_DIRECTIVE_IDS: Final[tuple[str, ...]] = (
+    "max-age",
+    "public-max-age",
+    "echoed-no-store",
+)
+"""Stable parametrize ids for :data:`_WEAKENING_DIRECTIVES`, in that order."""
+
+_CACHE_CONTROL_SPELLINGS: Final[tuple[str, ...]] = (
+    CACHE_CONTROL_HEADER,
+    CACHE_CONTROL_HEADER.lower(),
+    CACHE_CONTROL_HEADER.upper(),
+)
+"""The three ways a call site might spell the cache header at us.
+
+Parametrised rather than represented by the lower-case case alone because
+#1365's mutation battery had a mutant survive exactly that economy: a guard
+that compares the header name without folding it lets the second spelling
+through as a separate dict key, and Starlette renders a second key as a second
+header line rather than merging it.
+"""
+
+_CACHE_CONTROL_SPELLING_IDS: Final[tuple[str, ...]] = ("canonical", "lower", "upper")
+"""Stable parametrize ids for :data:`_CACHE_CONTROL_SPELLINGS`, in that order.
+
+Spelled out for the same reason :data:`_ECHOED_CEILING_SPELLING_IDS` is: the
+three values fold to one string, so ids derived from the values would collide.
+"""
+
+_ECHOED_AUTHORIZATION_SPELLINGS: Final[tuple[str, ...]] = (
+    AUTHORIZATION_HEADER,
+    AUTHORIZATION_HEADER.lower(),
+    AUTHORIZATION_HEADER.upper(),
+)
+"""The three ways a call site might name the credential header in its ``Vary``."""
+
+_ECHOED_AUTHORIZATION_SPELLING_IDS: Final[tuple[str, ...]] = (
+    "canonical",
+    "lower",
+    "upper",
+)
+"""Stable parametrize ids for :data:`_ECHOED_AUTHORIZATION_SPELLINGS`."""
+
+_ABOVE_CEILING_JOURNAL_BODY: Final[dict[str, str]] = {
+    "content": "vary probe",
+    "tier": "personal",
+}
+"""The ``PUT`` body that earns the ``403`` in :func:`_vary_cases`.
+
+A ``personal`` write under an ``open`` ceiling: admitted at the edge, refused
+once the object's own tier is known. Named here because three separate sweeps
+now drive that case and an inline copy in each is three chances to drift.
 """
 
 
@@ -567,6 +668,28 @@ def _vary_cases() -> tuple[tuple[str, dict[str, str], str, int], ...]:
     )
 
 
+def _drive_status_case(
+    vault: Path, path: str, request_headers: dict[str, str], method: str
+) -> httpx.Response:
+    """Drive one :func:`_vary_cases` row through the whole stack.
+
+    ``PUT`` is the one case needing a body; the others take none, and a body on
+    a ``GET`` would be refused before the headers under test are set.
+
+    Args:
+        vault: A seeded vault.
+        path: Request path.
+        request_headers: Headers to send.
+        method: HTTP method.
+
+    Returns:
+        The response, read after every middleware has run.
+    """
+    body = _ABOVE_CEILING_JOURNAL_BODY if method == "PUT" else None
+    with client(vault_path=vault) as test_client:
+        return test_client.request(method, path, headers=request_headers, json=body)
+
+
 @pytest.mark.parametrize(
     ("path", "request_headers", "method", "expected"),
     _vary_cases(),
@@ -594,11 +717,7 @@ def test_vary_is_set_on_every_response(
         method: HTTP method.
         expected: The status this case must produce.
     """
-    # ``PUT`` is the one case needing a body; the others take none, and a
-    # body on a ``GET`` would be refused before the header under test is set.
-    body = {"content": "vary probe", "tier": "personal"} if method == "PUT" else None
-    with client(vault_path=vault) as test_client:
-        response = test_client.request(method, path, headers=request_headers, json=body)
+    response = _drive_status_case(vault, path, request_headers, method)
     assert response.status_code == expected
     assert CEILING_HEADER.lower() in response.headers.get("vary", "").lower()
 
@@ -700,6 +819,7 @@ def test_a_caller_added_vary_token_is_not_discarded() -> None:
     assert len(lines) == 1
     assert _vary_token_set(lines[0]) == {
         CEILING_HEADER.lower(),
+        AUTHORIZATION_HEADER.lower(),
         _CALLER_VARY_TOKEN.lower(),
     }
 
@@ -715,13 +835,19 @@ def test_the_standing_vary_token_is_written_first() -> None:
     :func:`test_a_caller_echoing_the_standing_token_does_not_double_it` would
     become the flake that reports it.
 
-    Standing-token-first is also the honest reading order: the token the server
+    Standing-token-first is also the honest reading order: the tokens the server
     insists on, then whatever the call site asked to add.
+
+    The prefix is the *whole* standing value rather than the ceiling token alone
+    (#1129). Both standing tokens lead, in a fixed order, and a check that only
+    looked at the first of them would go green against a merge that appended
+    ``Authorization`` after the caller's tokens — an ordering nobody wrote, and
+    one that changes the rendered bytes without changing the token set.
     """
     response = json_response({}, HTTP_OK, headers={VARY_HEADER: _CALLER_VARY_TOKEN})
     lines = _rendered_vary(response)
     assert len(lines) == 1
-    assert lines[0].startswith(CEILING_HEADER)
+    assert lines[0].startswith(_STANDING_VARY)
 
 
 def test_a_lowercase_vary_cannot_smuggle_a_second_header_line() -> None:
@@ -737,7 +863,11 @@ def test_a_lowercase_vary_cannot_smuggle_a_second_header_line() -> None:
     response = json_response({}, HTTP_OK, headers={_LOWERCASE_VARY: "Cookie"})
     lines = _rendered_vary(response)
     assert len(lines) == 1
-    assert _vary_token_set(lines[0]) == {CEILING_HEADER.lower(), "cookie"}
+    assert _vary_token_set(lines[0]) == {
+        CEILING_HEADER.lower(),
+        AUTHORIZATION_HEADER.lower(),
+        "cookie",
+    }
 
 
 def test_both_spellings_of_vary_are_collected_into_the_one_value() -> None:
@@ -748,7 +878,7 @@ def test_both_spellings_of_vary_are_collected_into_the_one_value() -> None:
     rather than the first or the last one found, and a merge that took either
     end would pass every other test in this section. It is asserted byte-exact
     because it pins three properties at once — both values survive, the standing
-    token still leads, and the whole thing still renders as one header line.
+    tokens still lead, and the whole thing still renders as one header line.
     """
     response = json_response(
         {},
@@ -756,7 +886,7 @@ def test_both_spellings_of_vary_are_collected_into_the_one_value() -> None:
         headers={VARY_HEADER: _CALLER_VARY_TOKEN, _LOWERCASE_VARY: "Cookie"},
     )
     assert _rendered_vary(response) == [
-        f"{CEILING_HEADER}, {_CALLER_VARY_TOKEN}, Cookie"
+        f"{_STANDING_VARY}, {_CALLER_VARY_TOKEN}, Cookie"
     ]
 
 
@@ -789,7 +919,7 @@ def test_a_caller_echoing_the_standing_token_does_not_double_it(
         HTTP_OK,
         headers={VARY_HEADER: f"{spelling}, Cookie"},
     )
-    assert _rendered_vary(response) == [f"{CEILING_HEADER}, Cookie"]
+    assert _rendered_vary(response) == [f"{_STANDING_VARY}, Cookie"]
 
 
 def test_an_empty_vary_token_leaves_no_trailing_separator() -> None:
@@ -802,7 +932,7 @@ def test_an_empty_vary_token_leaves_no_trailing_separator() -> None:
     somewhere else fail for a reason nobody can find.
     """
     response = json_response({}, HTTP_OK, headers={VARY_HEADER: "Cookie,,"})
-    assert _rendered_vary(response) == [f"{CEILING_HEADER}, Cookie"]
+    assert _rendered_vary(response) == [f"{_STANDING_VARY}, Cookie"]
 
 
 def test_the_uncacheable_wildcard_token_survives_the_filter() -> None:
@@ -816,7 +946,7 @@ def test_the_uncacheable_wildcard_token_survives_the_filter() -> None:
     this module exists to close, arrived at from the opposite side.
     """
     response = json_response({}, HTTP_OK, headers={VARY_HEADER: "*"})
-    assert _rendered_vary(response) == [f"{CEILING_HEADER}, *"]
+    assert _rendered_vary(response) == [f"{_STANDING_VARY}, *"]
 
 
 @pytest.mark.parametrize(
@@ -842,7 +972,7 @@ def test_a_malformed_vary_token_never_reaches_the_header_value(
         why: What is wrong with it; supplies the parametrize id.
     """
     response = json_response({}, HTTP_OK, headers={VARY_HEADER: malformed})
-    assert _rendered_vary(response) == [CEILING_HEADER], why
+    assert _rendered_vary(response) == [_STANDING_VARY], why
 
 
 def test_a_malformed_token_is_not_whitespace_stripped_into_a_legal_one() -> None:
@@ -856,7 +986,7 @@ def test_a_malformed_token_is_not_whitespace_stripped_into_a_legal_one() -> None
     test about repair rather than about rejection.
     """
     response = json_response({}, HTTP_OK, headers={VARY_HEADER: _STRIPPABLE_VARY})
-    assert _rendered_vary(response) == [f"{CEILING_HEADER}, Cookie"]
+    assert _rendered_vary(response) == [f"{_STANDING_VARY}, Cookie"]
 
 
 def test_a_hostile_vary_cannot_forge_a_second_header() -> None:
@@ -880,7 +1010,7 @@ def test_a_hostile_vary_cannot_forge_a_second_header() -> None:
     assert b"x-creek-injected" not in block
     assert b"\r" not in block.replace(b"\r\n", b"")
     assert b"\n" not in block.replace(b"\r\n", b"")
-    assert _rendered_vary(response) == [CEILING_HEADER]
+    assert _rendered_vary(response) == [_STANDING_VARY]
 
 
 def test_a_non_colliding_caller_header_still_rides() -> None:
@@ -901,7 +1031,7 @@ def test_a_non_colliding_caller_header_still_rides() -> None:
         BEARER_CHALLENGE.encode("latin-1"),
     )
     assert challenge in response.raw_headers
-    assert _rendered_vary(response) == [CEILING_HEADER]
+    assert _rendered_vary(response) == [_STANDING_VARY]
 
 
 async def _vary_overriding_health(_request: Request) -> Response:
@@ -945,7 +1075,396 @@ def test_a_handler_cannot_override_the_standing_vary_through_the_stack(
     with client(vault_path=vault) as test_client:
         response = test_client.get(HEALTH_PATH, headers=headers())
     assert response.status_code == 200
-    assert response.headers.get_list("vary") == [f"{CEILING_HEADER}, Cookie"]
+    assert response.headers.get_list("vary") == [f"{_STANDING_VARY}, Cookie"]
+
+
+# --------------------------------------------------------------------------- #
+# no-store, and the credential the answer turns on (#1129)
+# --------------------------------------------------------------------------- #
+#
+# ``Vary`` tells an intermediary *what to key on*; it never tells it not to
+# store. Every ``/v1`` answer is computed from a bearer identity and an admitted
+# ceiling, so storing one at all is a bet that the next caller presenting a
+# different credential will be told apart by the key — and the key is whatever
+# the intermediary chose to honour. ``no-store`` declines the bet, and naming
+# ``Authorization`` in ``Vary`` is the belt to its braces: the two answer
+# different failure modes, and a cache that ignores one may still honour the
+# other.
+#
+# The directive is unconditional because every response is either one of the
+# five authenticated routes — ``BearerAuthMiddleware`` sits above the router, so
+# authentication is not a property a route can opt out of — or a refusal, and a
+# stored refusal is a denial of service served to a caller who would have been
+# admitted.
+
+
+def _rendered_cache_control(response: Response) -> list[str]:
+    """Return every ``cache-control`` header line *response* has rendered.
+
+    Read off ``raw_headers`` for the reason :func:`_rendered_vary` documents:
+    Starlette's mapping answers with the first match, so two lines and one line
+    are indistinguishable through it — and "one line, and it says ``no-store``"
+    is precisely the claim here, since a builder that *appended* the standing
+    directive to a caller's would render two.
+
+    Args:
+        response: The built response, before anything sends it.
+
+    Returns:
+        One decoded entry per rendered ``cache-control`` line, in render order.
+    """
+    return [
+        value.decode("latin-1")
+        for name, value in response.raw_headers
+        if name.decode("latin-1").lower() == _LOWERCASE_CACHE_CONTROL
+    ]
+
+
+def test_the_standing_header_names_are_the_published_wire_literals() -> None:
+    """The three new constants say what the contract says, and name a real header.
+
+    Every assertion in this section is written against the constants rather
+    than against literals, which buys legibility and costs rename-detection: a
+    mutant that renamed ``no-store`` to ``max-age=0`` would satisfy all of them
+    at once. This is where that is bought back — the same reason
+    ``tests/v1_api_support.py`` spells the wire vocabulary out rather than
+    importing it.
+
+    The last two assertions are the ones that matter most. ``Authorization`` is
+    a standing ``Vary`` token only because it is the header the caller's
+    credential actually arrives in; a constant that named some near-miss
+    spelling would produce a ``Vary`` that varies on nothing, and every other
+    assertion in this file would still be green.
+    """
+    assert AUTHORIZATION_HEADER == "Authorization"
+    assert CACHE_CONTROL_HEADER == "Cache-Control"
+    assert NO_STORE == "no-store"
+    assert AUTHORIZATION_HEADER in headers()
+    assert AUTHORIZATION_HEADER not in headers(token=None)
+
+
+@pytest.mark.parametrize(("method", "path"), MOUNTED, ids=MOUNTED_IDS)
+def test_no_store_rides_on_every_mounted_route(
+    vault: Path, method: str, path: str
+) -> None:
+    """All five published routes answer uncacheably, whatever they answer.
+
+    Every one of them sits below ``BearerAuthMiddleware`` — item 5 of the seven
+    layers, above the router — so there is no such thing as an unauthenticated
+    ``/v1`` route whose body a shared cache could safely hold. Health is the
+    tempting exception and is not one: it is still reached with a credential,
+    and a stored ``200`` for it is a stored ``200`` for a path an operator's
+    monitoring depends on being live rather than remembered.
+
+    The status is deliberately not pinned. ``POST /v1/reflections`` has no LLM
+    provider in a hermetic test environment and answers a refusal rather than a
+    ``200``; pinning the status here would make this test about provider wiring
+    instead of about caching, and the ``200`` case is pinned by the status-class
+    sweep below. What *is* pinned is that the probe reached a mounted route at
+    all — a ``404`` would also carry ``no-store``, so a sweep whose paths had
+    all gone stale would pass while probing nothing.
+
+    ``get_list`` rather than ``headers["cache-control"]``: httpx joins duplicate
+    lines with ``", "``, so a response carrying ``no-store`` twice, or carrying
+    ``no-store, max-age=600`` across two lines, reads as a single innocuous
+    string through the mapping.
+
+    Args:
+        vault: A seeded vault.
+        method: HTTP method under test.
+        path: Request path under test.
+    """
+    with client(vault_path=vault) as test_client:
+        response = _call(test_client, method, path, headers=headers())
+    assert response.status_code != _NOT_FOUND_STATUS
+    assert response.headers.get_list("cache-control") == [NO_STORE]
+
+
+@pytest.mark.parametrize(
+    ("path", "request_headers", "method", "expected"),
+    _vary_cases(),
+    ids=["401", "404", "422", "403", "200"],
+)
+def test_no_store_is_set_on_every_response(
+    vault: Path,
+    path: str,
+    request_headers: dict[str, str],
+    method: str,
+    expected: int,
+) -> None:
+    """Refusals are as uncacheable as successes, and for symmetric reasons.
+
+    A cached refusal is a denial of service: the ``422`` a caller earned by
+    declaring ``intimate`` would be replayed to the same caller declaring
+    ``personal``, and the ``401`` earned by omitting a credential would be
+    replayed to a request that carried one. A cached success is the disclosure
+    pointed the other way — one caller's ceiling-filtered wheel handed to
+    somebody who never presented a credential at all.
+
+    The same five rows as the ``Vary`` sweep, because the two headers protect
+    the same set of responses and a row present in one list and absent from the
+    other is how they would drift.
+
+    Args:
+        vault: A seeded vault.
+        path: Request path.
+        request_headers: Headers to send.
+        method: HTTP method.
+        expected: The status this case must produce.
+    """
+    response = _drive_status_case(vault, path, request_headers, method)
+    assert response.status_code == expected
+    assert response.headers.get_list("cache-control") == [NO_STORE]
+
+
+@pytest.mark.parametrize(
+    ("path", "request_headers", "method", "expected"),
+    _vary_cases(),
+    ids=["401", "404", "422", "403", "200"],
+)
+def test_vary_names_authorization_on_every_response(
+    vault: Path,
+    path: str,
+    request_headers: dict[str, str],
+    method: str,
+    expected: int,
+) -> None:
+    """The credential is part of the cache key, on every status class.
+
+    ``no-store`` is the instruction; this is the key an intermediary that
+    ignores the instruction — or a private cache that is entitled to store
+    anyway — must use. Every ``/v1`` body is a function of the authenticated
+    consumer as well as of the ceiling: two consumers presenting two valid
+    tokens can be told apart by the server and must be told apart by the store.
+
+    Asserted as the whole rendered line, not merely as membership. None of these
+    five responses carries a caller ``Vary``, so the standing value is the whole
+    value, and an equality is what notices a second ``vary`` line or a reordered
+    one — neither of which a membership test can see.
+
+    Args:
+        vault: A seeded vault.
+        path: Request path.
+        request_headers: Headers to send.
+        method: HTTP method.
+        expected: The status this case must produce.
+    """
+    response = _drive_status_case(vault, path, request_headers, method)
+    assert response.status_code == expected
+    assert AUTHORIZATION_HEADER.lower() in _vary_token_set(
+        response.headers.get("vary", "")
+    )
+    assert response.headers.get_list("vary") == [_STANDING_VARY]
+
+
+def test_the_unauthenticated_refusal_carries_both_standing_tokens_and_no_store(
+    vault: Path,
+) -> None:
+    """Yes, ``Vary: Authorization`` belongs on a response nobody authenticated.
+
+    The pinned answer to the question the two-token seed raises, because it
+    reads backwards: the caller sent no credential, so what could the answer
+    possibly vary on? Both directions of reuse, is the answer. A stored ``401``
+    that does not name ``Authorization`` may be served to a caller who *did*
+    present a valid token — a denial of service wearing the costume of a
+    credential failure, and one the caller cannot debug because their token was
+    never looked at. A stored ``200`` from that same cache may be served to a
+    caller who presented nothing, which is the disclosure. Naming the header on
+    the ``401`` closes the first; naming it on the ``200`` closes the second;
+    only doing both makes the entries mutually unmatchable.
+
+    ``no-store`` on the ``401`` is the same argument without the cache's
+    cooperation, which is why it is asserted here rather than left to the sweep.
+
+    Args:
+        vault: A seeded vault.
+    """
+    with client(vault_path=vault) as test_client:
+        response = test_client.get(HEALTH_PATH, headers=headers(token=None))
+    assert response.status_code == _UNAUTHENTICATED_STATUS
+    assert _vary_token_set(response.headers.get("vary", "")) == {
+        CEILING_HEADER.lower(),
+        AUTHORIZATION_HEADER.lower(),
+    }
+    assert response.headers.get_list("vary") == [_STANDING_VARY]
+    assert response.headers.get_list("cache-control") == [NO_STORE]
+
+
+async def _cache_control_overriding_health(_request: Request) -> Response:
+    """Answer health with a colliding, lowercased caller ``Cache-Control``.
+
+    The value is the plausible mistake rather than a hostile one: a handler
+    author who has decided their endpoint is public and cheap, and is right
+    about neither on this surface.
+
+    Args:
+        _request: Ignored, exactly as the real health handler ignores it.
+
+    Returns:
+        The health body, plus the directive the builder must overwrite.
+    """
+    return json_response(
+        HEALTH_BODY,
+        HTTP_OK,
+        headers={_LOWERCASE_CACHE_CONTROL: _PUBLIC_CACHE_DIRECTIVE},
+    )
+
+
+def test_a_handler_cannot_override_the_standing_cache_control_through_the_stack(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The directive survives a real handler and all seven middleware layers.
+
+    The twin of the ``Vary`` override test above, and health is the right probe
+    for the same reason: it is exempt from the contract-version gate and its
+    real handler is a bare ``json_response(HEALTH_BODY, HTTP_OK)``, so the
+    substitution changes exactly one thing.
+
+    It is worth driving through the stack rather than trusting the builder unit
+    tests because the claim is about what a cache would be handed, and a
+    middleware that re-wrapped or re-headed the response on the way out would
+    falsify it without touching :mod:`creek_mcp.httpapi.errors` at all.
+
+    Args:
+        vault: A seeded vault.
+        monkeypatch: Substitutes the health handler for one that collides.
+    """
+    monkeypatch.setitem(
+        handlers_module.HANDLERS, OP_HEALTH, _cache_control_overriding_health
+    )
+    with client(vault_path=vault) as test_client:
+        response = test_client.get(HEALTH_PATH, headers=headers())
+    assert response.status_code == 200
+    assert response.headers.get_list("cache-control") == [NO_STORE]
+
+
+def test_the_standing_headers_are_stamped_without_any_caller_header() -> None:
+    """The bare builder call — what every real handler makes — carries both.
+
+    Every other test in this section hands the builder something to react to,
+    and a policy implemented only on the collision path would satisfy all of
+    them while leaving the ordinary ``json_response(payload, status)`` — the
+    call five handlers and one error renderer actually make — bare. This is the
+    default path, asserted byte-exactly: two standing ``Vary`` tokens in a fixed
+    order on one line, and one ``no-store``.
+    """
+    response = json_response({}, HTTP_OK)
+    assert _rendered_vary(response) == [_STANDING_VARY]
+    assert _rendered_cache_control(response) == [NO_STORE]
+
+
+@pytest.mark.parametrize(
+    "directive", _WEAKENING_DIRECTIVES, ids=_WEAKENING_DIRECTIVE_IDS
+)
+@pytest.mark.parametrize(
+    "spelling", _CACHE_CONTROL_SPELLINGS, ids=_CACHE_CONTROL_SPELLING_IDS
+)
+def test_a_caller_cache_control_cannot_weaken_the_directive(
+    spelling: str, directive: str
+) -> None:
+    """Nine cells: three spellings times three directives, one rendered answer.
+
+    The spelling axis is not thoroughness for its own sake. ``Cache-Control``
+    and ``cache-control`` are one header on the wire and two keys in a dict, and
+    a guard that compares the name unfolded lets the second one through as a
+    passthrough header — Starlette then writes both, and which directive keys
+    the store becomes the intermediary's choice. #1365's mutation battery had a
+    mutant survive precisely this economy, on a test that used only lower-case
+    spellings.
+
+    The directive axis covers the three shapes a weakening arrives in: a bare
+    freshness lifetime, a ``public`` one that invites a *shared* store, and the
+    caller agreeing with the policy — which must still render once.
+
+    Args:
+        spelling: How the caller happens to capitalise the header name.
+        directive: The value the caller supplied.
+    """
+    response = json_response({}, HTTP_OK, headers={spelling: directive})
+    assert _rendered_cache_control(response) == [NO_STORE]
+
+
+def test_both_spellings_of_cache_control_collapse_to_one_line() -> None:
+    """Two colliding keys at once — the pathological dict, cache-side.
+
+    The same shape ``test_both_spellings_of_vary_are_collected_into_the_one_value``
+    covers, and it needs its own case for the same reason: collapsing it
+    correctly means finding *every* colliding key rather than the first or the
+    last one, and a builder that dropped either end would pass every
+    single-spelling case above.
+
+    The outcomes differ, and that is the point of having both tests. ``Vary``
+    unions, because more tokens is monotone toward safety; ``Cache-Control``
+    replaces, because ``no-store, max-age=600`` is self-contradictory and
+    ``public`` alone is strictly more cacheable than what the server insists on.
+    """
+    response = json_response(
+        {},
+        HTTP_OK,
+        headers={
+            CACHE_CONTROL_HEADER: _MAX_AGE_DIRECTIVE,
+            _LOWERCASE_CACHE_CONTROL: "public",
+        },
+    )
+    assert _rendered_cache_control(response) == [NO_STORE]
+
+
+def test_the_caller_cache_directive_is_dropped_rather_than_unioned() -> None:
+    """The caller's text is *absent*, not merely outranked.
+
+    Union is the right policy for ``Vary`` and the wrong one here, so the
+    absence has to be asserted rather than inferred from the presence of
+    ``no-store``. ``no-store, max-age=600`` contains ``no-store`` and would
+    satisfy a substring test, a token-membership test, and any assertion that
+    only counted header lines — while telling an intermediary two incompatible
+    things and leaving it to pick. RFC 9111 does not say which it must pick.
+
+    Asserted over the serialised header block rather than over the
+    ``cache-control`` value alone, so a directive relocated into some other
+    header on the way out is caught by the same line. Two nets, not one: the
+    caller's exact text, and then the bare directive *name*, which still catches
+    a survival that was rewritten on the way through — ``max-age=0`` is a
+    different string and the same mistake.
+    """
+    response = json_response(
+        {}, HTTP_OK, headers={CACHE_CONTROL_HEADER: _MAX_AGE_DIRECTIVE}
+    )
+    block = _serialised_header_block(response)
+    assert _MAX_AGE_DIRECTIVE.encode("latin-1") not in block
+    assert b"max-age" not in block
+    assert _rendered_cache_control(response) == [NO_STORE]
+
+
+@pytest.mark.parametrize(
+    "spelling",
+    _ECHOED_AUTHORIZATION_SPELLINGS,
+    ids=_ECHOED_AUTHORIZATION_SPELLING_IDS,
+)
+def test_a_caller_echoing_the_authorization_token_does_not_double_it(
+    spelling: str,
+) -> None:
+    """The second standing token deduplicates exactly as the first one does.
+
+    A call site that has read the contract and names the credential header in
+    its own ``Vary`` is the likeliest collision there is now that there are two
+    standing tokens, and it will spell the field name however it spells it. The
+    dedupe is case-folded, so all three spellings fold onto the server's — and a
+    half-folded dedupe that seeds its ``seen`` set folded but then tests the raw
+    token passes the lower-case echo by coincidence and doubles the upper-case
+    one.
+
+    The whole rendered value is asserted rather than the token set, because a
+    set cannot see a repetition at all.
+
+    Args:
+        spelling: How the caller happens to capitalise the credential header.
+    """
+    response = json_response(
+        {},
+        HTTP_OK,
+        headers={VARY_HEADER: f"{spelling}, Cookie"},
+    )
+    assert _rendered_vary(response) == [f"{_STANDING_VARY}, Cookie"]
 
 
 # --------------------------------------------------------------------------- #

--- a/creek-tools/tests/test_v1_api_hardening.py
+++ b/creek-tools/tests/test_v1_api_hardening.py
@@ -61,12 +61,14 @@ from starlette.responses import JSONResponse
 
 from creek.audit import log as audit_log_module
 from creek_mcp.api.models import ERROR_MESSAGES, ERROR_STATUS, ErrorCode
+from creek_mcp.api.routes import AUTHORIZATION_HEADER
 from creek_mcp.audit import MCP_AUDIT_RELPATH, verify_mcp_audit_chain
 from creek_mcp.httpapi import capabilities as capabilities_module
 from creek_mcp.httpapi import handlers as handlers_module
 from creek_mcp.httpapi import vault as vault_module
 from creek_mcp.httpapi.auth import BearerAuthMiddleware
 from creek_mcp.httpapi.context import LIFESPAN_SCOPE, UnsupportedScopeError
+from creek_mcp.httpapi.errors import NO_STORE
 from creek_mcp.httpapi.logging import ACCESS_LOGGER_NAME, ERROR_LOGGER_NAME
 from creek_mcp.httpapi.middleware.access_log import AccessLogMiddleware
 from creek_mcp.httpapi.middleware.boundary import ErrorBoundaryMiddleware
@@ -130,6 +132,15 @@ Spelled the same way ``tests/test_v1_api_not_implemented.py`` spells it, and
 derived in both places rather than imported from one into the other: no test
 module here imports from another, because a shared fixture that two suites
 disagreed about would make their refusal tests measure different things.
+"""
+
+_STANDING_VARY: Final[str] = f"{CEILING_HEADER}, {AUTHORIZATION_HEADER}"
+"""The whole ``Vary`` value a response with no caller ``Vary`` must render.
+
+Two tokens since #1129: an intermediary must key on the declared ceiling *and*
+on the credential, because every ``/v1`` body is a function of both. Composed
+here rather than restated as a literal so a third standing token is a one-line
+change; ``tests/test_v1_api_admission.py`` owns the policy tests behind it.
 """
 
 _SMALL_LIMIT: Final[int] = 64
@@ -1438,10 +1449,13 @@ def test_a_non_routing_http_exception_echoes_no_detail(
 
     ``content-type`` is asserted because it is what fails loudly if anyone
     "fixes" this by falling back to Starlette's default handler: that answers
-    ``text/plain`` with the detail *as* the body. ``Vary`` is asserted because
-    it is only unconditional while every response — this one included — is
-    built by the single response builder in
-    :mod:`creek_mcp.httpapi.errors`.
+    ``text/plain`` with the detail *as* the body. ``Vary`` and ``Cache-Control``
+    are asserted because they are only unconditional while every response —
+    this one included — is built by the single response builder in
+    :mod:`creek_mcp.httpapi.errors`. The ``500`` is the status class no other
+    sweep drives, and a stored fault is the worst entry of the lot: it outlives
+    the transient that caused it and is replayed to callers whose requests
+    would have succeeded.
 
     Args:
         vault: A seeded vault.
@@ -1460,7 +1474,8 @@ def test_a_non_routing_http_exception_echoes_no_detail(
     assert "HTTPException" not in response.text
     assert not contains_a_path(response.text)
     assert response.headers["content-type"].startswith("application/json")
-    assert response.headers["vary"] == CEILING_HEADER
+    assert response.headers["vary"] == _STANDING_VARY
+    assert response.headers.get_list("cache-control") == [NO_STORE]
 
 
 def test_a_non_routing_http_exception_is_logged_exactly_once(


### PR DESCRIPTION
## Summary

`/v1` bodies are computed from two things a cache cannot see in the URL — the declared tier
ceiling and the authenticated consumer — and until now the only thing stopping an intermediary
reusing one caller's body for another was a single `Vary` token. This adds the second token and
the directive that says not to store it at all:

```
Vary: X-Creek-Tier-Ceiling, Authorization
Cache-Control: no-store
```

Both are stamped by the one builder, `creek_mcp.httpapi.errors.json_response`, which is what makes
them unconditional rather than something each of the six call sites has to remember. #1128 (PR
#1365) chose **union** over discard for `Vary` explicitly so that this issue could add a token;
that is the two-line half of this change. The rest is the half #1365 said its shape did not
provide.

### The exposure is the `404`, not the `401`

Intersect the published status set `{200, 401, 403, 404, 409, 422, 500, 501, 503}` with the
statuses RFC 9110 §15.1 enumerates as *heuristically cacheable* `{200, 203, 204, 206, 300, 301,
404, 405, 410, 414, 501}` and the whole of it is **`{200, 404, 501}`** (verified against
`ERROR_STATUS`, not asserted). The routing `404` is reachable on any unrouted `/v1` path and
carries no freshness information, so a *conforming* shared cache may store and reuse it on
heuristic freshness alone. That is the one case here that is not merely prophylactic. The argument
is deliberately **not** rested on a cached `401` — that status is not on the heuristic list, so
that story needs a cache already violating the spec, and an argument that only holds against a
broken cache is one a reviewer can wave away.

### The two headers are independent, not one doubled

The issue's premise is a *misconfigured* cache — precisely the one that may ignore `no-store`. For
that cache the remedy is not a louder instruction but a correct cache **key**, and `Vary:
Authorization` is that key. Drop the directive and a compliant cache may store; drop the token and
a non-compliant one may mismatch. Neither subsumes the other, so a later "simplification" that
deletes one is a regression — the module docstring says so, to make that harder.

### Unconditional, not conditional on authentication

The title says "authenticated `/v1` responses"; stamping unconditionally is the only implementable
reading, and a strictly stronger one.

- `json_response` takes no `RequestContext`, so conditioning on `context.consumer` means threading
  a context through the builder and all six call sites, destroying the context-freedom that lets
  it be unit-tested as a pure function. The cheap alternative — stamping in `error_response` only
  — covers every refusal and no `200`, the exact inverse of what was asked.
- The condition would have nothing to decide. `BearerAuthMiddleware` is item 5 of the seven-layer
  stack, **above the router** (verified by building the stack, not by reading the comment), so all
  five routes are authenticated by construction.
- Where it *would* differ is on a route that does not exist yet: one mounted above the gate would
  silently stop being stamped, because such a condition is keyed on the stack's *order* rather
  than on anything the builder can see. The unconditional form cannot fail that way.

Cache-safety is a one-way ratchet, and every change here moves the safe direction: a token is
added to `Vary` (monotone under RFC 9111 §4.1 — reuse is a conjunction over the nominated names,
so more tokens can only shrink the set of requests an entry may serve) and a directive is added
that forbids storage outright. Nothing is made more cacheable and no `Vary` set shrinks.

### Two merge rules, deliberately not one mapping

`Vary` **unions** a caller's tokens; `Cache-Control` **replaces** them. #1365 declined a
`STANDING_HEADERS: Mapping[str, str]` for exactly this reason and the reasoning still holds — a
mapping would have to carry the rule as well as the name (`Mapping[str, MergeRule]`), a strictly
more complex type than two named constants and two named rules. What *is* shared is the mechanism:
`_folds_to(name, standing)` matches a header name case-folded for both, because `Vary` and `vary`
are one header on the wire and two keys in a dict.

Dropping a caller's `Cache-Control` whole is **not** directive-wise monotone, and the docstring
says so rather than claiming otherwise: `private` and `no-cache` are subsumed by `no-store`, but
`no-transform` and `must-understand` are not. It is chosen anyway, because preserving them means
parsing a header whose members take `=`-valued arguments and then ruling on whether `max-age=600`
contradicts `no-store` — a directive parser with a contradiction policy is a larger thing to get
wrong than the one directive it would rescue. No production call site passes a `Cache-Control`
today, so nothing pays for it. Prepending was rejected on evidence rather than taste: `no-store,
max-age=600` is self-contradictory, RFC 9111 does not say which half wins, and real caches resolve
it inconsistently.

`AUTHORIZATION_HEADER` moves to `creek_mcp/api/routes.py`, beside the two other published header
names. `auth.py` imports `errors.py`, so `errors.py` cannot import it back — but the real reason is
the invariant: the header the auth middleware **reads** and the header the `Vary` **names** must be
the same string, or the `Vary` declares a dependency on something no request carries.

## The P2-vs-P1 claim in the body does not hold

The issue is labelled **P1**; its body argues P2. I checked both clauses in code and left the label
alone.

| Clause | Verdict |
|---|---|
| "the default bind is loopback" | **True** — `DEFAULT_API_HOST = "127.0.0.1"` (`httpapi/cli.py:68`) |
| "a non-loopback bind already requires TLS" | **True** — `require_transport_confidentiality` (`transport_posture.py:89`), called at `cli.py:262` |
| "so there is no supported deployment today that puts a shared cache in the path" | **False** |

The conclusion does not follow from its premises. `docs/api.md` already documents fronting this
server with a reverse proxy as a supported deployment ("A reverse proxy, load balancer, or TLS
terminator placed in front of this server…"), and the TLS guard's own remediation text *recommends*
it: "Bind 127.0.0.1, terminate TLS in a reverse proxy". A reverse proxy is the canonical home of a
shared cache. Separately, `no-store` also governs **private** caches — a consumer's own HTTP client
writing tier-ceilinged vault content to disk — which a loopback bind does not mitigate at all.

**P1 is right; the body's own reasoning is what is wrong.** Not relabelled — flagging, not
deciding.

## Per-route decision

All five, because there is no unauthenticated route to spare:

| Route | Authenticated? | Stamped? |
|---|---|---|
| `GET /v1/capabilities` | Yes — below the bearer gate | Yes; body carries vault readiness |
| `PUT /v1/journal-entries/{external_id}` | Yes | Yes |
| `POST /v1/reflections` | Yes | Yes |
| `GET /v1/wheel` | Yes | Yes; ceiling-filtered aggregate |
| `GET /v1/health` | Yes | Yes |

`/v1/health` and `/v1/capabilities` look like the exceptions and are not — the bearer gate sits
above the router, so neither is reachable anonymously. Health is also the case where `no-store` is
affirmatively *correct* rather than a tolerated cost: a cached liveness probe reports "ok" for a
dead server, which is worse than no probe. No route loses a cache it was getting any value from.

`Vary: Authorization` **does** belong on unauthenticated responses too, and this is pinned by
`test_the_unauthenticated_refusal_carries_both_standing_tokens_and_no_store`. It reads backwards —
the caller sent no credential, so what can the answer vary on? — but reuse runs both directions: a
stored `401` that does not name `Authorization` may be served to a caller who *did* present a valid
token (a denial of service wearing the costume of a credential failure, undebuggable because the
token was never looked at), and a stored `200` may be served to one who presented nothing.

## Scope: two paths this does not reach

Both verified against the real app and filed rather than fixed here, and every claim in the new
prose is scoped to "every response **this builder constructs**" because of them:

- **#1369** — a trailing slash on any `/v1` path is answered by Starlette's router with a `307`
  before any handler runs: outside the published status set, past the contract-version gate, and
  carrying neither header.
- **#1370** — a fault in the outermost middleware escapes to Starlette's `ServerErrorMiddleware`
  and renders a bare `text/plain` `500`. Pre-existing; identical for `Vary` before this change.
- **#1371** — the published OpenAPI document declares no `securitySchemes`, though every route
  enforces a bearer. Found while relocating `AUTHORIZATION_HEADER`.

## Test plan

- **RED proven behaviourally**, not by ImportError: constants were added first with no wiring, then
  the suite run — **48 failures** against *rendered* response headers, including all five mounted
  routes and all five status classes through the real app.
- App-level tests drive `client(vault_path=vault)` and read `response.headers.get_list(...)` —
  `get_list`, never `headers[...]`, because httpx joins duplicate lines and would hide a doubled
  header or a `no-store, max-age=600` split across two lines. Builder-level tests read
  `raw_headers` and a reserialised header block.
- Parametrised over header **spellings** (canonical/lower/upper) for both `Cache-Control` and an
  echoed `Authorization` token — #1365's own battery had a mutant survive because a test used only
  lower-case.
- **Mutation battery: 11 mutants, 11 killed, zero survivors.** Seed loses `Authorization`; standing
  order reversed; dedupe `seen` seeded from only the first token; `Cache-Control` omitted; caller's
  value wins; unfolded name comparison; half-folded name comparison; `no-store` weakened to
  `no-cache, max-age=0`; `Cache-Control` unioned instead of replaced (killed by 12 assertions,
  including a `no-store, no-store` cell); `AUTHORIZATION_HEADER` near-miss spelling; directive
  stamped only on refusals.
- Twelve existing `Vary` assertions updated deliberately — byte-exact ones stayed byte-exact rather
  than being relaxed to set membership.
- **Gate 2: `./scripts/check-all.sh` exit 0** — 12/12 gates, 8948 passed, coverage 94.41%, mypy
  strict, xenon, interrogate, bandit, ruff clean. No bypasses added anywhere, tests included.

Gate 2.5 (`code-review-orchestrator`) returned two documentation blockers, both fixed and Gate 2
re-run to exit 0: the RFC 9110 §15.1 list had wrongly included `308` (it enumerates 11 codes, not
12 — the intersection was unaffected, but a wrong citation in *that* docstring is the one thing its
own text says is worse than silence), and `info.description` was the single place that dropped the
"this builder constructs" scoping used everywhere else. One non-blocking note accepted as-is:
`test_no_store_rides_on_every_mounted_route` asserts `status != 404` rather than a pinned status,
because reflections has no LLM provider in the hermetic environment and the `200` case is pinned
byte-exact elsewhere.

**OpenAPI golden: unchanged.** The byte-pinned artefacts are the component schemas under
`docs/contracts/adepthood-v1/schemas/`; no wire model, operation, parameter or status moved.
`info.description` prose changed (it stated the old one-token contract) and now interpolates from
the header constants so it cannot drift. Verified with `git diff --stat -- docs/contracts/`.

Closes #1129
Refs #1128
