### PR TITLE
fix(pipeline): one ingestor's output per source file, not every ingestor's

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -11,7 +11,7 @@ import sys
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, NoReturn, cast
+from typing import TYPE_CHECKING, Final, Literal, NoReturn, cast
 
 import typer
 from rich.console import Console
@@ -159,6 +159,14 @@ app.add_typer(purge_app, name="purge")
 app.add_typer(skills_app, name="skills")
 app.add_typer(compost_app, name="compost")
 console = Console()
+
+_SOURCE_COVERAGE_SAMPLE: Final[int] = 10
+"""How many contested/unclaimed source paths ``creek process`` lists.
+
+The full lists live on :class:`~creek.pipeline.PipelineResult`; the
+summary only samples them so a large source tree cannot bury the rest of
+the report.
+"""
 
 
 def _consent_log_dir(vault_path: Path) -> Path:
@@ -1313,11 +1321,58 @@ def process(
         f"[bold]Residue:[/bold] {result.residue} "
         "(would go to LLM if Pass-3 enabled)"
     )
+    _print_source_coverage(result)
     error_count = len(result.errors)
     error_style = "red" if error_count else "dim"
     console.print(f"[bold {error_style}]Errors:[/bold {error_style}] {error_count}")
     for err in result.errors:
         console.print(f"  [dim]{err}[/dim]")
+
+
+def _print_source_coverage(result: PipelineResult) -> None:
+    """Report source files that were contested or that nobody ingested.
+
+    Silent when there is nothing to say, so a clean run's summary keeps
+    its current shape.
+
+    *Contested* is the migration notice for issue #1304. Before that
+    change several ingestors could each write a fragment for the same
+    file; now one wins. The loser's fragments in an existing vault are
+    left exactly where they are — deleting a fragment is not something a
+    processing run gets to decide — so this names the affected files and
+    the read-only command that finds the strays.
+
+    *Unclaimed* names files that produced nothing at all, which was
+    previously silent.
+
+    Args:
+        result: The finished pipeline result.
+    """
+    if result.contested_sources:
+        console.print(
+            f"[bold yellow]Contested sources:[/bold yellow] "
+            f"{len(result.contested_sources)} "
+            "(more than one ingestor claimed these; one won)"
+        )
+        console.print(
+            "  [dim]A vault ingested before this release may still hold the "
+            "losing ingestor's fragments. Nothing is deleted automatically; "
+            "inspect with[/dim]"
+        )
+        console.print(
+            "  [dim]creek purge source --source-path <path> --match exact "
+            "--dry-run[/dim]"
+        )
+        for path in result.contested_sources[:_SOURCE_COVERAGE_SAMPLE]:
+            console.print(f"  [dim]{path}[/dim]")
+    if result.unclaimed_sources:
+        console.print(
+            f"[bold yellow]Unclaimed sources:[/bold yellow] "
+            f"{len(result.unclaimed_sources)} "
+            "(no ingestor produced a fragment for these)"
+        )
+        for path in result.unclaimed_sources[:_SOURCE_COVERAGE_SAMPLE]:
+            console.print(f"  [dim]{path}[/dim]")
 
 
 @app.command()

--- a/creek-tools/creek/ingest/code.py
+++ b/creek-tools/creek/ingest/code.py
@@ -30,29 +30,20 @@ from creek.ingest.base import (
     normalize_encoding,
     parse_authored_at,
 )
+from creek.ingest.routing import SKIPPED_DIRECTORY_NAMES
 from creek.models import SourcePlatform
 
 logger = logging.getLogger(__name__)
 
 # ---- Constants ----
 
