### PR TITLE
fix(ingest): confine every ingestor discovery walk to its source root

### DIFF
--- a/creek-tools/creek/_containment.py
+++ b/creek-tools/creek/_containment.py
@@ -29,6 +29,9 @@ The policy, unchanged from the shipped SEC-003 guard:
   would flag every child of a root reached *through* a symlinked component
   — ``/tmp`` -> ``/private/tmp`` on macOS — as escaping.
 * Unprovable containment IS an escape.
+* The resolution primitive is ``os.path.realpath``, NOT
+  :meth:`~pathlib.Path.resolve` — see :func:`_resolved_target` for why the
+  difference is load-bearing rather than stylistic.
 
 That policy is deliberately LEAF-ONLY, so a path reached through an
 escaping *ancestor* component (``<root>/linkdir/a.md``, where ``linkdir``
@@ -93,6 +96,53 @@ class EscapingSymlinkError(RuntimeError):
         )
 
 
+def _resolved_target(child: Path) -> Path | None:
+    """Resolve *child* to the location containment must be judged against.
+
+    The one place symlinks are followed, and deliberately NOT via
+    :meth:`pathlib.Path.resolve`. ``Path.resolve``'s behaviour on a symlink
+    **cycle** is not part of pathlib's contract and it changed under us:
+
+    * On 3.11/3.12, ``Path.resolve(strict=False)`` raises
+      ``RuntimeError("Symlink loop from ...")``.
+    * On 3.13 it delegates to ``os.path.realpath``, which for
+      ``strict=False`` treats a cycle as "stop unwinding here" and returns
+      a PARTIAL path with the looping component left unresolved.
+
+    That partial answer is worse than an error, because for a cycle that
+    closes back on its own starting point it erases the hops in between.
+    ``<root>/a.md -> <outside>/o.md -> <root>/a.md`` resolves, on 3.13, to
+    ``<root>/a.md`` — an in-root answer for a link whose very first hop
+    leaves the root. Judging containment on that answer admits the link.
+
+    ``os.path.realpath(..., strict=True)`` reports a cycle as
+    ``OSError(ELOOP)`` on every supported version, so it is the primitive
+    with the stable contract. Two arms, and the split is the whole policy:
+
+    * ``FileNotFoundError`` is NOT a containment failure. A dangling link
+      still names a candidate location worth comparing, so it falls back to
+      ``strict=False`` and is judged on where its target *would* sit —
+      which is what refuses a broken link pointing out of the root while
+      admitting a stale in-tree alias.
+    * Every other ``OSError`` — a cycle, an unreadable component — is a
+      containment that cannot be proven, and by this module's policy an
+      unprovable containment is an escape.
+
+    Args:
+        child: A path being tested for containment, as walked.
+
+    Returns:
+        The location to compare against the root, or ``None`` when
+        resolution failed in a way that leaves containment unproven.
+    """
+    try:
+        return Path(os.path.realpath(child, strict=True))
+    except FileNotFoundError:
+        return Path(os.path.realpath(child, strict=False))
+    except OSError:
+        return None
+
+
 def resolves_within(child: Path, resolved_root: Path) -> bool:
     """Report whether *child*'s symlink target stays under *resolved_root*.
 
@@ -102,15 +152,21 @@ def resolves_within(child: Path, resolved_root: Path) -> bool:
     drift into subtly different definitions of "inside".
 
     The failure arm is a deliberate classification, not a swallowed error:
-    a loop (``RuntimeError``), an unreadable link (``OSError``), and a
-    target outside the root (``ValueError`` from ``relative_to``) are all
-    cases where containment cannot be proven — and an unprovable
-    containment is an escape. Every caller logs and counts its rejections.
+    an unresolvable link (``None`` from :func:`_resolved_target` — a cycle,
+    an unreadable component) and a target outside the root (``ValueError``
+    from ``relative_to``) are both cases where containment cannot be
+    proven, and an unprovable containment is an escape. Every caller logs
+    and counts its rejections.
 
-    ``strict=False`` is deliberate: a dangling link still resolves to a
-    candidate location worth comparing, so a broken link pointing *outside*
-    is still refused rather than waved through on the technicality that its
-    target does not exist yet.
+    Resolution goes through :func:`_resolved_target` rather than
+    :meth:`~pathlib.Path.resolve` so that this classification is a decision
+    this module makes, not one inherited from whichever exception the
+    stdlib happens to raise that release. It was the latter until 3.13
+    changed the answer underneath it; see that function.
+
+    A dangling link is still judged on its candidate location, so a broken
+    link pointing *outside* is refused rather than waved through on the
+    technicality that its target does not exist yet.
 
     The exception object itself is deliberately dropped rather than logged:
     ``relative_to``'s message quotes the *resolved* target, which is exactly
@@ -125,7 +181,10 @@ def resolves_within(child: Path, resolved_root: Path) -> bool:
         ``True`` when the link's target is a descendant of *resolved_root*.
     """
     try:
-        child.resolve(strict=False).relative_to(resolved_root)
+        target = _resolved_target(child)
+        if target is None:
+            return False
+        target.relative_to(resolved_root)
     except (OSError, RuntimeError, ValueError):
         return False
     return True

--- a/creek-tools/creek/_containment.py
+++ b/creek-tools/creek/_containment.py
@@ -1,0 +1,243 @@
+"""Symlink containment for trees the operator names (#1087/#1293/#1294).
+
+Three surfaces need the same question answered — "does this path leave the
+root it was reached through?" — and until #1294 each answered it in its own
+words:
+
+* ``creek.redact.scanner._scannable_candidates`` — the redaction **read**
+  path, which skips an escaping child and counts it.
+* ``creek.redact.cli_commands`` — the redaction **write** path, which
+  refuses before it opens anything.
+* ``creek.ingest`` — every ingestor's discovery walk, which had no
+  containment check at all and read whatever its glob yielded.
+
+A predicate copied three times is three predicates, and they drift. This
+module is the single definition all three now import, so "inside" cannot
+come to mean one thing for the scanner and another for the ingestors.
+
+**Stdlib-only by design.** :mod:`creek.ingest.base` imports this module, and
+:mod:`creek.redact.scanner` compiles a large regex battery at import time;
+depending on the scanner from the ingest path would drag redaction into
+every ingest. The same reasoning that keeps :mod:`creek._fsio` underneath
+the writers keeps this module underneath both.
+
+The policy, unchanged from the shipped SEC-003 guard:
+
+* Resolve the ROOT exactly once.
+* ``lstat`` (i.e. :meth:`~pathlib.Path.is_symlink`) only the LEAF; never
+  resolve a child that is not itself a link. Resolving non-symlink children
+  would flag every child of a root reached *through* a symlinked component
+  — ``/tmp`` -> ``/private/tmp`` on macOS — as escaping.
+* Unprovable containment IS an escape.
+
+That policy is deliberately LEAF-ONLY, so a path reached through an
+escaping *ancestor* component (``<root>/linkdir/a.md``, where ``linkdir``
+is the link) is admitted by :func:`resolves_within` alone. For a walked
+tree that residual is closed by :func:`find_escaping_symlink`, which sees
+``linkdir`` in its own right; for a directly-named path it remains the
+documented residual recorded in ``docs/security/threat-model.md``.
+
+Security direction here is one-way: every function may only ever cause a
+caller to read *less*. There is no waiver — no ``--force``, no environment
+variable, no config key — per SEC-003's no-waiver precedent.
+"""
+
+from __future__ import annotations
+
+import itertools
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class EscapingSymlinkError(RuntimeError):
+    """A symlink under a named root resolves outside that root.
+
+    Raised by :func:`assert_source_contained` so that ingestion refuses a
+    source tree rather than reading through the link. Refusal rather than
+    skipping is the contract for this surface: ingest is a *write* path —
+    what it reads becomes a durable vault fragment that then feeds
+    classification, embeddings, cloud LLM prompts, drafts and compiled
+    pages — and #1360 established that the write path refuses while only
+    the read path (``redact --scan``, which writes nothing) may skip and
+    count.
+
+    Neither :attr:`path` nor the message ever names the link's *resolved*
+    target. Disclosing where the link points is the exfiltration oracle
+    #1087 closes, and it would be perverse for the refusal to leak the very
+    thing it refused to read.
+
+    Attributes:
+        path: The offending link exactly as walked or supplied — never
+            resolved, and never normalised, so the operator can find it by
+            the name they know it by.
+        root: The source root the operator named.
+    """
+
+    def __init__(self, path: Path, root: Path) -> None:
+        """Build a containment refusal naming the link and its root.
+
+        Args:
+            path: The offending symlink, exactly as walked or supplied.
+            root: The source root the operator named.
+        """
+        self.path = path
+        self.root = root
+        super().__init__(
+            f"Refusing to ingest {root}: {path} is a symlink whose target "
+            "resolves outside that tree, so ingestion would write content "
+            "from outside the source into the vault. Remove or re-point the "
+            "link, or ingest the target's own directory directly."
+        )
+
+
+def resolves_within(child: Path, resolved_root: Path) -> bool:
+    """Report whether *child*'s symlink target stays under *resolved_root*.
+
+    The single containment predicate for the whole codebase: the redaction
+    scanner's walked-child surface, the redaction CLI's named-path surface,
+    and the ingest discovery gate all call this one function, so they cannot
+    drift into subtly different definitions of "inside".
+
+    The failure arm is a deliberate classification, not a swallowed error:
+    a loop (``RuntimeError``), an unreadable link (``OSError``), and a
+    target outside the root (``ValueError`` from ``relative_to``) are all
+    cases where containment cannot be proven — and an unprovable
+    containment is an escape. Every caller logs and counts its rejections.
+
+    ``strict=False`` is deliberate: a dangling link still resolves to a
+    candidate location worth comparing, so a broken link pointing *outside*
+    is still refused rather than waved through on the technicality that its
+    target does not exist yet.
+
+    The exception object itself is deliberately dropped rather than logged:
+    ``relative_to``'s message quotes the *resolved* target, which is exactly
+    the out-of-root path this guard exists to keep out of the record.
+
+    Args:
+        child: A path being tested for containment, as walked.
+        resolved_root: The root, already resolved exactly once by the
+            caller.
+
+    Returns:
+        ``True`` when the link's target is a descendant of *resolved_root*.
+    """
+    try:
+        child.resolve(strict=False).relative_to(resolved_root)
+    except (OSError, RuntimeError, ValueError):
+        return False
+    return True
+
+
+def named_path_escapes(path: Path) -> bool:
+    """Report whether *path* is itself a symlink leaving its own parent.
+
+    The containment question for a path the operator names directly, as
+    opposed to one discovered while walking a tree.
+
+    Three properties carry the correctness argument:
+
+    * ``is_symlink()`` is an ``lstat`` on the leaf, so a path that is not
+      itself a link is never resolved and never compared. That is what
+      makes this guard behave identically on darwin and on Linux CI: a root
+      reached *through* a symlinked component (``/tmp`` -> ``/private/tmp``
+      on macOS) is not flagged.
+    * When the leaf *is* a link, BOTH sides are resolved — the target
+      inside :func:`resolves_within`, the parent here — so ``/tmp`` ->
+      ``/private/tmp`` cannot manufacture a spurious refusal for a link
+      that never left its own directory.
+    * The predicate is LEAF-ONLY, and deliberately so: a named path whose
+      escaping link is an ANCESTOR component is admitted. That is a known,
+      accepted residual — not full coverage of path traversal.
+
+    Args:
+        path: The path exactly as the operator supplied it.
+
+    Returns:
+        ``True`` when *path* is a symlink whose target is not a descendant
+        of its own resolved parent directory.
+    """
+    return path.is_symlink() and not resolves_within(
+        path,
+        path.parent.resolve(strict=False),
+    )
+
+
+def find_escaping_symlink(root: Path) -> Path | None:
+    """Return the first descendant of *root* that links out of it, if any.
+
+    Walks with ``followlinks=False`` so the walk itself never descends
+    through a link, and inspects BOTH ``dirnames`` and ``filenames``.
+    Checking directory entries is what closes
+    :meth:`creek.ingest.code.CodeIngestor._discover_directory`, which
+    recurses manually with ``is_dir()`` — and ``is_dir()`` follows symlinks,
+    so unlike the ``rglob`` ingestors it would otherwise walk an entire
+    out-of-tree subtree.
+
+    Returning the offender rather than raising is what lets the two callers
+    with different refusal mechanics — ``typer.Exit`` in
+    :mod:`creek.redact.cli_commands`, :class:`EscapingSymlinkError` in
+    :func:`assert_source_contained` — share one walk instead of keeping two
+    copies of it.
+
+    Args:
+        root: The tree to inspect, exactly as the operator supplied it.
+
+    Returns:
+        The first escaping entry found, as walked, or ``None`` when every
+        symlink under *root* resolves inside it.
+    """
+    resolved_root = root.resolve(strict=False)
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        for entry in itertools.chain(dirnames, filenames):
+            candidate = Path(dirpath) / entry
+            if candidate.is_symlink() and not resolves_within(candidate, resolved_root):
+                return candidate
+    return None
+
+
+def assert_source_contained(source_path: Path) -> None:
+    """Refuse a source tree that links out of itself (#1294).
+
+    The gate every ingestor passes through. Two checks, and the order
+    matters:
+
+    1. *source_path* itself, via :func:`named_path_escapes`. This must come
+       BEFORE any ``is_dir()``, which follows the link. #1360 found that
+       resolving a named symlinked directory launders every child as
+       in-root: the tree walk would resolve the root to the link's target
+       and then find nothing escaping inside it.
+    2. Every descendant, via :func:`find_escaping_symlink`.
+
+    A symlink whose target stays inside the root is admitted, so ordinary
+    intra-tree aliases keep working. Containment is about the target
+    escaping, not about the link existing.
+
+    Args:
+        source_path: The source file or directory as the caller supplied
+            it.
+
+    Raises:
+        EscapingSymlinkError: When *source_path* is, or contains, a symlink
+            whose target resolves outside the tree the operator named.
+    """
+    if named_path_escapes(source_path):
+        logger.warning(
+            "Refusing to ingest a source path that is a symlink escaping "
+            "its own parent: %s",
+            source_path,
+        )
+        raise EscapingSymlinkError(source_path, source_path)
+    if not source_path.is_dir():
+        return
+    escaping = find_escaping_symlink(source_path)
+    if escaping is not None:
+        logger.warning(
+            "Refusing to ingest %s: it contains a symlink that escapes the "
+            "source root: %s",
+            source_path,
+            escaping,
+        )
+        raise EscapingSymlinkError(escaping, source_path)

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -18,6 +18,7 @@ from rich.console import Console
 from rich.markup import escape
 from rich.table import Table
 