-_SKIP_DIRS: frozenset[str] = frozenset(
-    {
-        "node_modules",
-        "vendor",
-        ".git",
-        "__pycache__",
-        ".tox",
-        ".venv",
-        ".mypy_cache",
-        ".ruff_cache",
-        ".pytest_cache",
-        "dist",
-        "build",
-        ".eggs",
-    }
-)
-"""Directory names to skip during discovery."""
+_SKIP_DIRS: frozenset[str] = SKIPPED_DIRECTORY_NAMES
+"""Directory names to skip during discovery.
+
+Shared with the pipeline's unclaimed-source report (issue #1304) via
+:data:`creek.ingest.routing.SKIPPED_DIRECTORY_NAMES` — a file this walk
+declines to visit must not then be reported as an ingestor's oversight.
+"""
 
 _README_PATTERNS: tuple[str, ...] = (
     "README.md",

--- a/creek-tools/creek/ingest/documents.py
+++ b/creek-tools/creek/ingest/documents.py
@@ -581,10 +581,15 @@ class DocumentIngestor(Ingestor):
 
         Substack export directories (``posts.csv`` + per-post
         ``<id>.<slug>.html``) are claimed by ``SubstackIngestor``;
-        ``DocumentIngestor`` defers to it rather than double-emitting
-        every post as an opaque HTML document, so the auto-detect path
-        of ``creek process`` (which fans every registered ingestor at
-        the source) produces one fragment per essay, not two.
+        ``DocumentIngestor`` defers to it rather than emitting every
+        post a second time as an opaque HTML document. Since issue #1304
+        the pipeline would arbitrate that contest anyway — ``substack``
+        outranks ``document`` in
+        :data:`creek.ingest.routing.CLAIM_PRIORITY` — but narrowing the
+        claim here is still worth doing: it saves parsing a whole export
+        directory whose output is guaranteed to be discarded, and it
+        keeps ``creek ingest --type document`` honest, which the
+        arbiter never sees.
 
         Args:
             source_path: A file or directory path to search.

--- a/creek-tools/creek/ingest/generic.py
+++ b/creek-tools/creek/ingest/generic.py
@@ -47,6 +47,10 @@ _BINARY_CHECK_SIZE = 8192
 # If more than 10% of bytes are non-text control chars, treat as binary
 _BINARY_CONTROL_THRESHOLD = 0.10
 
+# UTF-16 byte-order marks. UTF-16 text is full of null bytes, so it trips
+# every binary heuristic here and has to be recognised before they run.
+_UTF16_BOMS: tuple[bytes, bytes] = (b"\xff\xfe", b"\xfe\xff")
+
 
 def _safe_file_mtime(path: Path) -> datetime | None:
     """Return *path*'s mtime as a tz-aware datetime, or ``None`` defensively.
@@ -113,7 +117,7 @@ def _try_decode(raw_bytes: bytes) -> str | None:
         return ""
 
     # Try UTF-16 first if BOM is present (contains null bytes so check before binary)
-    if raw_bytes[:2] in (b"\xff\xfe", b"\xfe\xff"):
+    if raw_bytes[:2] in _UTF16_BOMS:
         with suppress(UnicodeDecodeError, ValueError):
             return raw_bytes.decode("utf-16")
 
@@ -132,6 +136,39 @@ def _try_decode(raw_bytes: bytes) -> str | None:
 
     # Latin-1 as final fallback (can decode any byte sequence)
     return raw_bytes.decode("latin-1")
+
+
+def _read_unless_binary(file_path: Path) -> bytes | None:
+    """Read *file_path* whole, or return ``None`` once a prefix proves it binary.
+
+    ``parse`` has always discarded binary content (``_try_decode``
+    returns ``None`` for it), but ``discover`` used to slurp the entire
+    file into memory first — so a source tree of photos, videos or Office
+    documents was read cover to cover on every ``creek process`` run and
+    thrown away. This reads a bounded prefix, decides on that, and only
+    continues reading when the content might survive parsing.
+
+    Output-neutral by construction rather than by an extension list.
+    :func:`_is_binary_content` looks for a null byte anywhere and
+    otherwise scores only the first ``_BINARY_CHECK_SIZE`` bytes, so if
+    the prefix tests binary the whole file necessarily does too, and
+    ``parse`` would have dropped it. The UTF-16 BOM exemption is applied
+    here for the same reason ``_try_decode`` applies it: UTF-16 text is
+    riddled with nulls and is not binary.
+
+    Args:
+        file_path: File to read.
+
+    Returns:
+        The file's bytes, or ``None`` when it is binary and ``parse``
+        would have discarded it anyway.
+    """
+    with file_path.open("rb") as handle:
+        prefix = handle.read(_BINARY_CHECK_SIZE)
+        if prefix[:2] not in _UTF16_BOMS and _is_binary_content(prefix):
+            logger.debug("Skipping binary file without reading it: %s", file_path)
+            return None
+        return prefix + handle.read()
 
 
 class GenericIngestor(Ingestor):
@@ -170,12 +207,15 @@ class GenericIngestor(Ingestor):
             file_path: Path to the file.
 
         Returns:
-            A single-element list if the file is unclaimed, else empty.
+            A single-element list if the file is unclaimed and not
+            binary, else empty.
         """
         if file_path.suffix.lower() in _CLAIMED_EXTENSIONS:
             return []
 
-        raw_bytes = file_path.read_bytes()
+        raw_bytes = _read_unless_binary(file_path)
+        if raw_bytes is None:
+            return []
         _text, encoding = normalize_encoding(raw_bytes)
         return [
             RawDocument(
@@ -193,7 +233,8 @@ class GenericIngestor(Ingestor):
             dir_path: Directory path to search.
 
         Returns:
-            A list of ``RawDocument`` objects for unclaimed files.
+            A list of ``RawDocument`` objects for unclaimed, non-binary
+            files.
         """
         docs: list[RawDocument] = []
         for file_path in sorted(dir_path.rglob("*")):
@@ -202,7 +243,9 @@ class GenericIngestor(Ingestor):
             if file_path.suffix.lower() in _CLAIMED_EXTENSIONS:
                 continue
 
-            raw_bytes = file_path.read_bytes()
+            raw_bytes = _read_unless_binary(file_path)
+            if raw_bytes is None:
+                continue
             _text, encoding = normalize_encoding(raw_bytes)
             docs.append(
                 RawDocument(

--- a/creek-tools/creek/ingest/routing.py
+++ b/creek-tools/creek/ingest/routing.py
@@ -74,7 +74,10 @@ Each contested extension and the reason its winner wins:
   ``document`` on ``.html``, and letting the declared fallback outrank a
   specialist anywhere makes the order incoherent.
 * ``.csv``/``.xlsx`` -> **spreadsheet**, ``.pptx`` -> **presentation**,
-  images -> **image**, each over **generic**, for the same reason.
+  images -> **image**, ``.rtf``/``.docx``/``.pdf``/``.htm`` -> **document**,
+  each over **generic**, for the same reason. That completes
+  ``DocumentIngestor``'s extension set; ``generic`` claims everything
+  outside ``{.md, .json}``, so every one of them is contested.
 
 The winner is load-bearing beyond the body text: a fragment's id hashes
 ``source_path + timestamp + content`` (``creek.ingest.base``), and the

--- a/creek-tools/creek/ingest/routing.py
+++ b/creek-tools/creek/ingest/routing.py
@@ -1,0 +1,251 @@
+"""Decide which ingestor owns a source file when several claim it (#1304).
+
+``Pipeline._run_ingestion`` hands the whole source tree to every entry in
+:data:`creek.ingest.INGESTOR_REGISTRY`. That is deliberate — several
+ingestors identify their input by *sniffing* it, not by its extension —
+but it means a file claimed by two ingestors used to be written to the
+vault twice. Nothing de-duplicated it downstream: the vault writer
+de-collides a name clash with a ``-N`` suffix, so both copies landed.
+
+This module supplies the arbiter. Every ingestor still runs, and then
+:func:`arbitrate` groups the parsed fragments by
+:attr:`~creek.ingest.base.ParsedFragment.source_path` and keeps only the
+fragments of the highest-priority ingestor that actually produced output
+for that path.
+
+Why arbitrate after parsing rather than after ``discover()``
+------------------------------------------------------------
+A claim staked at discovery has to be trusted before anyone has read the
+file. When the winner's ``parse()`` then fails — a malformed ``.csv``, a
+password-protected ``.xlsx`` — the loser has already been discarded and
+the file's content is lost, where today it still lands as a generic
+fragment. Arbitrating on produced fragments makes that impossible by
+construction: an ingestor that produced nothing for a path is not a
+claimant. It also keeps today's memory profile, since one ingestor's
+documents are freed before the next runs.
+
+The enforced invariant is therefore "exactly one ingestor's output is
+**written** per source file", not "each file is parsed once". A contested
+*text* file is still parsed twice; that is CPU only. The one case where
+the wasted read mattered — ``GenericIngestor`` slurping whole binaries it
+was always going to discard — is fixed at its source in
+:mod:`creek.ingest.generic`.
+
+The priority order
+------------------
+:data:`CLAIM_PRIORITY` is a single total order over registry names rather
+than a per-extension table, so it is reviewable in one glance and cannot
+disagree with itself. It runs specific to general: structure- and
+content-sniffed exporters first (they recognise a file by its internals,
+so their claim is the strongest evidence available), then the
+extension-keyed specialists, then ``generic`` last — ``generic`` is by
+definition "nothing better claimed this" and must never beat a
+specialist.
+
+Each contested extension and the reason its winner wins:
+
+* ``.md`` -> **markdown** over **code**. ``CodeIngestor`` claims READMEs,
+  ``CLAUDE.md`` and ADRs (``creek/ingest/code.py`` ``_is_relevant_file``)
+  and tags them with an ``artifact_type`` plus a git first-commit
+  ``authored_at``. It also emits the file *verbatim*, so a README's YAML
+  frontmatter stays inline in the fragment body — directly beneath the
+  frontmatter block the vault writer adds, which is at best a stray
+  horizontal rule and at worst two frontmatter blocks in one note.
+  ``MarkdownIngestor`` splits that frontmatter out, promotes ``title``
+  and ``tags`` from it, and treats every ``.md`` the same way. Losing an
+  ``artifact_type`` label costs less than corrupting the body, and "every
+  ``.md`` is ingested by the markdown ingestor" is a rule an operator can
+  hold in their head.
+* ``.py`` -> **code** over **generic**. Code emits one fragment per
+  module and one per function; generic emits one fenced dump of the file.
+* ``.html`` -> **substack** over **document** over **generic**. Substack
+  recognises its own ``<postid>.<slug>.html`` naming and recovers post
+  metadata; ``DocumentIngestor`` extracts readable text; ``generic``
+  wraps the raw markup in a ```` ```html ```` fence, which is unreadable
+  as a note. (``DocumentIngestor`` already stands aside for a real
+  Substack export directory, so the full three-way only arises for a
+  stray post file outside one.)
+* ``.txt`` -> **document** over **generic**, and ADR ``.txt``/``.rst``
+  -> **code** over **document**. Note the trade this makes on a plain
+  ``.txt``: ``DocumentIngestor`` applies a heuristic that promotes the
+  first line to an ``#`` heading, where ``generic`` reproduces the text
+  verbatim. Verbatim is arguably the more faithful rendering of a log
+  file, but a total order cannot prefer ``generic`` on ``.txt`` and
+  ``document`` on ``.html``, and letting the declared fallback outrank a
+  specialist anywhere makes the order incoherent.
+* ``.csv``/``.xlsx`` -> **spreadsheet**, ``.pptx`` -> **presentation**,
+  images -> **image**, each over **generic**, for the same reason.
+
+The winner is load-bearing beyond the body text: a fragment's id hashes
+``source_path + timestamp + content`` (``creek.ingest.base``), and the
+ingestors disagree on both the body *and* the timestamp — ``CodeIngestor``
+stamps local time while the others stamp UTC. So arbitration also picks
+which timestamp survives, and with it the ``YYYY-MM-DD-`` prefix on the
+vault filename. Between 16:00 and midnight Pacific the two candidates
+fall on different calendar days.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, NamedTuple
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+    from creek.ingest.base import ParsedFragment
+
+logger = logging.getLogger(__name__)
+
+CLAIM_PRIORITY: tuple[str, ...] = (
+    # Tier 1 — structure- or content-sniffed exporters. These recognise a
+    # file by its internals (a Discord ``messages/<channel>/messages.json``
+    # tree, a ChatGPT top-level JSON list, a Claude export envelope, a
+    # Substack post filename), so no extension table can express them.
+    "discord",
+    "chatgpt",
+    "claude",
+    "substack",
+    # Tier 2 — extension-keyed specialists.
+    "markdown",
+    "code",
+    "spreadsheet",
+    "presentation",
+    "image",
+    "document",
+    # Tier 3 — the fallback. Always last.
+    "generic",
+)
+"""Total order over :data:`creek.ingest.INGESTOR_REGISTRY` keys, best first.
+
+Every registry key must appear exactly once; ``tests/test_ingest_routing.py``
+asserts that against the live registry, so adding a twelfth ingestor
+without ranking it is a CI failure rather than a silent demotion.
+"""
+
+SKIPPED_DIRECTORY_NAMES: frozenset[str] = frozenset(
+    {
+        "node_modules",
+        "vendor",
+        ".git",
+        "__pycache__",
+        ".tox",
+        ".venv",
+        ".mypy_cache",
+        ".ruff_cache",
+        ".pytest_cache",
+        "dist",
+        "build",
+        ".eggs",
+    }
+)
+"""Directory names that are machinery rather than authored content.
+
+Single definition, shared by ``CodeIngestor``'s discovery walk and by the
+pipeline's unclaimed-source report, so the two cannot drift apart and
+start disagreeing about whether a file was meant to be ingested.
+"""
+
+_BASE_RANKS: dict[str, int] = {name: rank for rank, name in enumerate(CLAIM_PRIORITY)}
+
+
+class Arbitration(NamedTuple):
+    """Outcome of resolving competing claims over one ingestion run.
+
+    Attributes:
+        winners: Ingestor name mapped to the fragments it keeps, in the
+            order that ingestor produced them. Every key of the input
+            mapping is present, possibly with an empty list.
+        contested: Sorted source paths that more than one ingestor
+            produced fragments for, and where output was therefore
+            dropped. Reported so an operator can find the losing
+            ingestor's stale fragments in a vault ingested before #1304.
+    """
+
+    winners: dict[str, list[ParsedFragment]]
+    contested: list[str]
+
+
+def _rank(claims: Mapping[str, Sequence[ParsedFragment]]) -> dict[str, int]:
+    """Rank every claiming ingestor, placing unranked names after ``generic``.
+
+    Names outside :data:`CLAIM_PRIORITY` — synthetic registries injected
+    by tests, or a third-party ingestor — rank behind the whole known
+    order, tie-broken by name so the result is deterministic. They still
+    win any path nobody else claims.
+
+    Args:
+        claims: Ingestor name mapped to the fragments it produced.
+
+    Returns:
+        Ingestor name mapped to its rank; lower wins.
+    """
+    ranks = _BASE_RANKS.copy()
+    unranked = sorted(name for name in claims if name not in _BASE_RANKS)
+    for offset, name in enumerate(unranked, start=1):
+        ranks[name] = len(CLAIM_PRIORITY) + offset
+    return ranks
+
+
+def _warn_unranked(contenders: set[str]) -> None:
+    """Warn when an ingestor outside :data:`CLAIM_PRIORITY` lost a contest.
+
+    Silent unless an unranked name actually competed: a registry holding
+    only unranked names (every mock-registry test does) never contests
+    anything and must not produce noise.
+
+    Args:
+        contenders: Names that took part in at least one contested path.
+    """
+    unranked = sorted(name for name in contenders if name not in _BASE_RANKS)
+    if unranked:
+        logger.warning(
+            "Ingestor(s) %s are not listed in CLAIM_PRIORITY and were ranked "
+            "after every known ingestor; add them to "
+            "creek.ingest.routing.CLAIM_PRIORITY to control the outcome.",
+            ", ".join(unranked),
+        )
+
+
+def arbitrate(claims: Mapping[str, Sequence[ParsedFragment]]) -> Arbitration:
+    """Keep one ingestor's fragments per source file.
+
+    For every distinct ``source_path`` across *claims*, the producing
+    ingestor with the lowest :data:`CLAIM_PRIORITY` rank wins and keeps
+    **all** of its fragments for that path — ``SpreadsheetIngestor``'s
+    one-per-sheet output and ``CodeIngestor``'s per-function output are
+    preserved intact. The invariant is one ingestor per source file, never
+    one fragment per source file.
+
+    An ingestor that produced no fragments for a path cannot win it, so a
+    claimant whose parse failed silently forfeits to whoever succeeded.
+
+    Args:
+        claims: Ingestor name mapped to the fragments it produced, in
+            registry order.
+
+    Returns:
+        The surviving fragments per ingestor, plus the contested paths.
+    """
+    ranks = _rank(claims)
+    owner: dict[str, str] = {}
+    contested: set[str] = set()
+    contenders: set[str] = set()
+
+    for name, fragments in claims.items():
+        for fragment in fragments:
+            incumbent = owner.get(fragment.source_path)
+            if incumbent is None:
+                owner[fragment.source_path] = name
+            elif incumbent != name:
+                contested.add(fragment.source_path)
+                contenders.update((incumbent, name))
+                if ranks[name] < ranks[incumbent]:
+                    owner[fragment.source_path] = name
+
+    _warn_unranked(contenders)
+    winners = {
+        name: [f for f in fragments if owner[f.source_path] == name]
+        for name, fragments in claims.items()
+    }
+    return Arbitration(winners=winners, contested=sorted(contested))

--- a/creek-tools/creek/pipeline.py
+++ b/creek-tools/creek/pipeline.py
@@ -50,14 +50,27 @@ from creek.config import CreekConfig
 from creek.consent import ConsentManager
 from creek.generate.indexes import IndexGenerator
 from creek.ingest import INGESTOR_REGISTRY
-from creek.ingest.base import IngestedFragment, assemble_ingested_fragment
+from creek.ingest.base import (
+    IngestedFragment,
+    ParsedFragment,
+    assemble_ingested_fragment,
+)
 from creek.ingest.ledger import LedgerRecord
+from creek.ingest.routing import SKIPPED_DIRECTORY_NAMES, Arbitration, arbitrate
 from creek.link.link_engine import LinkSummary, run_link
 from creek.models import Fragment, Frequency
 from creek.redact.scanner import RedactionScanner
 from creek.vault.writer import VaultWriter
 
 logger = logging.getLogger(__name__)
+
+_UNCLAIMED_LOG_SAMPLE: Final[int] = 10
+"""How many unclaimed source paths to name in the warning log line.
+
+The full list is always on :attr:`PipelineResult.unclaimed_sources`; the
+log only samples it, so a source tree with thousands of unreadable files
+cannot flood the console.
+"""
 
 _PROCESS_LINK_METHODS: Final[tuple[str, ...]] = ("eddies", "threads")
 """Linker stages ``creek process`` runs, in order — and why only these two.
@@ -242,6 +255,53 @@ class SymlinkEscapedSourceError(RuntimeError):
         )
 
 
+def _is_authored_content(path: Path, source_path: Path) -> bool:
+    """Decide whether *path* is a file a user meant to have ingested.
+
+    The exclusion contract behind
+    :attr:`PipelineResult.unclaimed_sources`, kept deliberately narrow
+    so the report stays trustworthy: directories are not files, and
+    anything beneath a directory named in
+    :data:`~creek.ingest.routing.SKIPPED_DIRECTORY_NAMES` or beneath a
+    dot-directory is machinery. The test is on the *parent* directories
+    only — a dotfile the user put in the source root is still their
+    file, and gets reported.
+
+    Args:
+        path: Candidate path, anywhere under *source_path*.
+        source_path: Root of the scanned source tree.
+
+    Returns:
+        ``True`` when *path* is a file worth reporting on.
+    """
+    if not path.is_file():
+        return False
+    return not any(
+        part in SKIPPED_DIRECTORY_NAMES or part.startswith(".")
+        for part in path.relative_to(source_path).parts[:-1]
+    )
+
+
+def _unclaimed_files(source_path: Path, seen: set[str]) -> list[str]:
+    """List source files that no ingestor produced a fragment from.
+
+    Args:
+        source_path: Root of the scanned source tree.
+        seen: Source paths every ingestor produced output for, taken
+            before arbitration so a losing claimant still counts as
+            having seen the file.
+
+    Returns:
+        Sorted absolute paths, excluding machinery per
+        :func:`_is_authored_content`.
+    """
+    return [
+        str(path)
+        for path in sorted(source_path.rglob("*"))
+        if str(path) not in seen and _is_authored_content(path, source_path)
+    ]
+
+
 class PipelineResult(BaseModel):
     """Aggregate counts from a full pipeline run.
 
@@ -283,6 +343,16 @@ class PipelineResult(BaseModel):
         errors: Human-readable error messages collected from each stage.
             Each entry is prefixed with its source ingestor name so the
             user can trace the failure back to the offending file.
+        contested_sources: Absolute paths of source files that more than
+            one ingestor produced fragments for. One ingestor's output
+            was kept (see :mod:`creek.ingest.routing`); the rest was
+            discarded before it reached the vault. Reported because a
+            vault ingested before #1304 already holds the discarded
+            ingestor's fragments and nothing removes them.
+        unclaimed_sources: Absolute paths of source files that produced
+            no fragments at all, under the exclusion contract in
+            :meth:`Pipeline._record_source_coverage`. Surfaces a
+            pre-existing silent drop rather than a new one.
     """
 
     files_scanned: int = 0
@@ -295,6 +365,8 @@ class PipelineResult(BaseModel):
     local_model_processed: int = 0
     residue: int = 0
     errors: list[str] = Field(default_factory=list)
+    contested_sources: list[str] = Field(default_factory=list)
+    unclaimed_sources: list[str] = Field(default_factory=list)
 
 
 class Pipeline:
@@ -576,26 +648,54 @@ class Pipeline:
     def _run_ingestion(
         self, source_path: Path, result: PipelineResult
     ) -> list[IngestedFragment]:
-        """Discover and run ingestors, returning structured fragment+body bundles.
+        """Run every ingestor, then keep one ingestor's output per source file.
 
-        For each ingestor in :data:`INGESTOR_REGISTRY`, this method:
+        Each entry in :data:`INGESTOR_REGISTRY` still sees the whole
+        source tree, because several ingestors identify their input by
+        sniffing its structure or content rather than by its extension —
+        a Discord export is a directory shape, a ChatGPT export is a
+        particular JSON envelope — and no dispatch table can express
+        that. What changed in issue #1304 is what happens next: the
+        collected fragments are arbitrated by
+        :func:`creek.ingest.routing.arbitrate`, so a file claimed by two
+        ingestors is written to the vault once, by the higher-priority
+        one, instead of twice.
 
-        1. Calls ``ingest()`` to produce parsed fragments and any errors.
-        2. Forwards each error onto :attr:`PipelineResult.errors`,
-           prefixed with the ingestor's registry key for traceability.
-        3. Assembles each parsed fragment into an :class:`IngestedFragment`
-           carrying a deterministic ``frag-`` ID and the converted body.
-        4. Treats per-fragment assembly failures as recoverable: the
+        Arbitration is on **written output**, not on parsing: contested
+        text files are still parsed by every claimant, and the losers'
+        fragments are discarded before assembly. That ordering is
+        deliberate — an ingestor that discovered a file but failed to
+        parse it forfeits, so a malformed spreadsheet still reaches the
+        vault as text instead of vanishing. See
+        :mod:`creek.ingest.routing` for the priority order and the
+        reasoning behind each contested extension.
+
+        The steps:
+
+        1. Call ``ingest()`` on every registered ingestor.
+        2. Forward **every** ingestor's errors onto
+           :attr:`PipelineResult.errors`, prefixed with its registry key
+           — including the losers', so arbitration never suppresses a
+           failure report.
+        3. Arbitrate, recording the contested paths on
+           :attr:`PipelineResult.contested_sources` and any file no
+           ingestor claimed on :attr:`PipelineResult.unclaimed_sources`.
+        4. Assemble each surviving fragment into an
+           :class:`IngestedFragment` carrying a deterministic ``frag-``
+           ID and the converted body.
+        5. Treat per-fragment assembly failures as recoverable: the
            failure is recorded on ``result.errors`` and skipped, rather
            than aborting the whole pipeline.
 
         Args:
             source_path: Directory containing source files.
-            result: Pipeline result; mutated to collect error messages.
+            result: Pipeline result; mutated to collect error messages,
+                contested paths and unclaimed paths.
 
         Returns:
             List of :class:`IngestedFragment` ready for classification
-            and vault writing.
+            and vault writing, with duplicates already removed — so
+            ``len()`` of it is an honest fragment count.
         """
         if not INGESTOR_REGISTRY:
             logger.warning(
@@ -604,14 +704,20 @@ class Pipeline:
             )
             return []
 
-        ingested: list[IngestedFragment] = []
+        claims: dict[str, list[ParsedFragment]] = {}
         for name, ingestor_cls in INGESTOR_REGISTRY.items():
             logger.info("Running ingestor: %s", name)
-            ingestor = ingestor_cls()
-            ingest_result = ingestor.ingest(source_path)
+            ingest_result = ingestor_cls().ingest(source_path)
             for err in ingest_result.errors:
                 result.errors.append(f"[{name}] {err}")
-            for parsed in ingest_result.fragments:
+            claims[name] = ingest_result.fragments.copy()
+
+        arbitration = arbitrate(claims)
+        self._record_source_coverage(source_path, claims, arbitration, result)
+
+        ingested: list[IngestedFragment] = []
+        for name, fragments in arbitration.winners.items():
+            for parsed in fragments:
                 try:
                     ingested.append(assemble_ingested_fragment(parsed))
                 except (KeyError, ValueError) as exc:
@@ -627,6 +733,72 @@ class Pipeline:
                     )
 
         return ingested
+
+    @staticmethod
+    def _record_source_coverage(
+        source_path: Path,
+        claims: dict[str, list[ParsedFragment]],
+        arbitration: Arbitration,
+        result: PipelineResult,
+    ) -> None:
+        """Record which source files were contested and which went unclaimed.
+
+        Both lists are diagnostics, not control flow — nothing is
+        skipped, deleted or retried on the strength of them.
+
+        *Contested* paths are the migration story for issue #1304. A
+        vault ingested before that change already holds the losing
+        ingestor's fragment, and nothing here removes it or ever
+        re-derives it: fragment ids hash source path, timestamp and
+        content, and the two ingestors disagree on the latter two, so
+        the survivor resolves to its own pre-existing id and the loser's
+        file is simply left behind. Naming the contested paths is what
+        makes those strays findable
+        (``creek purge source --source-path <path> --dry-run``).
+
+        *Unclaimed* paths are files no ingestor produced anything from.
+        The exclusion contract, deliberately narrow: directories are not
+        files; anything under a directory named in
+        :data:`~creek.ingest.routing.SKIPPED_DIRECTORY_NAMES` or under a
+        dot-directory is machinery rather than authored content. Note
+        this reports a pre-existing gap rather than a new one — a plain
+        ``.json`` that is not a chat export has always yielded nothing,
+        because the sniffers reject it and ``GenericIngestor`` excludes
+        the extension.
+
+        Args:
+            source_path: Root of the scanned source tree.
+            claims: Every ingestor's fragments *before* arbitration — a
+                loser still proves the file was seen.
+            arbitration: The resolved claims.
+            result: Pipeline result; mutated in place.
+        """
+        result.contested_sources = list(arbitration.contested)
+        if arbitration.contested:
+            logger.warning(
+                "%d source file(s) were claimed by more than one ingestor; "
+                "one ingestor's output was kept for each. A vault ingested "
+                "before issue #1304 may still hold the other's fragments as "
+                "strays -- they are not removed automatically.",
+                len(arbitration.contested),
+            )
+
+        if not source_path.is_dir():
+            return
+        seen = {
+            fragment.source_path
+            for fragments in claims.values()
+            for fragment in fragments
+        }
+        unclaimed = _unclaimed_files(source_path, seen)
+        result.unclaimed_sources = unclaimed
+        if unclaimed:
+            logger.warning(
+                "%d source file(s) produced no fragments -- no ingestor "
+                "claimed them: %s",
+                len(unclaimed),
+                ", ".join(unclaimed[:_UNCLAIMED_LOG_SAMPLE]),
+            )
 
     def _run_classification(
         self,

--- a/creek-tools/docs/ingestion.md
+++ b/creek-tools/docs/ingestion.md
@@ -19,9 +19,100 @@ Every ingestor is registered in `creek.ingest.INGESTOR_REGISTRY`. The table maps
 | `image`         | `.png` / `.jpg` / `.tiff` / `.pdf-page-as-image` via OCR.             | `pytesseract`, `pdf2image`, system `tesseract`, `poppler` |
 | `generic`       | Plain-text fallback for unknown extensions.                           | none                          |
 
-If `--type` is omitted, `creek process` picks ingestors by file extension.
+If `--type` is omitted, `creek process` resolves an owner per file — see
+[How `creek process` picks an ingestor](#how-creek-process-picks-an-ingestor).
 
 `gdrive` is **not** a `--type` (ARCH-001) — it is a downloader. Run `creek gdrive --download --staging <dir>` to mirror Drive files locally, then run `creek ingest --type document --input <dir>` (or `--type spreadsheet`, etc.) against the staged directory. See [Google Drive](#google-drive) below.
+
+## How `creek process` picks an ingestor
+
+`creek process` runs **every** registered ingestor over the source tree,
+because several of them recognise their input by its structure or content
+rather than its extension: a Discord export is a `messages/<channel>/`
+directory shape, a ChatGPT export is a particular JSON envelope, a
+Substack post is a `<postid>.<slug>.html` filename. No dispatch table can
+express those.
+
+It then **arbitrates**. Fragments are grouped by the source file they came
+from, and only the highest-priority ingestor that actually produced output
+for that file is kept. The order lives in
+`creek.ingest.routing.CLAIM_PRIORITY`, which reads specific to general:
+
+```
+discord · chatgpt · claude · substack     ← recognise the file's internals
+markdown · code · spreadsheet · presentation · image · document
+generic                                    ← "nothing better claimed it"
+```
+
+Two consequences worth knowing:
+
+* **One *ingestor* per file, not one *fragment* per file.** An ingestor
+  that wins a file keeps everything it produced for it — one fragment per
+  sheet of a workbook, one per module and function of a `.py` file, one
+  per turn pair of a conversation.
+* **The winner's rendering is the fragment.** A fragment's id hashes its
+  source path, timestamp and content, so the arbitration decides the body
+  text, the id, and the `YYYY-MM-DD-` prefix on the vault filename.
+
+Before this behaviour existed (issue #1304) every claimant's output was
+written, so a `.txt`, `.html`, `.csv`, `.py` or README-shaped `.md` file
+produced two or three fragments per run.
+
+### Upgrading a vault ingested before this change
+
+Nothing is migrated automatically, and nothing is deleted. Here is exactly
+what happens and what you may want to do.
+
+Re-running `creek process` over the same source produces the winning
+ingestor's fragment, which resolves to the id it already had, so it
+de-duplicates against itself as usual. The **losing** ingestor's fragments
+from earlier runs stay in the vault as strays: they have different ids
+(the two ingestors disagree on both body and timestamp), so nothing
+matches them, and now that the loser never runs against those files again
+nothing will ever revisit them. They are ordinary fragment notes — indexed,
+linkable, and indistinguishable from real ones apart from being a second
+copy of a file you only have one of.
+
+`creek process` now names the affected files for you:
+
+```
+Contested sources: 3 (more than one ingestor claimed these; one won)
+  A vault ingested before this release may still hold the losing
+  ingestor's fragments. Nothing is deleted automatically; inspect with
+  creek purge source --source-path <path> --match exact --dry-run
+  /home/me/notes/log.txt
+  ...
+```
+
+The recommended sequence, per file, is to look before you touch anything:
+
+```bash
+# 1. See every fragment in the vault that came from this source file.
+creek purge source --source-path /home/me/notes/log.txt --match exact --dry-run
+```
+
+If there is more than one, you have a stray. Two ways forward:
+
+* **Leave it.** It is a duplicate note, not corruption. This is the right
+  answer if you have hand-edited or hand-linked either copy — see the
+  caveat below.
+* **Purge and re-process.** `creek purge source --source-path <path>
+  --match exact --yes` deletes *every* fragment from that source (the
+  stray *and* the current one), then `creek process` recreates the
+  current one. Note the caveat: purging scrubs references, replacing
+  `[[wikilinks]]` to the deleted notes with `[purged]` across the vault,
+  and re-processing does **not** restore them.
+
+Two smaller changes ride along:
+
+* `.txt` and `.html` files now get `DocumentIngestor`'s rendering rather
+  than the generic fallback's, so their body — and therefore their id and
+  filename — differs from what a pre-#1304 run wrote. `GenericIngestor`
+  also stamped an `authored_at` in frontmatter that `DocumentIngestor`
+  leaves unset.
+* README, `CLAUDE.md` and ADR `.md` files go to `MarkdownIngestor` rather
+  than `CodeIngestor`, which keeps their YAML frontmatter out of the body
+  but drops the `artifact_type` label.
 
 ## Symlinks in a source tree
 

--- a/creek-tools/tests/e2e/test_full_pipeline_markdown.py
+++ b/creek-tools/tests/e2e/test_full_pipeline_markdown.py
@@ -13,6 +13,8 @@ review.
 
 from __future__ import annotations
 
+import os
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 import pytest
@@ -26,10 +28,20 @@ from creek.pipeline import Pipeline, PipelineResult
 pytestmark = pytest.mark.e2e
 
 
+_FIXED_MTIME = datetime(2026, 1, 2, 12, 0, tzinfo=UTC).timestamp()
+"""Pinned modification time so the vault filename's date prefix is exact.
+
+Ingestors derive a fragment's timestamp from the source file's mtime, and
+the vault writer prefixes the filename with it. Without pinning, the
+filename assertion below would only be checkable as a pattern.
+"""
+
+
 def _drop_markdown(source: Path, name: str, body: str) -> Path:
-    """Write a tiny markdown source file with deterministic content."""
+    """Write a tiny markdown source file with deterministic content and mtime."""
     file = source / name
     file.write_text(body, encoding="utf-8")
+    os.utime(file, (_FIXED_MTIME, _FIXED_MTIME))
     return file
 
 
@@ -48,10 +60,16 @@ def test_pipeline_creates_fragment_for_markdown_source(
     result = pipeline.run(source_path=synthetic_source, vault_path=synthetic_vault)
 
     assert isinstance(result, PipelineResult)
-    assert result.fragments_created >= 1, (
-        "Pipeline reported zero fragments for a non-empty markdown source "
-        "(BUG-001 sentinel)."
+    # Exact, not ``>= 1``. The lower bound this replaced could not detect
+    # duplication in principle, which is how issue #1304 — every ingestor
+    # run over every file — survived the whole life of this file.
+    written = sorted((synthetic_vault / "01-Fragments").rglob("*.md"))
+    assert result.fragments_created == 1, (
+        "Pipeline reported the wrong fragment count for a single markdown "
+        "source (BUG-001 / #1304 sentinel)."
     )
+    assert [path.name for path in written] == ["2026-01-02-Title.md"]
+    assert result.fragments_created == len(written)
 
 
 def test_pipeline_run_does_not_raise(

--- a/creek-tools/tests/e2e/test_full_pipeline_mixed_sources.py
+++ b/creek-tools/tests/e2e/test_full_pipeline_mixed_sources.py
@@ -1,0 +1,323 @@
+"""End-to-end guard: one ingestor's output per source file (issue #1304).
+
+``Pipeline._run_ingestion`` used to hand the whole source tree to every
+entry in :data:`creek.ingest.INGESTOR_REGISTRY` and keep everything each
+one returned. Extensions claimed by more than one ingestor therefore
+landed in the vault **twice or three times** — and never as an overwrite,
+because :func:`creek.vault.writer` de-collides colliding filenames with a
+``-N`` suffix. Measured on this branch's parent (``3796c39``):
+
+* ``{note.html, log.txt, a.md}`` -> **5** fragment files, zero errors.
+* The seven-file mixed tree below -> **14** fragments.
+
+Every assertion here is on **persisted vault state**, not on which
+ingestor the router picked: the defect was duplicate files on disk, so
+that is what must be counted. Fragments are attributed back to their
+source via the ``source.original_file`` frontmatter key that every
+ingestor writes.
+
+Deliberately *not* asserted: one fragment per source file. Several
+ingestors correctly emit N>1 for a single file — ``SpreadsheetIngestor``
+emits one per non-empty sheet (see issue #1305), ``CodeIngestor`` one per
+module/function/class, the chat ingestors one per turn pair. The
+invariant is one *ingestor* per source file.
+
+``test_chat_exports_still_produce_fragments`` is green before the fix and
+must stay green: the chat ingestors claim ``.json`` by sniffing content,
+not by extension, so any extension-table router would silently zero them.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+
+import frontmatter
+import pytest
+
+from creek.config import CreekConfig
+from creek.pipeline import Pipeline
+
+pytestmark = pytest.mark.e2e
+
+_CHATGPT_EXPORT = (
+    '[{"title": "A chat about creeks", "create_time": 1700000000.0, '
+    '"mapping": {"root": {"id": "root", "message": null, "parent": null, '
+    '"children": ["u1"]}, '
+    '"u1": {"id": "u1", "parent": "root", "children": ["a1"], "message": '
+    '{"id": "u1", "author": {"role": "user"}, "create_time": 1700000000.0, '
+    '"content": {"content_type": "text", "parts": ["What is an eddy?"]}}}, '
+    '"a1": {"id": "a1", "parent": "u1", "children": [], "message": '
+    '{"id": "a1", "author": {"role": "assistant"}, "create_time": 1700000001.0, '
+    '"content": {"content_type": "text", "parts": ["A slow swirl of water."]}}}}}]'
+)
+
+_DISCORD_MESSAGES = (
+    '[{"ID": "1", "Timestamp": "2024-01-01T00:00:00+00:00", '
+    '"Contents": "First message in the channel.", "Attachments": ""}, '
+    '{"ID": "2", "Timestamp": "2024-01-01T00:01:00+00:00", '
+    '"Contents": "Second message in the channel.", "Attachments": ""}]'
+)
+
+
+def _fragment_files(vault: Path) -> list[Path]:
+    """Return every fragment file the pipeline persisted, sorted by path."""
+    return sorted((vault / "01-Fragments").rglob("*.md"))
+
+
+def _fragments_per_source(vault: Path) -> Counter[str]:
+    """Count persisted fragment files per source file basename.
+
+    Reads ``source.original_file`` from each fragment's frontmatter —
+    the provenance key every ingestor writes — so a source file ingested
+    twice shows up as a count of two regardless of how the vault writer
+    de-collided the two filenames.
+
+    Args:
+        vault: Root of the vault the pipeline wrote into.
+
+    Returns:
+        Basename of each source file mapped to how many fragment files
+        in the vault cite it.
+    """
+    counts: Counter[str] = Counter()
+    for path in _fragment_files(vault):
+        source = frontmatter.load(path).metadata.get("source", {})
+        original = source.get("original_file") if isinstance(source, dict) else None
+        counts[Path(str(original)).name if original else "<unknown>"] += 1
+    return counts
+
+
+def _body_for(vault: Path, source_name: str) -> str:
+    """Return the body of the single fragment ingested from *source_name*.
+
+    Args:
+        vault: Root of the vault the pipeline wrote into.
+        source_name: Basename of the source file to look up.
+
+    Returns:
+        The fragment body text.
+
+    Raises:
+        AssertionError: When the vault holds anything other than exactly
+            one fragment for *source_name*.
+    """
+    bodies = []
+    for path in _fragment_files(vault):
+        post = frontmatter.load(path)
+        source = post.metadata.get("source", {})
+        original = source.get("original_file") if isinstance(source, dict) else None
+        if original and Path(str(original)).name == source_name:
+            bodies.append(post.content)
+    assert len(bodies) == 1, f"expected exactly one fragment for {source_name}"
+    return bodies[0]
+
+
+def _write_mixed_tree(source: Path) -> None:
+    """Populate *source* with one file per contested-extension family.
+
+    Covers every overlap the registry actually has: ``.md`` (code x
+    markdown, via the README/ADR patterns ``CodeIngestor`` claims),
+    ``.html`` three ways (substack x document x generic), ``.csv``
+    (spreadsheet x generic), ``.py`` (code x generic), plus a plain
+    ``.json`` that no ingestor claims at all.
+
+    Args:
+        source: Empty source directory to fill.
+    """
+    (source / "README.md").write_text(
+        "---\ntitle: My Readme\ntags: [creek]\n---\n\n# Readme\n\nReadme body.\n",
+        encoding="utf-8",
+    )
+    adr = source / "docs" / "architecture" / "ADR"
+    adr.mkdir(parents=True)
+    (adr / "0001-thing.md").write_text(
+        "# ADR 1: Thing\n\nWe decided the thing.\n", encoding="utf-8"
+    )
+    (source / "163000000.my-post.html").write_text(
+        "<html><body><h1>My Post</h1><p>A substack post body.</p></body></html>",
+        encoding="utf-8",
+    )
+    (source / "plain.html").write_text(
+        "<html><body><p>Plain html body here.</p></body></html>", encoding="utf-8"
+    )
+    (source / "sheet.csv").write_text("a,b\n1,2\n3,4\n", encoding="utf-8")
+    (source / "mod.py").write_text(
+        '"""Module docstring."""\n\n\ndef f() -> int:\n'
+        '    """Return one."""\n    return 1\n',
+        encoding="utf-8",
+    )
+    (source / "notes.json").write_text('{"unclaimed": true}\n', encoding="utf-8")
+
+
+def test_process_writes_one_fragment_per_source_file(
+    synthetic_vault: Path, synthetic_source: Path
+) -> None:
+    """The issue's own scenario: three files must write three fragments.
+
+    Pre-fix this wrote five — ``log.txt`` and ``note.html`` were each
+    claimed by both ``DocumentIngestor`` and ``GenericIngestor``.
+    """
+    (synthetic_source / "note.html").write_text(
+        "<html><body><h1>Title</h1><p>Hello world body text.</p></body></html>",
+        encoding="utf-8",
+    )
+    (synthetic_source / "log.txt").write_text(
+        "plain text line one\nline two\n", encoding="utf-8"
+    )
+    (synthetic_source / "a.md").write_text(
+        "# A\n\nSome markdown body.\n", encoding="utf-8"
+    )
+
+    result = Pipeline(config=CreekConfig()).run(
+        source_path=synthetic_source, vault_path=synthetic_vault
+    )
+
+    assert result.errors == []
+    assert result.fragments_created == 3
+    files = _fragment_files(synthetic_vault)
+    assert len(files) == 3, [p.name for p in files]
+    assert result.fragments_created == len(files)
+    assert _fragments_per_source(synthetic_vault) == Counter(
+        {"note.html": 1, "log.txt": 1, "a.md": 1}
+    )
+    # The vault writer de-collides duplicates with a ``-N`` suffix rather
+    # than overwriting, so a ``-1`` stem is the on-disk signature of the
+    # defect and must not appear.
+    assert not [p.name for p in files if p.stem.endswith("-1")]
+
+
+def test_contested_text_files_keep_the_specialist_rendering(
+    synthetic_vault: Path, synthetic_source: Path
+) -> None:
+    """The surviving body must be the specialist's, not the fallback's.
+
+    Arbitration decides which ingestor's *body* reaches the vault, and
+    the body feeds the fragment id, so the winner is load-bearing:
+    ``DocumentIngestor`` renders ``log.txt`` with its first line promoted
+    to a heading, while ``GenericIngestor`` dumps the text verbatim and
+    wraps ``.html`` in a fenced code block.
+    """
+    (synthetic_source / "log.txt").write_text(
+        "plain text line one\nline two\n", encoding="utf-8"
+    )
+    (synthetic_source / "plain.html").write_text(
+        "<html><body><p>Plain html body here.</p></body></html>", encoding="utf-8"
+    )
+
+    Pipeline(config=CreekConfig()).run(
+        source_path=synthetic_source, vault_path=synthetic_vault
+    )
+
+    assert _body_for(synthetic_vault, "log.txt").startswith("# plain text line one")
+    html_body = _body_for(synthetic_vault, "plain.html")
+    assert "Plain html body here." in html_body
+    assert "```html" not in html_body
+
+
+def test_mixed_extension_tree_routes_one_ingestor_per_file(
+    synthetic_vault: Path, synthetic_source: Path
+) -> None:
+    """Every contested extension resolves to exactly one ingestor.
+
+    Pre-fix this tree produced 14 fragments. Note ``mod.py`` keeps
+    **two** — ``CodeIngestor`` emits one per module and one per function
+    — which is why the invariant is one ingestor per file and never one
+    fragment per file (cf. ``SpreadsheetIngestor``'s per-sheet model,
+    issue #1305).
+    """
+    _write_mixed_tree(synthetic_source)
+
+    result = Pipeline(config=CreekConfig()).run(
+        source_path=synthetic_source, vault_path=synthetic_vault
+    )
+
+    assert _fragments_per_source(synthetic_vault) == Counter(
+        {
+            "README.md": 1,
+            "0001-thing.md": 1,
+            "163000000.my-post.html": 1,
+            "plain.html": 1,
+            "sheet.csv": 1,
+            "mod.py": 2,
+        }
+    )
+    assert len(_fragment_files(synthetic_vault)) == 7
+    assert result.fragments_created == 7
+    # ``.md`` goes to MarkdownIngestor, which splits YAML frontmatter out
+    # of the body; CodeIngestor would have left the ``---`` block inline.
+    assert not _body_for(synthetic_vault, "README.md").startswith("---")
+
+
+def test_unclaimed_source_files_are_reported_not_dropped(
+    synthetic_vault: Path, synthetic_source: Path
+) -> None:
+    """A file no ingestor claims is surfaced rather than vanishing.
+
+    A plain ``.json`` that is not a chat export has always produced zero
+    fragments — the sniffers reject it and ``GenericIngestor`` excludes
+    ``.json`` outright. Routing does not fix that, but it must stop it
+    being silent.
+    """
+    (synthetic_source / "notes.json").write_text('{"a": 1}\n', encoding="utf-8")
+    (synthetic_source / "kept.md").write_text("# Kept\n\nBody.\n", encoding="utf-8")
+
+    result = Pipeline(config=CreekConfig()).run(
+        source_path=synthetic_source, vault_path=synthetic_vault
+    )
+
+    assert [Path(p).name for p in result.unclaimed_sources] == ["notes.json"]
+    assert result.fragments_created == 1
+
+
+def test_contested_sources_are_reported_for_migration(
+    synthetic_vault: Path, synthetic_source: Path
+) -> None:
+    """Arbitrated files are named so an operator can find stale duplicates.
+
+    A vault ingested before this change already holds the losing
+    ingestor's fragment, and nothing re-derives or removes it. Reporting
+    the contested paths is what makes those orphans findable.
+    """
+    (synthetic_source / "log.txt").write_text("only a line\n", encoding="utf-8")
+    (synthetic_source / "solo.md").write_text("# Solo\n\nBody.\n", encoding="utf-8")
+
+    result = Pipeline(config=CreekConfig()).run(
+        source_path=synthetic_source, vault_path=synthetic_vault
+    )
+
+    assert [Path(p).name for p in result.contested_sources] == ["log.txt"]
+
+
+def test_chat_exports_still_produce_fragments(
+    synthetic_vault: Path, synthetic_source: Path
+) -> None:
+    """Content- and structure-sniffed ingestors must survive routing.
+
+    Green before the fix and required to stay green. ``ChatGPTIngestor``
+    and ``DiscordIngestor`` both claim ``.json`` paths that no extension
+    table routes to them, so any extension-keyed router would drop their
+    output to zero — silently, because ``GenericIngestor`` excludes
+    ``.json`` and cannot pick up the slack.
+    """
+    (synthetic_source / "conversations.json").write_text(
+        _CHATGPT_EXPORT, encoding="utf-8"
+    )
+    channel = synthetic_source / "messages" / "c123456"
+    channel.mkdir(parents=True)
+    (channel / "messages.json").write_text(_DISCORD_MESSAGES, encoding="utf-8")
+    (channel / "channel.json").write_text(
+        '{"id": "c123456", "name": "general"}', encoding="utf-8"
+    )
+
+    result = Pipeline(config=CreekConfig()).run(
+        source_path=synthetic_source, vault_path=synthetic_vault
+    )
+
+    platforms = Counter(
+        str(frontmatter.load(p).metadata.get("source", {}).get("platform"))
+        for p in _fragment_files(synthetic_vault)
+    )
+    assert platforms["chatgpt"] >= 1, platforms
+    assert platforms["discord"] >= 1, platforms
+    assert result.fragments_created == sum(platforms.values())

--- a/creek-tools/tests/test_ingest_generic.py
+++ b/creek-tools/tests/test_ingest_generic.py
@@ -13,12 +13,14 @@ from __future__ import annotations
 import os
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import BinaryIO
 from zoneinfo import ZoneInfo
 
 import pytest
 
 from creek.ingest.base import IngestResult, ParsedFragment, RawDocument
 from creek.ingest.generic import (
+    _BINARY_CHECK_SIZE,
     GenericIngestor,
     _is_binary_content,
     _try_decode,
@@ -597,3 +599,138 @@ class TestGenericIngestorAuthoredAt:
         )
         fm = ingestor.generate_frontmatter(fragment)
         assert "authored_at" not in fm
+
+
+# ---- Discover-time binary skip (issue #1304) ----
+
+
+class _CountingHandle:
+    """A binary file handle that records how many bytes were read through it."""
+
+    def __init__(self, handle: BinaryIO, tally: list[int]) -> None:
+        """Wrap *handle*, appending each read size to *tally*."""
+        self._handle = handle
+        self._tally = tally
+
+    def read(self, size: int = -1) -> bytes:
+        """Read from the wrapped handle and record the byte count."""
+        chunk = self._handle.read(size)
+        self._tally.append(len(chunk))
+        return chunk
+
+    def __enter__(self) -> _CountingHandle:
+        """Enter the wrapped handle's context."""
+        self._handle.__enter__()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        """Close the wrapped handle."""
+        self._handle.close()
+
+
+class TestDiscoverSkipsBinariesUnread:
+    """``discover`` must not slurp files ``parse`` was always going to drop.
+
+    Output-neutral: every case here produced zero fragments before issue
+    #1304 too, because ``parse`` discarded the content after reading it.
+    What changes is that the bytes are no longer read.
+    """
+
+    def test_binary_file_is_not_discovered(
+        self, ingestor: GenericIngestor, tmp_path: Path
+    ) -> None:
+        """A binary file yields no raw document at all."""
+        (tmp_path / "shot.png").write_bytes(b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR")
+
+        assert ingestor.discover(tmp_path) == []
+
+    def test_binary_file_produced_no_fragment_before_either(
+        self, ingestor: GenericIngestor, tmp_path: Path
+    ) -> None:
+        """The skip is output-neutral: parsing it would have yielded nothing.
+
+        Feeds ``parse`` the document ``discover`` used to build, proving
+        the fragment count is unchanged rather than merely asserting the
+        new behaviour.
+        """
+        path = tmp_path / "shot.png"
+        path.write_bytes(b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR")
+        pre_change_doc = RawDocument(
+            path=path,
+            content=path.read_bytes(),
+            metadata={"source_type": "generic"},
+            detected_encoding="utf-8",
+        )
+
+        assert ingestor.parse(pre_change_doc) == []
+        assert ingestor.ingest(tmp_path).fragments == []
+
+    def test_only_a_bounded_prefix_of_a_binary_file_is_read(
+        self,
+        ingestor: GenericIngestor,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A 4 MB binary costs one small read, not four megabytes of them."""
+        (tmp_path / "big.bin").write_bytes(b"\x00\xff" * (2 * 1024 * 1024))
+        tally: list[int] = []
+        real_open = Path.open
+
+        def counting_open(self: Path, *args: object, **kwargs: object) -> object:
+            handle = real_open(self, *args, **kwargs)  # type: ignore[arg-type]
+            return _CountingHandle(handle, tally)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(Path, "open", counting_open)
+
+        assert ingestor.discover(tmp_path) == []
+        assert sum(tally) <= _BINARY_CHECK_SIZE, tally
+
+    def test_utf16_text_survives_the_skip(
+        self, ingestor: GenericIngestor, tmp_path: Path
+    ) -> None:
+        """UTF-16 is null-heavy but is text, and must still be ingested.
+
+        The BOM carve-out exists in ``_try_decode`` for exactly this
+        reason; the discover-time check has to honour it or the change
+        would silently drop real content.
+        """
+        (tmp_path / "wide.txt").write_bytes("Hello from UTF-16.".encode("utf-16"))
+
+        fragments = ingestor.ingest(tmp_path).fragments
+
+        assert [f.content.strip() for f in fragments] == ["Hello from UTF-16."]
+
+    def test_a_single_binary_file_path_is_not_discovered(
+        self, ingestor: GenericIngestor, tmp_path: Path
+    ) -> None:
+        """The single-file discovery arm skips binaries too."""
+        path = tmp_path / "shot.png"
+        path.write_bytes(b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR")
+
+        assert ingestor.discover(path) == []
+
+    def test_an_empty_file_is_still_discovered(
+        self, ingestor: GenericIngestor, tmp_path: Path
+    ) -> None:
+        """Empty is not binary; the prior behaviour of discovering it holds."""
+        (tmp_path / "empty.txt").write_bytes(b"")
+
+        assert [doc.path.name for doc in ingestor.discover(tmp_path)] == ["empty.txt"]
+
+    def test_a_text_file_larger_than_the_prefix_is_read_in_full(
+        self, ingestor: GenericIngestor, tmp_path: Path
+    ) -> None:
+        """Reading a bounded prefix must not truncate the document.
+
+        The prefix is only a binary *test*; everything past it still has
+        to reach the fragment, or the change would quietly amputate every
+        source file over 8 KiB.
+        """
+        body = "line of text\n" * ((_BINARY_CHECK_SIZE // 13) + 500)
+        (tmp_path / "long.txt").write_text(body, encoding="utf-8")
+
+        fragments = ingestor.ingest(tmp_path).fragments
+
+        assert len(fragments) == 1
+        assert fragments[0].content == body
+        assert len(fragments[0].content) > _BINARY_CHECK_SIZE

--- a/creek-tools/tests/test_ingest_generic.py
+++ b/creek-tools/tests/test_ingest_generic.py
@@ -13,11 +13,11 @@ from __future__ import annotations
 import os
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import BinaryIO
 from zoneinfo import ZoneInfo
 
 import pytest
 
+from creek.ingest import generic as generic_module
 from creek.ingest.base import IngestResult, ParsedFragment, RawDocument
 from creek.ingest.generic import (
     _BINARY_CHECK_SIZE,
@@ -604,30 +604,6 @@ class TestGenericIngestorAuthoredAt:
 # ---- Discover-time binary skip (issue #1304) ----
 
 
-class _CountingHandle:
-    """A binary file handle that records how many bytes were read through it."""
-
-    def __init__(self, handle: BinaryIO, tally: list[int]) -> None:
-        """Wrap *handle*, appending each read size to *tally*."""
-        self._handle = handle
-        self._tally = tally
-
-    def read(self, size: int = -1) -> bytes:
-        """Read from the wrapped handle and record the byte count."""
-        chunk = self._handle.read(size)
-        self._tally.append(len(chunk))
-        return chunk
-
-    def __enter__(self) -> _CountingHandle:
-        """Enter the wrapped handle's context."""
-        self._handle.__enter__()
-        return self
-
-    def __exit__(self, *exc: object) -> None:
-        """Close the wrapped handle."""
-        self._handle.close()
-
-
 class TestDiscoverSkipsBinariesUnread:
     """``discover`` must not slurp files ``parse`` was always going to drop.
 
@@ -665,25 +641,54 @@ class TestDiscoverSkipsBinariesUnread:
         assert ingestor.parse(pre_change_doc) == []
         assert ingestor.ingest(tmp_path).fragments == []
 
-    def test_only_a_bounded_prefix_of_a_binary_file_is_read(
+    def test_the_binary_verdict_is_reached_on_a_bounded_prefix(
         self,
         ingestor: GenericIngestor,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """A 4 MB binary costs one small read, not four megabytes of them."""
+        """A 4 MB binary is judged on 8 KiB, not on four megabytes.
+
+        Spies on the predicate rather than on the file handle: if
+        ``discover`` ever goes back to slurping the file and testing the
+        whole thing, the recorded length changes and this fails.
+        """
         (tmp_path / "big.bin").write_bytes(b"\x00\xff" * (2 * 1024 * 1024))
-        tally: list[int] = []
-        real_open = Path.open
+        judged: list[int] = []
+        real_predicate = generic_module._is_binary_content
 
-        def counting_open(self: Path, *args: object, **kwargs: object) -> object:
-            handle = real_open(self, *args, **kwargs)  # type: ignore[arg-type]
-            return _CountingHandle(handle, tally)  # type: ignore[arg-type]
+        def spy(raw_bytes: bytes) -> bool:
+            judged.append(len(raw_bytes))
+            return real_predicate(raw_bytes)
 
-        monkeypatch.setattr(Path, "open", counting_open)
+        monkeypatch.setattr(generic_module, "_is_binary_content", spy)
 
         assert ingestor.discover(tmp_path) == []
-        assert sum(tally) <= _BINARY_CHECK_SIZE, tally
+        assert judged == [_BINARY_CHECK_SIZE]
+
+    def test_a_null_byte_past_the_prefix_is_left_to_parse(
+        self,
+        ingestor: GenericIngestor,
+        tmp_path: Path,
+    ) -> None:
+        """The prefix check must not claim to see bytes it never read.
+
+        The edge the output-neutrality argument turns on: a file whose
+        first 8 KiB are clean text but which turns binary later. The
+        prefix cannot know that, so ``discover`` has to hand the file on
+        and let ``parse`` — which does see the whole thing — drop it.
+        Ending up with a *fragment* here would be new output; skipping at
+        discover would be the prefix overreaching.
+        """
+        path = tmp_path / "late.txt"
+        path.write_bytes(b"a" * (_BINARY_CHECK_SIZE + 16) + b"\x00tail")
+
+        discovered = ingestor.discover(tmp_path)
+
+        assert [doc.path.name for doc in discovered] == ["late.txt"]
+        assert discovered[0].content == path.read_bytes()
+        assert ingestor.parse(discovered[0]) == []
+        assert ingestor.ingest(tmp_path).fragments == []
 
     def test_utf16_text_survives_the_skip(
         self, ingestor: GenericIngestor, tmp_path: Path

--- a/creek-tools/tests/test_ingest_routing.py
+++ b/creek-tools/tests/test_ingest_routing.py
@@ -1,0 +1,265 @@
+"""Unit tests for the ingestor claim arbiter (issue #1304).
+
+The e2e counterpart (``tests/e2e/test_full_pipeline_mixed_sources.py``)
+asserts on what lands in the vault. These assert the arbiter's contract
+directly, including the cases that are awkward to stage on disk: an
+ingestor that produced nothing, an ingestor nobody has ranked, and
+fragment ordering.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+import pytest
+
+from creek.ingest import INGESTOR_REGISTRY
+from creek.ingest.base import ParsedFragment
+from creek.ingest.routing import CLAIM_PRIORITY, arbitrate
+
+
+def _fragment(source: str, marker: str) -> ParsedFragment:
+    """Build a minimal fragment identifiable by *marker*.
+
+    Args:
+        source: Value for ``source_path``, the arbitration key.
+        marker: Goes into ``content`` so assertions can name the exact
+            fragment that survived.
+
+    Returns:
+        A fragment carrying just enough to be arbitrated.
+    """
+    return ParsedFragment(
+        content=marker,
+        metadata={},
+        source_path=source,
+        timestamp=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+
+
+def _markers(fragments: list[ParsedFragment]) -> list[str]:
+    """Return the ``content`` marker of each fragment, in order."""
+    return [fragment.content for fragment in fragments]
+
+
+def test_claim_priority_covers_the_whole_registry_exactly() -> None:
+    """Every registered ingestor is ranked, and nothing else is.
+
+    This is the forcing function: adding a twelfth ingestor without
+    deciding where it sits fails here rather than silently landing
+    behind ``generic`` at runtime.
+    """
+    assert set(CLAIM_PRIORITY) == set(INGESTOR_REGISTRY)
+    assert len(CLAIM_PRIORITY) == len(set(CLAIM_PRIORITY))
+
+
+def test_generic_is_ranked_last() -> None:
+    """The declared fallback must never outrank a specialist."""
+    assert CLAIM_PRIORITY[-1] == "generic"
+
+
+def test_sniffing_ingestors_outrank_extension_specialists() -> None:
+    """Structure- and content-sniffed claims beat extension-keyed ones.
+
+    A Discord export's ``messages.json`` and a Substack post's ``.html``
+    are recognised by their internals; whoever merely matched the
+    extension has weaker evidence.
+    """
+    ranks = {name: index for index, name in enumerate(CLAIM_PRIORITY)}
+    for sniffer in ("discord", "chatgpt", "claude", "substack"):
+        for by_extension in ("markdown", "code", "document", "generic"):
+            assert ranks[sniffer] < ranks[by_extension]
+
+
+@pytest.mark.parametrize(
+    ("winner", "loser"),
+    [
+        ("markdown", "code"),
+        ("code", "generic"),
+        ("substack", "document"),
+        ("document", "generic"),
+        ("spreadsheet", "generic"),
+        ("presentation", "generic"),
+        ("image", "generic"),
+    ],
+)
+def test_contested_path_goes_to_the_higher_priority_producer(
+    winner: str, loser: str
+) -> None:
+    """Each documented contest resolves the documented way.
+
+    Order of the input mapping must not matter, so both orderings are
+    exercised.
+    """
+    for claims in (
+        {winner: [_fragment("/s/f", "win")], loser: [_fragment("/s/f", "lose")]},
+        {loser: [_fragment("/s/f", "lose")], winner: [_fragment("/s/f", "win")]},
+    ):
+        outcome = arbitrate(claims)
+        assert _markers(outcome.winners[winner]) == ["win"]
+        assert outcome.winners[loser] == []
+        assert outcome.contested == ["/s/f"]
+
+
+def test_a_producer_of_nothing_never_wins_a_path() -> None:
+    """An ingestor that emitted no fragments for a path cannot claim it.
+
+    This is the whole reason arbitration runs after parsing: a
+    higher-priority ingestor whose ``parse`` failed forfeits, and the
+    content still reaches the vault via whoever succeeded.
+    """
+    outcome = arbitrate(
+        {"spreadsheet": [], "generic": [_fragment("/s/broken.csv", "fallback")]}
+    )
+
+    assert _markers(outcome.winners["generic"]) == ["fallback"]
+    assert outcome.contested == []
+
+
+def test_a_multi_fragment_winner_keeps_every_fragment_for_that_path() -> None:
+    """One *ingestor* per file, never one *fragment* per file.
+
+    ``SpreadsheetIngestor`` emits one fragment per non-empty sheet (see
+    issue #1305) and ``CodeIngestor`` one per module and function.
+    Collapsing those to a single fragment would be a different bug.
+    """
+    outcome = arbitrate(
+        {
+            "spreadsheet": [
+                _fragment("/s/book.xlsx", "sheet-1"),
+                _fragment("/s/book.xlsx", "sheet-2"),
+                _fragment("/s/book.xlsx", "sheet-3"),
+            ],
+            "generic": [_fragment("/s/book.xlsx", "whole-file")],
+        }
+    )
+
+    assert _markers(outcome.winners["spreadsheet"]) == [
+        "sheet-1",
+        "sheet-2",
+        "sheet-3",
+    ]
+    assert outcome.winners["generic"] == []
+
+
+def test_uncontested_paths_are_untouched_and_not_reported() -> None:
+    """Files only one ingestor claimed pass straight through."""
+    outcome = arbitrate(
+        {
+            "markdown": [_fragment("/s/a.md", "md")],
+            "generic": [_fragment("/s/b.txt", "txt")],
+        }
+    )
+
+    assert _markers(outcome.winners["markdown"]) == ["md"]
+    assert _markers(outcome.winners["generic"]) == ["txt"]
+    assert outcome.contested == []
+
+
+def test_fragment_order_within_an_ingestor_is_preserved() -> None:
+    """Surviving fragments keep the order their ingestor produced them in.
+
+    Fragment order drives vault write order and, on a name collision,
+    which file gets the ``-N`` suffix.
+    """
+    outcome = arbitrate(
+        {
+            "code": [
+                _fragment("/s/a.py", "module-a"),
+                _fragment("/s/b.py", "module-b"),
+                _fragment("/s/a.py", "function-a"),
+            ],
+            "generic": [_fragment("/s/a.py", "dump-a")],
+        }
+    )
+
+    assert _markers(outcome.winners["code"]) == [
+        "module-a",
+        "module-b",
+        "function-a",
+    ]
+
+
+def test_an_unranked_ingestor_wins_paths_nobody_else_claims_silently(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A registry of names the arbiter has never heard of still works.
+
+    ``tests/test_pipeline.py`` patches ``INGESTOR_REGISTRY`` with
+    synthetic keys such as ``{"mock": ...}``. Those must ingest normally
+    and, since nothing contests them, must not log a warning.
+    """
+    with caplog.at_level(logging.WARNING, logger="creek.ingest.routing"):
+        outcome = arbitrate({"mock": [_fragment("/s/broken.md", "mocked")]})
+
+    assert _markers(outcome.winners["mock"]) == ["mocked"]
+    assert outcome.contested == []
+    assert caplog.records == []
+
+
+def test_an_unranked_ingestor_loses_a_contest_and_says_so(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An unranked name ranks behind every known one, and warns when it matters.
+
+    Silently demoting an ingestor nobody ranked is how this defect class
+    comes back, so the contest is announced.
+    """
+    with caplog.at_level(logging.WARNING, logger="creek.ingest.routing"):
+        outcome = arbitrate(
+            {
+                "generic": [_fragment("/s/f.txt", "known")],
+                "bespoke": [_fragment("/s/f.txt", "unranked")],
+            }
+        )
+
+    assert _markers(outcome.winners["generic"]) == ["known"]
+    assert outcome.winners["bespoke"] == []
+    assert "bespoke" in caplog.text
+    assert "CLAIM_PRIORITY" in caplog.text
+
+
+def test_two_unranked_ingestors_resolve_deterministically_by_name() -> None:
+    """Ties among unranked names break on the name, not on dict order."""
+    fragments = {
+        "zeta": [_fragment("/s/f", "zeta")],
+        "alpha": [_fragment("/s/f", "alpha")],
+    }
+
+    assert _markers(arbitrate(fragments).winners["alpha"]) == ["alpha"]
+    assert _markers(arbitrate(dict(reversed(fragments.items()))).winners["alpha"]) == [
+        "alpha"
+    ]
+
+
+def test_empty_claims_arbitrate_to_nothing() -> None:
+    """An empty registry produces no winners and no contests."""
+    outcome = arbitrate({})
+
+    assert outcome.winners == {}
+    assert outcome.contested == []
+
+
+def test_contested_paths_are_reported_sorted_and_deduplicated() -> None:
+    """Each contested path appears once, in sorted order.
+
+    Enough paths, in a deliberately reversed input order, that the
+    assertion cannot pass by accident: the arbiter accumulates contests
+    in a set, whose iteration order is neither sorted nor stable across
+    interpreter runs.
+    """
+    names = [f"/s/{letter}.txt" for letter in "jihgfedcba"]
+    outcome = arbitrate(
+        {
+            "document": [_fragment(path, f"doc-{path}") for path in names],
+            "generic": [
+                *[_fragment(path, f"gen-{path}") for path in names],
+                _fragment("/s/uncontested.txt", "gen-solo"),
+            ],
+        }
+    )
+
+    assert outcome.contested == sorted(names)
+    assert _markers(outcome.winners["generic"]) == ["gen-solo"]
+    assert len(outcome.winners["document"]) == len(names)

--- a/creek-tools/tests/test_pipeline_source_coverage.py
+++ b/creek-tools/tests/test_pipeline_source_coverage.py
@@ -1,0 +1,246 @@
+"""Pipeline reporting of contested and unclaimed source files (issue #1304).
+
+Two diagnostics, neither of which changes what the pipeline does:
+
+* ``contested_sources`` — files more than one ingestor produced output
+  for. It is the migration notice: a vault ingested before #1304 already
+  holds the losing ingestor's fragment and nothing removes it, so the
+  path has to be named or the stray is unfindable.
+* ``unclaimed_sources`` — files that produced nothing at all. A
+  pre-existing silent drop, now audible.
+
+The arbiter's own contract is covered in ``tests/test_ingest_routing.py``
+and its effect on the vault in
+``tests/e2e/test_full_pipeline_mixed_sources.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from creek.cli import app
+from creek.config import CreekConfig
+from creek.ingest.base import IngestResult, ParsedFragment
+from creek.pipeline import Pipeline, PipelineResult
+from creek.scaffold import scaffold_vault
+
+
+@pytest.fixture()
+def vault(tmp_path: Path) -> Path:
+    """A real scaffolded vault, as ``creek init`` would build it."""
+    path = tmp_path / "vault"
+    scaffold_vault(path)
+    return path
+
+
+@pytest.fixture()
+def source(tmp_path: Path) -> Path:
+    """An empty source directory for the test to populate."""
+    path = tmp_path / "source"
+    path.mkdir()
+    return path
+
+
+def _run(source: Path, vault: Path) -> PipelineResult:
+    """Run the real pipeline over *source* into *vault*."""
+    return Pipeline(config=CreekConfig()).run(source_path=source, vault_path=vault)
+
+
+class TestUnclaimedSources:
+    """Files no ingestor produced a fragment for are named, not swallowed."""
+
+    def test_a_plain_json_is_reported(self, source: Path, vault: Path) -> None:
+        """The pre-existing drop: a ``.json`` that is not a chat export.
+
+        The chat sniffers reject it and ``GenericIngestor`` excludes the
+        extension outright, so it has always yielded nothing.
+        """
+        (source / "notes.json").write_text('{"a": 1}\n', encoding="utf-8")
+
+        result = _run(source, vault)
+
+        assert [Path(p).name for p in result.unclaimed_sources] == ["notes.json"]
+        assert result.fragments_created == 0
+
+    def test_an_ingested_file_is_not_reported(self, source: Path, vault: Path) -> None:
+        """Anything that produced a fragment stays off the list."""
+        (source / "note.md").write_text("# Note\n\nBody.\n", encoding="utf-8")
+
+        result = _run(source, vault)
+
+        assert result.unclaimed_sources == []
+
+    def test_a_losing_ingestors_file_is_not_reported_as_unclaimed(
+        self, source: Path, vault: Path
+    ) -> None:
+        """Arbitration must not manufacture unclaimed files.
+
+        The diff runs against the fragments produced *before*
+        arbitration, so a file whose only surviving claimant lost is
+        still 'seen'. Getting this wrong would report every contested
+        file twice, in two contradictory lists.
+        """
+        (source / "log.txt").write_text("a line\n", encoding="utf-8")
+
+        result = _run(source, vault)
+
+        assert result.unclaimed_sources == []
+        assert [Path(p).name for p in result.contested_sources] == ["log.txt"]
+
+    def test_machinery_directories_are_excluded(
+        self, source: Path, vault: Path
+    ) -> None:
+        """Build output and VCS internals are not authored content.
+
+        The exclusion list is shared with ``CodeIngestor``'s discovery
+        walk so the two cannot disagree about what was meant to be
+        ingested.
+        """
+        (source / "node_modules" / "pkg").mkdir(parents=True)
+        (source / "node_modules" / "pkg" / "meta.json").write_text("{}\n")
+        (source / ".cache").mkdir()
+        (source / ".cache" / "state.json").write_text("{}\n")
+        (source / "wanted.json").write_text("{}\n")
+
+        result = _run(source, vault)
+
+        assert [Path(p).name for p in result.unclaimed_sources] == ["wanted.json"]
+
+    def test_a_dotfile_at_the_source_root_is_still_reported(
+        self, source: Path, vault: Path
+    ) -> None:
+        """Only dot-*directories* are machinery; a dotfile is a file.
+
+        The exclusion tests the parent directories, not the filename, so
+        a file the operator deliberately put in the source root is
+        reported however it is named.
+        """
+        (source / ".secrets.json").write_text("{}\n", encoding="utf-8")
+
+        result = _run(source, vault)
+
+        assert [Path(p).name for p in result.unclaimed_sources] == [".secrets.json"]
+
+    def test_a_single_file_source_reports_nothing(
+        self, source: Path, vault: Path
+    ) -> None:
+        """A file, not a directory, as the source root must not crash."""
+        note = source / "note.md"
+        note.write_text("# Note\n\nBody.\n", encoding="utf-8")
+
+        result = Pipeline(config=CreekConfig()).run(source_path=note, vault_path=vault)
+
+        assert result.unclaimed_sources == []
+
+
+class TestArbitrationNeverSuppressesAnError:
+    """Every ingestor's errors reach the operator, winner or loser.
+
+    Arbitration discards *fragments*. Discarding an ingestor's error
+    report along with them would make failure invisible in exactly the
+    cases that matter most: an ingestor that produced nothing because it
+    crashed, and an ingestor that lost the file it failed on.
+    """
+
+    def _registry(
+        self, fragments: list[ParsedFragment], errors: list[str]
+    ) -> dict[str, MagicMock]:
+        """Build a single-entry registry returning *fragments* and *errors*."""
+        ingestor = MagicMock()
+        ingestor.return_value.ingest.return_value = IngestResult(
+            fragments=fragments, errors=errors
+        )
+        return {"mock": ingestor}
+
+    def test_an_ingestor_that_produced_nothing_still_reports_its_errors(
+        self, source: Path, vault: Path
+    ) -> None:
+        """Zero fragments plus an error is the OCR-unavailable case.
+
+        ``ImageIngestor`` does exactly this when the ``tesseract`` binary
+        is missing. Tying error reporting to fragment output would hide
+        it completely.
+        """
+        registry = self._registry([], ["parse error for shot.png: no tesseract"])
+
+        with patch("creek.pipeline.INGESTOR_REGISTRY", registry):
+            result = _run(source, vault)
+
+        assert result.errors == ["[mock] parse error for shot.png: no tesseract"]
+
+    def test_a_losing_ingestors_errors_still_reach_the_result(
+        self, source: Path, vault: Path
+    ) -> None:
+        """Losing the arbitration does not retract a failure report."""
+        (source / "log.txt").write_text("a line\n", encoding="utf-8")
+
+        result = _run(source, vault)
+        # ``generic`` loses ``log.txt`` to ``document``; both ran, and
+        # neither is filtered out of the error channel by having lost.
+        assert result.errors == []
+        assert [Path(p).name for p in result.contested_sources] == ["log.txt"]
+
+        registry = self._registry([], ["generic: unreadable encoding"])
+        with patch("creek.pipeline.INGESTOR_REGISTRY", registry):
+            mocked = _run(source, vault)
+        assert mocked.errors == ["[mock] generic: unreadable encoding"]
+
+
+class TestProcessCommandOutput:
+    """What an operator actually sees on the terminal."""
+
+    def _process(self, source: Path, vault: Path) -> str:
+        """Invoke ``creek process`` and return its rendered output."""
+        result = CliRunner().invoke(
+            app,
+            [
+                "process",
+                "--source",
+                str(source),
+                "--vault",
+                str(vault),
+                "--yes",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        return result.output
+
+    def test_contested_sources_are_reported_with_the_cleanup_command(
+        self, source: Path, vault: Path
+    ) -> None:
+        """The migration notice names the read-only command that finds strays.
+
+        Nothing is deleted on the operator's behalf, so the notice has to
+        carry enough to act on: the count, the paths, and the dry-run
+        purge invocation that lists what is actually in the vault.
+        """
+        (source / "log.txt").write_text("a line\n", encoding="utf-8")
+
+        output = self._process(source, vault)
+
+        assert "Contested sources: 1" in output
+        assert "creek purge source --source-path" in output
+        assert "--dry-run" in output
+
+    def test_unclaimed_sources_are_reported(self, source: Path, vault: Path) -> None:
+        """A file that produced nothing is named in the summary."""
+        (source / "notes.json").write_text("{}\n", encoding="utf-8")
+
+        output = self._process(source, vault)
+
+        assert "Unclaimed sources: 1" in output
+        assert "notes.json" in output
+
+    def test_a_clean_run_says_neither(self, source: Path, vault: Path) -> None:
+        """No contest and no drop means the summary keeps its old shape."""
+        (source / "note.md").write_text("# Note\n\nBody.\n", encoding="utf-8")
+
+        output = self._process(source, vault)
+
+        assert "Contested sources" not in output
+        assert "Unclaimed sources" not in output
+        assert "Fragments created: 1" in output


### PR DESCRIPTION
## Summary

`Pipeline._run_ingestion` handed the whole source tree to all eleven entries in `INGESTOR_REGISTRY` and kept everything each one returned. The ingestors' claims overlap, so any contested file was written to the vault two or three times — never as an overwrite, because the vault writer de-collides a name clash with a `-N` suffix, so both copies land.

Measured by execution on this PR's base (`3796c39`), not inferred:

| source | before | after |
|---|---|---|
| `{note.html, log.txt, a.md}` | **5** fragment files, 0 errors | **3** |
| 7-file mixed tree (`README.md`, ADR `.md`, substack `.html`, plain `.html`, `.csv`, `.py`, `.json`) | **14** fragments | **7** |

Per-file, before: `README.md` 2 (code + markdown), ADR `0001-thing.md` 2, `163000000.my-post.html` **3** (substack + document + generic), `plain.html` 2, `sheet.csv` 2, `mod.py` 3.

Note the issue body is wrong on two points, both corrected here. It says `.md` is the one extension that cannot duplicate — it duplicates via `CodeIngestor`, which claims READMEs, `CLAUDE.md` and ADRs (`creek/ingest/code.py` `_is_relevant_file`). And it names `run_ingest(ingestor_cls=…)` as the routing contract that already exists; that is not a router, the caller supplies the class.

### The fix

Every ingestor still runs. `discord`, `chatgpt`, `claude` and `substack` recognise their input by its structure or content — a `messages/<channel>/messages.json` tree, a particular JSON envelope, a `<postid>.<slug>.html` filename — so no dispatch table can express their claims. An extension-keyed router would silently zero all four: their files are `.json`, `GenericIngestor` excludes `.json`, and nothing would pick up the slack. `tests/e2e/test_full_pipeline_mixed_sources.py::test_chat_exports_still_produce_fragments` is the guard for exactly that, green before and after.

What is new is `creek/ingest/routing.py`: a single total order `CLAIM_PRIORITY` over registry names, and `arbitrate()`, which groups the parsed fragments by `source_path` and keeps only the highest-priority ingestor that **actually produced output** for that path.

Arbitration runs **after** parsing rather than after `discover()`, deliberately. A claim staked at discovery has to be trusted before anyone has read the file, so when the winner's `parse()` then fails — a malformed `.csv`, a password-protected `.xlsx` — the loser is already discarded and the content is lost, where today it still lands as a generic fragment. Arbitrating on produced fragments makes that impossible by construction, and keeps today's memory profile (one ingestor's documents are freed before the next runs, rather than all eleven coexisting).

The invariant is **one ingestor per source file, never one fragment per source file**. `SpreadsheetIngestor` keeps emitting one fragment per non-empty sheet (this is #1305's model, and a winner keeps *all* its fragments for a path), `CodeIngestor` one per module and function, chat exports one per turn pair.

`creek ingest --type <x>` is unchanged by construction: `creek/ingest/base.py` is untouched, so every caller-chosen-class path still runs the ingestor the caller asked for over files the arbiter would have assigned elsewhere.

### Migration: the losing ingestor's already-written fragments

This is the mirror of what #1329 handled by pinning ids, and pinning does not help here. The *winner* re-resolves to its own pre-existing id and de-duplicates cleanly. The **loser's** fragments in an existing vault are real, indexed, linkable notes with different ids (the two ingestors disagree on both body and timestamp), and now that the loser will never run against those files again, nothing will ever revisit them.

**Decision: detect and report; delete nothing.** Deleting a fragment is not a call a processing run gets to make, and the operator may have hand-edited or hand-linked either copy. So the pipeline names the affected files instead of acting on them.

What an operator sees on the next `creek process`:

```
Contested sources: 3 (more than one ingestor claimed these; one won)
  A vault ingested before this release may still hold the losing ingestor's
  fragments. Nothing is deleted automatically; inspect with
  creek purge source --source-path <path> --match exact --dry-run
  /home/me/notes/log.txt
  ...
```

The recommended per-file sequence, documented in `docs/ingestion.md`, is to look first: `creek purge source --source-path <path> --match exact --dry-run` lists every vault fragment whose `source.original_file` is that path. More than one means a stray. Then either leave it (it is a duplicate note, not corruption) or purge-and-reprocess — with the caveat, stated in the doc, that purging scrubs references to `[purged]` across the vault and re-processing does not restore them.

`creek doctor`-style automated duplicate detection is a follow-up, filed as #1384.

### The `authored_at` consequence, named

The issue body defers per-ingestor `authored_at` divergence as separate. It is not fully separable — it is *why* the duplicates landed under different date-prefixed filenames, and the routing decision silently picks which timestamp survives. Concretely:

- Fragment ids hash `source_path + timestamp + content`, so the winner determines the body, the id **and** the `YYYY-MM-DD-` filename prefix.
- `CodeIngestor` stamps local time while the others stamp UTC. Between 16:00 and midnight Pacific those are different calendar days, which is why the original report shows `2026-08-10-log.md` and `2026-08-11-log.md` side by side.
- `GenericIngestor` writes an `authored_at` frontmatter key from the file mtime; `DocumentIngestor` leaves it unset. So `.txt`/`.html` fragments lose that key as a consequence of `document` winning.

All three are recorded in the `creek/ingest/routing.py` module docstring and the upgrade section of `docs/ingestion.md`.

### The priority order, and the two contests that are judgement calls

`discord · chatgpt · claude · substack` (sniffed) → `markdown · code · spreadsheet · presentation · image · document` → `generic` (the declared fallback, always last). One total order rather than a per-extension table, so it is reviewable at a glance and cannot disagree with itself. Every contested extension is justified in the module docstring; two deserve calling out here because I went against the pre-agreed plan on one of them:

- **`.md` → `markdown` over `code`** (the plan said `code`). `CodeIngestor` emits the file verbatim, so a README's YAML frontmatter stays inline in the fragment body — directly beneath the frontmatter block the vault writer adds. Verified: `code` yields `content='---\ntitle: My Readme\n…'` and `title='README.md'`; `markdown` splits the frontmatter, promotes `title: My Readme` and `tags`. Losing an `artifact_type` label costs less than a note with two frontmatter blocks in it, and "every `.md` goes to the markdown ingestor" is a rule an operator can hold in their head.
- **`.txt` → `document` over `generic`.** This is the weaker of the two: `DocumentIngestor` promotes the first line to an `#` heading (`# plain text line one`) where `generic` reproduces the text verbatim, and verbatim is arguably more faithful for a log file. But a total order cannot prefer `generic` on `.txt` and `document` on `.html`, and letting the declared fallback outrank a specialist anywhere makes the order incoherent. Named as a trade in the docstring rather than glossed.

### Riders

- **`GenericIngestor` no longer reads binaries it will discard.** `discover()` used to `read_bytes()` the whole file and `parse()` then dropped it; a tree of photos or Office documents was read cover to cover on every run. It now reads a bounded 8 KiB prefix and decides on that. **Output-neutral by proof, not by an extension list**: `_is_binary_content` returns True on a null byte *anywhere* or a >10% control-char ratio in the first 8192 bytes, so prefix-binary implies whole-file-binary implies `_try_decode` would have returned `None`. The UTF-16 BOM carve-out is replicated (UTF-16 text is null-heavy and is not binary) and locked by a test. This is why `.pdf` needed no special-casing despite being able to be pure ASCII: the predicate decides, not the extension.
- **No new silent drops.** `PipelineResult.unclaimed_sources` names files no ingestor produced anything from, with an explicit exclusion contract (directories; anything under a `SKIPPED_DIRECTORY_NAMES` or dot-directory; parent directories only, so a dotfile in the source root is still reported). This surfaces the *pre-existing* drop of a non-chat-export `.json`; fixing that drop is out of scope.
- **`_SKIP_DIRS` has one definition now.** `CodeIngestor` imports `routing.SKIPPED_DIRECTORY_NAMES`, so the discovery walk and the unclaimed report cannot drift into disagreeing about what was meant to be ingested.
- **Errors are never suppressed by arbitration.** Every ingestor's errors reach `result.errors`, losers included, and an ingestor that produced *zero* fragments still reports (that is the tesseract-missing case for `ImageIngestor`). This was a real hole the mutation battery found; it now has two tests.

## Test plan

**RED, proved on persisted vault state** — the defect is duplicate files on disk, so the assertions count files, not routing decisions. Fragments are attributed to their source via the `source.original_file` frontmatter key.

```
tests/e2e/test_full_pipeline_mixed_sources.py::test_process_writes_one_fragment_per_source_file
  E  assert 5 == 3
tests/e2e/test_full_pipeline_mixed_sources.py::test_mixed_extension_tree_routes_one_ingestor_per_file
  E  {'README.md': 2} != {'README.md': 1}
  E  {'0001-thing.md': 2} != {'0001-thing.md': 1}
  E  {'mod.py': 3} != {'mod.py': 2}
  E  {'sheet.csv': 2} != {'sheet.csv': 1}
  E  {'163000000.my-post.html': 3} != {'163000000.my-post.html': 1}
  E  {'plain.html': 2} != {'plain.html': 1}
```

`test_chat_exports_still_produce_fragments` passed at base and still passes — it is the guard that kills any extension-table design.

**New/changed tests**

- `tests/e2e/test_full_pipeline_mixed_sources.py` (new, 6 tests). A new module rather than an edit to the shared `test_full_pipeline_markdown.py`, which #1303 also wanted to extend; #1303 chose a new module (`test_full_pipeline_linking.py`) for the same reason.
- `tests/test_ingest_routing.py` (new, 19 tests). Includes `set(CLAIM_PRIORITY) == set(INGESTOR_REGISTRY)` as a forcing function: adding a twelfth ingestor without ranking it is a CI red, not a silent demotion behind `generic`.
- `tests/test_pipeline_source_coverage.py` (new, 11 tests). Exclusion contract, error preservation, and the rendered `creek process` output.
- `tests/test_ingest_generic.py` (+8). Binary skip at both discovery arms, UTF-16 survival, a >8 KiB text file round-tripping in full, an empty file still discovered, the late-binary edge, and a boundedness assertion (a 4 MB binary is judged on exactly 8192 bytes).
- `tests/e2e/test_full_pipeline_markdown.py`: the `assert result.fragments_created >= 1` at line 51 — a bound that cannot detect duplication *in principle*, and the reason this defect survived the whole life of the file — is now an exact count plus the exact on-disk filename, with the source mtime pinned so the date prefix is deterministic.
- **Zero edits** to the twelve `patch("creek.pipeline.INGESTOR_REGISTRY", …)` sites in `tests/test_pipeline.py` / `tests/test_pipeline_no_llm.py`. They pass untouched, which is a design constraint the approach was chosen to satisfy: the pipeline still calls `ingest()`, and their single synthetic `"mock"` key is unranked, uncontested, and wins silently.

**Mutation battery — 26 mutants, 24 killed, 2 survivors, both proven equivalent.**

Killed: reverting arbitration entirely; swapping `markdown`/`code`; ranking `generic` first; inverting the rank comparison; never recording a contest; ranking unranked names first; dropping the unranked warning; keeping every fragment; not sorting `contested`; dropping either half of the exclusion contract; excluding on the filename as well as the parents; suppressing either report field; dropping the UTF-16 carve-out; truncating reads at the prefix; never skipping binaries; always refusing to read; widening the prefix read; testing the whole file at discover; assembling from raw claims; never contesting; silencing the CLI report; suppressing a zero-output ingestor's errors.

Two of those mutants exist because the battery initially missed them. `suppressing a zero-output ingestor's errors` survived the first run — a genuine hole, since that is exactly the shape of `ImageIngestor` when `tesseract` is missing; it now has two tests. `testing the whole file at discover` was added on review feedback and covers the edge the output-neutrality argument actually turns on: a file whose first 8 KiB are clean text but which turns binary later.

Survivors, and why each is genuinely equivalent rather than assumed to be:

1. **`<` → `<=` in `arbitrate`.** The branch is guarded by `incumbent != name`, and `_rank` is injective (`CLAIM_PRIORITY` has no duplicates — asserted; unranked names get `len(CLAIM_PRIORITY) + offset` from distinct offsets over a sorted distinct name list). So `ranks[a] == ranks[b]` is unreachable for `a != b`. Confirmed by 20,000 randomised `_rank` calls over mixed known/unknown name sets: zero collisions.
2. **`claims` → `arbitration.winners` when building the `seen` set for `unclaimed_sources`.** Every source path in `claims` has exactly one owner, and that owner's fragments for that path are all kept and non-empty, so the two path sets are identical. Confirmed by 20,000 randomised arbitrations: zero differences. `claims` is kept anyway because "a loser still proves the file was seen" is the property that should hold if winners are ever filtered.

**Gates.** `./scripts/check-all.sh` → **exit 0**, 12/12 checks, 9090 passed, 94.44% aggregate coverage, per-file gate green (`creek/ingest/routing.py` 94.92%, `creek/pipeline.py` 99.31%, `creek/ingest/generic.py` 97.20%). `./scripts/test.sh --e2e` → 23 passed. No new `# noqa`, `type: ignore`, or skip anywhere, tests included.

**Pre-push self-review (Gate 2.5)** returned one blocker and three nits; all four are addressed in this branch:

1. *(blocker)* Two unjustified `# type: ignore[arg-type]` in a new test that monkeypatched `Path.open` to count bytes read. `tests/` is outside mypy's scope (#1366), so those would have been permanent debt no gate ever exercises. Fixed properly rather than tagged: the test now spies on `_is_binary_content` and asserts the predicate was handed exactly 8192 bytes, which is a more direct statement of the property anyway and needs no ignores.
2. `.rtf` was missing from the "each contested extension" enumeration in the `routing.py` docstring, which claims to be exhaustive. Added, along with the rest of `DocumentIngestor`'s set.
3. No test covered a file whose first 8 KiB are clean but which turns binary later — the edge the output-neutrality argument depends on. Added, and added as a mutant.
4. The extra `rglob` walk for `unclaimed_sources` and the `creek/pipeline.py` line count were raised as informational; the line count is in the "not satisfied" list below.

## Acceptance criteria not satisfied

Listed rather than glossed.

1. **"No source file is *parsed* by two ingestors in the same run."** This PR enforces the adjacent invariant: exactly one ingestor's output is **written** per source file. A contested *text* file is still parsed by every claimant and the losers' fragments are discarded before assembly — CPU only, within today's memory profile. The literal parsed-once invariant requires trusting a claim before parse, which is precisely what destroys content when the winner's parse then fails, and needs a `claims()` protocol on `Ingestor`; that is a larger PR and should not ride on this one. The binary sub-case the AC calls out explicitly — `GenericIngestor` reading `.docx`/`.pdf`/`.xlsx`/`.pptx`/images it will discard — **is** closed, at discover.
2. **Reusing `route_to_ingestor` / `_INGESTOR_BY_EXTENSION`** (`creek/ingest/gdrive.py`) is deliberately declined. It is extension-only and cannot express the sniffed claims of discord/chatgpt/claude/substack, and its missing `.py` key (would downgrade code ingestion to Generic) and missing `.json` key (would route to Generic, which excludes `.json`, yielding zero fragments) are what duplicating claim logic produces. It solves a different problem — naming an ingestor for one already-downloaded file with no directory discovery (`creek_mcp/tools/upload.py`). Leaving it alone keeps `upload.py`, `staged_names.py`, `connectors.py`, `journal_staging.py` and their tests entirely out of the blast radius. Unification is a follow-up.
3. **`creek/pipeline.py` grew 951 → 1123 lines**, crossing pylint's C0302 1000-line threshold. 19 such warnings already exist repo-wide and the pylint gate is score-based and passes, so I did not split the module in this PR; flagging it rather than letting it pass unremarked.

Closes #1304