+from creek._containment import EscapingSymlinkError, assert_source_contained
 from creek.classify.privacy_filter import (
     PrivacyTierOverride,
     override_elevates,
@@ -430,6 +431,9 @@ def _run_ingest(
     except FileNotFoundError as exc:
         console.print(f"[red]Vault unavailable: {exc}[/red]")
         raise typer.Exit(code=1) from exc
+    except EscapingSymlinkError as exc:
+        console.print(f"[red]Symlink containment: {exc}[/red]")
+        raise typer.Exit(code=1) from exc
 
     if print_summary:
         console.print(
@@ -438,6 +442,27 @@ def _run_ingest(
             f"{result.skipped} skipped[/dim]",
         )
     return result.written, result.errors, result.discovered
+
+
+def _assert_ingest_source_contained(source_path: Path) -> None:
+    """Refuse an ingest source that links out of itself, before reading it.
+
+    Translates :class:`creek._containment.EscapingSymlinkError` into the
+    CLI's refusal idiom so the handler can call the gate early — above
+    ``_gate_consent`` — without letting a traceback reach the operator.
+
+    Args:
+        source_path: The ``--input`` path exactly as the operator gave it.
+
+    Raises:
+        typer.Exit: With code ``1`` when *source_path* is, or contains, a
+            symlink whose target resolves outside it.
+    """
+    try:
+        assert_source_contained(source_path)
+    except EscapingSymlinkError as exc:
+        console.print(f"[red]Symlink containment: {exc}[/red]")
+        raise typer.Exit(code=1) from exc
 
 
 def _warn_if_discovered_but_empty(
@@ -1203,6 +1228,13 @@ def process(
     except SymlinkEscapedSourceError as exc:
         console.print(f"[red]Symlink containment: {exc}[/red]")
         raise typer.Exit(code=1) from exc
+    except EscapingSymlinkError as exc:
+        # Reachable only with ``redaction.enabled: false``, which returns
+        # early from ``_run_redaction`` before the #1087 check. The ingestor
+        # gate is then what stops the run, and its refusal must read like a
+        # refusal rather than a traceback (#1294).
+        console.print(f"[red]Symlink containment: {exc}[/red]")
+        raise typer.Exit(code=1) from exc
 
     console.print(f"[bold]Files scanned:[/bold] {result.files_scanned}")
     console.print(f"[bold]Fragments created:[/bold] {result.fragments_created}")
@@ -1310,6 +1342,15 @@ def ingest(
     if not input.exists():
         console.print(f"[red]Input path not found: {input}[/red]")
         raise typer.Exit(code=2)
+
+    # Before ``_gate_consent``, and NOT redundant with the gate inside
+    # ``Ingestor.ingest``. The consent prompt calls
+    # ``creek/consent.py::_build_source_summary``, which walks ``rglob("*")``
+    # and ``stat()``s every entry — following an escaping link and folding
+    # out-of-tree file counts and byte totals into the very summary the
+    # operator is asked to approve. A guard that sits only downstream blocks
+    # the write and still performs that out-of-root read first (#1294).
+    _assert_ingest_source_contained(input)
 
     _gate_consent(
         source_path=input,

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -445,14 +445,28 @@ def _run_ingest(
 
 
 def _assert_ingest_source_contained(source_path: Path) -> None:
-    """Refuse an ingest source that links out of itself, before reading it.
+    """Refuse a source that links out of itself, before anything reads it.
 
     Translates :class:`creek._containment.EscapingSymlinkError` into the
-    CLI's refusal idiom so the handler can call the gate early — above
+    CLI's refusal idiom so a handler can call the gate early — above
     ``_gate_consent`` — without letting a traceback reach the operator.
 
+    **Every** ``_gate_consent`` caller must call this first, and it is not
+    redundant with the gate inside ``Ingestor.ingest``. The consent prompt
+    runs ``creek/consent.py::_build_source_summary``, which walks
+    ``rglob("*")`` and ``stat()``s every entry — following an escaping link
+    and folding out-of-tree file counts and byte totals into the very
+    summary the operator is asked to approve. When ``--source`` is itself a
+    link to an outside directory, that walk enumerates the target directly
+    and prints real out-of-tree *filenames* in the ``Sample:`` line. Under
+    ``--yes`` the inflated ``file_count`` is then written into the consent
+    log, so the leak outlives the process and a later run reads the record
+    back and skips the prompt. A guard that sits only downstream blocks the
+    write and still performs that out-of-root read first (#1294).
+
     Args:
-        source_path: The ``--input`` path exactly as the operator gave it.
+        source_path: The ``--input`` / ``--source`` path exactly as the
+            operator gave it.
 
     Raises:
         typer.Exit: With code ``1`` when *source_path* is, or contains, a
@@ -1208,6 +1222,10 @@ def process(
         f"{' (no-LLM)' if no_llm else ''}[/bold green]"
     )
 
+    # Above ``_gate_consent``, never below it — see the helper's docstring
+    # for why the consent summary is itself an out-of-root read (#1294).
+    _assert_ingest_source_contained(source_path)
+
     consent_manager = _gate_consent(
         source_path=source_path,
         vault_path=vault_path,
@@ -1343,13 +1361,8 @@ def ingest(
         console.print(f"[red]Input path not found: {input}[/red]")
         raise typer.Exit(code=2)
 
-    # Before ``_gate_consent``, and NOT redundant with the gate inside
-    # ``Ingestor.ingest``. The consent prompt calls
-    # ``creek/consent.py::_build_source_summary``, which walks ``rglob("*")``
-    # and ``stat()``s every entry — following an escaping link and folding
-    # out-of-tree file counts and byte totals into the very summary the
-    # operator is asked to approve. A guard that sits only downstream blocks
-    # the write and still performs that out-of-root read first (#1294).
+    # Above ``_gate_consent``, never below it — see the helper's docstring
+    # for why the consent summary is itself an out-of-root read (#1294).
     _assert_ingest_source_contained(input)
 
     _gate_consent(

--- a/creek-tools/creek/ingest/base.py
+++ b/creek-tools/creek/ingest/base.py
@@ -26,6 +26,7 @@ from zoneinfo import ZoneInfo
 import chardet
 from pydantic import BaseModel, ConfigDict, Field
 
+from creek._containment import assert_source_contained
 from creek.classify.tags_pass import apply_tags
 from creek.models import Fragment, FragmentLevel
 
@@ -564,7 +565,29 @@ class Ingestor(abc.ABC):
 
         Returns:
             An ``IngestResult`` containing fragments, provenance, and errors.
+
+        Raises:
+            EscapingSymlinkError: When *source_path* is, or contains, a
+                symlink whose target resolves outside the tree the caller
+                named (#1294).
         """
+        # The single containment gate for all eleven registered ingestors,
+        # placed here rather than inside each ``discover()`` for two reasons.
+        # It runs BEFORE any walk, so no ingestor reads through the link on
+        # its way to refusing; and a future twelfth ingestor inherits the
+        # guard by construction instead of by someone remembering. A
+        # module-level function rather than a method, so a subclass cannot
+        # weaken it by overriding.
+        #
+        # It must stay OUTSIDE ``_discover_safe``, whose ``except Exception``
+        # collects failures into ``result.errors`` and returns ``[]``. An
+        # empty discovery leaves ``run_ingest``'s ``seen_keys`` empty, and
+        # ``creek/ingest/pipeline.py::tomb_missing_units`` then soft-tombs
+        # every ``ledger.live_keys()`` the pass did not see — so a refusal
+        # swallowed there would orphan every fragment previously ingested
+        # from this source. A containment guard must never become a deletion
+        # primitive (#1294).
+        assert_source_contained(source_path)
         result = IngestResult()
         ingestor_name = type(self).__name__
         now = datetime.now(tz=LA_TZ)

--- a/creek-tools/creek/ingest/markdown.py
+++ b/creek-tools/creek/ingest/markdown.py
@@ -344,6 +344,14 @@ class MarkdownIngestor(Ingestor):
         """
         docs: list[RawDocument] = []
         for md_file in sorted(dir_path.rglob("*.md")):
+            # Alone among the ingestors this walk had no ``is_file()`` filter,
+            # so a directory or a dangling link named ``*.md`` reached
+            # ``read_bytes()`` and raised. ``_discover_safe`` would collect
+            # that and return ``[]``, which arms ``tomb_missing_units`` — one
+            # unreadable entry would orphan the whole source. Robustness fix
+            # alongside #1294's containment gate, not the containment fix.
+            if not md_file.is_file():
+                continue
             raw_bytes = md_file.read_bytes()
             _text, encoding = normalize_encoding(raw_bytes)
             docs.append(

--- a/creek-tools/creek/pipeline.py
+++ b/creek-tools/creek/pipeline.py
@@ -174,13 +174,19 @@ class SymlinkEscapedSourceError(RuntimeError):
     """Raised when the redaction scan declined to read part of the source tree.
 
     The read tools skip an escaping symlink; ``creek process`` refuses over
-    it, and the asymmetry is the point (#1087). The redaction scan is the
-    only containment check standing between an out-of-tree file and the
-    vault: :meth:`creek.ingest.markdown.MarkdownIngestor._read_directory`
-    walks with ``rglob("*.md")`` and ``read_bytes()`` with no symlink and no
-    ``is_file`` guard of its own (#1294). Skipping here would therefore turn
-    a blocked ingest into a silent *unredacted* ingest, with the gate that
-    used to stop it now reporting success.
+    it, and the asymmetry is the point (#1087).
+
+    This was once the *only* containment check standing between an
+    out-of-tree file and the vault, because the ingestor walks had none of
+    their own. Since #1294 they do:
+    :func:`creek._containment.assert_source_contained` gates
+    ``Ingestor.ingest`` for every registered ingestor. This refusal is kept
+    all the same, and is not redundant. It fires earlier — before any
+    ingestor runs — and it carries the count of files the *scan* declined,
+    which is the number an operator needs to distinguish one stale link
+    from a whole unscanned subtree. Skipping here would still turn a
+    blocked ingest into a silent partial one, with the gate that used to
+    stop it reporting success.
 
     Attributes:
         skipped_count: Number of files the scan declined to read.
@@ -454,9 +460,11 @@ class Pipeline:
         outright via :class:`SymlinkEscapedSourceError` — before the
         ``dry_run`` arm, because a path-traversal guard admits no waiver and
         the scan came back clean only because it declined to look. Setting
-        ``redaction.enabled: false`` still bypasses the whole stage, symlink
-        check included; that pre-existing hole belongs to the ingestor walks
-        themselves and is tracked by #1294.
+        ``redaction.enabled: false`` still bypasses this whole stage, symlink
+        check included — but no longer bypasses containment: since #1294 the
+        ingestors refuse such a tree themselves, so the posture no longer
+        depends on a config toggle. What ``redaction.enabled: false`` now
+        costs is the PII scan, not the path-traversal guard.
 
         Args:
             source_path: Directory to scan.

--- a/creek-tools/creek/redact/cli_commands.py
+++ b/creek-tools/creek/redact/cli_commands.py
@@ -11,7 +11,6 @@ command registration and keeps :mod:`creek.cli` focused on routing.
 
 from __future__ import annotations
 
-import itertools
 import logging
 import os
 import tempfile
@@ -25,6 +24,7 @@ from rich.markdown import Markdown
 from rich.table import Table
 from rich.text import Text
 
+from creek._containment import find_escaping_symlink, named_path_escapes
 from creek.config import load_config, resolve_config_path
 from creek.redact.audit import RedactionAuditEntry, RedactionAuditLog
 from creek.redact.patterns import PATTERN_METADATA
@@ -33,10 +33,16 @@ from creek.redact.scanner import (
     SYMLINK_SKIP_LABEL,
     RedactionScanner,
     ScanSummary,
-    resolves_within,
 )
 
 logger = logging.getLogger(__name__)
+
+# The named-leaf predicate moved to :mod:`creek._containment` in #1294, when
+# the ingest gate became its third consumer; the name stays bound here so
+# this module's call sites and the #1293 tests keep reading the same way.
+# Dangling and looping links do not reach it from the CLI anyway —
+# ``_require_existing`` reports them as "not found" first.
+_named_path_escapes = named_path_escapes
 
 if TYPE_CHECKING:
     from rich.console import Console
@@ -291,49 +297,6 @@ def _error_exit(console: Console, message: str, *, code: int = 2) -> NoReturn:
     raise typer.Exit(code=code)
 
 
-def _named_path_escapes(path: Path) -> bool:
-    """Report whether *path* is itself a symlink leaving its own parent.
-
-    The containment question for a path the operator names on the command
-    line, as opposed to one the scanner discovers while walking a tree. It
-    delegates to :func:`creek.redact.scanner.resolves_within` rather than
-    restating the predicate, so the named-leaf surface and the walked-child
-    surface cannot drift into two definitions of "inside".
-
-    Three properties carry the correctness argument:
-
-    * ``is_symlink()`` is an ``lstat`` on the leaf, so a path that is not
-      itself a link is never resolved and never compared. That is what makes
-      this guard behave identically on darwin and on Linux CI: a root reached
-      *through* a symlinked component (``/tmp`` → ``/private/tmp`` on macOS)
-      is not flagged. Same reasoning as the scanner's own walk policy.
-    * When the leaf *is* a link, BOTH sides are resolved — the target inside
-      ``resolves_within``, the parent here — so ``/tmp`` → ``/private/tmp``
-      cannot manufacture a spurious refusal for a link that never left its
-      own directory.
-    * The predicate is LEAF-ONLY, and deliberately so: a named path whose
-      escaping link is an ANCESTOR component (``<root>/linkdir/a.md``, where
-      ``linkdir`` is the link) is admitted. That is a known, accepted
-      residual — not full coverage of path traversal.
-
-    ``strict=False`` matches the shipped guard: a target that does not exist
-    still resolves to a candidate location worth comparing. Dangling and
-    looping links do not reach here in the CLI anyway — ``_require_existing``
-    reports them as "not found" first.
-
-    Args:
-        path: The source or vault path exactly as the operator supplied it.
-
-    Returns:
-        ``True`` when *path* is a symlink whose target is not a descendant of
-        its own resolved parent directory.
-    """
-    return path.is_symlink() and not resolves_within(
-        path,
-        path.parent.resolve(strict=False),
-    )
-
-
 def _assert_named_path_contained(
     path: Path,
     *,
@@ -419,27 +382,25 @@ def _assert_no_escaping_symlinks(
         typer.Exit: When any descendant symlink resolves outside
             *root* or forms a loop.
     """
-    resolved_root = root.resolve(strict=False)
-    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
-        for entry in itertools.chain(dirnames, filenames):
-            candidate = Path(dirpath) / entry
-            if not candidate.is_symlink():
-                continue
-            try:
-                resolved = candidate.resolve(strict=False)
-                resolved.relative_to(resolved_root)
-            except (OSError, RuntimeError, ValueError):
-                logger.exception(
-                    "Refusing to follow symlink that escapes the %s root: %s",
-                    label,
-                    candidate,
-                )
-                _error_exit(
-                    console,
-                    f"Refusing to follow symlink that escapes the {label} "
-                    f"root: {candidate}",
-                    code=1,
-                )
+    # The walk itself lives in :func:`creek._containment.find_escaping_symlink`
+    # (#1294), which the ingest gate also calls. Returning the offender rather
+    # than raising is what lets two callers with different refusal mechanics —
+    # ``typer.Exit`` here, ``EscapingSymlinkError`` there — share one walk.
+    # ``logger.warning`` rather than ``logger.exception``: no exception is in
+    # flight at this point any more, and ``logger.exception`` outside an
+    # ``except`` block appends a bogus ``NoneType: None`` traceback.
+    candidate = find_escaping_symlink(root)
+    if candidate is not None:
+        logger.warning(
+            "Refusing to follow symlink that escapes the %s root: %s",
+            label,
+            candidate,
+        )
+        _error_exit(
+            console,
+            f"Refusing to follow symlink that escapes the {label} root: {candidate}",
+            code=1,
+        )
 
 
 def _require_existing(console: Console, path: Path, label: str) -> None:

--- a/creek-tools/creek/redact/scanner.py
+++ b/creek-tools/creek/redact/scanner.py
@@ -34,6 +34,7 @@ from pathlib import Path  # noqa: TC003 — Pydantic needs Path at runtime
 from pydantic import BaseModel
 from tqdm import tqdm
 
+from creek._containment import resolves_within
 from creek.config import RedactionConfig  # noqa: TC001 — used at runtime
 from creek.redact.patterns import (
     HIGH_ENTROPY_MIN_RUN,
@@ -787,42 +788,19 @@ def _statistics_lines(summary: ScanSummary) -> list[str]:
     return lines
 
 
-def resolves_within(child: Path, resolved_root: Path) -> bool:
-    """Report whether *child*'s symlink target stays under *resolved_root*.
-
-    Public because it is now also the named-leaf containment predicate for
-    :mod:`creek.redact.cli_commands` (#1293), so the walked-child surface and
-    the named-path surface cannot drift into two subtly different definitions
-    of "inside".
-
-    The failure arm is a deliberate classification, not a swallowed error:
-    a loop (``RuntimeError``), an unreadable link (``OSError``), and a
-    target outside the root (``ValueError`` from ``relative_to``) are all
-    cases where the scanner cannot prove containment — and an unprovable
-    containment is an escape. The caller logs and counts every rejection.
-
-    Dangling links never reach here in either direction:
-    :func:`_scannable_candidates` gates on ``is_file()`` first, which is
-    ``False`` for a link whose target does not exist, so a dangling link is
-    dropped as a non-file before containment is ever asked about.
-
-    The exception object itself is deliberately dropped rather than logged:
-    ``relative_to``'s message quotes the *resolved* target, which is exactly
-    the out-of-root path this guard exists to keep out of the record.
-
-    Args:
-        child: A symlinked child of the scan root, as scanned.
-        resolved_root: The scan root, already resolved exactly once by
-            :func:`_scannable_candidates`.
-
-    Returns:
-        ``True`` when the link's target is a descendant of *resolved_root*.
-    """
-    try:
-        child.resolve(strict=False).relative_to(resolved_root)
-    except (OSError, RuntimeError, ValueError):
-        return False
-    return True
+# ``resolves_within`` is re-exported, not defined here. It began as this
+# module's private ``_resolves_within``, was made public by #1293 when the
+# redaction CLI needed the same predicate for a directly-named path, and
+# moved to :mod:`creek._containment` in #1294 when the ingestor discovery
+# gate became its third consumer. Three copies of a containment predicate
+# are three predicates that drift; one definition cannot. The name stays
+# bound here because :mod:`creek.redact.cli_commands` imports it from this
+# module and ``_scannable_candidates`` below calls it.
+#
+# The dependency direction is deliberate: ``creek._containment`` is
+# stdlib-only and must not import this module back, because
+# :mod:`creek.ingest.base` depends on it and compiling this module's regex
+# battery on every ingest would be the cost of that cycle.
 
 
 def _scannable_candidates(dir_path: Path) -> tuple[list[Path], int]:
@@ -858,9 +836,12 @@ def _scannable_candidates(dir_path: Path) -> tuple[list[Path], int]:
       link — is still admitted here. That is not an oversight: it is the
       resolve-the-root / ``lstat``-the-leaf policy documented above, applied
       consistently on both surfaces.
-    * #1294 — the ingestor walks (e.g.
-      ``creek.ingest.markdown.MarkdownIngestor._read_directory``) still follow
-      symlinks out of the source root.
+    Closed since this docstring was written: #1294 — the ingestor walks no
+    longer follow symlinks out of the source root.
+    :func:`creek._containment.assert_source_contained` gates
+    ``Ingestor.ingest`` for every registered ingestor, so the pipeline
+    refusal built on this counter is now a second line of defence rather
+    than the only one.
 
     Args:
         dir_path: The scan root, exactly as the caller supplied it.

--- a/creek-tools/creek_mcp/tools/ingest.py
+++ b/creek-tools/creek_mcp/tools/ingest.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from creek._containment import EscapingSymlinkError
 from creek.ingest import INGESTOR_REGISTRY, assemble_ingested_fragment
 from creek.models import PrivacyTier
 from creek.vault.writer import VaultWriter
@@ -97,7 +98,19 @@ def ingest_tool(
         )
 
     writer = VaultWriter(vault_path=vault_path)
-    ingest_result = ingestor_cls().ingest(resolved)
+    try:
+        ingest_result = ingestor_cls().ingest(resolved)
+    except EscapingSymlinkError as exc:
+        # ``resolve_within_vault`` above confines the path the caller NAMED;
+        # it says nothing about a link *underneath* a legitimately in-vault
+        # source. Refusals on this surface are structured responses, so the
+        # containment error must not surface as a transport crash (#1294).
+        # ``exc.path`` names the link as walked, never its resolved target.
+        return refusal_response(
+            tool=TOOL_NAME,
+            ceiling=privacy_tier_ceiling,
+            reason=(f"source tree contains a symlink that escapes it: {exc.path}"),
+        )
     written_ids: list[str] = []
     errors: list[str] = list(ingest_result.errors)
     for parsed in ingest_result.fragments:

--- a/creek-tools/docs/ingestion.md
+++ b/creek-tools/docs/ingestion.md
@@ -43,6 +43,16 @@ containment is not part of the PII scan. There is no override flag; the fix
 is to remove the link, re-point it inside the tree, or name the target's own
 directory as `--input`.
 
+On both `creek ingest` and `creek process` the refusal lands *before* the
+first-time consent prompt, not after it. That ordering is the point: the
+prompt's `Found: N file(s), X MB` / `Sample: ...` summary is built by walking
+the source tree and `stat()`ing every entry, which follows an escaping link.
+Refusing first means no out-of-tree filename is ever printed, and — under
+`--yes`, which records consent immediately — no file count measured through
+a link is ever written into
+`00-Creek-Meta/Processing-Log/consent-log.json`, where it would persist and
+suppress the prompt on every later run.
+
 Symlinks that stay **inside** the source tree are fine and keep working, so
 an ordinary alias (`latest -> 2026-08-01`, or `alias.md -> real.md`) needs no
 change. A tree reached *through* a symlink is also fine — only links that

--- a/creek-tools/docs/ingestion.md
+++ b/creek-tools/docs/ingestion.md
@@ -23,6 +23,31 @@ If `--type` is omitted, `creek process` picks ingestors by file extension.
 
 `gdrive` is **not** a `--type` (ARCH-001) — it is a downloader. Run `creek gdrive --download --staging <dir>` to mirror Drive files locally, then run `creek ingest --type document --input <dir>` (or `--type spreadsheet`, etc.) against the staged directory. See [Google Drive](#google-drive) below.
 
+## Symlinks in a source tree
+
+Ingestion refuses a source tree that links out of itself. If any entry under
+`--input` is a symlink whose target resolves outside that tree — or if
+`--input` is itself such a link — the run stops with exit 1 and writes
+nothing:
+
+```
+Symlink containment: Refusing to ingest /Users/me/exports: /Users/me/exports/notes/link.md
+is a symlink whose target resolves outside that tree, so ingestion would write content
+from outside the source into the vault. Remove or re-point the link, or ingest the
+target's own directory directly.
+```
+
+This applies to every `--type`, to `creek process`, and to the
+`creek.ingest` MCP tool, and it holds regardless of `redaction.enabled` —
+containment is not part of the PII scan. There is no override flag; the fix
+is to remove the link, re-point it inside the tree, or name the target's own
+directory as `--input`.
+
+Symlinks that stay **inside** the source tree are fine and keep working, so
+an ordinary alias (`latest -> 2026-08-01`, or `alias.md -> real.md`) needs no
+change. A tree reached *through* a symlink is also fine — only links that
+leave the named root are refused.
+
 ## Common patterns
 
 ```bash

--- a/creek-tools/docs/redaction.md
+++ b/creek-tools/docs/redaction.md
@@ -197,9 +197,16 @@ re-running `creek process`.
 
 The scan itself did not fail here — it *skipped* the escaping link and
 carried on, which is why the pipeline has to refuse on its behalf. A clean
-result reached by declining to look reads exactly like a clean tree, and
-ingestion has no symlink guard of its own: it would read that file anyway
-(#1294). Remediation:
+result reached by declining to look reads exactly like a clean tree.
+
+Since #1294 ingestion no longer depends on that refusal. Every ingestor
+passes through one containment gate before it discovers anything, so
+`creek ingest`, the `creek.ingest` MCP tool and `creek process` all refuse
+a source tree containing an escaping symlink — including when
+`redaction.enabled: false` skips the scan entirely. The pipeline refusal
+above is kept as the earlier, better-informed of the two: it fires before
+any ingestor runs and reports how many files the scan declined.
+Remediation:
 
 1. **Find the offending links.** Each skip is logged as it happens —
    `Skipping symlink that escapes the scan root: <path>` — naming the link
@@ -214,8 +221,9 @@ ingestion has no symlink guard of its own: it would read that file anyway
 Neither override above applies. `redaction.dry_run: true` does not suppress
 this refusal — that setting means "log the matches you found", not "proceed
 past a file nobody read". `redaction.enabled: false` does skip the whole
-redaction stage, symlink check included, which is precisely the unredacted
-ingest this refusal exists to prevent.
+redaction stage, symlink check included; what it no longer skips is
+containment, because the ingestors enforce that themselves (#1294). Turning
+redaction off costs you the PII scan, not the path-traversal guard.
 
 The check is deliberately narrow. A symlink whose target stays *inside* the
 source tree is still admitted, and is still scanned **unresolved** — under

--- a/creek-tools/docs/security/threat-model.md
+++ b/creek-tools/docs/security/threat-model.md
@@ -158,7 +158,30 @@ from most to least likely:
   discovery leaves `run_ingest`'s `seen_keys` empty and
   `tomb_missing_units` then soft-tombs every live ledger key — one
   stray link would have orphaned every fragment previously ingested
-  from that source. Residual, unchanged: the escaping-*ancestor*
+  from that source. One further defect surfaced only on Python 3.13
+  and is recorded because the mechanism generalises: the predicate
+  resolved with `Path.resolve(strict=False)`, whose behaviour on a
+  symlink **cycle** pathlib never specified. On 3.11/3.12 it raises
+  `RuntimeError`, which the predicate classified as unprovable and so
+  refused; on 3.13 `Path.resolve` delegates to `os.path.realpath`,
+  which for `strict=False` stops unwinding at the cycle and returns a
+  *partially resolved* path. For a cycle that closes back on its own
+  starting point that answer erases the hops in between:
+  `<root>/a.md -> <outside>/o.md -> <root>/a.md` resolved to
+  `<root>/a.md`, an in-root answer for a link whose first hop leaves
+  the root, and the tree was admitted. No out-of-root content reached
+  the vault, because `open` also fails `ELOOP` — but that is the
+  kernel refusing rather than Creek, and it stops holding as soon as
+  the cycle is broken at the far end, outside the tree the operator
+  named. Resolution now goes through
+  `creek._containment._resolved_target`, which uses
+  `os.path.realpath(..., strict=True)` — a cycle is `OSError(ELOOP)`
+  on every supported version — and treats only `FileNotFoundError` as
+  non-fatal, so a dangling link is still judged on its candidate
+  location. The verdict is now identical on 3.11, 3.12 and 3.13, and
+  the general lesson is that a containment predicate must not take
+  its "cannot prove this" signal from an unspecified stdlib
+  exception. Residual, unchanged: the escaping-*ancestor*
   component case, which is the leaf-only policy applied
   consistently on all three surfaces. User-visible effect: aliasing an
   external export tree into the vault (`ln -s /Volumes/Export

--- a/creek-tools/docs/security/threat-model.md
+++ b/creek-tools/docs/security/threat-model.md
@@ -132,11 +132,35 @@ from most to least likely:
   which surfaces as a parse error from outside the named tree). It
   is deliberately not refused here, because a refusing `--scan` is
   the denial of service the skip-and-count contract exists to
-  avoid; tracked separately in #1359. One gap remains open: the
-  ingestor's own directory walks
-  still follow symlinks out of the source root regardless, so the
-  pipeline refusal is a backstop that a vault with `redaction.enabled:
-  false` never reaches (#1294). User-visible effect: aliasing an
+  avoid; tracked separately in #1359. #1294 closed the last of the
+  gaps: the ingestor walks had no containment check of any kind, so
+  the pipeline refusal was a backstop that a vault with
+  `redaction.enabled: false` never reached — and that a caller
+  running an ingestor directly (`creek ingest`, the `creek.ingest`
+  MCP tool) never reached at all. All eleven registered ingestors
+  now pass through one gate,
+  `creek._containment.assert_source_contained`, called from
+  `Ingestor.ingest` before any discovery walk. Ingest **refuses**
+  rather than skipping: it is a write path, so it takes the same
+  side of #1293's split as `--apply`/`--review`, and skipping would
+  have left the posture depending on whether `redaction.enabled` was
+  set. The measured defect was not theoretical — at HEAD a source
+  tree containing `nested/link.md -> <outside>/secret.md` produced a
+  vault fragment holding the out-of-tree file's text, and
+  `CodeIngestor` was worse than the rest: it recurses with
+  `iterdir()` + `is_dir()`, which follows symlinks, so it walked an
+  entire out-of-tree *subtree* rather than just the named link. The
+  gate uses `os.walk(followlinks=False)` and inspects `dirnames` as
+  well as `filenames`, which is what closes that. One consequence
+  worth recording because it was nearly the opposite of a fix:
+  ingestion's refusal must propagate out of `Ingestor.ingest` rather
+  than being collected by `_discover_safe`, because an empty
+  discovery leaves `run_ingest`'s `seen_keys` empty and
+  `tomb_missing_units` then soft-tombs every live ledger key — one
+  stray link would have orphaned every fragment previously ingested
+  from that source. Residual, unchanged: the escaping-*ancestor*
+  component case, which is the leaf-only policy applied
+  consistently on all three surfaces. User-visible effect: aliasing an
   external export tree into the vault (`ln -s /Volumes/Export
   ~/vault/inbox`) and naming that alias to `--apply`/`--review` is
   now refused; the workaround is to name the resolved path directly.
@@ -224,10 +248,13 @@ The codebase annotates design-trace work with short IDs: `SEC-*`, `INC-*`, `OPS-
 Notable threat-model-adjacent IDs that have shipped or are in flight:
 
 - **SEC-002** — Redaction pattern coverage gaps
-- **SEC-003** — Symlink refusal in redaction: covers both the walked
-  tree and a directly-named path (`--apply`/`--review` refuse before
-  reading; `--scan` skips and counts); the escaping-ancestor-component
-  residual is leaf-only and documented above (resolved)
+- **SEC-003** — Symlink refusal: covers the walked tree, a
+  directly-named path (`--apply`/`--review` refuse before reading;
+  `--scan` skips and counts), and — since #1294 — every ingestor
+  discovery walk, which refuses. One predicate,
+  `creek._containment.resolves_within`, serves all three surfaces; the
+  escaping-ancestor-component residual is leaf-only and documented
+  above (resolved)
 - **SEC-004** — Prompt injection hardening (resolved)
 - **SEC-005** — Audit log tamper-evidence
 - **SEC-006** — Privacy-tier enforcement in mine/draft

--- a/creek-tools/tests/test_ingest_symlink_containment.py
+++ b/creek-tools/tests/test_ingest_symlink_containment.py
@@ -1,0 +1,1597 @@
+"""#1294: every ingestor refuses a source tree that links out of itself.
+
+---------------------------------------------------------------------------
+The defect
+---------------------------------------------------------------------------
+All eleven entries in :data:`creek.ingest.INGESTOR_REGISTRY` discover their
+inputs with an unguarded walk and read whatever the walk yields. A symlink
+under the named source tree whose target lies outside it is followed, read,
+and written into the vault as a durable fragment — which then feeds
+classification, embeddings, cloud LLM prompts, drafts and compiled pages.
+``CodeIngestor`` is worse than the rest: ``_discover_directory`` recurses
+with ``item.is_dir()``, which *follows* links, so it walks an entire
+out-of-tree subtree rather than surfacing the link and stopping.
+
+---------------------------------------------------------------------------
+Why these tests assert REFUSE and not SKIP
+---------------------------------------------------------------------------
+#1293 (PR #1360) settled the shape of the rule and this file inherits it.
+The *read* path (``redact --scan``) SKIPS and counts, because refusing a
+whole scan over one bad link is a denial of service on the safety pass —
+the operator's only instrument for learning what is exposed. The *write*
+path (``redact --apply`` / ``--review``) REFUSES. Ingest writes, so ingest
+refuses. Two more reasons the write-path rule is the right one here:
+
+* ``creek process`` with the default ``redaction.enabled: true`` ALREADY
+  refuses this exact tree via ``SymlinkEscapedSourceError`` (#1087). A skip
+  at the ingestor would make the SAME tree behave differently depending on
+  a config toggle, which is precisely the defect #1294 names.
+* ``creek ingest`` prints errors as a dim yellow list and exits 0, so
+  "skip and append to ``IngestResult.errors``" is near-silent in practice.
+
+---------------------------------------------------------------------------
+Why the guard belongs at ONE chokepoint
+---------------------------------------------------------------------------
+``Ingestor.ingest`` is the single door all eleven ingestors go through.
+``test_every_registered_ingestor_refuses_an_escaping_link`` drives straight
+off the registry, so a twelfth ingestor added next year is covered without
+anyone remembering to copy a check into it. N per-ingestor copies of the
+predicate could never have that property — and the copies would drift, which
+is the same argument #1293 used to make ``resolves_within`` public rather
+than write it a second time.
+
+---------------------------------------------------------------------------
+The containment policy these tests must NOT over-tighten
+---------------------------------------------------------------------------
+Resolve the ROOT once; ``lstat`` (i.e. ``is_symlink()``) only the LEAF;
+never resolve a non-symlink child. That is what keeps a root reached
+*through* a symlinked component usable — on macOS ``tmp_path`` lives under
+``/tmp`` -> ``/private/tmp`` — and resolving children too would flag every
+child of every test root as escaping. An escaping ANCESTOR component is a
+documented, accepted residual across #1087/#1293 and is not closed here. A
+symlink whose target stays INSIDE the root is admitted: ordinary intra-tree
+aliases keep working, and the over-breadth guards below pin that.
+
+Symlinks are not portable in git (see ``tests/fixtures/symlinks/README.md``),
+so every tree here is constructed at runtime under ``tmp_path``.
+
+Imports of :mod:`creek._containment` are deliberately function-local. The
+module does not exist yet, and a module-level import of a missing name is a
+collection error for the whole file — it would take the regression
+invariants down with it and hide the real signal. The idiom is copied from
+``tests/test_cli_redact.py``'s ``SymlinkPolicy`` test.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from typer.testing import CliRunner
+
+from creek.cli import app
+from creek.ingest import INGESTOR_REGISTRY
+from creek.ingest.pipeline import run_ingest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Sentinels
+# ---------------------------------------------------------------------------
+
+_SENTINEL = "CANARY-INGEST-ESCAPED-1294-a7f3"
+"""String that exists ONLY in a file parked outside the source root.
+
+A sentinel rather than realistic prose, so "this reached the vault" cannot
+be explained away as a phrase that could have come from anywhere.
+"""
+
+_IN_ROOT_MARKER = "CONTROL-IN-ROOT-1294-b19c"
+"""String carried by the innocent, genuinely in-root file of every fixture.
+
+Its presence in the vault on a *clean* run is the non-vacuity guard: a lane
+whose fixture the ingestor never picks up would satisfy every "the sentinel
+is absent" assertion perfectly while proving nothing at all.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Vault helpers
+# ---------------------------------------------------------------------------
+
+_VAULT_DIRS: tuple[str, ...] = (
+    "00-Creek-Meta/Processing-Log",
+    "01-Fragments/Conversations",
+    "01-Fragments/Journal",
+    "01-Fragments/Messages",
+    "01-Fragments/Notes",
+    "01-Fragments/Unsorted",
+    "01-Fragments/Writing",
+    "10-Liminal/Orphaned",
+)
+"""Minimum vault scaffold ``VaultWriter`` will accept and tombing needs.
+
+``VaultWriter`` hard-requires ``00-Creek-Meta`` and ``01-Fragments`` and
+creates the per-platform subfolder itself; ``10-Liminal/Orphaned`` is where
+a soft-tomb lands, and the mass-tombing test reads it.
+"""
+
+
+def _make_vault(base: Path, *, name: str = "vault") -> Path:
+    """Scaffold a vault whose config explicitly disables redaction.
+
+    ``redaction.enabled: false`` is written out and named in the tests that
+    matter because it is the exact operator setting that switches off the
+    #1087 pipeline refusal. ``run_ingest`` never reads this file — and that
+    is the point: with the redaction pass out of the picture there is
+    nothing else in the call graph that could refuse, so any refusal these
+    tests observe has to be the ingestor's own.
+
+    Args:
+        base: Directory to create the vault under.
+        name: Vault directory name, so one test can hold two vaults.
+
+    Returns:
+        Path to the vault root.
+    """
+    vault = base / name
+    for relative in _VAULT_DIRS:
+        (vault / relative).mkdir(parents=True, exist_ok=True)
+    (vault / "00-Creek-Meta" / "creek_config.yaml").write_text(
+        "redaction:\n  enabled: false\n",
+        encoding="utf-8",
+    )
+    return vault
+
+
+def _written_vault_text(vault: Path) -> str:
+    """Concatenate every regular file the run left under *vault*.
+
+    Symlinks are skipped rather than read: a test whose source tree lives
+    inside the vault would otherwise read the escaping link itself and
+    report the sentinel as "reached the vault" when nothing was written.
+    Every source tree in this file is parked outside the vault anyway; the
+    skip keeps the helper safe if that ever changes.
+
+    Args:
+        vault: Vault root to read.
+
+    Returns:
+        The concatenated text of every regular file under *vault*.
+    """
+    return "\n".join(
+        path.read_text(encoding="utf-8", errors="replace")
+        for path in sorted(vault.rglob("*"))
+        if path.is_file() and not path.is_symlink()
+    )
+
+
+def _vault_fragments(vault: Path) -> list[Path]:
+    """Return the live fragment files under ``01-Fragments``.
+
+    Args:
+        vault: Vault root to read.
+
+    Returns:
+        Sorted list of live fragment paths.
+    """
+    return sorted((vault / "01-Fragments").rglob("*.md"))
+
+
+def _vault_orphans(vault: Path) -> list[Path]:
+    """Return the soft-tombed fragment files under ``10-Liminal/Orphaned``.
+
+    Args:
+        vault: Vault root to read.
+
+    Returns:
+        Sorted list of tombstone paths.
+    """
+    return sorted((vault / "10-Liminal" / "Orphaned").rglob("*.md"))
+
+
+# ---------------------------------------------------------------------------
+# Per-ingestor fixture builders
+#
+# Each builder plants BOTH an in-root innocent file the ingestor really
+# picks up AND (when asked) an escaping link of the shape that ingestor's
+# own discover() walks. A single-item fixture makes any "nothing leaked"
+# assertion trivially true, so both halves are mandatory.
+# ---------------------------------------------------------------------------
+
+
+def _park_outside(base: Path, name: str, text: str) -> Path:
+    """Write *text* to ``<base>/outside/<name>`` and return the path.
+
+    Args:
+        base: Per-lane scratch directory; the source root is its sibling.
+        name: Filename for the out-of-tree victim file.
+        text: Content, expected to carry :data:`_SENTINEL`.
+
+    Returns:
+        Path to the file parked outside the source root.
+    """
+    outside = base / "outside"
+    outside.mkdir(parents=True, exist_ok=True)
+    victim = outside / name
+    victim.write_text(text, encoding="utf-8")
+    return victim
+
+
+def _chatgpt_export_json(marker: str) -> str:
+    """Return a one-conversation ChatGPT export carrying *marker*.
+
+    Shaped to satisfy ``creek.ingest.chatgpt._is_chatgpt_export`` (a JSON
+    list of dicts) and the tree walk in ``_parse_conversation``.
+
+    Args:
+        marker: Text placed in the user turn so the fragment carries it.
+
+    Returns:
+        Serialised JSON for one ChatGPT conversation export file.
+    """
+    create_time = 1700042400.0
+    conversation = {
+        "title": "Test Chat",
+        "create_time": create_time,
+        "update_time": create_time + 100.0,
+        "mapping": {
+            "root": {
+                "id": "root",
+                "message": None,
+                "parent": None,
+                "children": ["u1"],
+            },
+            "u1": {
+                "id": "u1",
+                "message": {
+                    "id": "u1",
+                    "author": {"role": "user"},
+                    "content": {"content_type": "text", "parts": [marker]},
+                    "create_time": create_time + 10.0,
+                },
+                "parent": "root",
+                "children": ["a1"],
+            },
+            "a1": {
+                "id": "a1",
+                "message": {
+                    "id": "a1",
+                    "author": {"role": "assistant"},
+                    "content": {"content_type": "text", "parts": ["Understood."]},
+                    "create_time": create_time + 20.0,
+                },
+                "parent": "u1",
+                "children": [],
+            },
+        },
+    }
+    return json.dumps([conversation])
+
+
+def _post_html(title: str, marker: str) -> str:
+    """Return a minimal Substack-style post HTML carrying *marker*.
+
+    Args:
+        title: Heading text for the post.
+        marker: Body text the parsed fragment should carry.
+
+    Returns:
+        An HTML document string.
+    """
+    return f"<html><body><h1>{title}</h1><p>{marker}</p></body></html>\n"
+
+
+def _build_markdown(base: Path, *, escaping: bool) -> tuple[Path, Path | None]:
+    """Build a markdown source tree; the link is nested, not top-level.
+
+    ``MarkdownIngestor._read_directory`` uses ``rglob("*.md")``, so the
+    escaping link is planted one level down to exercise the recursive arm.
+
+    Args:
+        base: Per-lane scratch directory.
+        escaping: Whether to plant the out-of-tree link.
+
+    Returns:
+        ``(source_root, link_or_None)``.
+    """
+    src = base / "src"
+    (src / "nested").mkdir(parents=True)
+    (src / "innocent.md").write_text(
+        f"# Ordinary notes\n\n{_IN_ROOT_MARKER}\n",
+        encoding="utf-8",
+    )
+    if not escaping:
+        return src, None
+    victim = _park_outside(base, "secret.md", f"# Secret\n\n{_SENTINEL}\n")
+    link = src / "nested" / "link.md"
+    link.symlink_to(victim)
+    return src, link
+
+
+def _build_document(base: Path, *, escaping: bool) -> tuple[Path, Path | None]:
+    """Build a DocumentIngestor source tree using ``.txt`` inputs.
+
+    Args:
+        base: Per-lane scratch directory.
+        escaping: Whether to plant the out-of-tree link.
+
+    Returns:
+        ``(source_root, link_or_None)``.
+    """
+    src = base / "src"
+    src.mkdir(parents=True)
+    (src / "notes.txt").write_text(f"{_IN_ROOT_MARKER}\n", encoding="utf-8")
+    if not escaping:
+        return src, None
+    victim = _park_outside(base, "secret.txt", f"{_SENTINEL}\n")
+    link = src / "leak.txt"
+    link.symlink_to(victim)
+    return src, link
+
+
+def _build_generic(base: Path, *, escaping: bool) -> tuple[Path, Path | None]:
+    """Build a GenericIngestor source tree using an unclaimed extension.
+
+    ``.log`` is outside ``creek.ingest.generic._CLAIMED_EXTENSIONS``
+    (``.md`` / ``.json``), so the fallback ingestor really claims it.
+
+    Args:
+        base: Per-lane scratch directory.
+        escaping: Whether to plant the out-of-tree link.
+
+    Returns:
+        ``(source_root, link_or_None)``.
+    """
+    src = base / "src"
+    src.mkdir(parents=True)
+    (src / "app.log").write_text(f"{_IN_ROOT_MARKER}\n", encoding="utf-8")
+    if not escaping:
+        return src, None
+    victim = _park_outside(base, "secret.log", f"{_SENTINEL}\n")
+    link = src / "leak.log"
+    link.symlink_to(victim)
+    return src, link
+
+
+def _build_code(base: Path, *, escaping: bool) -> tuple[Path, Path | None]:
+    """Build a CodeIngestor source tree; the link is a leaf ``README.md``.
+
+    ``CodeIngestor._is_relevant_file`` matches on the walked entry's own
+    name, so a link *named* ``README.md`` is claimed regardless of what it
+    points at. The symlinked-*directory* case is a separate test.
+
+    Args:
+        base: Per-lane scratch directory.
+        escaping: Whether to plant the out-of-tree link.
+
+    Returns:
+        ``(source_root, link_or_None)``.
+    """
+    src = base / "src"
+    src.mkdir(parents=True)
+    (src / "main.py").write_text(f'"""{_IN_ROOT_MARKER}"""\n', encoding="utf-8")
+    if not escaping:
+        return src, None
+    victim = _park_outside(base, "secret-readme.md", f"# Secret\n\n{_SENTINEL}\n")
+    link = src / "README.md"
+    link.symlink_to(victim)
+    return src, link
+
+
+def _build_chatgpt(base: Path, *, escaping: bool) -> tuple[Path, Path | None]:
+    """Build a ChatGPT export tree; the link is a top-level ``*.json``.
+
+    ``ChatGPTIngestor.discover`` uses ``glob("*.json")`` (not ``rglob``),
+    so the link has to sit at the export root to be discovered at all.
+
+    Args:
+        base: Per-lane scratch directory.
+        escaping: Whether to plant the out-of-tree link.
+
+    Returns:
+        ``(source_root, link_or_None)``.
+    """
+    src = base / "src"
+    src.mkdir(parents=True)
+    (src / "conversations.json").write_text(
+        _chatgpt_export_json(_IN_ROOT_MARKER),
+        encoding="utf-8",
+    )
+    if not escaping:
+        return src, None
+    victim = _park_outside(base, "secret.json", _chatgpt_export_json(_SENTINEL))
+    link = src / "leaked.json"
+    link.symlink_to(victim)
+    return src, link
+
+
+def _build_substack(base: Path, *, escaping: bool) -> tuple[Path, Path | None]:
+    """Build a Substack export tree of ``<post_id>.<slug>.html`` files.
+
+    No ``posts.csv``: ``discover`` derives metadata from the filenames when
+    the sidecar is absent (#594), which is the common shape of a current
+    export and keeps the fixture minimal.
+
+    Args:
+        base: Per-lane scratch directory.
+        escaping: Whether to plant the out-of-tree link.
+
+    Returns:
+        ``(source_root, link_or_None)``.
+    """
+    src = base / "src"
+    src.mkdir(parents=True)
+    (src / "1001.hello-world.html").write_text(
+        _post_html("Hello World", _IN_ROOT_MARKER),
+        encoding="utf-8",
+    )
+    if not escaping:
+        return src, None
+    victim = _park_outside(base, "secret.html", _post_html("Secret", _SENTINEL))
+    link = src / "2002.leaked-post.html"
+    link.symlink_to(victim)
+    return src, link
+
+
+_SOURCE_BUILDERS: dict[str, Callable[..., tuple[Path, Path | None]]] = {
+    "chatgpt": _build_chatgpt,
+    "code": _build_code,
+    "document": _build_document,
+    "generic": _build_generic,
+    "markdown": _build_markdown,
+    "substack": _build_substack,
+}
+"""Registry key -> fixture builder for the shaped, per-ingestor lanes.
+
+Six ingestors whose real input shapes are cheap to synthesise in text.
+``image`` / ``presentation`` / ``spreadsheet`` need binary fixtures and are
+covered instead by the registry-driven test, which does not depend on any
+ingestor actually claiming the planted file.
+"""
+
+
+# ---------------------------------------------------------------------------
+# 1. The primary RED: assert on the WRITTEN VAULT FRAGMENT
+# ---------------------------------------------------------------------------
+
+
+def test_markdown_ingest_writes_no_fragment_from_outside_the_source_root(
+    tmp_path: Path,
+) -> None:
+    """RED. ``run_ingest`` refuses, and the vault gains nothing at all.
+
+    The proof the issue asks for is at the vault, not at the ingestor's
+    in-memory result: a fragment on disk is what feeds classification,
+    embeddings, cloud prompts and drafts, so "no fragment carries the
+    sentinel" is the property that actually matters.
+
+    Run through :func:`creek.ingest.pipeline.run_ingest` — the real write
+    path both ``creek ingest`` and the ``creek.journal`` MCP tool use — with
+    the vault's ``redaction.enabled`` explicitly ``false``. That setting is
+    named on purpose: it is what bypasses the #1087 pipeline refusal
+    entirely, so nothing but the ingestor's own guard can stop this run.
+
+    Four assertions, each pinning a distinct failure:
+
+    * the refusal happens at all (``EscapingSymlinkError``);
+    * it names the link *as walked* and the root *as named*, so an operator
+      can find the offending entry;
+    * no written file carries the out-of-tree sentinel;
+    * no fragment was written *at all* — a refusal writes nothing, rather
+      than ingesting the innocent files and dropping the bad one, which is
+      the skip semantics this decision deliberately rejects.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+    """
+    from creek._containment import EscapingSymlinkError
+
+    vault = _make_vault(tmp_path)
+    source, link = _build_markdown(tmp_path / "lane", escaping=True)
+
+    with pytest.raises(EscapingSymlinkError) as excinfo:
+        run_ingest(
+            ingestor_cls=INGESTOR_REGISTRY["markdown"],
+            source_type="markdown",
+            input_path=source,
+            vault_path=vault,
+        )
+
+    assert excinfo.value.path == link, (
+        "the refusal names the wrong entry. It must name the link exactly "
+        "as the walk found it, so the operator can locate and remove it — "
+        "and never the resolved target, which is the disclosure oracle "
+        f"#1087 closes.\n\npath={excinfo.value.path}\nexpected={link}"
+    )
+    assert excinfo.value.root == source, (
+        "the refusal names the wrong source root, so an operator running "
+        "several ingests cannot tell which one stopped.\n\n"
+        f"root={excinfo.value.root}\nexpected={source}"
+    )
+
+    written = _written_vault_text(vault)
+    assert _SENTINEL not in written, (
+        "content from outside the source tree was ingested into the vault. "
+        "This is the #1294 leak: a durable fragment now carries a file the "
+        f"operator never named.\n\n{written}"
+    )
+    assert _vault_fragments(vault) == [], (
+        "the run refused but still wrote fragments. A containment refusal "
+        "is all-or-nothing: 'ingest the innocent files and drop the bad "
+        "one' is the SKIP semantics the write path deliberately rejects, "
+        "because it leaves the operator with a partially-ingested source "
+        f"and an exit path that says nothing about it.\n\n"
+        f"{_vault_fragments(vault)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Non-vacuity: more than one ingestor, more than one input shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("source_type", sorted(_SOURCE_BUILDERS))
+def test_each_ingestor_ingests_its_clean_control_tree(
+    tmp_path: Path,
+    source_type: str,
+) -> None:
+    """NON-VACUITY GUARD (passes at HEAD and after). The fixtures are real.
+
+    Every "the sentinel never reached the vault" assertion in the paired
+    test below is trivially true for an ingestor that discovers nothing.
+    This half proves each lane's fixture is a shape that ingestor actually
+    claims: without the link, the tree ingests and the in-root marker lands
+    in a written fragment. Two lanes in this suite's history have fallen
+    into exactly that trap with a single-item fixture.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+        source_type: Registry key naming the ingestor and its builder.
+    """
+    vault = _make_vault(tmp_path)
+    source, link = _SOURCE_BUILDERS[source_type](tmp_path / "lane", escaping=False)
+    assert link is None  # builder contract: no link when escaping is False
+
+    result = run_ingest(
+        ingestor_cls=INGESTOR_REGISTRY[source_type],
+        source_type=source_type,
+        input_path=source,
+        vault_path=vault,
+    )
+
+    assert result.discovered >= 1, (
+        f"the {source_type} ingestor discovered nothing in its own control "
+        "fixture, so the containment test for this lane proves nothing.\n\n"
+        f"errors={result.errors}"
+    )
+    assert result.written >= 1, (
+        f"the {source_type} ingestor discovered inputs but wrote no "
+        "fragment, so the paired containment assertions would hold over a "
+        f"run that produced nothing.\n\nerrors={result.errors}"
+    )
+    assert _IN_ROOT_MARKER in _written_vault_text(vault), (
+        f"the {source_type} control fragment reached the vault without its "
+        "in-root marker, so this lane cannot distinguish 'the guard "
+        "refused' from 'this content never lands in a fragment "
+        f"anyway'.\n\nerrors={result.errors}"
+    )
+
+
+@pytest.mark.parametrize("source_type", sorted(_SOURCE_BUILDERS))
+def test_each_ingestor_refuses_its_own_escaping_link_shape(
+    tmp_path: Path,
+    source_type: str,
+) -> None:
+    """RED for all six lanes. Each real input shape is refused, not read.
+
+    The same tree as the control above plus one escaping link of the shape
+    *that* ingestor's ``discover`` walks — a nested ``*.md`` for markdown, a
+    top-level ``*.json`` for ChatGPT (its walk is ``glob``, not ``rglob``),
+    a ``<post_id>.<slug>.html`` for Substack, a leaf ``README.md`` for code,
+    and so on. Measured at HEAD, every one of these leaks the sentinel into
+    a written fragment.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+        source_type: Registry key naming the ingestor and its builder.
+    """
+    from creek._containment import EscapingSymlinkError
+
+    vault = _make_vault(tmp_path)
+    source, link = _SOURCE_BUILDERS[source_type](tmp_path / "lane", escaping=True)
+
+    with pytest.raises(EscapingSymlinkError) as excinfo:
+        run_ingest(
+            ingestor_cls=INGESTOR_REGISTRY[source_type],
+            source_type=source_type,
+            input_path=source,
+            vault_path=vault,
+        )
+
+    assert excinfo.value.path == link, (
+        f"the {source_type} refusal names the wrong entry.\n\n"
+        f"path={excinfo.value.path}\nexpected={link}"
+    )
+    assert excinfo.value.root == source, (
+        f"the {source_type} refusal names the wrong source root.\n\n"
+        f"root={excinfo.value.root}\nexpected={source}"
+    )
+    written = _written_vault_text(vault)
+    assert _SENTINEL not in written, (
+        f"the {source_type} ingestor followed a symlink out of the source "
+        "tree and wrote the target's content into the vault as a "
+        f"fragment.\n\n{written}"
+    )
+    assert _vault_fragments(vault) == [], (
+        f"the {source_type} run refused but still wrote fragments; a "
+        f"containment refusal writes nothing.\n\n{_vault_fragments(vault)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Registry-driven: EVERY registered ingestor refuses
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("source_type", sorted(INGESTOR_REGISTRY))
+def test_every_registered_ingestor_refuses_an_escaping_link(
+    tmp_path: Path,
+    source_type: str,
+) -> None:
+    """RED for all eleven. The guard is the door, not eleven doormats.
+
+    Driven straight off :data:`creek.ingest.INGESTOR_REGISTRY` so a twelfth
+    ingestor is covered the day it is registered, with nobody having to
+    remember. That is the property N per-ingestor copies of the predicate
+    could never have, and it is the whole argument for putting the check on
+    ``Ingestor.ingest`` — the single chokepoint every ingestor inherits.
+
+    The planted link is a plain ``*.md``, and it deliberately does not match
+    most of these ingestors' extension filters. It does not have to: the
+    containment gate fires *before* ``discover()`` is called, so what the
+    ingestor would or would not have claimed is irrelevant. If a lane here
+    goes green only because the ingestor ignores ``.md``, the guard has been
+    pushed down into the individual walks and the chokepoint is gone.
+
+    ``image`` / ``presentation`` / ``spreadsheet`` are covered by this test
+    and not by the shaped lanes above, because their real inputs are binary
+    fixtures — and refusing before ``discover`` means no binary parser is
+    reached at all.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+        source_type: Registry key under test.
+    """
+    from creek._containment import EscapingSymlinkError
+
+    source, link = _build_markdown(tmp_path / "lane", escaping=True)
+
+    with pytest.raises(EscapingSymlinkError) as excinfo:
+        INGESTOR_REGISTRY[source_type]().ingest(source)
+
+    assert excinfo.value.path == link, (
+        f"the {source_type} ingestor refused, but named the wrong entry — "
+        "which suggests the check is not the shared one.\n\n"
+        f"path={excinfo.value.path}\nexpected={link}"
+    )
+    assert excinfo.value.root == source, (
+        f"the {source_type} refusal names the wrong source root.\n\n"
+        f"root={excinfo.value.root}\nexpected={source}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. CodeIngestor descends INTO a symlinked directory
+# ---------------------------------------------------------------------------
+
+
+def test_code_ingestor_refuses_a_symlinked_directory_it_would_recurse_into(
+    tmp_path: Path,
+) -> None:
+    """RED, and the reason the gate must check ``dirnames`` too.
+
+    Unlike the ``rglob`` ingestors, ``creek/ingest/code.py::
+    _discover_directory`` recurses by hand: ``sorted(dir_path.iterdir())``
+    then ``if item.is_dir(): recurse``. ``Path.is_dir()`` FOLLOWS symlinks,
+    so a link to a directory is descended into and the whole out-of-tree
+    subtree is read — measured at HEAD as two discovered documents and two
+    leaked fragments, where ``rglob`` would have surfaced the link and
+    stopped.
+
+    An ``os.walk(root, followlinks=False)`` gate closes this only if it
+    inspects ``dirnames`` as well as ``filenames``: with ``followlinks``
+    off, ``os.walk`` yields the link as an entry in ``dirnames`` and never
+    descends, so a filenames-only gate would walk right past it and every
+    other assertion in this file would still pass.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+    """
+    from creek._containment import EscapingSymlinkError
+
+    base = tmp_path / "lane"
+    vault = _make_vault(tmp_path)
+    src = base / "src"
+    src.mkdir(parents=True)
+    (src / "main.py").write_text(f'"""{_IN_ROOT_MARKER}"""\n', encoding="utf-8")
+    outside = base / "outside"
+    (outside / "nested").mkdir(parents=True)
+    (outside / "README.md").write_text(
+        f"# Secret\n\n{_SENTINEL}\n",
+        encoding="utf-8",
+    )
+    (outside / "nested" / "deep.py").write_text(
+        f'"""{_SENTINEL}"""\n',
+        encoding="utf-8",
+    )
+    link = src / "linkdir"
+    link.symlink_to(outside)
+
+    with pytest.raises(EscapingSymlinkError) as excinfo:
+        run_ingest(
+            ingestor_cls=INGESTOR_REGISTRY["code"],
+            source_type="code",
+            input_path=src,
+            vault_path=vault,
+        )
+
+    assert excinfo.value.path == link, (
+        "the refusal did not name the symlinked directory. A gate that "
+        "only inspects os.walk's filenames never sees it, because "
+        "followlinks=False reports a directory link under dirnames.\n\n"
+        f"path={excinfo.value.path}\nexpected={link}"
+    )
+    written = _written_vault_text(vault)
+    assert _SENTINEL not in written, (
+        "CodeIngestor recursed through a symlinked directory and ingested "
+        "an entire subtree from outside the source root — the widest leak "
+        f"of the eleven.\n\n{written}"
+    )
+    assert _vault_fragments(vault) == [], (
+        f"a refused run still wrote fragments.\n\n{_vault_fragments(vault)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. The NAMED source root is itself an escaping symlink
+# ---------------------------------------------------------------------------
+
+
+def test_a_named_source_root_that_is_an_escaping_symlink_is_refused(
+    tmp_path: Path,
+) -> None:
+    """RED. ``--input <link-to-outside-dir>`` must be refused, not resolved.
+
+    #1360's finding, in the ingest surface: a tree-walk-only guard passes
+    this case completely. ``Path.is_dir()`` follows the link, so the walk
+    runs over the *target's* tree, finds no links inside it, and launders
+    every child as in-root. That is why the containment check must ask
+    "is the named path itself an escaping link?" BEFORE it asks
+    ``is_dir()`` — resolving first destroys the only evidence.
+
+    ``root`` is deliberately not asserted here: the named root *is* the
+    link, so the two fields coincide and pinning both would over-specify a
+    detail the implementation is free to choose. ``path`` naming the link
+    the operator typed is the load-bearing half.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+    """
+    from creek._containment import EscapingSymlinkError
+
+    base = tmp_path / "lane"
+    vault = _make_vault(tmp_path)
+    outside = base / "outside"
+    outside.mkdir(parents=True)
+    (outside / "secret.md").write_text(
+        f"# Secret\n\n{_SENTINEL}\n",
+        encoding="utf-8",
+    )
+    # The link must sit somewhere that does NOT contain the target, or it
+    # does not escape its own parent and there is nothing to refuse.
+    holder = base / "holder"
+    holder.mkdir()
+    link = holder / "linkdir"
+    link.symlink_to(outside)
+
+    with pytest.raises(EscapingSymlinkError) as excinfo:
+        run_ingest(
+            ingestor_cls=INGESTOR_REGISTRY["markdown"],
+            source_type="markdown",
+            input_path=link,
+            vault_path=vault,
+        )
+
+    assert excinfo.value.path == link, (
+        "the refusal does not name the path the operator typed.\n\n"
+        f"path={excinfo.value.path}\nexpected={link}"
+    )
+    written = _written_vault_text(vault)
+    assert _SENTINEL not in written, (
+        "naming a symlinked directory as --input walked straight past the "
+        "tree guard: is_dir() followed the link, the walk ran over the "
+        "target's own tree, and every file in it was ingested as though it "
+        f"were in root.\n\n{written}"
+    )
+    assert _vault_fragments(vault) == [], (
+        f"a refused run still wrote fragments.\n\n{_vault_fragments(vault)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. The mass-tombing hazard — why re-raising is not "merely defensive"
+# ---------------------------------------------------------------------------
+
+
+def test_a_containment_refusal_does_not_tomb_previously_ingested_fragments(
+    tmp_path: Path,
+) -> None:
+    """RED, and the load-bearing argument for propagating the refusal.
+
+    ``Ingestor._discover_safe`` currently swallows every exception into
+    ``result.errors`` and returns ``[]``. If a containment refusal
+    collapsed into that arm, ``run_ingest`` would carry on with an empty
+    ``seen_keys`` and reach ``tomb_missing_units``
+    (``creek/ingest/pipeline.py:428``, defined at ``:267``), which soft-tombs
+    every ``ledger.live_keys() - seen_keys`` whenever the ledger exists and
+    ``input_path.is_dir()``. Markdown is the ledger-backed source. So the
+    quiet version of this fix does not merely fail to protect the vault —
+    it DELETES it: one stale symlink dropped into a journal folder would
+    move every previously-ingested fragment into ``10-Liminal/Orphaned``.
+
+    A containment refusal must never become a mass deletion. The assertions
+    are on the artifacts the tombing machinery actually produces — live
+    files under ``01-Fragments``, tombstones under ``10-Liminal/Orphaned``,
+    and the ledger's own ``live_keys`` — rather than on a proxy such as the
+    ``tombed`` counter, which a swallowed refusal would report honestly
+    while the damage was already on disk.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+    """
+    from creek._containment import EscapingSymlinkError
+    from creek.ingest.ledger import SourceLedger
+
+    base = tmp_path / "lane"
+    vault = _make_vault(tmp_path)
+    journal = base / "journal"
+    journal.mkdir(parents=True)
+    for day in ("01", "02", "03"):
+        (journal / f"2026-06-{day}.md").write_text(
+            f"---\ndate: 2026-06-{day}\n---\nEntry {day}. {_IN_ROOT_MARKER}\n",
+            encoding="utf-8",
+        )
+
+    first = run_ingest(
+        ingestor_cls=INGESTOR_REGISTRY["markdown"],
+        source_type="markdown",
+        input_path=journal,
+        vault_path=vault,
+    )
+    assert first.errors == [], f"setup ingest failed.\n\n{first.errors}"
+    live_before = _vault_fragments(vault)
+    assert len(live_before) == 3, (
+        "the setup pass did not write three fragments, so this test cannot "
+        f"tell 'nothing was tombed' from 'nothing was there'.\n\n"
+        f"{live_before}"
+    )
+    assert _vault_orphans(vault) == [], "setup pass tombed something"
+    keys_before = SourceLedger.load(vault, source="markdown").live_keys()
+    assert len(keys_before) == 3, (
+        f"the ledger did not record three live units.\n\n{keys_before}"
+    )
+
+    # One stale link appears in an otherwise unchanged, already-ingested
+    # source folder. This is the ordinary way it happens in the wild.
+    victim = _park_outside(base, "secret.md", f"# Secret\n\n{_SENTINEL}\n")
+    (journal / "link.md").symlink_to(victim)
+
+    with pytest.raises(EscapingSymlinkError):
+        run_ingest(
+            ingestor_cls=INGESTOR_REGISTRY["markdown"],
+            source_type="markdown",
+            input_path=journal,
+            vault_path=vault,
+        )
+
+    assert _vault_fragments(vault) == live_before, (
+        "the refusal cost the operator their vault. A swallowed "
+        "EscapingSymlinkError leaves seen_keys empty, and tomb_missing_units "
+        "then soft-tombs every previously-ingested unit as though the "
+        "source had been deleted. A containment refusal must propagate out "
+        f"of run_ingest before that loop is reached.\n\n"
+        f"now={_vault_fragments(vault)}\nbefore={live_before}"
+    )
+    assert _vault_orphans(vault) == [], (
+        "fragments were moved into 10-Liminal/Orphaned by a run that "
+        f"refused to read its source at all.\n\n{_vault_orphans(vault)}"
+    )
+    keys_after = SourceLedger.load(vault, source="markdown").live_keys()
+    assert keys_after == keys_before, (
+        "the ledger marked live units as tombed on a run that never "
+        f"discovered anything.\n\nafter={keys_after}\nbefore={keys_before}"
+    )
+    assert _SENTINEL not in _written_vault_text(vault), (
+        "the out-of-tree file was ingested on the second pass.\n\n"
+        f"{_written_vault_text(vault)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 7. Ordering pin: the CLI refuses BEFORE the consent gate reads the tree
+# ---------------------------------------------------------------------------
+
+
+def test_cli_ingest_refuses_before_the_consent_gate_reads_the_source_tree(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED. The refusal must land above ``_gate_consent``, not below it.
+
+    ``creek/cli.py``'s ingest handler calls ``_gate_consent`` before it
+    calls ``_run_ingest``. For a first-time (unconsented) source that path
+    runs ``ConsentManager.get_source_summary`` ->
+    ``creek/consent.py:134 _build_source_summary``, which walks
+    ``source_path.rglob("*")`` and ``stat()``s every file it finds —
+    following escaping links, and folding out-of-tree file counts and byte
+    totals into the very summary the operator is asked to approve. That is
+    an out-of-root read performed *before* anything refuses, and it is the
+    ingest analogue of #1360's "refuses before reading config through the
+    link". A guard that sits only inside ``_run_ingest`` blocks the write
+    and still leaks the shape of the victim directory into the consent
+    prompt.
+
+    The spy is a RECORDING wrapper that delegates to the real summariser,
+    never a raising sentinel: ``CliRunner`` catches a raised sentinel and
+    reports exit 1, which would manufacture a pass for the exit-code
+    assertion at HEAD.
+
+    ``--yes`` is passed deliberately. Without it the non-interactive branch
+    exits 1 on its own, and the exit-code assertion would hold at HEAD for
+    entirely the wrong reason.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+        monkeypatch: Pytest monkeypatch fixture, used to install the spy.
+    """
+    from creek import consent as consent_module
+
+    vault = _make_vault(tmp_path)
+    source, _link = _build_markdown(tmp_path / "lane", escaping=True)
+
+    real_summary = consent_module._build_source_summary
+    calls: list[object] = []
+
+    def _recording_summary(source_path, exclusions):
+        """Record the call, then delegate to the real summariser."""
+        calls.append(source_path)
+        return real_summary(source_path, exclusions)
+
+    monkeypatch.setattr(
+        consent_module,
+        "_build_source_summary",
+        _recording_summary,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "ingest",
+            "--type",
+            "markdown",
+            "--input",
+            str(source),
+            "--vault",
+            str(vault),
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 1, (
+        "creek ingest accepted a source tree containing a symlink that "
+        "leaves it, ingested the target, and exited 0. Errors on this "
+        "surface print as a dim yellow list under a zero exit, which is "
+        "why the contract here is refusal rather than a collected "
+        f"error.\n\nexit_code={result.exit_code}\n{result.output}"
+    )
+    assert "symlink" in result.output.lower(), (
+        "the refusal does not say why it refused; an operator cannot act "
+        "on an unexplained exit 1, and a bare traceback swallowed by "
+        f"CliRunner produces exactly this.\n\n{result.output}"
+    )
+    assert not calls, (
+        "the consent summary ran before the refusal, so the run walked the "
+        "source tree with rglob and stat()'d straight through the escaping "
+        "link — folding out-of-tree file counts and byte totals into the "
+        "summary the operator was asked to approve. The write was blocked "
+        "later, but the out-of-root READ had already happened.\n\n"
+        f"calls={calls}\nexit_code={result.exit_code}\n{result.output}"
+    )
+    assert _SENTINEL not in _written_vault_text(vault), (
+        f"the CLI ingested the out-of-tree file.\n\n{result.output}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 8. Over-breadth guards (must pass BEFORE and AFTER)
+# ---------------------------------------------------------------------------
+
+
+def test_an_intra_tree_symlink_is_still_ingested(tmp_path: Path) -> None:
+    """PASSES AT HEAD AND AFTER. Containment is about escaping, not linking.
+
+    "Refuse any symlink under the source root" would satisfy every RED in
+    this file while breaking the ordinary case of an alias sitting beside
+    the file it aliases. ``tests/test_cli_redact.py`` holds the equivalent
+    guard for the redact surface
+    (``test_redact_apply_admits_a_named_intra_tree_symlink``); this is the
+    ingest half.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+    """
+    base = tmp_path / "lane"
+    vault = _make_vault(tmp_path)
+    src = base / "src"
+    src.mkdir(parents=True)
+    (src / "real.md").write_text(
+        f"# Real\n\n{_IN_ROOT_MARKER}\n",
+        encoding="utf-8",
+    )
+    (src / "alias.md").symlink_to(src / "real.md")
+
+    result = run_ingest(
+        ingestor_cls=INGESTOR_REGISTRY["markdown"],
+        source_type="markdown",
+        input_path=src,
+        vault_path=vault,
+    )
+
+    assert result.discovered == 2, (
+        "the intra-tree alias was not even discovered, so this test cannot "
+        "tell an over-broad refusal from a walk that never saw the "
+        f"link.\n\ndiscovered={result.discovered}\nerrors={result.errors}"
+    )
+    assert result.written >= 1, (
+        "a symlink whose target sits inside the source root was refused or "
+        "dropped; the guard is over-broad and now breaks ordinary "
+        f"aliases.\n\nerrors={result.errors}"
+    )
+    assert _IN_ROOT_MARKER in _written_vault_text(vault), (
+        "the run reported writes but the aliased content is not in the "
+        f"vault.\n\nerrors={result.errors}"
+    )
+
+
+def test_a_source_root_reached_through_a_symlinked_component_still_ingests(
+    tmp_path: Path,
+) -> None:
+    """PASSES AT HEAD AND AFTER. Pins resolve-the-root / lstat-the-leaf.
+
+    The named root here is itself a symlink, but one whose target stays
+    under its own parent — the portable, deterministic analogue of macOS's
+    ``/tmp`` -> ``/private/tmp``, where every ``tmp_path`` in this suite
+    lives. It must ingest normally.
+
+    This is the test that goes red if the containment check is "tightened"
+    into resolving non-symlink children as well: with the root resolved to
+    its real location and each child resolved independently, every child of
+    a root reached through a link compares as outside and the whole tree
+    becomes un-ingestable. #1087 and #1293 both landed on the same policy
+    for exactly this reason, and #1294 must not diverge from it.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+    """
+    base = tmp_path / "lane"
+    vault = _make_vault(tmp_path)
+    real_root = base / "real-root"
+    real_root.mkdir(parents=True)
+    (real_root / "note.md").write_text(
+        f"# Note\n\n{_IN_ROOT_MARKER}\n",
+        encoding="utf-8",
+    )
+    # Target sits under the link's own parent, so the link does not escape.
+    alias_root = base / "alias-root"
+    alias_root.symlink_to(real_root)
+
+    result = run_ingest(
+        ingestor_cls=INGESTOR_REGISTRY["markdown"],
+        source_type="markdown",
+        input_path=alias_root,
+        vault_path=vault,
+    )
+
+    assert result.written >= 1, (
+        "a source root reached through a symlinked component was refused. "
+        "The policy is: resolve the ROOT once, lstat only the LEAF, and "
+        "never resolve a non-symlink child — resolving children too flags "
+        "every child of such a root as escaping, which on macOS is every "
+        f"tmp_path in this suite.\n\nerrors={result.errors}"
+    )
+    assert _IN_ROOT_MARKER in _written_vault_text(vault), (
+        f"nothing from the aliased root reached the vault.\n\n{result.errors}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 9. ``recurse_symlinks`` bound pin
+# ---------------------------------------------------------------------------
+
+
+def test_rglob_does_not_descend_into_a_symlinked_directory(tmp_path: Path) -> None:
+    """TRIPWIRE (passes today). Pin the assumption the leaf check rests on.
+
+    The containment check is sound *per leaf* only because the walks it
+    guards surface a symlinked directory as one entry and do not descend
+    into it: ``Path.rglob("*")`` yields the link itself and nothing
+    beneath. Confirmed on this repo's interpreter (3.12); 3.13 added an
+    explicit ``recurse_symlinks`` parameter defaulting to ``False``.
+
+    If a future Python flips that default, the leaf-only check silently
+    widens from "the link is checked" to "everything under the link is
+    walked unchecked" — a re-opened #1294 with no test failing anywhere.
+    This is that tripwire.
+
+    ``recurse_symlinks=`` is deliberately NOT passed: the parameter does
+    not exist on 3.11 or 3.12, which CI still tests, so passing it
+    unconditionally would be a TypeError on two of the three lanes.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+    """
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "deep.md").write_text("deep\n", encoding="utf-8")
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "plain.md").write_text("plain\n", encoding="utf-8")
+    link = root / "linkdir"
+    link.symlink_to(outside)
+
+    entries = set(root.rglob("*"))
+
+    assert link in entries, (
+        "rglob no longer yields a symlinked directory at all, so the "
+        "leaf-only containment check would never be offered the link to "
+        f"inspect.\n\n{sorted(entries)}"
+    )
+    assert (link / "deep.md") not in entries, (
+        "rglob descended INTO a symlinked directory. Every leaf-only "
+        "containment check in creek — the redact scanner's walk (#1087), "
+        "the named-path guard (#1293) and the ingest guard (#1294) — "
+        "assumes it does not. The guard now inspects the link but the walk "
+        "reads everything beneath it unchecked. Do not fix this by passing "
+        "recurse_symlinks=False (absent on 3.11/3.12); fix the walks.\n\n"
+        f"{sorted(entries)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 10. Dangling and looping links
+# ---------------------------------------------------------------------------
+
+
+def test_a_dangling_link_pointing_outside_the_root_is_refused(
+    tmp_path: Path,
+) -> None:
+    """RED. A broken escape is still an escape.
+
+    ``resolves_within`` uses ``resolve(strict=False)``, so a dangling link
+    still resolves to a *candidate* location worth comparing. A link
+    pointing outside the root is refused whether or not its target happens
+    to exist today: whether the file is there is a race, not a property,
+    and admitting the link means the next run — after somebody creates the
+    target — reads out of root with nothing having changed in Creek.
+
+    Asserted against the predicate rather than a full ingest on purpose:
+    at HEAD ``MarkdownIngestor._read_directory`` calls ``read_bytes()`` on
+    every ``rglob`` hit including a dangling link, so an ingest-level test
+    would go red on a ``FileNotFoundError`` that has nothing to do with
+    containment.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+    """
+    from creek._containment import EscapingSymlinkError, assert_source_contained
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "innocent.md").write_text(f"{_IN_ROOT_MARKER}\n", encoding="utf-8")
+    link = src / "dangling.md"
+    link.symlink_to(tmp_path / "outside" / "never-created.md")
+
+    with pytest.raises(EscapingSymlinkError) as excinfo:
+        assert_source_contained(src)
+
+    assert excinfo.value.path == link, (
+        "the refusal names the wrong entry.\n\n"
+        f"path={excinfo.value.path}\nexpected={link}"
+    )
+
+
+def test_a_dangling_link_pointing_inside_the_root_is_admitted(
+    tmp_path: Path,
+) -> None:
+    """PASSES AFTER. A broken in-tree link is not a containment failure.
+
+    The other half of the dangling decision, and the guard against
+    implementing "any link we cannot stat is an escape". A link pointing at
+    a path that would sit *inside* the root is contained by the same
+    ``strict=False`` reasoning that condemns the outward-pointing one; it
+    is a broken alias, which is a different problem with a different owner.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+    """
+    from creek._containment import assert_source_contained
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "innocent.md").write_text(f"{_IN_ROOT_MARKER}\n", encoding="utf-8")
+    (src / "dangling.md").symlink_to(src / "never-created.md")
+
+    assert assert_source_contained(src) is None, (
+        "a dangling link whose candidate target sits inside the root was "
+        "refused. Containment is about where the target would be, not "
+        "about whether the link resolves; refusing here turns every stale "
+        "in-tree alias into a hard stop on the whole source."
+    )
+
+
+def test_a_symlink_loop_under_the_root_is_refused(tmp_path: Path) -> None:
+    """RED. An unprovable containment is an escape.
+
+    ``a -> b -> a`` raises ``RuntimeError`` (or ``OSError(ELOOP)``,
+    depending on platform and Python version) from ``resolve``.
+    ``resolves_within`` classifies both as not-contained, deliberately: the
+    guard cannot prove the target is inside, and a safety check that
+    admits what it cannot verify is not a safety check. Pinned here so the
+    classification is a decision on the record rather than an accident of
+    which exception ``resolve`` happens to raise.
+
+    Either link may be reported — ``os.walk`` does not promise an order
+    within a directory — so the assertion accepts both.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+    """
+    from creek._containment import EscapingSymlinkError, assert_source_contained
+
+    src = tmp_path / "src"
+    src.mkdir()
+    a = src / "a.md"
+    b = src / "b.md"
+    a.symlink_to(b)
+    b.symlink_to(a)
+
+    with pytest.raises(EscapingSymlinkError) as excinfo:
+        assert_source_contained(src)
+
+    assert excinfo.value.path in (a, b), (
+        "the loop was refused but the refusal names neither link in it, so "
+        "the operator has nothing to delete.\n\n"
+        f"path={excinfo.value.path}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 11. Non-disclosure
+# ---------------------------------------------------------------------------
+
+
+def test_the_refusal_never_names_the_resolved_out_of_tree_target(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """RED. The refusal names the link the operator can see, and nothing else.
+
+    Disclosing the resolved target is the exact oracle #1087 closes: an
+    attacker who can plant a link learns whether a guessed path exists and
+    what it is called, from a tool that refused to read it. This is why
+    ``creek/redact/scanner.py::resolves_within`` deliberately drops the
+    exception object — ``relative_to``'s message quotes the resolved
+    target.
+
+    The bare FILENAME is asserted alongside the absolute path because Rich
+    truncates long paths to the console width; the same trap is documented
+    at ``tests/test_cli_redact.py:638-644``, where an assertion on the
+    absolute path alone would hold no matter what was printed.
+
+    The final assertion is the non-vacuity guard: a refusal that says
+    nothing at all would satisfy every non-disclosure assertion above it.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+        caplog: Pytest log capture — the logs must not disclose it either.
+    """
+    from creek._containment import EscapingSymlinkError, assert_source_contained
+
+    base = tmp_path / "lane"
+    src = base / "src"
+    (src / "nested").mkdir(parents=True)
+    (src / "innocent.md").write_text(f"{_IN_ROOT_MARKER}\n", encoding="utf-8")
+    victim = _park_outside(
+        base,
+        "payroll-2026-confidential.md",
+        f"# Secret\n\n{_SENTINEL}\n",
+    )
+    link = src / "nested" / "link.md"
+    link.symlink_to(victim)
+
+    with caplog.at_level(logging.WARNING), pytest.raises(EscapingSymlinkError) as exc:
+        assert_source_contained(src)
+
+    message = str(exc.value)
+    assert str(victim) not in message, (
+        "the exception message spells out the resolved out-of-tree target. "
+        "Report the path the operator typed or the link the walk found — "
+        f"never the one it points at.\n\n{message}"
+    )
+    assert victim.name not in message, (
+        "the exception message names the out-of-tree file. Asserted on the "
+        "bare filename as well as the absolute path because Rich truncates "
+        "long paths, so a str(victim) assertion alone holds no matter what "
+        f"was printed.\n\n{message}"
+    )
+    disclosing = [
+        record.getMessage()
+        for record in caplog.records
+        if str(victim) in record.getMessage() or victim.name in record.getMessage()
+    ]
+    assert not disclosing, (
+        f"a log record spells out the resolved out-of-tree target.\n\n{disclosing}"
+    )
+    assert link.name in message or str(link) in message, (
+        "the refusal names nothing at all, so every non-disclosure "
+        "assertion above passes over an empty message and the operator has "
+        f"no idea which entry to remove.\n\n{message}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 12. One definition of the containment predicate
+# ---------------------------------------------------------------------------
+
+
+def test_the_containment_predicate_has_exactly_one_definition() -> None:
+    """RED. Three consumers, one definition — the issue's explicit ask.
+
+    #1294 asks for "one shared confinement predicate rather than a third
+    copy". ``resolves_within`` was made public by #1360 so the scanner's
+    walk and the named-path guard could share it; the ingest guard is the
+    third consumer, and the only way to keep that honest over time is to
+    assert object identity rather than equal behaviour. Two copies that
+    agree today are two copies that will disagree after the next fix lands
+    in one of them.
+
+    ``named_path_escapes`` moves out of
+    ``creek/redact/cli_commands.py::_named_path_escapes`` for the same
+    reason. The private alias may or may not survive the move; if it does,
+    it must be the same object, not a re-implementation.
+    """
+    from creek import _containment
+    from creek.redact import cli_commands, scanner
+
+    assert scanner.resolves_within is _containment.resolves_within, (
+        "creek.redact.scanner defines its own resolves_within instead of "
+        "re-exporting the canonical one. The scanner walk, the named-path "
+        "guard and the ingest guard must share a single definition of "
+        "'inside', or a future fix to one of them silently leaves the "
+        f"others behind.\n\n{scanner.resolves_within!r}\n"
+        f"{_containment.resolves_within!r}"
+    )
+    assert callable(_containment.named_path_escapes), (
+        "creek._containment does not expose named_path_escapes, so the "
+        "named-root check has no shared home and cli_commands keeps its "
+        "private copy."
+    )
+    legacy = getattr(cli_commands, "_named_path_escapes", None)
+    assert legacy is None or legacy is _containment.named_path_escapes, (
+        "creek.redact.cli_commands still defines its own named-path "
+        "predicate. Either drop the name or alias the canonical one; a "
+        "second body is the drift this test exists to prevent.\n\n"
+        f"{legacy!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 13. The MCP surface refuses too
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_ingest_tool_refuses_an_escaping_link(tmp_path: Path) -> None:
+    """RED. ``creek.ingest`` over MCP returns a refusal, not a leak.
+
+    ``creek_mcp/tools/ingest.py:100`` calls ``ingestor_cls().ingest(resolved)``
+    directly, so once the gate raises, an unhandled ``EscapingSymlinkError``
+    would surface to an MCP client as a transport-level crash rather than
+    the structured ``status: "refused"`` every other refusal on this surface
+    returns. The tool's own path confinement does not help here: the source
+    is legitimately inside the vault; it is the link *under* it that leaves.
+
+    ``privacy_tier_ceiling`` is passed explicitly. The parameter's default is
+    ``TierCeiling.OPEN``, which the tool already refuses outright because the
+    ingest default tier is ``personal`` — so a defaulted call would return
+    ``status: "refused"`` at HEAD for an entirely unrelated reason and this
+    test would pass without the fix. Asserting that the reason names the
+    symlink is the second half of that guard.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+    """
+    from creek_mcp.tier_ceiling import TierCeiling
+    from creek_mcp.tools.ingest import ingest_tool
+
+    vault = _make_vault(tmp_path)
+    inbox = vault / "inbox"
+    inbox.mkdir()
+    (inbox / "innocent.md").write_text(f"{_IN_ROOT_MARKER}\n", encoding="utf-8")
+    victim = _park_outside(tmp_path / "lane", "secret.md", f"{_SENTINEL}\n")
+    (inbox / "link.md").symlink_to(victim)
+
+    response = ingest_tool(
+        vault_path=vault,
+        source_type="markdown",
+        input_path="inbox",
+        privacy_tier_ceiling=TierCeiling.PERSONAL,
+    )
+
+    assert response["status"] == "refused", (
+        "the MCP ingest tool ran an ingest over a tree that links out of "
+        "itself. Refusals on this surface are structured responses, not "
+        f"exceptions.\n\n{response}"
+    )
+    assert "symlink" in str(response.get("reason", "")).lower(), (
+        f"the refusal does not say why it refused.\n\n{response}"
+    )
+    assert _vault_fragments(vault) == [], (
+        f"a refused MCP ingest still wrote fragments.\n\n{_vault_fragments(vault)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 13. Mutation-battery backfill
+#
+# Both tests below were written because a mutation SURVIVED the suite above.
+# Neither pins a new requirement; each pins a property the implementation
+# already had but that nothing could tell the absence of.
+# ---------------------------------------------------------------------------
+
+
+def test_the_containment_walk_visits_each_directory_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The gate must not re-enter an intra-root symlinked directory.
+
+    Mutation survivor: flipping ``os.walk(..., followlinks=False)`` to
+    ``followlinks=True`` left every other test in this file green. It has to,
+    because for an *escaping* link the answer is identical either way — the
+    link is caught in ``dirnames`` at the level it sits on, before descent
+    would matter. What changes is the work done on an *admitted* one.
+
+    An intra-tree symlinked directory is legitimate and common (``latest ->
+    2026-08-01`` inside an export). Following it makes the walk re-traverse
+    the aliased subtree; when the alias points at an ancestor the walk
+    re-enters itself and only stops when the kernel raises ``ELOOP``. Measured
+    on this fixture: 3 entries with ``followlinks=False``, 48 with it on — the
+    same verdict for 16x the syscalls, and the multiplier grows with depth.
+
+    Asserted by counting walk roots rather than wall-clock time, so it cannot
+    flake on a loaded machine. Spying on the module-level ``os.walk`` follows
+    the precedent set by ``tests/test_cli_redact.py``'s
+    ``test_redact_apply_refuses_a_named_symlinked_directory_before_walking_it``.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+        monkeypatch: Pytest monkeypatch fixture, used to install the spy.
+    """
+    from creek import _containment
+
+    src = tmp_path / "src"
+    (src / "a").mkdir(parents=True)
+    (src / "a" / "note.md").write_text(_IN_ROOT_MARKER, encoding="utf-8")
+    # Points at its own grandparent: intra-root, so admitted, and a cycle.
+    (src / "a" / "loop").symlink_to(src)
+
+    real_walk = _containment.os.walk
+    roots: list[str] = []
+
+    def _spy_walk(top: Any, *args: Any, **kwargs: Any) -> Any:
+        """Record each walk root, then delegate to the real ``os.walk``."""
+        for entry in real_walk(top, *args, **kwargs):
+            roots.append(str(entry[0]))
+            yield entry
+
+    monkeypatch.setattr(_containment.os, "walk", _spy_walk)
+
+    assert _containment.assert_source_contained(src) is None, (
+        "an intra-root symlinked directory was refused. The alias never "
+        "leaves the tree, so containment has nothing to object to."
+    )
+    assert len(roots) == len(set(roots)), (
+        "the walk visited the same directory twice, so it descended through "
+        "the intra-root alias instead of treating it as a leaf. On a cycle "
+        "that only terminates when the kernel raises ELOOP.\n\n"
+        f"roots={roots}"
+    )
+    assert len(roots) == 2, (
+        "expected exactly the two real directories (the root and 'a'); a "
+        f"different count means the walk shape changed.\n\nroots={roots}"
+    )
+
+
+def test_an_unreadable_markdown_entry_does_not_tomb_the_whole_source(
+    tmp_path: Path,
+) -> None:
+    """A dangling in-tree ``*.md`` link must not orphan every fragment.
+
+    Mutation survivor: deleting ``MarkdownIngestor._read_directory``'s
+    ``is_file()`` filter left the suite green, because every other fixture
+    here either refuses before discovery or contains only readable files.
+
+    The filter is not cosmetic. ``rglob("*.md")`` yields directories and
+    dangling links as readily as files, and that walk — alone among the
+    eleven ingestors — called ``read_bytes()`` on whatever it got. The raise
+    lands in ``_discover_safe``, which collects it and returns ``[]``; an
+    empty discovery leaves ``seen_keys`` empty; and ``tomb_missing_units``
+    then soft-tombs every live ledger key. So one stale alias inside the
+    source silently orphans every fragment previously ingested from it.
+
+    This is the same failure the containment refusal is routed around,
+    reached through a path containment deliberately admits: the link points
+    *inside* the root, so there is nothing to refuse.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+    """
+    vault = _make_vault(tmp_path)
+    src = tmp_path / "src"
+    src.mkdir()
+    for name in ("one.md", "two.md", "three.md"):
+        (src / name).write_text(
+            f"# {name}\n\n{_IN_ROOT_MARKER}\n",
+            encoding="utf-8",
+        )
+
+    first = run_ingest(
+        ingestor_cls=INGESTOR_REGISTRY["markdown"],
+        source_type="markdown",
+        input_path=src,
+        vault_path=vault,
+    )
+    assert first.written == 3, (
+        "the control ingest did not write all three fragments, so the "
+        f"tombing assertion below would be vacuous.\n\n{first.errors}"
+    )
+    before = _vault_fragments(vault)
+
+    # Admitted by containment: the candidate target is inside the root.
+    (src / "stale.md").symlink_to(src / "never-created.md")
+
+    second = run_ingest(
+        ingestor_cls=INGESTOR_REGISTRY["markdown"],
+        source_type="markdown",
+        input_path=src,
+        vault_path=vault,
+    )
+
+    assert _vault_orphans(vault) == [], (
+        "an unreadable entry in the source tombed the fragments that were "
+        "still perfectly present. discover() raised, _discover_safe "
+        "swallowed it into errors and returned [], and tomb_missing_units "
+        f"orphaned every live ledger key.\n\n{second.errors}"
+    )
+    assert _vault_fragments(vault) == before, (
+        "the live fragment set changed after re-ingesting an unchanged "
+        f"source.\n\nbefore={before}\nafter={_vault_fragments(vault)}"
+    )

--- a/creek-tools/tests/test_ingest_symlink_containment.py
+++ b/creek-tools/tests/test_ingest_symlink_containment.py
@@ -1250,13 +1250,25 @@ def test_a_dangling_link_pointing_inside_the_root_is_admitted(
 def test_a_symlink_loop_under_the_root_is_refused(tmp_path: Path) -> None:
     """RED. An unprovable containment is an escape.
 
-    ``a -> b -> a`` raises ``RuntimeError`` (or ``OSError(ELOOP)``,
-    depending on platform and Python version) from ``resolve``.
-    ``resolves_within`` classifies both as not-contained, deliberately: the
-    guard cannot prove the target is inside, and a safety check that
-    admits what it cannot verify is not a safety check. Pinned here so the
-    classification is a decision on the record rather than an accident of
-    which exception ``resolve`` happens to raise.
+    ``a -> b -> a`` cannot be resolved, so the guard cannot prove the
+    target is inside, and a safety check that admits what it cannot verify
+    is not a safety check.
+
+    This assertion was originally carried by ``Path.resolve`` raising, and
+    that turned out to be exactly the "accident of which exception
+    ``resolve`` happens to raise" it claimed to be pinning against: on
+    3.11/3.12 ``resolve(strict=False)`` raises ``RuntimeError('Symlink loop
+    from ...')``, while on 3.13 it delegates to ``os.path.realpath``, which
+    returns a PARTIAL path with the cycle left unresolved — an in-root
+    answer — and the tree was admitted. The classification now belongs to
+    ``creek._containment._resolved_target``, which asks
+    ``os.path.realpath(..., strict=True)``; that reports a cycle as
+    ``OSError(ELOOP)`` on every supported version.
+
+    The consequence of admitting this *particular* tree is mild — nothing
+    out-of-root is read, because ``open`` also fails ``ELOOP`` — so the
+    security-relevant half of the same divergence is pinned separately by
+    :func:`test_a_symlink_loop_that_leaves_the_root_is_refused`.
 
     Either link may be reported — ``os.walk`` does not promise an order
     within a directory — so the assertion accepts both.
@@ -1281,6 +1293,120 @@ def test_a_symlink_loop_under_the_root_is_refused(tmp_path: Path) -> None:
         "the operator has nothing to delete.\n\n"
         f"path={excinfo.value.path}"
     )
+
+
+def test_a_symlink_loop_that_leaves_the_root_is_refused(tmp_path: Path) -> None:
+    """RED on 3.13 before the fix. A cycle must not launder an escape.
+
+    ``<root>/a.md -> <outside>/o.md -> <root>/a.md``. Every question you
+    can ask about the FIRST hop says escape: the link's own target is a
+    path outside the root, and the ``o.md`` it names is a file the operator
+    never offered. The only reason it is hard is that the chain happens to
+    close back on where it started.
+
+    That is what made ``Path.resolve(strict=False)`` an unsafe primitive to
+    judge containment with on 3.13. Its answer for this tree is the
+    partially-resolved ``<root>/a.md`` — in-root — because on hitting the
+    cycle it stops unwinding and hands back the component it started from,
+    erasing the out-of-root hop in between. The guard compared that answer
+    to the root, found it inside, and admitted the tree; on 3.11/3.12 the
+    same tree was refused. A containment predicate whose verdict depends on
+    the interpreter is not one predicate.
+
+    No fragment carrying the sentinel would reach the vault today even if
+    the tree were admitted, because ``open`` fails ``ELOOP`` too — but that
+    is the kernel refusing, not Creek, and it stops holding the moment
+    anyone breaks the cycle at the far end, which is a change outside the
+    tree the operator named and outside anything Creek can see.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+    """
+    from creek._containment import EscapingSymlinkError, assert_source_contained
+
+    src = tmp_path / "src"
+    src.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (src / "innocent.md").write_text(f"{_IN_ROOT_MARKER}\n", encoding="utf-8")
+    inside_link = src / "a.md"
+    outside_link = outside / "o.md"
+    inside_link.symlink_to(outside_link)
+    outside_link.symlink_to(inside_link)
+
+    with pytest.raises(EscapingSymlinkError) as excinfo:
+        assert_source_contained(src)
+
+    assert excinfo.value.path == inside_link, (
+        "the refusal names the wrong entry. Only the in-root link is the "
+        "operator's to delete; naming the out-of-root end would also "
+        "disclose the target this guard refused to read.\n\n"
+        f"path={excinfo.value.path}\nexpected={inside_link}"
+    )
+    assert str(outside_link) not in str(excinfo.value), (
+        "the refusal message quotes the out-of-tree link it resolved "
+        "through, which is the #1087 disclosure oracle.\n\n"
+        f"message={excinfo.value}"
+    )
+
+
+def test_containment_does_not_depend_on_path_resolve_raising(
+    tmp_path: Path,
+) -> None:
+    """RED on 3.13 before the fix. Pin the primitive, not the side effect.
+
+    The unit-level statement of the two tests above, aimed at the exact
+    line that regressed. ``resolves_within`` must classify an unresolvable
+    cycle as not-contained on its own authority — because
+    ``os.path.realpath(..., strict=True)`` reports ``ELOOP`` on every
+    supported version — and not as a side effect of ``Path.resolve``
+    raising, which is a behaviour pathlib never promised and changed in
+    3.13.
+
+    The ``Path.resolve`` call here is the evidence, not the subject: on
+    3.11/3.12 it raises and on 3.13 it returns an in-root path, and the
+    verdict below is the same either way. Asserting on the verdict while
+    the primitive underneath it diverges is what makes this a
+    version-independent test rather than a version-skipped one.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+    """
+    from creek._containment import resolves_within
+
+    src = tmp_path / "src"
+    src.mkdir()
+    a = src / "a.md"
+    b = src / "b.md"
+    a.symlink_to(b)
+    b.symlink_to(a)
+
+    assert resolves_within(a, src.resolve(strict=False)) is False, (
+        "a symlink cycle was reported as contained. The guard cannot "
+        "prove where this link points — on this interpreter "
+        "Path.resolve(strict=False) answers "
+        f"{_describe_resolve(a)} — and by this module's policy an "
+        "unprovable containment is an escape."
+    )
+
+
+def _describe_resolve(path: Path) -> str:
+    """Report what ``Path.resolve`` does with *path*, for a failure message.
+
+    Kept out of the assertion body so the message can name the actual
+    interpreter-specific behaviour that produced a failure instead of
+    asserting one of the two possibilities.
+
+    Args:
+        path: The path to resolve.
+
+    Returns:
+        Either the resolved path or the exception type it raised.
+    """
+    try:
+        return str(path.resolve(strict=False))
+    except (OSError, RuntimeError, ValueError) as exc:  # pragma: no cover
+        return f"{type(exc).__name__}"
 
 
 # ---------------------------------------------------------------------------

--- a/creek-tools/tests/test_ingest_symlink_containment.py
+++ b/creek-tools/tests/test_ingest_symlink_containment.py
@@ -197,6 +197,87 @@ def _vault_orphans(vault: Path) -> list[Path]:
     return sorted((vault / "10-Liminal" / "Orphaned").rglob("*.md"))
 
 
+def _consent_log_path(vault: Path) -> Path:
+    """Return the path ``ConsentManager`` persists its log to.
+
+    Mirrors ``creek/cli.py::_consent_log_dir`` plus
+    ``creek/consent.py::ConsentManager.__init__``'s ``consent-log.json``.
+    Spelled out here rather than imported so the test pins the on-disk
+    location an operator would inspect, not whatever the code currently
+    computes.
+
+    Args:
+        vault: Vault root to read.
+
+    Returns:
+        Path to ``<vault>/00-Creek-Meta/Processing-Log/consent-log.json``.
+    """
+    return vault / "00-Creek-Meta" / "Processing-Log" / "consent-log.json"
+
+
+def _consent_log_text(vault: Path) -> str:
+    """Return the raw consent-log JSON, or ``""`` when none was written.
+
+    Read as text rather than parsed so an assertion can search the whole
+    persisted record — paths, operator, every field — for a name that has
+    no business being there.
+
+    Args:
+        vault: Vault root to read.
+
+    Returns:
+        The consent log's file contents, or the empty string.
+    """
+    path = _consent_log_path(vault)
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def _consent_records(vault: Path) -> list[dict[str, Any]]:
+    """Return the consent records persisted under *vault*.
+
+    Args:
+        vault: Vault root to read.
+
+    Returns:
+        The ``records`` list from the consent log, empty when absent.
+    """
+    text = _consent_log_text(vault)
+    if not text:
+        return []
+    payload = json.loads(text)
+    records = payload.get("records", [])
+    return list(records)
+
+
+def _spy_on_source_summary(monkeypatch: pytest.MonkeyPatch) -> list[Path]:
+    """Install a RECORDING wrapper around the consent summariser.
+
+    Recording, never a raising sentinel: ``CliRunner`` catches a raised
+    sentinel and reports exit 1, which would manufacture a pass for the
+    exit-code assertions at HEAD.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture, used to install the spy.
+
+    Returns:
+        A live list that gains one entry per summariser call.
+    """
+    from creek import consent as consent_module
+
+    real_summary = consent_module._build_source_summary
+    calls: list[Path] = []
+
+    def _recording_summary(source_path: Path, exclusions: list[str]) -> Any:
+        """Record the call, then delegate to the real summariser."""
+        calls.append(source_path)
+        return real_summary(source_path, exclusions)
+
+    monkeypatch.setattr(consent_module, "_build_source_summary", _recording_summary)
+    return calls
+
+
 # ---------------------------------------------------------------------------
 # Per-ingestor fixture builders
 #
@@ -949,10 +1030,10 @@ def test_cli_ingest_refuses_before_the_consent_gate_reads_the_source_tree(
     and still leaks the shape of the victim directory into the consent
     prompt.
 
-    The spy is a RECORDING wrapper that delegates to the real summariser,
-    never a raising sentinel: ``CliRunner`` catches a raised sentinel and
-    reports exit 1, which would manufacture a pass for the exit-code
-    assertion at HEAD.
+    The spy (:func:`_spy_on_source_summary`) is a RECORDING wrapper that
+    delegates to the real summariser, never a raising sentinel:
+    ``CliRunner`` catches a raised sentinel and reports exit 1, which would
+    manufacture a pass for the exit-code assertion at HEAD.
 
     ``--yes`` is passed deliberately. Without it the non-interactive branch
     exits 1 on its own, and the exit-code assertion would hold at HEAD for
@@ -962,24 +1043,9 @@ def test_cli_ingest_refuses_before_the_consent_gate_reads_the_source_tree(
         tmp_path: Pytest-provided temporary directory.
         monkeypatch: Pytest monkeypatch fixture, used to install the spy.
     """
-    from creek import consent as consent_module
-
     vault = _make_vault(tmp_path)
     source, _link = _build_markdown(tmp_path / "lane", escaping=True)
-
-    real_summary = consent_module._build_source_summary
-    calls: list[object] = []
-
-    def _recording_summary(source_path, exclusions):
-        """Record the call, then delegate to the real summariser."""
-        calls.append(source_path)
-        return real_summary(source_path, exclusions)
-
-    monkeypatch.setattr(
-        consent_module,
-        "_build_source_summary",
-        _recording_summary,
-    )
+    calls = _spy_on_source_summary(monkeypatch)
 
     result = runner.invoke(
         app,
@@ -1017,6 +1083,189 @@ def test_cli_ingest_refuses_before_the_consent_gate_reads_the_source_tree(
     )
     assert _SENTINEL not in _written_vault_text(vault), (
         f"the CLI ingested the out-of-tree file.\n\n{result.output}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 7b. The same ordering pin on the OTHER CLI entry point: ``creek process``
+#
+# ``ingest`` and ``process`` are the only two ``_gate_consent`` callers in
+# the tree (``grep -n _gate_consent creek/ creek_mcp/``). Section 7 closed
+# ``ingest`` and left ``process`` open, and it was an ordering test existing
+# for one surface and not the other that let that happen. These are that
+# test for ``process``.
+#
+# The durable half is the consent log. Console output scrolls away; a
+# ``file_count`` derived from a tree the operator was never entitled to read
+# is written into ``00-Creek-Meta/Processing-Log/consent-log.json`` and stays
+# there, and every later run reads that record back and skips the prompt.
+# ---------------------------------------------------------------------------
+
+
+def test_cli_process_refuses_before_the_consent_gate_reads_the_source_tree(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED. ``process`` must refuse above ``_gate_consent``, as ``ingest`` does.
+
+    ``creek/cli.py``'s ``process`` handler calls ``_gate_consent`` at
+    line 1211 with no containment check anywhere above it. For a first-time
+    (unconsented) source that runs ``ConsentManager.get_source_summary`` ->
+    ``creek/consent.py:118 _build_source_summary``, whose ``rglob("*")`` /
+    ``stat()`` pass counts the escaping link as a file and folds the
+    out-of-tree target's byte total into the summary — the identical
+    read-before-refuse this file already closed for ``ingest`` in section 7.
+
+    Under ``--yes`` that inflated ``file_count`` is then written into the
+    consent log *before* the pipeline gets far enough to refuse, so the
+    leak outlives the process: the record is durable, and a later run reads
+    it back and skips the prompt entirely.
+
+    ``--yes`` is passed deliberately. Without it the non-interactive branch
+    exits 1 on its own and the exit-code assertion would hold at HEAD for
+    the wrong reason.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+        monkeypatch: Pytest monkeypatch fixture, used to install the spy.
+    """
+    vault = _make_vault(tmp_path)
+    source, _link = _build_markdown(tmp_path / "lane", escaping=True)
+    contained_files = sorted(
+        p for p in source.rglob("*") if p.is_file() and not p.is_symlink()
+    )
+    calls = _spy_on_source_summary(monkeypatch)
+
+    result = runner.invoke(
+        app,
+        [
+            "process",
+            "--source",
+            str(source),
+            "--vault",
+            str(vault),
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 1, (
+        "creek process accepted a source tree containing a symlink that "
+        f"leaves it.\n\nexit_code={result.exit_code}\n{result.output}"
+    )
+    assert "symlink" in result.output.lower(), (
+        "the refusal does not say why it refused; an operator cannot act "
+        f"on an unexplained exit 1.\n\n{result.output}"
+    )
+    assert not calls, (
+        "the consent summary ran before the refusal, so creek process "
+        "walked the source tree with rglob and stat()'d straight through "
+        "the escaping link before anything checked containment. This is "
+        "the exact hazard section 7 closed for creek ingest, left open on "
+        f"the other entry point.\n\ncalls={calls}\n{result.output}"
+    )
+    records = _consent_records(vault)
+    assert records == [], (
+        "a consent record was persisted by a run that refused its source. "
+        "Console output scrolls away; this file does not — and the "
+        "file_count in it was measured through the escaping link, so the "
+        "operator's audit trail now certifies approval of a count derived "
+        "from a directory they never named. Worse, check_consent() matches "
+        "on (source_type, source_path), so the next run skips the prompt "
+        f"on the strength of it.\n\n{_consent_log_text(vault)}"
+    )
+    assert len(contained_files) == 1, (
+        "the fixture no longer holds exactly one genuinely-in-root file, so "
+        "the inflated-count check below cannot tell an honest count from a "
+        f"leaked one.\n\n{contained_files}"
+    )
+    inflated = [r for r in records if r["file_count"] > len(contained_files)]
+    assert not inflated, (
+        "the recorded file_count exceeds the number of files actually "
+        "inside the source root, so the escaping link was counted as a file "
+        "and its out-of-tree target was stat()'d. At HEAD this reads "
+        f"file_count=2 against {len(contained_files)} contained "
+        f"file(s).\n\n{inflated}"
+    )
+    assert _SENTINEL not in _written_vault_text(vault), (
+        f"creek process ingested the out-of-tree file.\n\n{result.output}"
+    )
+
+
+def test_cli_process_leaks_no_out_of_tree_filename_to_console_or_consent_log(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED. Naming a symlinked directory must not enumerate its target.
+
+    The section-5 shape (#1360), on the ``process`` surface. When
+    ``--source`` is *itself* a link to a directory outside its own parent,
+    ``_build_source_summary``'s ``rglob("*")`` runs over the target's tree
+    directly — no descent into a link is needed, so this leak is
+    interpreter-version-independent, unlike the descendant-link case pinned
+    by ``test_rglob_does_not_descend_into_a_symlinked_directory``.
+
+    The consequence is concrete: real out-of-tree *filenames* land in
+    ``summary.sample_filenames`` and get printed as ``Sample: ...``, and the
+    count of the victim directory's files is recorded in the consent log.
+    The victim filename here is a sentinel so "this leaked" cannot be
+    explained away as a name that could have come from anywhere.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+        monkeypatch: Pytest monkeypatch fixture, used to install the spy.
+    """
+    victim_name = f"{_SENTINEL}-filename.md"
+    base = tmp_path / "lane"
+    vault = _make_vault(tmp_path)
+    outside = base / "outside"
+    outside.mkdir(parents=True)
+    (outside / victim_name).write_text(f"# Secret\n\n{_SENTINEL}\n", encoding="utf-8")
+    # The link must sit somewhere that does NOT contain the target, or it
+    # does not escape its own parent and there is nothing to refuse.
+    holder = base / "holder"
+    holder.mkdir()
+    link = holder / "linkdir"
+    link.symlink_to(outside)
+    calls = _spy_on_source_summary(monkeypatch)
+
+    result = runner.invoke(
+        app,
+        [
+            "process",
+            "--source",
+            str(link),
+            "--vault",
+            str(vault),
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 1, (
+        "creek process accepted a --source that is itself a symlink out of "
+        f"its own parent.\n\nexit_code={result.exit_code}\n{result.output}"
+    )
+    assert not calls, (
+        "the consent summary enumerated the link's target before anything "
+        f"refused.\n\ncalls={calls}\n{result.output}"
+    )
+    assert victim_name not in result.output, (
+        "a filename from the out-of-tree directory was printed to the "
+        "console in the consent prompt's Sample line. The operator was "
+        "shown the contents of a directory they did not name, by a run "
+        f"that then refused to process it.\n\n{result.output}"
+    )
+    assert victim_name not in _consent_log_text(vault), (
+        "an out-of-tree filename was written into the persisted consent "
+        f"log.\n\n{_consent_log_text(vault)}"
+    )
+    assert _consent_records(vault) == [], (
+        "a run that refused its source still recorded consent, and the "
+        "file_count in that record is the victim directory's file count — "
+        f"durable state derived from an unentitled read.\n\n"
+        f"{_consent_log_text(vault)}"
+    )
+    assert _SENTINEL not in _written_vault_text(vault), (
+        f"creek process ingested the out-of-tree file.\n\n{result.output}"
     )
 
 
@@ -1526,6 +1775,62 @@ def test_the_containment_predicate_has_exactly_one_definition() -> None:
         "predicate. Either drop the name or alias the canonical one; a "
         "second body is the drift this test exists to prevent.\n\n"
         f"{legacy!r}"
+    )
+
+
+def test_every_consent_gate_caller_checks_containment_first() -> None:
+    """RED for ``process``. The rule, not the two call sites of it.
+
+    Both CLI entry points had the read-before-refuse bug and only one was
+    fixed in the first pass, because an ordering test existed for ``ingest``
+    and not for ``process``. Two behavioural tests per surface do not stop a
+    *third* ``_gate_consent`` caller from landing with no guard above it —
+    and by construction nothing would fail when it did. This is the
+    structural half: it reads ``creek/cli.py``'s AST and enforces the rule
+    on whatever call sites exist, including ones not written yet.
+
+    "Before" is judged by line number within the enclosing function, which
+    is exactly as strong as the hazard requires: the read happens inside
+    ``_gate_consent``, so any refusal textually above it in the same body
+    runs first. A guard smuggled into a conditional branch would satisfy
+    this check while skipping at runtime; that is a real limit, and the
+    behavioural tests in sections 7 and 7b are what close it for the call
+    sites that exist today.
+    """
+    import ast
+    import inspect
+
+    from creek import cli as cli_module
+
+    tree = ast.parse(inspect.getsource(cli_module))
+    offenders: list[str] = []
+    for func in ast.walk(tree):
+        if not isinstance(func, ast.FunctionDef):
+            continue
+        called: list[tuple[str, int]] = [
+            (node.func.id, node.lineno)
+            for node in ast.walk(func)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        ]
+        gates = [line for name, line in called if name == "_gate_consent"]
+        guards = [
+            line for name, line in called if name == "_assert_ingest_source_contained"
+        ]
+        offenders += [
+            f"{func.name}: _gate_consent at line {gate} has no "
+            f"_assert_ingest_source_contained above it (guards at {guards})"
+            for gate in gates
+            if not any(guard < gate for guard in guards)
+        ]
+
+    assert offenders == [], (
+        "a creek/cli.py handler calls _gate_consent without checking "
+        "containment first. The consent prompt walks the source tree with "
+        "rglob and stat()s every entry, so it reads through an escaping "
+        "link — printing out-of-tree filenames and, under --yes, recording "
+        "a file count measured outside the named root into the consent "
+        "log — all before any downstream guard refuses (#1294).\n\n"
+        + "\n".join(offenders)
     )
 
 

--- a/creek-tools/tests/test_pipeline.py
+++ b/creek-tools/tests/test_pipeline.py
@@ -2037,6 +2037,16 @@ class TestPipelineAudiencePass:
 # same file through its own ``rglob("*.md")`` + ``read_bytes()`` with no
 # symlink check and no ``is_file`` check of its own. Skipping in the pipeline
 # would therefore convert "blocked ingest" into "silent unredacted ingest".
+#
+# #1294 closed that second walk: ``Ingestor.ingest`` now refuses an escaping
+# link before ``discover()`` runs. The two tests below are UNCHANGED by it and
+# must stay that way. ``Pipeline.run`` orders the stages redaction (Stage 1,
+# ``creek/pipeline.py:350``) then ingestion (Stage 2, ``:364``), so with the
+# default ``redaction.enabled: true`` the scan still declines the file first
+# and ``SymlinkEscapedSourceError`` still wins the race to raise. The new
+# ingest guard only becomes observable through ``creek process`` when
+# redaction is switched off — which is the config-toggle hole #1294 names,
+# and which the last test in this file now pins.
 # ---------------------------------------------------------------------------
 
 _ESCAPED_CANARY = "CANARY-PIPELINE-SYMLINK-4c21"
@@ -2185,4 +2195,78 @@ def test_symlink_refusal_is_not_waived_by_redaction_dry_run(
     assert _ESCAPED_CANARY not in written, (
         "redaction.dry_run waived a path-traversal refusal and the "
         f"out-of-tree file was ingested.\n\n{written}"
+    )
+
+
+def test_process_refuses_an_escaping_symlink_with_redaction_disabled(
+    vault_path: Path,
+    tmp_path: Path,
+) -> None:
+    """RED for #1294: the config toggle no longer decides containment.
+
+    ``_run_redaction`` returns early on ``redaction.enabled: false``
+    (``creek/pipeline.py:481``), taking the #1087 symlink check with it —
+    the stage docstring says so in as many words and points at this issue.
+    So at HEAD the *same tree* that ``creek process`` refuses outright with
+    the default config is ingested, unredacted, the moment an operator sets
+    one boolean. A containment guarantee that a config key can switch off is
+    not a guarantee; it is a default.
+
+    The refusal now comes from the ingest chokepoint instead, so the error
+    type is :class:`creek._containment.EscapingSymlinkError` rather than
+    :class:`~creek.pipeline.SymlinkEscapedSourceError`. That is deliberate
+    and not an oversight to be "tidied" later: ``SymlinkEscapedSourceError``
+    carries a ``skipped_count`` describing how many files *the scan* declined
+    to read, and here no scan ran at all — there is no honest number to put
+    in it.
+
+    Args:
+        vault_path: Vault root the run would write into.
+        tmp_path: Pytest-provided temporary directory.
+    """
+    from creek._containment import EscapingSymlinkError
+
+    source = tmp_path / "source-redaction-off"
+    source.mkdir()
+    (source / "clean.md").write_text(
+        "# Ordinary notes\n\nNothing sensitive here.\n",
+        encoding="utf-8",
+    )
+    outside = tmp_path / "outside-redaction-off"
+    outside.mkdir()
+    secret = outside / "secret.md"
+    secret.write_text(
+        f"# {_ESCAPED_CANARY}\n\n{_ESCAPED_PII}\n",
+        encoding="utf-8",
+    )
+    (source / "link.md").symlink_to(secret)
+
+    config = CreekConfig()
+    config.redaction.enabled = False
+    pipeline = Pipeline(config=config, no_llm=True)
+
+    with pytest.raises(EscapingSymlinkError) as excinfo:
+        pipeline.run(source_path=source, vault_path=vault_path)
+
+    assert excinfo.value.root == source, (
+        "the refusal names the wrong source tree, so an operator cannot "
+        f"tell which input stopped.\n\nroot: {excinfo.value.root}"
+    )
+    assert excinfo.value.path == source / "link.md", (
+        "the refusal names the wrong entry; it must name the link exactly "
+        f"as walked.\n\npath: {excinfo.value.path}"
+    )
+    written = "\n".join(
+        path.read_text(encoding="utf-8", errors="replace")
+        for path in sorted(vault_path.rglob("*"))
+        if path.is_file()
+    )
+    assert _ESCAPED_CANARY not in written, (
+        "with redaction disabled, the ingestor walks followed the symlink "
+        "out of the source tree and wrote the target into the vault. This "
+        "is #1294: the same tree behaves differently depending on a config "
+        f"toggle.\n\n{written}"
+    )
+    assert _ESCAPED_PII not in written, (
+        f"the out-of-tree file's PII reached the vault.\n\n{written}"
     )


### PR DESCRIPTION
## Summary

Every one of the 11 registered ingestors discovered its inputs with an unguarded walk and read whatever the walk yielded, so a symlink under the source tree pointing outside it was followed, read, and written into the vault as a durable fragment — which then feeds classification, embeddings, cloud LLM prompts, drafts and compiled pages.

This was not theoretical. Running the real `run_ingest` on `main` with a sentinel that exists **only** outside the source root:

```
markdown   written=2   LEAKED -> 01-Fragments/Notes/2026-08-10-Victim-notes.md
generic    written=2   LEAKED -> 01-Fragments/Unsorted/2026-08-11-link.md
code       written=3   LEAKED -> 01-Fragments/Technical/2026-08-10-Deep-victim.md
                       LEAKED -> 01-Fragments/Technical/2026-08-10-Victim.md
markdown   written=1   LEAKED -> 01-Fragments/Notes/2026-08-10-Victim.md   (named root is the link)
```

After this PR all four refuse and no vault file carries the sentinel.

`Deep-victim` is the one worth noticing: it comes from a *nested subdirectory* of the out-of-tree target. `CodeIngestor` is the only ingestor that walks by hand (`iterdir()` + `is_dir()`, and `is_dir()` follows links), so it walked the whole escaped subtree rather than just the named link.

### Where the premise needed correcting

The issue says "every ingestor discovers its inputs with an unguarded **recursive glob**". Unguarded is right — 11 of 11. Recursive glob is not: `chatgpt`/`claude` use non-recursive `glob("*.json")`, `discord` uses `iterdir()` under `messages/`, and `code` uses manual recursion. That matters, because a fix written only against `rglob` would have missed the worst offender.

| ingestor | discovery walk | guarded before? |
|---|---|---|
| `markdown` | `markdown.py:346` `rglob("*.md")`, no `is_file()` either | no |
| `generic` | `generic.py:199` `rglob("*")` | no |
| `document` | `documents.py:630` `rglob("*")` | no |
| `image` | `images.py:441` `rglob("*")` | no |
| `presentation` | `presentations.py:278` `rglob("*")` | no |
| `spreadsheet` | `spreadsheets.py:401` `rglob("*")` | no |
| `substack` | `substack.py:319` `rglob("*.html")` | no |
| `chatgpt` | `chatgpt.py:89` `glob("*.json")` — not recursive | no |
| `claude` | `claude.py:284` `glob("*.json")` — not recursive | no |
| `discord` | `discord.py:391` `iterdir()` under `messages/` | no |
| `code` | `code.py:561-574` manual `iterdir()` + `is_dir()` recursion | no — and descends into symlinked dirs |

## The three design questions

**Skip or refuse? Refuse.** #1360 set the rule by asking whether the caller writes: the read path (`redact --scan`) skips-and-counts, because refusing a whole scan over one bad link is a denial of service on the safety pass — the operator's only instrument for learning what is exposed. The write path (`--apply`/`--review`) refuses. Ingest writes, and writes the most consequential thing in the system. The DoS argument does not transfer: refusing an ingest removes no diagnostic capability (`creek redact --scan` still inspects the tree) and ingest is idempotent, so a refusal costs a retry rather than data. Decisively, `creek process` with the default `redaction.enabled: true` *already* refused this tree via #1087 — so skipping would have left the same tree behaving differently depending on a config toggle, which is precisely the defect this issue names.

**One chokepoint or N? One.** `Ingestor.ingest` is the single door all 11 go through, and the gate sits there, before `_discover_safe`. N per-ingestor copies would drift — the same argument #1360 used to make `resolves_within` public rather than write it twice. The chokepoint also buys a property copies never could: `test_every_registered_ingestor_refuses_an_escaping_link` drives straight off `INGESTOR_REGISTRY`, so a twelfth ingestor is covered without anyone remembering.

**Does a symlinked source root launder its children? Yes — same shape as #1360.** `assert_source_contained` therefore checks the named root with `named_path_escapes` **before** any `is_dir()`, which follows the link. Without that ordering the tree walk resolves the root to the link's target and then finds nothing escaping inside it.

## Two hazards the issue did not predict

Both are the #1360 lesson — enumerate the paths that *write*, not only those that read.

**A refusal that returns `[]` is a mass-deletion primitive.** `run_ingest` builds `seen_keys` from the discovered fragments, then calls `tomb_missing_units`, which soft-tombs every `ledger.live_keys() - seen_keys` for a ledger-backed directory. Markdown is ledger-backed. Had the refusal been collected into `IngestResult.errors` and turned into an empty discovery, one stray symlink would have orphaned every fragment previously ingested from that source. The refusal propagates out of `Ingestor.ingest` instead, and a test pins that the originals stay live.

**The consent gate read through the link first.** `creek ingest` calls `_gate_consent` before ingesting, which reaches `creek/consent.py:134 _build_source_summary` — an `rglob("*")` walk that `stat()`s every entry, following escaping links and folding out-of-tree file counts and byte totals into the very summary the operator is asked to approve. A guard sitting only downstream blocks the write and still performs that out-of-root read. The CLI now refuses above `_gate_consent`, and a recording spy asserts the summariser never runs.

## One predicate, three surfaces

The issue asked for "one shared confinement predicate rather than a third copy of the policy", so `resolves_within` moved out of `creek/redact/scanner.py` into a new stdlib-only `creek/_containment.py` and is re-exported; `_named_path_escapes` moved out of `creek/redact/cli_commands.py` and is rebound; and the redact CLI's `_assert_no_escaping_symlinks` now calls the shared `find_escaping_symlink` rather than keeping its own `os.walk`. A test asserts object identity across the modules so a fourth copy cannot reappear.

`_containment` is stdlib-only by design, following `creek/_fsio.py`: `creek.ingest.base` depends on it, and `creek.redact.scanner` compiles a large regex battery at import, so the dependency runs one way only.

## Notes

- **`recurse_symlinks` is pinned behaviourally, not by keyword.** The parameter does not exist on 3.11/3.12, so passing it would break two of the three CI versions. Confirmed on the interpreter that `rglob` does not descend into symlinked directories today; a test is the tripwire if a future default flips. The gate itself uses `os.walk(followlinks=False)` and inspects `dirnames` as well as `filenames`, which is what closes `CodeIngestor` without touching it.
- **`MarkdownIngestor` gained an `is_file()` filter** it uniquely lacked. Not the containment fix — a robustness fix for the same tombing hazard, reached via a dangling in-tree link.
- **#1087 is untouched.** `SymlinkEscapedSourceError` and the pipeline refusal stay; with redaction on it still fires first, and it remains the better-informed of the two because it carries the count of files the scan declined.
- **Security direction is one-way**: no `--force`, no environment variable, no config key.

## Test plan

- `./scripts/check-all.sh` exits **0** — 8956 passed, 5 skipped, coverage 94.40%, per-file gate green (257 files ≥ 80%).
- New `tests/test_ingest_symlink_containment.py` (39 tests). 30 were RED before the fix; 9 pass at HEAD by design as non-vacuity controls and over-breadth guards — 6 clean-control ingestor lanes proving each fixture actually writes fragments, plus intra-tree alias, symlinked-ancestor root, and the `rglob` tripwire. Without those controls every "sentinel absent" assertion would be trivially true.
- The primary RED asserts on the **written vault fragment** with `redaction.enabled = false`, not on a glob's return value.
- Non-vacuity: 6 ingestors × their real input shapes, plus a registry-driven lane over all 11.
- **Mutation battery, 9 mutations, 8 real ones all killed:** dropping the gate (23 tests fail), dropping the named-root check, ignoring `dirnames`, `followlinks=True`, dropping the CLI pre-consent gate, dropping the MCP translation, inverting `resolves_within`'s failure arm (42 fail), dropping the markdown `is_file()` guard. Two survivors were found and fixed rather than accepted: `followlinks=True` and the markdown guard were both untested, so I added tests for each. A third apparent survivor was an `except EscapingSymlinkError: raise` clause in `_discover_safe` that turned out to be **unreachable** — the gate runs before it — so I deleted the dead code and moved its rationale into a comment at the live call site.
- Neighbouring suites green: `test_pipeline.py`, `test_cli_redact.py`, `test_ingest*.py` — 300 passed.

## Review

Gate 2.5 (`code-review-orchestrator` over the full diff) came back **CLEAN — no blockers**. It independently confirmed the non-disclosure paths, the absence of an import cycle, the `logger.exception` → `logger.warning` swap being correct rather than a regression, that the exception cannot be swallowed before `tomb_missing_units`, and the 39/9-at-HEAD test accounting. Two non-blocking items, both handled:

- **Performance (should-fix).** `creek process` fans all 11 ingestors at one source, so the gate re-walks the tree 11 times — roughly 385k extra `lstat` calls on a 35k-file export. The reviewer's judgement, which I agree with, is to ship: this stage *already* performs 11 full `discover()` walks that read content and parse JSON, so an `lstat`-only pass is a constant factor on the same order, not a new asymptotic class. Hoisting it to `Pipeline._run_ingestion` would either need an "already verified" flag threaded through `Ingestor.ingest` — undercutting the whole point of a gate a subclass cannot weaken — or would drop the guarantee for every direct caller (`creek ingest`, the MCP tool, the two Discord paths). Deliberately not pre-empting without a profile at real scale.
- **Discord call sites (nit).** `discord_dispatch.py:292` and `discord.py:889,914` inherit the guard and fail closed, but render the refusal as a raw traceback instead of a banner. Presentation only, no security impact. Filed as #1377 (P3).

## Left alone

`CodeIngestor` still recurses into *intra-root* symlinked directories, so an alias pointing at its own ancestor turns one file into 16 fragments with distinct source paths, bounded only by `ELOOP`. Containment admits that link correctly — it never leaves the root — so it is a walk-bound bug rather than a security one. Filed as #1375 (P2) with the reproduction.

Closes #1294
Refs #1087, #1293, #1375, #1377
