### PR TITLE
fix(ingest): give every sheet of a workbook its own identity

### DIFF
--- a/creek-tools/creek/fragment.py
+++ b/creek-tools/creek/fragment.py
@@ -286,8 +286,12 @@ class FragmentationEngine:
         Returns:
             List of child fragments with parent_id metadata.
         """
+        # ``identity_key``, not ``source_path``, so a parent that addresses a
+        # sub-unit of a file (a workbook sheet) derives a distinct parent id
+        # rather than colliding with its siblings (#1305). Identical to
+        # ``source_path`` for every fragment that carries no unit.
         parent_id = generate_fragment_id(
-            parent.source_path,
+            parent.identity_key,
             parent.timestamp,
             parent.content,
         )

--- a/creek-tools/creek/ingest/base.py
+++ b/creek-tools/creek/ingest/base.py
@@ -28,6 +28,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from creek._containment import assert_source_contained
 from creek.classify.tags_pass import apply_tags
+from creek.ingest.source_unit import compose_source_unit
 from creek.models import Fragment, FragmentLevel
 
 logger = logging.getLogger(__name__)
@@ -91,7 +92,31 @@ class ParsedFragment(BaseModel):
     """
 
     source_path: str
-    """Path to the original source file."""
+    """Path to the original source file.
+
+    Always the *whole file*, verbatim, even for an ingestor that emits
+    several fragments from it. Downstream consumers rely on that: the
+    per-file titles in :mod:`creek.ingest.code` and :mod:`creek.ingest.generic`,
+    the extension dispatch in :meth:`Ingestor.discover`, and — load-bearing
+    since #1304 — :func:`creek.ingest.routing.arbitrate`, which decides which
+    ingestor owns a file by grouping fragments on exactly this string. A
+    sub-unit discriminator belongs on :attr:`source_unit`, never here.
+    """
+
+    source_unit: str | None = None
+    """The sub-unit of :attr:`source_path` this fragment addresses (#1305).
+
+    ``None`` for the overwhelmingly common one-fragment-per-file case, and
+    for the *single*-sheet workbook — a CSV or a one-sheet XLSX derives
+    exactly the identity it derived before this field existed, which is what
+    keeps every such fragment already in an operator's vault from being
+    re-minted and duplicated on its next ingest.
+
+    Set only where one file genuinely contains several independently
+    identifiable units: today that is ``SpreadsheetIngestor``'s sheets. It
+    reaches identity through :attr:`identity_key` and nothing else, so
+    adding one cannot disturb a consumer of :attr:`source_path`.
+    """
 
     timestamp: datetime
     """Timestamp associated with this fragment."""
@@ -111,6 +136,25 @@ class ParsedFragment(BaseModel):
     markdown, html, code, …) that don't need structured payloads are
     not forced to set a slot they don't use.
     """
+
+    @property
+    def identity_key(self) -> str:
+        """Return the string that identifies this fragment's source (#1305).
+
+        The **only** input any identity derivation may take from a parsed
+        fragment's provenance: :func:`generate_fragment_id`, the provenance
+        entry in :meth:`Ingestor._process_fragment`, and the ledger key in
+        :func:`creek.ingest.pipeline.attach_origin_key` all read this rather
+        than :attr:`source_path`.
+
+        Equal to :attr:`source_path` whenever :attr:`source_unit` is unset,
+        so every ingestor that predates #1305 derives byte-identical ids.
+
+        Returns:
+            ``source_path`` composed with ``source_unit``, or ``source_path``
+            unchanged when there is no unit.
+        """
+        return compose_source_unit(self.source_path, self.source_unit)
 
 
 class ProvenanceEntry(BaseModel):
@@ -404,14 +448,23 @@ def assemble_ingested_fragment(parsed: ParsedFragment) -> IngestedFragment:
 
     Step 4 lives here rather than in each ingestor because this function
     is the **universal ingest chokepoint**: every adapter and every CLI
-    surface funnels through it (``creek/pipeline.py:498`` for ``creek
-    process``, ``creek/ingest/pipeline.py:309`` for ``creek ingest`` /
-    ``creek sync`` / the MCP tool, ``creek/ingest/discord.py:839`` for
-    Discord capture). Wiring it once here is what makes ``tags``
-    populated for markdown, Discord, ChatGPT, Substack and the rest in
-    one place, and it is why the ``creek process`` path needs no separate
-    call further down the pipeline — nothing between here and the write
-    mutates the body the hashtags come from.
+    surface funnels through it —
+    :meth:`creek.pipeline.Pipeline._run_ingestion` for ``creek process``,
+    :func:`creek.ingest.pipeline.run_ingest` for ``creek ingest`` /
+    ``creek sync`` / the ``creek.upload`` MCP tool,
+    :func:`creek_mcp.tools.ingest.ingest_tool` for the ``creek.ingest`` MCP
+    tool, and :mod:`creek.ingest.discord` for Discord capture. Wiring it
+    once here is what makes ``tags`` populated for markdown, Discord,
+    ChatGPT, Substack and the rest in one place, and it is why the ``creek
+    process`` path needs no separate call further down the pipeline —
+    nothing between here and the write mutates the body the hashtags come
+    from.
+
+    Callers are named by *symbol*, not by file and line. The four
+    ``path:line`` citations this paragraph used to carry had every one of
+    them rotted by the time #1305 read them (``creek/pipeline.py:498`` had
+    drifted into an unrelated function), and the MCP ingest tool — a real
+    caller — was missing entirely.
 
     Args:
         parsed: A parsed fragment produced by an ingestor's four-stage
@@ -440,7 +493,7 @@ def assemble_ingested_fragment(parsed: ParsedFragment) -> IngestedFragment:
     body: str = str(parsed.metadata["markdown"])
 
     frontmatter_dict["id"] = generate_fragment_id(
-        parsed.source_path,
+        parsed.identity_key,
         parsed.timestamp,
         parsed.content,
     )
@@ -709,8 +762,10 @@ class Ingestor(abc.ABC):
             ingestor_name: The class name of this ingestor.
             now: The current timestamp for provenance.
         """
+        # ``identity_key``, not ``source_path``: a provenance entry per sheet,
+        # matching the one fragment id per sheet the same key mints (#1305).
         frag_id = generate_fragment_id(
-            fragment.source_path, fragment.timestamp, fragment.content
+            fragment.identity_key, fragment.timestamp, fragment.content
         )
 
         # Stage 3: Convert to markdown

--- a/creek-tools/creek/ingest/ledger.py
+++ b/creek-tools/creek/ingest/ledger.py
@@ -21,6 +21,8 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+from creek.ingest.source_unit import SOURCE_UNIT_SEPARATOR
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -151,6 +153,55 @@ class SourceLedger:
     def live_keys(self) -> set[str]:
         """Return the tracked source keys that are not tombed (#674)."""
         return {key for key, rec in self._records.items() if not rec.tombed}
+
+    def all_keys(self) -> set[str]:
+        """Return every tracked source key, tombed or not (#1305).
+
+        The counterpart to :meth:`live_keys`, for the readers that must not
+        treat a tombed record as absence. A soft-tombed unit's fragment was
+        moved to ``10-Liminal/Orphaned/``, not deleted, so a gate deciding
+        whether an identity *owns anything* has to count it — ``live_keys``
+        answers a different question, and answering this one with it is how
+        a gate comes to admit a caller to content that still exists.
+
+        Returns:
+            All tracked source keys.
+        """
+        return set(self._records)
+
+    def records_for(self, base_key: str) -> list[tuple[str, LedgerRecord]]:
+        """Return every record keyed on *base_key* or a sub-unit of it (#1305).
+
+        :meth:`get` answers "what is this file's fragment", which stopped
+        being a question with one answer once one file could hold several
+        independently identified units — the sheets of a workbook. A caller
+        holding only the file's path (the ``creek.upload`` tool holds a
+        staged path, never a sheet name) has no way to enumerate the units
+        without this.
+
+        Both the exact key and its ``<base_key>#<unit>`` children are
+        returned, so a single-unit source still answers with its one record
+        and callers need no special case for the two shapes.
+
+        The ``#`` scan cannot mis-fire for the upload ledger, its only
+        caller: staged filenames come from ``creek_mcp.staged_names.safe_stem``,
+        whose slug regex excludes ``#`` outright, so no staged path can look
+        like a composed key.
+
+        Args:
+            base_key: The whole file's source key.
+
+        Returns:
+            ``(source_key, record)`` pairs ordered by key, so a caller that
+            reduces the list to one id — a response's ``fragment_id`` —
+            picks the same one on every run.
+        """
+        prefix = f"{base_key}{SOURCE_UNIT_SEPARATOR}"
+        return sorted(
+            (key, record)
+            for key, record in self._records.items()
+            if key == base_key or key.startswith(prefix)
+        )
 
     def __len__(self) -> int:
         """Return the number of distinct source keys tracked."""

--- a/creek-tools/creek/ingest/pipeline.py
+++ b/creek-tools/creek/ingest/pipeline.py
@@ -20,12 +20,13 @@ from dataclasses import dataclass, field
 from pathlib import Path  # runtime use: resolving recorded source paths
 from typing import TYPE_CHECKING, Final
 
-from creek.ingest.base import assemble_ingested_fragment
+from creek.ingest.base import assemble_ingested_fragment, generate_fragment_id
+from creek.ingest.source_unit import compose_source_unit
 
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Sequence
     from datetime import datetime
 
     from creek.ingest.base import Ingestor, ParsedFragment
@@ -236,10 +237,25 @@ def attach_origin_key(
     fragment: Fragment,
     vault_path: Path,
 ) -> None:
-    """Stamp the fragment's ``source.origin_key`` before it is written (#672)."""
+    """Stamp the fragment's ``source.origin_key`` before it is written (#672).
+
+    The key addresses the *unit* the fragment came from, not merely the file
+    (#1305). Composed after :func:`derive_source_key` rather than by handing
+    it a pre-composed string, so that function keeps resolving a path that
+    actually exists on disk and the vault-relative/bare-filename choice is
+    made on the real file.
+
+    This is the half of #1305 a per-sheet fragment id does not reach.
+    ``derive_source_key`` keys on the file, so without the unit every sheet
+    of a workbook shares one ``origin_key`` and one ledger record, and
+    :func:`write_fragment_idempotent` then reassigns ``fragment.id`` to the
+    record's id and overwrites sheet 1 with sheet 2 — reporting ``updated``
+    while losing the content.
+    """
     if ledger is None:
         return
-    fragment.source.origin_key = derive_source_key(parsed.source_path, vault_path)
+    base_key = derive_source_key(parsed.source_path, vault_path)
+    fragment.source.origin_key = compose_source_unit(base_key, parsed.source_unit)
 
 
 def record_in_ledger(
@@ -493,6 +509,85 @@ def unpinned_vault_warning(
     return _UNPINNED_VAULT_WARNING
 
 
+_COLLAPSED_UNIT_WARNING_TEMPLATE = (
+    "This vault holds {count} fragment(s) written before #1305, when every "
+    "sheet of a multi-sheet workbook shared one fragment id and only the "
+    "FIRST reached disk. Each one is now superseded by the per-sheet "
+    "fragments this run writes, and is left in place: {sample}. Nothing is "
+    "deleted automatically — inspect with `creek purge source "
+    "--source-path <path> --match exact --dry-run`, and purge only what you "
+    "recognise. Links pointing at a superseded fragment keep resolving to "
+    "it until you do."
+)
+"""Advisory for a vault still holding pre-#1305 collapsed fragments."""
+
+_COLLAPSED_UNIT_SAMPLE = 3
+"""How many superseded ids the advisory names before it stops listing."""
+
+
+def collapsed_unit_warning(
+    writer: VaultWriter,
+    fragments: Sequence[ParsedFragment],
+) -> str | None:
+    """Return the pre-#1305 collapsed-fragment advisory, or ``None`` (#1305).
+
+    Before #1305 every sheet of a multi-sheet workbook derived the same
+    fragment id, so ``_write_model``'s first-writer-wins dedup kept sheet 1
+    and silently dropped the rest. This run writes each sheet under its own
+    id, which is the fix — but it also means the single fragment the old
+    derivation left in an operator's vault is now superseded by N new ones
+    and is not overwritten by any of them.
+
+    **Detected, reported, and left alone.** That is deliberately the same
+    answer #1304 gave the same shape of problem: naming the strays and
+    handing over a read-only inspection command, rather than deleting vault
+    content on the strength of a heuristic. Deleting a fragment is not
+    something an ingest run gets to decide, and the id recomputation below,
+    however exact, cannot know whether the operator has since edited that
+    file, linked to it, or curated it into a thread.
+
+    The detection needs no vault walk, no frontmatter parsing and no
+    scoping heuristic, because the superseded id is *exactly* what this
+    same fragment would have hashed to with no unit — same source path,
+    same timestamp, same content. So it is recomputed from the parsed
+    fragment in hand and looked up in the writer's id index. That also
+    sidesteps the two traps a frontmatter-based detector hits (``ingested``
+    reads back as a ``str``, and its trailing ``Z`` hashes differently from
+    the ``+00:00`` the derivation emits) by never reading frontmatter.
+
+    It follows that the advisory is self-clearing: once the operator purges
+    the superseded fragments, the lookup misses and the run goes quiet. It
+    is also silent on a fresh vault and on every single-unit source, which
+    keeps no unit and therefore has nothing to supersede.
+
+    Args:
+        writer: The vault writer, consulted read-only via
+            :meth:`~creek.vault.writer.VaultWriter.find_fragment`.
+        fragments: This run's parsed fragments, before any are written.
+
+    Returns:
+        The advisory text, or ``None`` when no superseded fragment is
+        present.
+    """
+    superseded: list[str] = []
+    for parsed in fragments:
+        if parsed.source_unit is None:
+            continue
+        legacy_id = generate_fragment_id(
+            parsed.source_path, parsed.timestamp, parsed.content
+        )
+        if legacy_id in superseded:
+            continue
+        if writer.find_fragment(legacy_id) is not None:
+            superseded.append(legacy_id)
+    if not superseded:
+        return None
+    sample = ", ".join(sorted(superseded)[:_COLLAPSED_UNIT_SAMPLE])
+    if len(superseded) > _COLLAPSED_UNIT_SAMPLE:
+        sample = f"{sample}, …"
+    return _COLLAPSED_UNIT_WARNING_TEMPLATE.format(count=len(superseded), sample=sample)
+
+
 def run_ingest(
     *,
     ingestor_cls: type[Ingestor],
@@ -573,6 +668,13 @@ def run_ingest(
     unpinned = unpinned_vault_warning(source_type, vault_path)
     if unpinned is not None:
         warn(unpinned)
+
+    # Same reason as above: checked before the write loop, so the operator
+    # is told about superseded fragments before the run that supersedes
+    # them finishes rather than after (#1305).
+    collapsed = collapsed_unit_warning(writer, ingest_result.fragments)
+    if collapsed is not None:
+        warn(collapsed)
 
     errors: list[str] = [f"[{source_type}] {err}" for err in ingest_result.errors]
     written = 0

--- a/creek-tools/creek/ingest/source_unit.py
+++ b/creek-tools/creek/ingest/source_unit.py
@@ -1,0 +1,120 @@
+"""Compose and split the sub-unit half of a source key (#1305).
+
+Most ingestors map one source *file* to one fragment, so the file's path is
+a sufficient identity. Some do not: ``SpreadsheetIngestor`` emits one
+fragment per sheet of a workbook, and every one of those sheets shares a
+single file. Until #1305 they also shared a single fragment id, a single
+provenance entry and a single ledger record, so ``_write_model``'s
+first-writer-wins dedup (``creek/vault/writer.py``) silently dropped every
+sheet after the first.
+
+The fix is to give such a fragment a *sub-unit* discriminator, and this
+module owns the one spelling of how that discriminator is joined to and
+recovered from a path. Three unrelated layers have to agree on it — the
+ingest derivation that mints it, the upload ledger that stores it, and the
+RTBF purge sweep that has to find the underlying file again — and a
+separator that three modules each spell for themselves is a separator that
+will eventually be spelled two ways.
+
+Why ``#``
+---------
+It is not legal in a ``safe_stem`` slug (``creek_mcp.tools.upload``'s
+``_SLUG_RE`` is ``[^A-Za-z0-9._-]+``), so no staged upload path can contain
+one and the upload ledger's key space stays unambiguous. It is legal in a
+POSIX filename, though, which is why :func:`split_source_unit` is documented
+as a *hypothesis* rather than a parse: a caller must try the whole key first
+and fall back to the split only when the whole key resolves to nothing.
+
+Deliberately free of heavy imports. :mod:`creek.purge.engine` and
+:mod:`creek_mcp.tools.upload` both need it, and neither should be made to
+pull :mod:`creek.classify` in behind it.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+SOURCE_UNIT_SEPARATOR: Final[str] = "#"
+"""Joins a source path to the sub-unit of it a fragment addresses."""
+
+_UNIT_SEPARATOR_REPLACEMENT: Final[str] = "-"
+"""What a separator inside a unit name is rewritten to. See :func:`sanitize_unit`."""
+
+
+def sanitize_unit(unit: str) -> str:
+    """Return *unit* with every separator rewritten, so it cannot be ambiguous.
+
+    The separator is legal in the things units are named after — Excel
+    permits ``#`` in a sheet title — and a unit containing one produces a
+    key that cannot be read back. ``book.xlsx#Rev#2`` splits at the *last*
+    separator to ``("book.xlsx#Rev", "2")``, naming a file that does not
+    exist; the RTBF purge sweep then finds no staged source and silently
+    leaves the operator's document on disk.
+
+    Rewriting at mint time is the fix, rather than teaching every reader to
+    try successive splits: it makes "the unit half of a composed key never
+    contains a separator" an invariant of the key space instead of a
+    property each reader has to rediscover. One rpartition is then exact
+    for every key this module produced.
+
+    Callers that derive a unit from user-controlled text must apply this
+    **before** de-duplicating, not after — two distinct names that sanitize
+    to the same string (``Rev#2`` and ``Rev-2``) must be seen as a
+    collision by the de-duplicator, or they silently mint one id for two
+    units, which is the very defect #1305 exists to fix.
+
+    Args:
+        unit: The raw unit name.
+
+    Returns:
+        *unit* with each separator replaced by
+        :data:`_UNIT_SEPARATOR_REPLACEMENT`.
+    """
+    return unit.replace(SOURCE_UNIT_SEPARATOR, _UNIT_SEPARATOR_REPLACEMENT)
+
+
+def compose_source_unit(path: str, unit: str | None) -> str:
+    """Return the source key addressing *unit* within *path*.
+
+    The unit is passed through :func:`sanitize_unit` so a composed key can
+    always be split back apart. That is enforced here, at the single place
+    keys are minted, rather than trusted to each caller.
+
+    Args:
+        path: The source key or path of the whole file.
+        unit: The sub-unit discriminator, or ``None`` for the whole file.
+
+    Returns:
+        ``path`` unchanged when *unit* is ``None`` or empty, else
+        ``f"{path}#{sanitized}"``. An empty unit is treated as no unit
+        deliberately: a key ending in a bare separator would be a second
+        spelling of "the whole file", and two spellings of one identity is
+        how the same fragment comes to be written twice.
+    """
+    if not unit:
+        return path
+    return f"{path}{SOURCE_UNIT_SEPARATOR}{sanitize_unit(unit)}"
+
+
+def split_source_unit(key: str) -> tuple[str, str | None]:
+    """Split *key* into its path half and its sub-unit half, if it has one.
+
+    This is a **hypothesis, not a parse**. ``#`` is a legal character in a
+    POSIX filename, so ``report#1.xlsx`` is indistinguishable from unit
+    ``1.xlsx`` of a file named ``report``. Callers must therefore try the
+    whole key first and consult this only when that resolved to nothing —
+    which is exactly what the purge engine's staged-source sweep does, so
+    a genuinely ``#``-named file keeps winning.
+
+    Args:
+        key: A source key, with or without a sub-unit suffix.
+
+    Returns:
+        ``(path, unit)``, with *unit* ``None`` when *key* carries no
+        separator or when the text after the last separator is empty
+        (mirroring :func:`compose_source_unit`, which never mints one).
+    """
+    path, separator, unit = key.rpartition(SOURCE_UNIT_SEPARATOR)
+    if not separator or not unit:
+        return key, None
+    return path, unit

--- a/creek-tools/creek/ingest/spreadsheets.py
+++ b/creek-tools/creek/ingest/spreadsheets.py
@@ -24,10 +24,11 @@ from __future__ import annotations
 
 import csv
 import logging
+from collections import Counter
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import chardet
 
@@ -38,7 +39,11 @@ from creek.ingest.base import (
     file_modified_time,
     parse_authored_at,
 )
+from creek.ingest.source_unit import sanitize_unit
 from creek.models import SourcePlatform
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +85,73 @@ class SheetData:
     def is_empty(self) -> bool:
         """``True`` when neither headers nor rows carry any signal."""
         return not self.rows and not self.headers
+
+
+_BLANK_SHEET_UNIT = "sheet"
+"""Stand-in unit for a sheet whose name is blank or whitespace (#1305).
+
+A blank name has nothing to key on, and the two obvious alternatives are
+both wrong: an empty discriminator is a second spelling of "the whole
+file" (see :func:`~creek.ingest.source_unit.compose_source_unit`), and a
+bare positional index is not order-stable, because empty sheets are
+skipped and a sheet that gains content shifts every index after it.
+Normalising to a name lets the ordinary duplicate-name rule below carry
+the blank case too.
+"""
+
+
+def _sheet_unit_keys(sheets: Sequence[SheetData]) -> list[str | None]:
+    """Return the per-sheet source-unit discriminator for *sheets* (#1305).
+
+    Two rules, in this order.
+
+    **A single non-empty sheet gets no discriminator at all.** This is the
+    migration answer, achieved by construction rather than by a backfill:
+    every CSV and every one-sheet XLSX derives byte-identical identity
+    before and after #1305, so nothing already in an operator's vault is
+    re-minted and duplicated on its next ingest. There is no ledger to pin
+    spreadsheets into — ``ledger_for_source`` returns ``None`` for every
+    source type but markdown — so a #1329-style migration is unavailable
+    here, and this carve-out is what replaces it.
+
+    **Otherwise the discriminator is the sheet's name**, passed through
+    :func:`~creek.ingest.source_unit.sanitize_unit`, with a blank name
+    normalised to :data:`_BLANK_SHEET_UNIT` and the *n*-th (n>=2)
+    occurrence of an already-seen name suffixed ``~<n>``. Excel forbids
+    duplicate sheet names, but a hand-built or stub workbook does not, and
+    a bare name would silently restore the very collision this fixes.
+
+    The occurrence ordinal is counted over names, not positions, so
+    inserting a *differently* named sheet anywhere in the workbook leaves
+    every existing sheet's unit — and therefore its fragment id — untouched.
+    That order-stability is why the "empty discriminator for sheet index 0"
+    shortcut is rejected: an inserted first sheet would inherit the previous
+    first sheet's id, and because ``_write_model`` is first-writer-wins
+    (``creek/vault/writer.py``) the newcomer would then be silently dropped
+    while the real first sheet duplicated.
+
+    Args:
+        sheets: The workbook's non-empty sheets, in workbook order.
+
+    Returns:
+        One entry per input sheet, positionally aligned: ``None`` for the
+        single-sheet case, else the sheet's unit key.
+    """
+    if len(sheets) < 2:
+        return [None] * len(sheets)
+    seen: Counter[str] = Counter()
+    units: list[str | None] = []
+    for sheet in sheets:
+        # Sanitised BEFORE counting, not after: Excel permits ``#`` in a
+        # sheet title, and two titles that sanitise to the same string
+        # (``Rev#2`` and ``Rev-2``) must be seen here as the collision they
+        # are. Sanitising downstream of the counter would mint one unit —
+        # and so one id — for both, restoring this issue's own defect.
+        name = sanitize_unit(sheet.name.strip()) or _BLANK_SHEET_UNIT
+        seen[name] += 1
+        occurrence = seen[name]
+        units.append(name if occurrence == 1 else f"{name}~{occurrence}")
+    return units
 
 
 @dataclass(frozen=True)
@@ -436,10 +508,12 @@ class SpreadsheetIngestor(Ingestor):
         workbook = self.backend.read_workbook(raw.path, has_header=has_header)
         timestamp = file_modified_time(raw.path)
         authored_at = _extract_xlsx_authored_at(raw.path)
+        # Materialised before the loop because the *number* of non-empty
+        # sheets decides whether a discriminator is emitted at all (#1305).
+        sheets = [sheet for sheet in workbook.sheets if not sheet.is_empty]
+        units = _sheet_unit_keys(sheets)
         fragments: list[ParsedFragment] = []
-        for sheet in workbook.sheets:
-            if sheet.is_empty:
-                continue
+        for sheet, unit in zip(sheets, units, strict=True):
             column_count = (
                 len(sheet.headers)
                 if sheet.headers
@@ -455,7 +529,12 @@ class SpreadsheetIngestor(Ingestor):
                         "columns": column_count,
                         "authored_at": authored_at,
                     },
+                    # The whole file, always. The per-sheet discriminator
+                    # rides on ``source_unit``; overloading this string would
+                    # break `creek.ingest.routing.arbitrate`, which decides
+                    # ingestor ownership by grouping on it (#1304).
                     source_path=str(raw.path),
+                    source_unit=unit,
                     timestamp=timestamp,
                     payload=sheet,
                 ),
@@ -483,15 +562,45 @@ class SpreadsheetIngestor(Ingestor):
         ``modified``) lands on the frontmatter as an ISO string when
         present; absent for CSV and for XLSX files whose core
         properties carry no creation date.
+
+        #1305: ``title`` is now always emitted, and names the sheet when
+        the fragment carries a sheet unit. Two reasons it cannot be left
+        to the ``setdefault`` fallback in
+        :func:`~creek.ingest.base.assemble_ingested_fragment`. First, that
+        fallback is ``Path(source_path).stem``, which is the *workbook*
+        for every sheet — the fallback does not accidentally save us.
+        Second, ``sheet`` / ``rows`` / ``columns`` above never reach a
+        file: :class:`~creek.models.Fragment` leaves pydantic's default
+        ``extra="ignore"``, so ``Fragment.model_validate`` drops them.
+        After #1305 the title, the filename it produces, and the body
+        heading are the only per-sheet markers in the vault, which makes
+        emitting one a correctness requirement rather than a nicety. That
+        drop is accepted here and tracked in #1392 rather than fixed
+        under a bugfix, because widening what survives validation is a
+        repo-wide frontmatter change.
+
+        A fragment with **no** unit — a CSV, a one-sheet XLSX — gets the
+        bare stem, which is byte-identical to what the fallback produced
+        before this change. Naming the lone sheet there would move the
+        computed filename of every such fragment already in a vault; the
+        id pin is only half a pin if the filename still churns.
         """
+        original_file = str(
+            fragment.metadata.get("original_file", fragment.source_path)
+        )
+        stem = Path(original_file).stem
+        sheet_name = str(fragment.metadata.get("sheet", "")).strip()
+        # A blank sheet name falls back to its unit key rather than to the
+        # empty string, which would render as ``"book — "`` and sanitise to
+        # a bare ``book`` — indistinguishable from the no-unit case.
+        label = sheet_name or fragment.source_unit
+        title = f"{stem} — {label}" if fragment.source_unit else stem
         frontmatter_dict: dict[str, Any] = {
             "type": "fragment",
+            "title": title,
             "source": {
                 "platform": SourcePlatform.SPREADSHEET.value,
-                "original_file": fragment.metadata.get(
-                    "original_file",
-                    fragment.source_path,
-                ),
+                "original_file": original_file,
             },
             "sheet": fragment.metadata.get("sheet", ""),
             "rows": fragment.metadata.get("rows", 0),

--- a/creek-tools/creek/ingest/spreadsheets.py
+++ b/creek-tools/creek/ingest/spreadsheets.py
@@ -154,6 +154,35 @@ def _sheet_unit_keys(sheets: Sequence[SheetData]) -> list[str | None]:
     return units
 
 
+def _sheet_label(fragment: ParsedFragment) -> str:
+    """Return the operator-visible name of *fragment*'s sheet (#1305).
+
+    The **de-duplicated** ``source_unit``, never the raw
+    ``metadata["sheet"]``. Excel forbids duplicate sheet titles but a
+    hand-built workbook does not, and two sheets both named ``Data`` carry
+    the identical raw name. :func:`_sheet_unit_keys` already resolved that
+    collision into ``Data`` and ``Data~2``; deriving the title and the body
+    heading from the raw name instead hands the operator two fragments with
+    distinct ids, distinct files and identical text — disambiguated in the
+    index, indistinguishable everywhere they actually read it.
+
+    Consuming the unit also makes the visible label and the ``…#<unit>``
+    source key the same string, so a fragment can be matched by eye to the
+    ledger and purge records that name it.
+
+    Args:
+        fragment: A parsed spreadsheet fragment.
+
+    Returns:
+        The fragment's ``source_unit`` when it has one, else the raw sheet
+        name. That fallback is reached only by a source carrying no unit at
+        all — a CSV, a one-sheet XLSX — which has no sibling to be confused
+        with, and whose pre-#1305 rendering is preserved verbatim so no
+        fragment already in a vault is re-titled.
+    """
+    return fragment.source_unit or str(fragment.metadata.get("sheet", "Sheet"))
+
+
 @dataclass(frozen=True)
 class WorkbookData:
     """A workbook (XLSX or CSV) decomposed into sheets.
@@ -542,13 +571,17 @@ class SpreadsheetIngestor(Ingestor):
         return fragments
 
     def convert_to_markdown(self, fragment: ParsedFragment) -> str:
-        """Render the sheet as a GFM table with optional summary truncation."""
+        """Render the sheet as a GFM table with optional summary truncation.
+
+        #1305: the heading names the sheet by its **de-duplicated unit**
+        via :func:`_sheet_label`, not by the raw sheet name. See that
+        function for why the distinction is the whole point.
+        """
         headers, rows = _extract_headers_and_rows(fragment)
-        sheet_name = str(fragment.metadata.get("sheet", "Sheet"))
         original = Path(
             str(fragment.metadata.get("original_file", fragment.source_path))
         )
-        lines = [f"# {original.name} — {sheet_name}", ""]
+        lines = [f"# {original.name} — {_sheet_label(fragment)}", ""]
         if not headers and not rows:
             lines.append("_(empty sheet)_")
             return "\n".join(lines) + "\n"
@@ -563,8 +596,9 @@ class SpreadsheetIngestor(Ingestor):
         present; absent for CSV and for XLSX files whose core
         properties carry no creation date.
 
-        #1305: ``title`` is now always emitted, and names the sheet when
-        the fragment carries a sheet unit. Two reasons it cannot be left
+        #1305: ``title`` is now always emitted, and names the sheet — by
+        its de-duplicated unit, see :func:`_sheet_label` — when the
+        fragment carries one. Two reasons it cannot be left
         to the ``setdefault`` fallback in
         :func:`~creek.ingest.base.assemble_ingested_fragment`. First, that
         fallback is ``Path(source_path).stem``, which is the *workbook*
@@ -589,12 +623,7 @@ class SpreadsheetIngestor(Ingestor):
             fragment.metadata.get("original_file", fragment.source_path)
         )
         stem = Path(original_file).stem
-        sheet_name = str(fragment.metadata.get("sheet", "")).strip()
-        # A blank sheet name falls back to its unit key rather than to the
-        # empty string, which would render as ``"book — "`` and sanitise to
-        # a bare ``book`` — indistinguishable from the no-unit case.
-        label = sheet_name or fragment.source_unit
-        title = f"{stem} — {label}" if fragment.source_unit else stem
+        title = f"{stem} — {_sheet_label(fragment)}" if fragment.source_unit else stem
         frontmatter_dict: dict[str, Any] = {
             "type": "fragment",
             "title": title,

--- a/creek-tools/creek/purge/engine.py
+++ b/creek-tools/creek/purge/engine.py
@@ -41,6 +41,7 @@ import yaml
 from pydantic import BaseModel, Field
 
 from creek.ingest.journal_staging import ADEPTHOOD_STAGING_RELDIRS
+from creek.ingest.source_unit import split_source_unit
 from creek.purge.audit import PurgeAuditEntry, PurgeAuditLog, PurgeOutcomeStatus
 
 if TYPE_CHECKING:
@@ -981,25 +982,76 @@ class PurgeEngine:
         origin_key = _extract_source_origin_key(post)
         if not origin_key:
             return
-        staged_path = self._resolve_pointer_in_vault(
-            origin_key,
-            field="source.origin_key",
-        )
+        staged_path = self._resolve_staged_source(origin_key)
         if staged_path is None:
-            return
-        if not self._in_any_staging_root(staged_path):
-            logger.warning(
-                "Ignoring source.origin_key %r that resolves outside "
-                "the Adepthood staging dirs %s",
-                origin_key,
-                [str(reldir) for reldir in ADEPTHOOD_STAGING_RELDIRS],
-            )
-            return
-        if not staged_path.is_file():
             return
         result.journal_staged_removed += 1
         if not self.dry_run:
             staged_path.unlink(missing_ok=True)
+
+    def _resolve_staged_source(self, origin_key: str) -> Path | None:
+        """Resolve *origin_key* to the staged file to delete, or ``None``.
+
+        Tries the key whole, then — only if that named no file — as a
+        ``<path>#<unit>`` sub-unit key whose path half is the real staged
+        document (#1305). Both guards are re-applied on the fallback: the
+        recovered path must resolve inside the vault
+        (:meth:`_resolve_pointer_in_vault`) and inside a declared staging
+        root (:meth:`_in_any_staging_root`). The fallback therefore only
+        ever widens what is deleted *within* the staging roots — a ratchet
+        in the restrictive direction, never a relaxation.
+
+        Order is load-bearing in both directions. Whole-key-first means a
+        genuinely ``#``-named document (``report#1.xlsx``) keeps resolving
+        to itself rather than steering the delete at a different file
+        called ``report``; ``#`` is legal in a POSIX filename, so the split
+        is a hypothesis and must never pre-empt the literal reading.
+        Fallback-at-all is what stops an uploaded workbook surviving an
+        RTBF request: since #1305 each sheet's ``origin_key`` names a
+        sub-unit, which resolves inside the staging root but is not a file,
+        so the ``is_file()`` check alone left the operator's document on
+        disk after the erasure meant to remove it.
+
+        Args:
+            origin_key: The fragment's ``source.origin_key``, verbatim.
+
+        Returns:
+            The staged file to unlink, or ``None`` to skip — a missing,
+            unresolvable, out-of-vault or out-of-staging key is a no-op
+            rather than an error, per this engine's pointer contract.
+        """
+        for candidate_key in self._staged_key_candidates(origin_key):
+            resolved = self._resolve_pointer_in_vault(
+                candidate_key,
+                field="source.origin_key",
+            )
+            if resolved is None:
+                continue
+            if not self._in_any_staging_root(resolved):
+                logger.warning(
+                    "Ignoring source.origin_key %r that resolves outside "
+                    "the Adepthood staging dirs %s",
+                    candidate_key,
+                    [str(reldir) for reldir in ADEPTHOOD_STAGING_RELDIRS],
+                )
+                continue
+            if resolved.is_file():
+                return resolved
+        return None
+
+    @staticmethod
+    def _staged_key_candidates(origin_key: str) -> list[str]:
+        """Return *origin_key* readings to try, most literal first (#1305).
+
+        Args:
+            origin_key: The fragment's ``source.origin_key``, verbatim.
+
+        Returns:
+            The whole key, followed by its path half when it carries a
+            sub-unit suffix. One entry for every key that does not.
+        """
+        base, unit = split_source_unit(origin_key)
+        return [origin_key] if unit is None else [origin_key, base]
 
     def _purge_voice_artifacts(
         self,

--- a/creek-tools/creek/vault/writer.py
+++ b/creek-tools/creek/vault/writer.py
@@ -884,6 +884,28 @@ class VaultWriter:
                 return found
         return None
 
+    def find_fragment(self, fragment_id: str) -> Path | None:
+        """Return the live fragment file for *fragment_id*, or ``None``.
+
+        The public read-only view of the per-directory id index that
+        :meth:`tomb_fragment` and :meth:`update_fragment` already navigate
+        by. Exposed for #1305's un-migrated-vault advisory, which has to
+        answer "does this vault still hold the id the old derivation would
+        have minted?" without walking and parsing every fragment file.
+
+        Read-only and index-backed, so asking is cheap and asking cannot
+        change anything.
+
+        Args:
+            fragment_id: The id to look for.
+
+        Returns:
+            The fragment's path, or ``None`` when the vault does not hold
+            it (including when ``01-Fragments/`` does not exist).
+        """
+        with self._lock:
+            return self._find_in_fragments_locked(fragment_id)
+
     def _relocate_fragment_locked(
         self,
         existing: Path,

--- a/creek-tools/creek_mcp/tools/upload.py
+++ b/creek-tools/creek_mcp/tools/upload.py
@@ -246,10 +246,6 @@ def _ledgered_names_for_id(vault_path: Path, external_id: str) -> dict[str, list
     A ledger record survives the file it points at, so this survey does not
     go blind at exactly the moment it matters.
 
-    Args:
-        vault_path: Vault root.
-        external_id: The caller's idempotency key.
-
     Tombed records are counted too (:meth:`~creek.ingest.ledger.SourceLedger.all_keys`,
     not ``live_keys``): a soft-tombed fragment still exists, under
     ``10-Liminal/Orphaned/``, and for a gate whose failure mode is

--- a/creek-tools/creek_mcp/tools/upload.py
+++ b/creek-tools/creek_mcp/tools/upload.py
@@ -63,6 +63,7 @@ from creek.ingest import INGESTOR_REGISTRY, route_to_ingestor
 from creek.ingest.journal_staging import UPLOAD_LEDGER_SOURCE, UPLOAD_STAGING_RELDIR
 from creek.ingest.ledger import SourceLedger
 from creek.ingest.pipeline import derive_source_key, run_ingest
+from creek.ingest.source_unit import split_source_unit
 from creek.models import PrivacyTier
 from creek_mcp.audit import MCPAuditLog
 from creek_mcp.read_gate import refuse_above_ceiling
@@ -158,12 +159,38 @@ def _stage_upload(
     return staged
 
 
-def _resolve_fragment_id(vault_path: Path, staged: Path) -> str | None:
-    """Return the fragment id the upload ledger mapped this staged file to."""
-    record = SourceLedger.load(vault_path, source=UPLOAD_LEDGER_SOURCE).get(
-        derive_source_key(str(staged), vault_path)
-    )
-    return record.fragment_id if record is not None else None
+def _resolve_fragment_ids(vault_path: Path, staged: Path) -> list[str]:
+    """Return every fragment id the upload ledger maps this staged file to.
+
+    Plural since #1305. One staged document can hold several independently
+    identified units — an uploaded ``.xlsx`` routes to ``SpreadsheetIngestor``,
+    which emits one fragment per sheet and ledgers each under its own
+    ``<staged path>#<sheet>`` key. The singular predecessor asked
+    :meth:`~creek.ingest.ledger.SourceLedger.get` for the bare staged path
+    and got ``None`` for exactly those uploads, and every one of this
+    module's four callers reads a ``None`` as *this id owns nothing*:
+
+    * :func:`_refuse_unadmitted_overwrite` would compute ``existing=None``
+      and admit a caller at ``ceiling=open`` to overwrite an intimate
+      workbook — the #970 gate defeated;
+    * :func:`_discard_unreferenced` would unlink a staged workbook that N
+      live fragments still reach through ``origin_key``, which is the RTBF
+      sweep's only route to those bytes;
+    * :func:`_refuse_extension_conflict` would report no conflict and fork
+      one ``external_id`` onto two live fragments;
+    * the response and audit entry would name one sheet out of N.
+
+    Args:
+        vault_path: Vault root.
+        staged: The staged file's path.
+
+    Returns:
+        The mapped fragment ids in ledger-key order, or ``[]`` when the
+        ledger knows nothing about this staged file.
+    """
+    ledger = SourceLedger.load(vault_path, source=UPLOAD_LEDGER_SOURCE)
+    base_key = derive_source_key(str(staged), vault_path)
+    return [record.fragment_id for _key, record in ledger.records_for(base_key)]
 
 
 def _existing_tier(vault_path: Path, fragment_ids: list[str]) -> PrivacyTier:
@@ -193,6 +220,65 @@ def _existing_tier(vault_path: Path, fragment_ids: list[str]) -> PrivacyTier:
         resolves to a readable fragment.
     """
     return max_source_tier(source_tiers(vault_path, fragment_ids))
+
+
+def _ledgered_names_for_id(vault_path: Path, external_id: str) -> dict[str, list[str]]:
+    """Return the fragment ids the upload LEDGER holds for *external_id* (#1305).
+
+    Grouped by staged filename, so a caller can ask both "does this id own
+    anything" and "does it own something under a *different* extension".
+
+    The ledger, not the staging directory, is the authority on what an
+    ``external_id`` owns — and after #1305 the difference is a privacy
+    ratchet rather than a nicety.
+
+    Purging **one** sheet of an N-sheet upload deletes the shared staged
+    workbook (that is the RTBF contract: the source bytes go) while the
+    other N-1 sheet fragments stay live, still ledgered, still possibly
+    ``intimate``. A survey keyed on :meth:`~pathlib.Path.iterdir` then sees
+    an empty staging dir, reports that the id owns nothing, and lets a
+    caller at ``ceiling=open`` through as a *creation*. The re-upload
+    restages to the same deterministic path, ``write_fragment_idempotent``
+    matches the surviving siblings by their intact ledger keys, and
+    overwrites intimate fragments with the low-ceiling caller's bytes —
+    reachable through two individually legitimate operations.
+
+    A ledger record survives the file it points at, so this survey does not
+    go blind at exactly the moment it matters.
+
+    Args:
+        vault_path: Vault root.
+        external_id: The caller's idempotency key.
+
+    Tombed records are counted too (:meth:`~creek.ingest.ledger.SourceLedger.all_keys`,
+    not ``live_keys``): a soft-tombed fragment still exists, under
+    ``10-Liminal/Orphaned/``, and for a gate whose failure mode is
+    *admitting* a caller, over-counting is the safe error.
+
+    Args:
+        vault_path: Vault root.
+        external_id: The caller's idempotency key.
+
+    Returns:
+        Staged filename mapped to the fragment ids ledgered under it (the
+        bare key and every ``…#<unit>`` child), ordered by ledger key.
+        Empty when the ledger knows nothing about this id.
+    """
+    stem = safe_stem(external_id)
+    staging = UPLOAD_STAGING_RELDIR.as_posix()
+    grouped: dict[str, list[str]] = {}
+    ledger = SourceLedger.load(vault_path, source=UPLOAD_LEDGER_SOURCE)
+    for key in sorted(ledger.all_keys()):
+        base, _unit = split_source_unit(key)
+        parent, _, name = base.rpartition("/")
+        if parent != staging:
+            continue
+        if name != stem and not name.startswith(f"{stem}."):
+            continue
+        record = ledger.get(key)
+        if record is not None:
+            grouped.setdefault(name, []).append(record.fragment_id)
+    return grouped
 
 
 def _staged_for_id(vault_path: Path, external_id: str) -> list[Path]:
@@ -253,10 +339,15 @@ def _refuse_unadmitted_overwrite(
         names neither the resolved fragment nor its tier.
     """
     del filename
+    # Surveyed from the LEDGER, not from a staging-directory listing
+    # (#1305). One staged workbook owns one fragment per sheet, so the
+    # survey is a flat union over units; and a ledger record outlives the
+    # staged file, so purging one sheet — which deletes the shared workbook
+    # while its siblings stay live and intimate — cannot blind this gate.
     ids = [
         fragment_id
-        for staged in _staged_for_id(vault_path, external_id)
-        if (fragment_id := _resolve_fragment_id(vault_path, staged)) is not None
+        for fragment_ids in _ledgered_names_for_id(vault_path, external_id).values()
+        for fragment_id in fragment_ids
     ]
     existing = None if not ids else _existing_tier(vault_path, ids)
     return refuse_above_ceiling(tool=TOOL_NAME, content_tier=existing, ceiling=ceiling)
@@ -286,7 +377,12 @@ def _discard_unreferenced(vault_path: Path, staged: Path) -> None:
         vault_path: Vault root.
         staged: The staged path the failed ingest was pointed at.
     """
-    if _resolve_fragment_id(vault_path, staged) is None:
+    # Deleted only when the ledger maps this staged path to NOTHING. A
+    # workbook whose sheets are ledgered under `<path>#<sheet>` keys has an
+    # empty *exact*-key lookup but a non-empty unit list, and unlinking it
+    # would destroy the bytes N live fragments still reach through
+    # `origin_key` (#1305).
+    if not _resolve_fragment_ids(vault_path, staged):
         staged.unlink(missing_ok=True)
 
 
@@ -323,18 +419,22 @@ def _refuse_extension_conflict(
         structured refusal naming the extension already bound to the id.
     """
     target = _upload_staged_path(vault_path, external_id, filename)
-    # Ledger-backed only. An unreferenced staged file is not a fragment anyone
-    # can purge, so treating it as a conflict would refuse with a remedy —
-    # "purge the existing fragment" — that cannot be carried out.
+    # Ledger-backed only, and now read straight off the ledger rather than
+    # off a directory listing (#1305). An unreferenced staged file is not a
+    # fragment anyone can purge, so treating it as a conflict would refuse
+    # with a remedy — "purge the existing fragment" — that cannot be carried
+    # out. Conversely a ledgered fragment whose staged bytes a sibling's
+    # purge already removed IS still a conflict, and a listing-based survey
+    # would miss exactly that case.
     conflicting = [
-        staged
-        for staged in _staged_for_id(vault_path, external_id)
-        if staged != target and _resolve_fragment_id(vault_path, staged) is not None
+        name
+        for name in _ledgered_names_for_id(vault_path, external_id)
+        if name != target.name
     ]
     if not conflicting:
         return None
     bound = ", ".join(
-        sorted({staged.suffix or "(no extension)" for staged in conflicting})
+        sorted({Path(name).suffix or "(no extension)" for name in conflicting})
     )
     return refusal_response(
         tool=TOOL_NAME,
@@ -725,8 +825,13 @@ def upload_tool(
         _discard_unreferenced(vault_path, staged)
         return result
 
-    fragment_id = _resolve_fragment_id(vault_path, staged)
-    affected = [fragment_id] if fragment_id else []
+    # Every fragment the staged document produced, in ledger-key order, so
+    # an RTBF request answered from this audit entry reaches all of them
+    # (#1305). ``fragment_id`` keeps its singular contract by naming the
+    # first in that order — deterministic across runs, and for the
+    # one-fragment-per-file majority it is still simply *the* fragment.
+    affected = _resolve_fragment_ids(vault_path, staged)
+    fragment_id = affected[0] if affected else None
     MCPAuditLog(vault_path).append(
         tool=TOOL_NAME,
         args=audit_args,

--- a/creek-tools/creek_mcp/tools/upload.py
+++ b/creek-tools/creek_mcp/tools/upload.py
@@ -277,39 +277,6 @@ def _ledgered_names_for_id(vault_path: Path, external_id: str) -> dict[str, list
     return grouped
 
 
-def _staged_for_id(vault_path: Path, external_id: str) -> list[Path]:
-    """Return every staged upload bound to *external_id*, whatever its extension.
-
-    The staged filename is ``<stem><suffix>``, so the ledger — which keys on
-    that path — actually keys identity on ``(external_id, extension)`` rather
-    than on ``external_id`` alone. This function recovers the id-only view the
-    tool's contract promises, and is what stops a re-send under a changed
-    extension from silently forking into a second, unrelated fragment while
-    orphaning the first one's staged bytes (a hole in the RTBF coverage this
-    tool exists to provide).
-
-    Matching is on the full name, not :attr:`Path.stem`: ``safe_stem`` permits
-    ``.`` in its slug, so ``Path("a.b-<digest>.pdf").stem`` is ``a.b-<digest>``
-    and a stem comparison would mis-group unrelated ids.
-
-    Args:
-        vault_path: Vault root.
-        external_id: The caller's idempotency key.
-
-    Returns:
-        Sorted staged paths, or ``[]`` when the staging dir does not exist.
-    """
-    stem = safe_stem(external_id)
-    staging = vault_path / UPLOAD_STAGING_RELDIR
-    if not staging.is_dir():
-        return []
-    return sorted(
-        path
-        for path in staging.iterdir()
-        if path.is_file() and (path.name == stem or path.name.startswith(f"{stem}."))
-    )
-
-
 def _refuse_unadmitted_overwrite(
     vault_path: Path, external_id: str, filename: str, ceiling: TierCeiling
 ) -> dict[str, Any] | None:

--- a/creek-tools/tests/test_ingest_ledger.py
+++ b/creek-tools/tests/test_ingest_ledger.py
@@ -18,9 +18,13 @@ import frontmatter
 from creek.cli import _run_ingest
 from creek.ingest import INGESTOR_REGISTRY
 from creek.ingest.ledger import LedgerRecord, SourceLedger
+from creek.ingest.pipeline import run_ingest
+from creek.ingest.spreadsheets import SpreadsheetIngestor
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from creek.ingest.pipeline import IngestRunResult
 
 
 def _make_vault(tmp_path: Path) -> Path:
@@ -198,3 +202,145 @@ class TestMarkdownLedgerWiring:
         vault = _make_vault(tmp_path)
         # No markdown ingest run -> no ledger file should exist.
         assert not SourceLedger.path_for(vault, "discord").exists()
+
+
+# ---- Per-sheet ledger identity for uploaded workbooks (#1305) ----------
+
+
+_UPLOAD_RELDIR = "00-Creek-Meta/adepthood/uploads"
+"""Vault-relative staging directory the upload path writes into."""
+
+_EXPECTED_SHEET_KEYS = {
+    f"{_UPLOAD_RELDIR}/book.xlsx#Budget",
+    f"{_UPLOAD_RELDIR}/book.xlsx#Notes",
+    f"{_UPLOAD_RELDIR}/book.xlsx#Q3",
+}
+"""The three per-sheet ``source_key`` values one staged workbook must produce."""
+
+
+def _stage_multi_sheet_workbook(vault: Path) -> Path:
+    """Write a real 3-sheet workbook into the upload staging directory.
+
+    Each sheet carries a header row and a data row so none of them is
+    dropped by the ``sheet.is_empty`` filter in ``SpreadsheetIngestor.parse``.
+    """
+    import openpyxl
+
+    staged = vault / _UPLOAD_RELDIR / "book.xlsx"
+    staged.parent.mkdir(parents=True, exist_ok=True)
+    workbook = openpyxl.Workbook()
+    first = workbook.active
+    assert first is not None
+    first.title = "Budget"
+    workbook.create_sheet(title="Notes")
+    workbook.create_sheet(title="Q3")
+    for index, name in enumerate(("Budget", "Notes", "Q3")):
+        worksheet = workbook[name]
+        worksheet.append(["item", "amount"])
+        worksheet.append([f"row-{index}", str(index * 10)])
+    workbook.save(staged)
+    return staged
+
+
+def _ingest_staged_workbook(vault: Path, staged: Path) -> IngestRunResult:
+    """Run the spreadsheet ingestor over the staged upload, ledger-backed."""
+    return run_ingest(
+        ingestor_cls=SpreadsheetIngestor,
+        source_type="spreadsheet",
+        input_path=staged,
+        vault_path=vault,
+        ledger_source="upload",
+    )
+
+
+def _fragment_paths(vault: Path) -> list[Path]:
+    """Return every fragment markdown file under ``01-Fragments``, sorted."""
+    return sorted((vault / "01-Fragments").rglob("*.md"))
+
+
+class TestUploadedWorkbookLedgerIdentity:
+    """A staged multi-sheet workbook is one ledgered unit per sheet (#1305)."""
+
+    def test_ledgered_multi_sheet_workbook_is_created_then_unchanged(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Three sheets create three fragments, then re-ingest as three unchanged.
+
+        Measured at HEAD, this run reports::
+
+            run1  created=1 updated=0 unchanged=2  files=1
+            run2  created=0 updated=0 unchanged=3  files=1
+
+        and the one surviving file holds the FIRST sheet (``Budget``) —
+        ``VaultWriter._write_model``'s duplicate-id early return
+        returns the already-written path for a duplicate id, so the first
+        writer wins and sheets 2..N are dropped. Any assertion phrased
+        around "the last sheet survives" would be red before *and* after
+        the fix and would certify nothing.
+
+        A per-sheet *fragment id* alone does not fix this run, which is
+        why the ledgered path needs its own test. ``derive_source_key``
+        keys on the file, so all three sheets resolve to one
+        ``origin_key``, one ``LedgerRecord``, and therefore one identity:
+        ``write_fragment_idempotent`` assigns ``fragment.id =
+        record.fragment_id`` on every branch of ``write_fragment_idempotent``
+        and the freshly-derived per-sheet ids are overwritten before the
+        write. The ledger key has to become per-sheet too.
+
+        ``updated`` must stay at zero on both runs. Nothing was edited
+        between them, so an ``updated`` count here is three sheets
+        overwriting each other in place — the loss wearing a success
+        message.
+        """
+        vault = _make_vault(tmp_path)
+        staged = _stage_multi_sheet_workbook(vault)
+
+        run1 = _ingest_staged_workbook(vault, staged)
+        assert run1.errors == [], run1.errors
+        assert (run1.created, run1.updated, run1.unchanged) == (3, 0, 0)
+        assert len(_fragment_paths(vault)) == 3
+
+        run2 = _ingest_staged_workbook(vault, staged)
+        assert run2.errors == [], run2.errors
+        assert (run2.created, run2.updated, run2.unchanged) == (0, 0, 3)
+        assert len(_fragment_paths(vault)) == 3
+
+    def test_ledgered_sheet_origin_keys_are_per_sheet_and_stable(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Each sheet gets its own ``origin_key``, and it does not move on re-ingest.
+
+        ``source.origin_key`` is the key the RTBF purge sweep matches on,
+        so it is not merely an identity nicety: a workbook whose three
+        sheets share one key is three fragments the operator can only
+        delete as one, and a key that changes between two identical
+        ingests is a fragment the purge can no longer find at all.
+
+        At HEAD all three sheets derive the same key
+        (``00-Creek-Meta/adepthood/uploads/book.xlsx``), so the ledger
+        holds exactly one record and this test is red on the key set.
+        """
+        vault = _make_vault(tmp_path)
+        staged = _stage_multi_sheet_workbook(vault)
+
+        first = _ingest_staged_workbook(vault, staged)
+        assert first.errors == [], first.errors
+
+        ledger = SourceLedger.load(vault, source="upload")
+        assert len(ledger) == 3
+        assert ledger.live_keys() == _EXPECTED_SHEET_KEYS
+
+        posts = _written_fragments(vault)
+        assert len(posts) == 3
+        assert {post["source"]["origin_key"] for post in posts} == _EXPECTED_SHEET_KEYS
+        for post in posts:
+            record = ledger.get(post["source"]["origin_key"])
+            assert record is not None, post["source"]["origin_key"]
+            assert record.fragment_id == post["id"]
+
+        second = _ingest_staged_workbook(vault, staged)
+        assert second.errors == [], second.errors
+        reloaded = SourceLedger.load(vault, source="upload")
+        assert reloaded.live_keys() == _EXPECTED_SHEET_KEYS

--- a/creek-tools/tests/test_mcp_upload.py
+++ b/creek-tools/tests/test_mcp_upload.py
@@ -790,3 +790,560 @@ def test_a_corrected_extension_after_a_failed_ingest_is_accepted(
     assert retried["action"] == "created"
     assert len(_fragments(vault)) == 1
     assert len(_staged(vault)) == 1
+
+
+# --------------------------------------------------------------------------
+# Multi-sheet workbooks (#1305)
+#
+# A `.xlsx` routes to `SpreadsheetIngestor`, which emits one fragment per
+# non-empty sheet. Until #1305 all N shared one fragment id, so the ledgered
+# upload path wrote exactly one fragment and reported the other N-1 as
+# `unchanged` — the loss wearing a success message.
+#
+# The fix gives each sheet its own ledger key, which is what these tests are
+# really about: the upload tool resolves an `external_id` back to its
+# fragment through that key, and a staged path that now maps to N records
+# instead of 0-or-1 is load-bearing for the #970 tier gate, for
+# `_discard_unreferenced`, and for the audit log.
+# --------------------------------------------------------------------------
+
+_SHEET_NAMES = ("Budget", "Notes", "Q3")
+
+
+def _multi_sheet_xlsx_bytes(tmp_path: Path, marker: str = "june") -> bytes:
+    """Build a genuine three-sheet ``.xlsx`` and return its bytes.
+
+    Args:
+        tmp_path: Directory to build the workbook in.
+        marker: Cell value written into every sheet, so a caller can produce
+            byte-different content for the same sheet layout.
+
+    Returns:
+        The workbook's bytes.
+    """
+    path = tmp_path / f"multi-{marker}.xlsx"
+    workbook = Workbook()
+    first = workbook.active
+    assert first is not None
+    first.title = _SHEET_NAMES[0]
+    for index, name in enumerate(_SHEET_NAMES):
+        sheet = first if index == 0 else workbook.create_sheet(name)
+        sheet["A1"] = "label"
+        sheet["B1"] = "value"
+        sheet["A2"] = f"{name}-{marker}"
+        sheet["B2"] = index
+    workbook.save(path)
+    return path.read_bytes()
+
+
+def _origin_keys(vault: Path) -> list[str]:
+    """Return every fragment's ``source.origin_key``, sorted.
+
+    Args:
+        vault: Vault root.
+
+    Returns:
+        The sorted origin keys, with a missing key rendered as ``"<none>"``
+        so an absent key fails an equality assertion loudly.
+    """
+    keys = []
+    for path in _fragments(vault):
+        source = frontmatter.load(path).metadata.get("source", {})
+        key = source.get("origin_key") if isinstance(source, dict) else None
+        keys.append(str(key) if key else "<none>")
+    return sorted(keys)
+
+
+def test_multi_sheet_upload_writes_one_fragment_per_sheet(tmp_path: Path) -> None:
+    """An uploaded three-sheet workbook lands three fragments, not one.
+
+    Measured at HEAD before the fix: ``created=1 unchanged=2``, one file on
+    disk holding the FIRST sheet (``Budget``) — ``_write_model`` takes the
+    lock, finds the id already written and returns the existing path, so
+    writes 2..N are silent no-ops. The issue body's claim that the LAST
+    sheet survives is backwards.
+    """
+    vault = _vault(tmp_path / "vault")
+
+    result = upload_tool(
+        vault_path=vault,
+        filename="book.xlsx",
+        content_base64=_b64(_multi_sheet_xlsx_bytes(tmp_path)),
+        external_id="u-multi",
+        timestamp=_TS,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+    assert result["status"] == "ok"
+    assert result["action"] == "created"
+    fragments = _fragments(vault)
+    assert len(fragments) == 3, [p.name for p in fragments]
+    # The heading names the STAGED file, not the caller's filename: only the
+    # extension of a caller-supplied name is ever trusted, and only to route.
+    staged_name = f"{safe_stem('u-multi')}.xlsx"
+    headings = sorted(
+        line
+        for path in fragments
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.startswith("# ")
+    )
+    assert headings == [f"# {staged_name} — {name}" for name in sorted(_SHEET_NAMES)]
+
+
+def test_multi_sheet_upload_reports_every_sheet_in_the_audit_log(
+    tmp_path: Path,
+) -> None:
+    """``affected_fragment_ids`` must hold all three ids, each exactly once.
+
+    At HEAD the tool resolves the staged path to at most ONE ledger record,
+    so the response's ``fragment_id`` names a single sheet and the audit
+    entry under-reports what the call touched. An audit record that names
+    one of three fragments is a false record, and it is the record an RTBF
+    request is answered from.
+    """
+    vault = _vault(tmp_path / "vault")
+
+    result = upload_tool(
+        vault_path=vault,
+        filename="book.xlsx",
+        content_base64=_b64(_multi_sheet_xlsx_bytes(tmp_path)),
+        external_id="u-multi-audit",
+        timestamp=_TS,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+    affected = result["affected_fragment_ids"]
+    assert len(affected) == 3
+    assert len(set(affected)) == 3
+    assert result["fragment_id"] == affected[0]
+    on_disk = {frontmatter.load(p).metadata["id"] for p in _fragments(vault)}
+    assert set(affected) == on_disk
+    entry = next(e for e in _audit(vault) if e.get("affected_fragment_ids"))
+    assert sorted(entry["affected_fragment_ids"]) == sorted(affected)
+
+
+def test_multi_sheet_upload_resend_is_a_true_no_op(tmp_path: Path) -> None:
+    """Re-sending identical bytes reports ``unchanged`` and adds no fragment.
+
+    ``updated`` here would be the failure this issue is about: post-fix but
+    pre-ledger-key, the run overwrote sheet 1 with sheet 2 and then sheet 3
+    and reported ``updated=2``, which reads like work was done.
+    """
+    vault = _vault(tmp_path / "vault")
+    payload = _b64(_multi_sheet_xlsx_bytes(tmp_path))
+
+    def _send() -> dict[str, Any]:
+        """Send the identical workbook under a stable external id."""
+        return upload_tool(
+            vault_path=vault,
+            filename="book.xlsx",
+            content_base64=payload,
+            external_id="u-multi-resend",
+            timestamp=_TS,
+            privacy_tier_ceiling=TierCeiling.OPEN,
+        )
+
+    first = _send()
+    keys_after_first = _origin_keys(vault)
+    second = _send()
+
+    assert first["action"] == "created"
+    assert second["action"] == "unchanged"
+    assert len(_fragments(vault)) == 3
+    assert len(_staged(vault)) == 1
+    # The origin key is the RTBF purge key; a key that moves on re-ingest
+    # silently drops the old fragment out of every purge the vault offers.
+    assert _origin_keys(vault) == keys_after_first
+    assert sorted(second["affected_fragment_ids"]) == sorted(
+        first["affected_fragment_ids"]
+    )
+
+
+def test_multi_sheet_origin_keys_name_each_sheet(tmp_path: Path) -> None:
+    """Each sheet fragment carries its own ``…/book.xlsx#<sheet>`` key."""
+    vault = _vault(tmp_path / "vault")
+
+    upload_tool(
+        vault_path=vault,
+        filename="book.xlsx",
+        content_base64=_b64(_multi_sheet_xlsx_bytes(tmp_path)),
+        external_id="u-multi-keys",
+        timestamp=_TS,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+    staged_name = f"{safe_stem('u-multi-keys')}.xlsx"
+    base = f"{UPLOAD_STAGING_RELDIR.as_posix()}/{staged_name}"
+    assert _origin_keys(vault) == sorted(f"{base}#{name}" for name in _SHEET_NAMES)
+
+
+def test_multi_sheet_resend_is_still_refused_above_ceiling(tmp_path: Path) -> None:
+    """The #970 gate must still see an intimate workbook it cannot read.
+
+    GREEN at HEAD (one collapsed fragment resolves fine), and it is the
+    guard that the per-sheet ledger key does not defeat the gate. Resolving
+    the staged path to a single record returns ``None`` once the ledger
+    holds only ``…#<sheet>`` keys, which makes ``existing`` ``None`` and
+    ADMITS a caller at ``ceiling=open`` to overwrite intimate content.
+    Read this as a ratchet test, not as the issue's red test.
+    """
+    vault = _vault(tmp_path / "vault")
+    first = upload_tool(
+        vault_path=vault,
+        filename="book.xlsx",
+        content_base64=_b64(_multi_sheet_xlsx_bytes(tmp_path, marker="tender")),
+        external_id="u-multi-tier",
+        timestamp=_TS,
+        tier="intimate",
+        privacy_tier_ceiling=TierCeiling.INTIMATE,
+    )
+    assert first["status"] == "ok"
+    assert first["fragment_id"] is not None
+    assert len(first["affected_fragment_ids"]) == 3
+
+    refused = upload_tool(
+        vault_path=vault,
+        filename="book.xlsx",
+        content_base64=_b64(_multi_sheet_xlsx_bytes(tmp_path, marker="benign")),
+        external_id="u-multi-tier",
+        timestamp=_TS,
+        tier="open",
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+    assert refused["status"] == "refused"
+    assert set(refused) == _REFUSAL_KEYS
+    assert refused["reason"] == GENERIC_ABOVE_CEILING_REASON
+    assert len(_fragments(vault)) == 3
+
+
+def test_multi_sheet_extension_conflict_is_still_refused(tmp_path: Path) -> None:
+    """A re-send of the same id under a new extension must still be refused.
+
+    ``_refuse_extension_conflict`` asks whether the OTHER staged paths for
+    this id resolve to a fragment. With per-sheet keys the bare staged path
+    resolves to nothing, so a single-record lookup would answer "no
+    conflict" and fork the id onto two live fragments, orphaning the
+    workbook's staged bytes.
+    """
+    vault = _vault(tmp_path / "vault")
+    upload_tool(
+        vault_path=vault,
+        filename="book.xlsx",
+        content_base64=_b64(_multi_sheet_xlsx_bytes(tmp_path)),
+        external_id="u-multi-ext",
+        timestamp=_TS,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+    conflicted = upload_tool(
+        vault_path=vault,
+        filename="book.txt",
+        content_base64=_b64(b"a plain text re-type of the same document"),
+        external_id="u-multi-ext",
+        timestamp=_TS,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+    assert conflicted["status"] == "refused"
+    assert ".xlsx" in conflicted["reason"]
+    assert len(_fragments(vault)) == 3
+    assert len(_staged(vault)) == 1
+
+
+def test_failed_resend_does_not_discard_a_referenced_workbook(
+    tmp_path: Path,
+) -> None:
+    """``_discard_unreferenced`` must not unlink a workbook three sheets cite.
+
+    Keyed on "does the ledger know this staged path", which with per-sheet
+    keys is no longer a single-record question. Answering it with a
+    single-record lookup deletes the staged bytes that three live fragments
+    still reach through ``origin_key`` — the RTBF sweep's only route to
+    them — on the first re-send whose ingest errors.
+    """
+    vault = _vault(tmp_path / "vault")
+    upload_tool(
+        vault_path=vault,
+        filename="book.xlsx",
+        content_base64=_b64(_multi_sheet_xlsx_bytes(tmp_path)),
+        external_id="u-multi-fail",
+        timestamp=_TS,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert len(_staged(vault)) == 1
+
+    failed = upload_tool(
+        vault_path=vault,
+        filename="book.xlsx",
+        content_base64=_b64(_multi_sheet_xlsx_bytes(tmp_path, marker="second")),
+        external_id="u-multi-fail",
+        timestamp=_TS,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+        run=_failing_runner,
+    )
+
+    assert failed["status"] == "refused"
+    assert len(_staged(vault)) == 1, "a referenced workbook must survive a failure"
+    assert len(_fragments(vault)) == 3
+
+
+def test_single_sheet_upload_keeps_a_bare_origin_key(tmp_path: Path) -> None:
+    """A one-sheet workbook must be untouched by the sub-unit scheme.
+
+    The single-sheet carve-out is the migration answer: every CSV and
+    single-sheet XLSX already in an operator vault keeps its exact id, its
+    exact filename and its exact ``origin_key``, so re-ingesting an
+    untouched file after this change is still a no-op rather than a
+    duplicate. This pins the key half of that.
+    """
+    vault = _vault(tmp_path / "vault")
+
+    upload_tool(
+        vault_path=vault,
+        filename="budget.xlsx",
+        content_base64=_b64(_xlsx_bytes(tmp_path)),
+        external_id="u-single",
+        timestamp=_TS,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+    staged_name = f"{safe_stem('u-single')}.xlsx"
+    assert _origin_keys(vault) == [f"{UPLOAD_STAGING_RELDIR.as_posix()}/{staged_name}"]
+    assert len(_fragments(vault)) == 1
+
+
+def test_multi_sheet_fragment_id_is_stable_under_sheet_order(tmp_path: Path) -> None:
+    """The response's singular ``fragment_id`` must not depend on sheet order.
+
+    ``fragment_id`` reduces N sheets to one id, and callers persist it as
+    the handle they later purge by. Reducing by *ledger-key order* makes
+    that choice a property of the workbook; reducing by dict-insertion
+    order makes it a property of the order the JSONL happened to be
+    written and re-read in, which is not a promise the ledger makes.
+
+    Sheet names are deliberately anti-alphabetical so the two orders
+    disagree: insertion gives ``Zeta`` first, key order gives ``Alpha``.
+    """
+    vault = _vault(tmp_path / "vault")
+    names = ("Zeta", "Alpha", "Mid")
+    path = tmp_path / "ordered.xlsx"
+    workbook = Workbook()
+    first = workbook.active
+    assert first is not None
+    first.title = names[0]
+    for index, name in enumerate(names):
+        sheet = first if index == 0 else workbook.create_sheet(name)
+        sheet["A1"] = "label"
+        sheet["A2"] = name
+    workbook.save(path)
+
+    result = upload_tool(
+        vault_path=vault,
+        filename="ordered.xlsx",
+        content_base64=_b64(path.read_bytes()),
+        external_id="u-order",
+        timestamp=_TS,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+    staged_name = f"{safe_stem('u-order')}.xlsx"
+    base = f"{UPLOAD_STAGING_RELDIR.as_posix()}/{staged_name}"
+    assert _origin_keys(vault) == sorted(f"{base}#{name}" for name in names)
+    # Alphabetically first key, not workbook-first sheet.
+    alpha_id = frontmatter.load(
+        next(
+            p
+            for p in _fragments(vault)
+            if frontmatter.load(p).metadata["source"]["origin_key"] == f"{base}#Alpha"
+        )
+    ).metadata["id"]
+    assert result["fragment_id"] == alpha_id
+    assert result["affected_fragment_ids"][0] == alpha_id
+
+
+def test_purging_one_sheet_does_not_open_the_tier_gate_on_its_siblings(
+    tmp_path: Path,
+) -> None:
+    """Purge one sheet, then re-upload at ``open``: still refused.
+
+    The two-step privacy bypass this guards. Purging ONE sheet fragment of
+    an N-sheet intimate upload deletes the shared staged workbook — that is
+    the RTBF contract, the source bytes go — while the other N-1 sheet
+    fragments stay live, intimate, and still ledgered.
+
+    A #970 overwrite gate that surveys the STAGING DIRECTORY then sees
+    nothing, concludes the ``external_id`` owns nothing, and admits a
+    caller at ``ceiling=open`` as a *creation*. The re-upload restages to
+    the same deterministic path, ``write_fragment_idempotent`` matches the
+    surviving siblings by their intact ledger keys, and overwrites intimate
+    content with the low-ceiling caller's bytes. Two individually
+    legitimate operations, one tier bypass.
+
+    A ledger record outlives the file it points at, which is why the survey
+    reads the ledger.
+    """
+    vault = _vault(tmp_path / "vault")
+    first = upload_tool(
+        vault_path=vault,
+        filename="book.xlsx",
+        content_base64=_b64(_multi_sheet_xlsx_bytes(tmp_path, marker="tender")),
+        external_id="u-purge-gate",
+        timestamp=_TS,
+        tier="intimate",
+        privacy_tier_ceiling=TierCeiling.INTIMATE,
+    )
+    assert first["status"] == "ok"
+    victim, *survivors = sorted(first["affected_fragment_ids"])
+    assert len(survivors) == 2
+
+    purge = PurgeEngine(vault).purge_fragment(victim)
+
+    assert purge.journal_staged_removed == 1
+    assert _staged(vault) == [], "the shared workbook is gone, by design"
+    assert len(_fragments(vault)) == 2, "the sibling sheets are still live"
+
+    refused = upload_tool(
+        vault_path=vault,
+        filename="book.xlsx",
+        content_base64=_b64(_multi_sheet_xlsx_bytes(tmp_path, marker="benign")),
+        external_id="u-purge-gate",
+        timestamp=_TS,
+        tier="open",
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+    assert refused["status"] == "refused"
+    assert set(refused) == _REFUSAL_KEYS
+    assert refused["reason"] == GENERIC_ABOVE_CEILING_REASON
+    # Nothing restaged, and the surviving intimate fragments are untouched.
+    assert _staged(vault) == []
+    assert len(_fragments(vault)) == 2
+    assert {frontmatter.load(p).metadata["id"] for p in _fragments(vault)} == set(
+        survivors
+    )
+    assert _leaking_files(vault, b"benign") == []
+
+
+def test_extension_conflict_survives_a_purge_of_the_staged_bytes(
+    tmp_path: Path,
+) -> None:
+    """A ledgered fragment whose staged bytes are gone is still a conflict.
+
+    Same root cause as the tier-gate case: the conflict survey must read
+    the ledger, not a directory listing. Otherwise purging one sheet lets
+    the same ``external_id`` be re-sent under a different extension, forking
+    it onto a second live fragment while the first's siblings remain.
+    """
+    vault = _vault(tmp_path / "vault")
+    first = upload_tool(
+        vault_path=vault,
+        filename="book.xlsx",
+        content_base64=_b64(_multi_sheet_xlsx_bytes(tmp_path)),
+        external_id="u-purge-ext",
+        timestamp=_TS,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    PurgeEngine(vault).purge_fragment(sorted(first["affected_fragment_ids"])[0])
+    assert _staged(vault) == []
+
+    conflicted = upload_tool(
+        vault_path=vault,
+        filename="book.txt",
+        content_base64=_b64(b"a plain text re-type of the same document"),
+        external_id="u-purge-ext",
+        timestamp=_TS,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+    assert conflicted["status"] == "refused"
+    assert ".xlsx" in conflicted["reason"]
+    assert _staged(vault) == []
+    assert len(_fragments(vault)) == 2
+
+
+def test_a_tombed_ledger_record_still_closes_the_tier_gate(tmp_path: Path) -> None:
+    """A soft-tombed record must not read as "this id owns nothing".
+
+    Tombing is unreachable for uploads today — ``tomb_missing_units``
+    requires both a ``TOMBING_SOURCES`` source type and a *directory*
+    input, and ``creek.upload`` always passes a single file — so this
+    seeds the record directly rather than pretending to reach it.
+
+    The branch is kept because tombing is a soft delete: the fragment
+    still exists under ``10-Liminal/Orphaned/``. Surveying ``live_keys``
+    would hand a caller at ``ceiling=open`` a clean "creation" over
+    content that is merely filed elsewhere, and the day uploads become
+    tombable that would be a silent tier bypass rather than a new bug.
+    """
+    from creek.ingest.ledger import SourceLedger
+
+    vault = _vault(tmp_path / "vault")
+    first = upload_tool(
+        vault_path=vault,
+        filename="tender.txt",
+        content_base64=_b64(b"a tender upload " + _SECRET),
+        external_id="u-tombed",
+        timestamp=_TS,
+        tier="intimate",
+        privacy_tier_ceiling=TierCeiling.INTIMATE,
+    )
+    assert first["status"] == "ok"
+
+    ledger = SourceLedger.load(vault, source="upload")
+    key = next(iter(ledger.live_keys()))
+    record = ledger.get(key)
+    assert record is not None
+    ledger.record(key, record.fragment_id, record.content_hash, tombed=True)
+    assert SourceLedger.load(vault, source="upload").live_keys() == set()
+
+    refused = upload_tool(
+        vault_path=vault,
+        filename="tender.txt",
+        content_base64=_b64(b"benign overwrite attempt"),
+        external_id="u-tombed",
+        timestamp=_TS,
+        tier="open",
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+    assert refused["status"] == "refused"
+    assert refused["reason"] == GENERIC_ABOVE_CEILING_REASON
+    assert _leaking_files(vault, _SECRET) != [], "the intimate content survives"
+
+
+def test_a_same_named_key_outside_the_staging_dir_does_not_block_an_upload(
+    tmp_path: Path,
+) -> None:
+    """The survey is scoped to the staging dir, so a stem collision elsewhere
+    cannot produce a phantom refusal.
+
+    The upload ledger is shared machinery: ``derive_source_key`` falls back
+    to a bare filename for an out-of-vault source, and a borrowed ledger
+    could hold a key under some other directory. Matching on the filename
+    alone would let such a key masquerade as this ``external_id``'s own
+    content and refuse a legitimate first upload — a gate that fails
+    *closed* on unrelated state is still a gate that is wrong.
+    """
+    from creek.ingest.ledger import SourceLedger
+
+    vault = _vault(tmp_path / "vault")
+    stem = safe_stem("u-scoped")
+    decoy_ledger = SourceLedger.load(vault, source="upload")
+    decoy_ledger.record(f"01-Fragments/{stem}.txt", "frag-decoy", "deadbeef")
+    decoy_ledger.record(f"{stem}.txt", "frag-decoy-bare", "deadbeef")
+
+    result = upload_tool(
+        vault_path=vault,
+        filename="notes.txt",
+        content_base64=_b64(b"a perfectly ordinary first upload"),
+        external_id="u-scoped",
+        timestamp=_TS,
+        tier="open",
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+    assert result["status"] == "ok"
+    assert result["action"] == "created"
+    assert len(_fragments(vault)) == 1
+    assert "frag-decoy" not in result["affected_fragment_ids"]

--- a/creek-tools/tests/test_multi_sheet_surfaces.py
+++ b/creek-tools/tests/test_multi_sheet_surfaces.py
@@ -1,0 +1,390 @@
+"""Multi-sheet workbooks on the surfaces that bypass ``run_ingest`` (#1305).
+
+Three of the four ways a workbook reaches a vault go through
+:func:`creek.ingest.pipeline.run_ingest`; two do not, and a
+``run_ingest``-only test therefore certifies nothing about them:
+
+* the ``creek.ingest`` MCP tool calls ``writer.write_fragment`` itself and
+  builds its audit record from the ids it collected on the way, so before
+  #1305 it recorded the SAME id N times in ``affected_fragment_ids`` — a
+  false audit record, and audit records are what an RTBF request is
+  answered from;
+* ``creek process`` assembles every fragment and writes them in a later
+  stage, having classified all N first, so before #1305 it paid N-1 LLM
+  classification calls and then discarded their results when the writer
+  deduped the ids.
+
+The last test covers the un-migrated-vault advisory, which is this
+change's answer to the fragments the old derivation left behind.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import TYPE_CHECKING
+
+import frontmatter
+import pytest
+from openpyxl import Workbook
+
+from creek.config import CreekConfig
+from creek.ingest.base import generate_fragment_id
+from creek.ingest.pipeline import run_ingest
+from creek.ingest.spreadsheets import SpreadsheetIngestor
+from creek.pipeline import Pipeline
+from creek_mcp.audit import MCP_AUDIT_RELPATH
+from creek_mcp.tier_ceiling import TierCeiling
+from creek_mcp.tools.ingest import ingest_tool
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_SHEET_NAMES = ("Budget", "Notes", "Q3")
+
+
+def _write_workbook(path: Path, names: tuple[str, ...] = _SHEET_NAMES) -> Path:
+    """Write a real multi-sheet XLSX at *path* and return it.
+
+    Args:
+        path: Destination file.
+        names: Sheet names, in workbook order. Each sheet gets a header
+            row and one data row so none is skipped as empty.
+
+    Returns:
+        *path*, for chaining.
+    """
+    workbook = Workbook()
+    first = workbook.active
+    assert first is not None
+    first.title = names[0]
+    for index, name in enumerate(names):
+        sheet = first if index == 0 else workbook.create_sheet(name)
+        sheet["A1"] = "label"
+        sheet["B1"] = "value"
+        sheet["A2"] = name
+        sheet["B2"] = index
+    path.parent.mkdir(parents=True, exist_ok=True)
+    workbook.save(path)
+    return path
+
+
+def _fragment_files(vault: Path) -> list[Path]:
+    """Return every persisted fragment file, sorted by path.
+
+    Args:
+        vault: Vault root.
+
+    Returns:
+        The fragment paths under ``01-Fragments``.
+    """
+    return sorted((vault / "01-Fragments").rglob("*.md"))
+
+
+def _scaffold(tmp_path: Path) -> Path:
+    """Create the minimal vault layout ``VaultWriter`` and the audit log need.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+
+    Returns:
+        The vault root.
+    """
+    vault = tmp_path / "vault"
+    for sub in ("00-Creek-Meta/State", "00-Creek-Meta/audit", "01-Fragments"):
+        (vault / sub).mkdir(parents=True, exist_ok=True)
+    return vault
+
+
+def test_mcp_ingest_tool_returns_and_audits_one_id_per_sheet(
+    tmp_path: Path,
+) -> None:
+    """The ``creek.ingest`` tool must report three distinct ids, not one thrice.
+
+    Pre-fix this returned ``written=3`` with three IDENTICAL entries in
+    ``affected_fragment_ids`` while only one file reached disk: a run that
+    over-reports what it wrote and names a fragment twice that does not
+    exist. This surface never calls ``run_ingest``, so the ledgered and
+    unledgered regression tests do not reach it.
+    """
+    vault = _scaffold(tmp_path)
+    source = vault / "00-Inbox"
+    _write_workbook(source / "book.xlsx")
+
+    result = ingest_tool(
+        vault_path=vault,
+        source_type="spreadsheet",
+        input_path=str(source),
+        privacy_tier_ceiling=TierCeiling.PERSONAL,
+    )
+
+    assert result["status"] == "ok"
+    affected = result["affected_fragment_ids"]
+    assert len(affected) == 3
+    assert len(set(affected)) == 3
+    assert result["written"] == 3
+    files = _fragment_files(vault)
+    assert len(files) == 3, [p.name for p in files]
+    assert {frontmatter.load(p).metadata["id"] for p in files} == set(affected)
+
+    entries = [
+        json.loads(line)
+        for line in (vault / MCP_AUDIT_RELPATH).read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    logged = [
+        e["affected_fragment_ids"] for e in entries if e.get("affected_fragment_ids")
+    ]
+    assert len(logged) == 1
+    assert sorted(logged[0]) == sorted(affected)
+    assert len(set(logged[0])) == 3, "the audit record must not repeat one id"
+
+
+@pytest.mark.e2e
+def test_creek_process_writes_one_file_per_sheet(tmp_path: Path) -> None:
+    """``creek process`` persists all three sheets, not just the first.
+
+    ``Pipeline`` assembles every fragment, classifies them, and writes in a
+    later stage. Pre-fix the three sheets shared one id, so the writer's
+    dedup kept the first and dropped two — after they had each been
+    classified. The wasted classification calls are a side effect this fix
+    removes; the assertion here is about what reaches disk.
+    """
+    from creek.scaffold import scaffold_vault
+
+    vault = tmp_path / "vault"
+    scaffold_vault(vault)
+    source = tmp_path / "source"
+    _write_workbook(source / "book.xlsx")
+
+    # ``no_llm=True`` keeps this hermetic: without it the run reaches the
+    # LLM classifier on any machine with ollama up or a provider key set,
+    # which is network egress from a test that is about file counts.
+    result = Pipeline(config=CreekConfig(), no_llm=True).run(
+        source_path=source, vault_path=vault
+    )
+
+    assert result.errors == []
+    files = _fragment_files(vault)
+    assert len(files) == 3, [p.name for p in files]
+    assert result.fragments_created == 3
+    headings = sorted(
+        line
+        for path in files
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.startswith("# ")
+    )
+    assert headings == [f"# book.xlsx — {name}" for name in sorted(_SHEET_NAMES)]
+    # The writer de-collides a name clash with a ``-N`` suffix rather than
+    # overwriting, so a ``-1`` stem is the on-disk signature of the defect.
+    assert not [p.name for p in files if p.stem.endswith("-1")]
+
+
+def test_unmigrated_vault_is_warned_about_not_silently_duplicated(
+    tmp_path: Path,
+) -> None:
+    """A pre-#1305 collapsed fragment is named, and nothing is deleted.
+
+    Seeds the exact state an operator's vault is in: one workbook already
+    ingested under the old derivation, leaving a single fragment holding
+    the first sheet. The next ingest writes the three per-sheet fragments
+    and must say so — the superseded fragment is left in place, because
+    deleting vault content is not a decision an ingest run gets to make
+    (the same answer #1304 gave the same shape of problem).
+    """
+    vault = _scaffold(tmp_path)
+    book = _write_workbook(tmp_path / "src" / "book.xlsx")
+
+    # The pre-#1305 state, reproduced through the real derivation: with a
+    # single non-empty sheet no unit is emitted, so this run writes exactly
+    # the fragment the old code wrote for the whole workbook.
+    legacy_book = tmp_path / "src2" / "book.xlsx"
+    _write_workbook(legacy_book, names=("Budget",))
+    legacy = run_ingest(
+        ingestor_cls=SpreadsheetIngestor,
+        source_type="spreadsheet",
+        input_path=legacy_book,
+        vault_path=vault,
+    )
+    assert legacy.created == 1
+    assert legacy.warnings == []
+    seeded = _fragment_files(vault)
+    assert len(seeded) == 1
+
+    warnings: list[str] = []
+    result = run_ingest(
+        ingestor_cls=SpreadsheetIngestor,
+        source_type="spreadsheet",
+        input_path=book,
+        vault_path=vault,
+        on_warning=warnings.append,
+    )
+
+    assert result.created == 3
+    assert result.warnings == warnings
+    assert len(warnings) == 0, "a different workbook must not raise the advisory"
+    # Four files: the seeded single-sheet fragment plus three per-sheet ones.
+    assert len(_fragment_files(vault)) == 4
+    assert seeded[0].exists(), "nothing is deleted by an ingest run"
+
+
+def test_collapsed_fragment_from_the_same_workbook_raises_the_advisory(
+    tmp_path: Path,
+) -> None:
+    """Re-ingesting the very workbook that collapsed names its stray fragment.
+
+    The superseded id is recomputable exactly — it is what this same
+    fragment hashes to with no unit — so detection needs no vault walk, no
+    frontmatter parsing and no ``platform`` heuristic. The advisory is
+    self-clearing: purge the named fragment and the next run is quiet.
+    """
+    vault = _scaffold(tmp_path)
+    book = tmp_path / "src" / "book.xlsx"
+    _write_workbook(book, names=("Budget",))
+
+    first = run_ingest(
+        ingestor_cls=SpreadsheetIngestor,
+        source_type="spreadsheet",
+        input_path=book,
+        vault_path=vault,
+    )
+    assert first.created == 1
+    assert first.warnings == []
+    collapsed = _fragment_files(vault)[0]
+    collapsed_id = str(frontmatter.load(collapsed).metadata["id"])
+
+    # The operator adds two sheets to the same file. The workbook now yields
+    # three units, so the old whole-file id is superseded.
+    mtime = book.stat().st_mtime
+    _write_workbook(book)
+    os.utime(book, (mtime, mtime))
+
+    warnings: list[str] = []
+    second = run_ingest(
+        ingestor_cls=SpreadsheetIngestor,
+        source_type="spreadsheet",
+        input_path=book,
+        vault_path=vault,
+        on_warning=warnings.append,
+    )
+
+    assert second.created == 3
+    assert len(warnings) == 1
+    assert collapsed_id in warnings[0]
+    assert "Nothing is deleted automatically" in warnings[0]
+    assert "--dry-run" in warnings[0]
+    assert second.warnings == warnings
+    assert collapsed.exists(), "the advisory reports; it never deletes"
+    assert len(_fragment_files(vault)) == 4
+
+    # Self-clearing: with the superseded fragment gone the run goes quiet.
+    collapsed.unlink()
+    third_warnings: list[str] = []
+    run_ingest(
+        ingestor_cls=SpreadsheetIngestor,
+        source_type="spreadsheet",
+        input_path=book,
+        vault_path=vault,
+        on_warning=third_warnings.append,
+    )
+    assert third_warnings == []
+
+
+def test_each_sheet_gets_its_own_provenance_entry(tmp_path: Path) -> None:
+    """Provenance must record three distinct ids, not one three times.
+
+    ``Ingestor._process_fragment`` mints the provenance id from a SECOND,
+    independent call to ``generate_fragment_id``. Fixing only the call in
+    ``assemble_ingested_fragment`` leaves the append-only provenance log —
+    the record of what this ingest actually did — claiming one fragment was
+    written three times. Caught by mutating that call site back to
+    ``source_path``, which every other test in this change survived.
+    """
+    book = _write_workbook(tmp_path / "src" / "book.xlsx")
+
+    result = SpreadsheetIngestor().ingest(book)
+
+    assert len(result.fragments) == 3
+    provenance_ids = [entry.fragment_id for entry in result.provenance]
+    assert len(provenance_ids) == 3
+    assert len(set(provenance_ids)) == 3
+    assert set(provenance_ids) == {
+        generate_fragment_id(parsed.identity_key, parsed.timestamp, parsed.content)
+        for parsed in result.fragments
+    }
+
+
+def test_single_sheet_re_ingest_raises_no_collapsed_advisory(tmp_path: Path) -> None:
+    """Re-ingesting an unchanged one-sheet workbook must stay quiet.
+
+    The advisory recomputes "the id this fragment would have had with no
+    unit". For a unit-less fragment that is simply its OWN id, which the
+    vault holds from the previous run — so without the ``source_unit is
+    None`` guard every re-ingest of every CSV and one-sheet XLSX would
+    accuse the operator of an un-migrated vault. A warning that fires on
+    correct state is a warning that gets trained away.
+    """
+    vault = _scaffold(tmp_path)
+    book = tmp_path / "src" / "book.csv"
+    book.parent.mkdir(parents=True, exist_ok=True)
+    book.write_text("a,b\n1,2\n", encoding="utf-8")
+
+    first = run_ingest(
+        ingestor_cls=SpreadsheetIngestor,
+        source_type="spreadsheet",
+        input_path=book,
+        vault_path=vault,
+    )
+    warnings: list[str] = []
+    second = run_ingest(
+        ingestor_cls=SpreadsheetIngestor,
+        source_type="spreadsheet",
+        input_path=book,
+        vault_path=vault,
+        on_warning=warnings.append,
+    )
+
+    assert first.warnings == []
+    assert second.warnings == []
+    assert warnings == []
+    assert len(_fragment_files(vault)) == 1
+
+
+def test_collapsed_advisory_names_each_superseded_id_once(tmp_path: Path) -> None:
+    """One superseded fragment must be reported as one, not once per sheet.
+
+    All N sheets of a workbook recompute the SAME superseded id — that is
+    the defect — so an undeduplicated advisory reports ``3 fragment(s)``
+    and lists the identical id three times, overstating by a factor of N
+    exactly how much stray content the operator has to review.
+    """
+    vault = _scaffold(tmp_path)
+    book = tmp_path / "src" / "book.xlsx"
+    _write_workbook(book, names=("Budget",))
+    run_ingest(
+        ingestor_cls=SpreadsheetIngestor,
+        source_type="spreadsheet",
+        input_path=book,
+        vault_path=vault,
+    )
+    mtime = book.stat().st_mtime
+    _write_workbook(book)
+    os.utime(book, (mtime, mtime))
+
+    warnings: list[str] = []
+    run_ingest(
+        ingestor_cls=SpreadsheetIngestor,
+        source_type="spreadsheet",
+        input_path=book,
+        vault_path=vault,
+        on_warning=warnings.append,
+    )
+
+    assert len(warnings) == 1
+    assert "1 fragment(s)" in warnings[0]
+    collapsed_id = str(
+        frontmatter.load(
+            next(p for p in _fragment_files(vault) if p.name.endswith("-book.md"))
+        ).metadata["id"]
+    )
+    assert warnings[0].count(collapsed_id) == 1

--- a/creek-tools/tests/test_purge_sheet_units.py
+++ b/creek-tools/tests/test_purge_sheet_units.py
@@ -1,0 +1,318 @@
+"""RTBF purge over a sub-unit ``source.origin_key`` (#1305).
+
+Issue #1305 gives each sheet of a multi-sheet workbook its own fragment id
+*and* its own ledger key, so an uploaded workbook's fragments now carry an
+``origin_key`` of the form ``…/uploads/book.xlsx#Budget`` rather than the
+bare staged path.
+
+That is the point where a spreadsheet bugfix turns into a privacy question.
+``PurgeEngine._purge_staged_source_entry`` deletes the staged source a
+purged fragment points at, and it reaches it by resolving ``origin_key``
+inside the vault. A key naming a sub-unit resolves to a path that is inside
+the staging root but is **not a file**, so the ``is_file()`` guard returns
+early and the raw workbook — the operator's actual document — survives the
+erasure request meant to remove it.
+
+These tests pin both halves of the answer: the sweep must follow a sub-unit
+key back to the workbook, and it must not have loosened a single one of the
+containment guards to do it. A key that is genuinely a ``#``-named file
+still wins on the whole-key attempt, and a traversal key with a unit suffix
+is still refused.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import frontmatter
+import pytest
+
+from creek.ingest.journal_staging import UPLOAD_STAGING_RELDIR
+from creek.ingest.source_unit import compose_source_unit, split_source_unit
+from creek.purge import PurgeEngine
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_WORKBOOK_SECRET = "synthetic-workbook-secret-1305"
+"""Sentinel written into the staged workbook so its survival is detectable."""
+
+
+def _make_vault(tmp_path: Path) -> Path:
+    """Create the minimal vault layout the purge engine requires.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+
+    Returns:
+        The vault root.
+    """
+    vault = tmp_path / "vault"
+    for sub in (
+        "00-Creek-Meta/Processing-Log",
+        "01-Fragments/Documents",
+        "02-Threads/Active",
+        "03-Eddies",
+        "04-Praxis",
+    ):
+        (vault / sub).mkdir(parents=True, exist_ok=True)
+    (vault / "00-Creek-Meta" / "creek_config.yaml").write_text(
+        "# minimal marker for GAP-003\n", encoding="utf-8"
+    )
+    return vault
+
+
+def _stage_workbook(vault: Path, name: str = "book.xlsx") -> Path:
+    """Write a stand-in staged workbook carrying the secret sentinel.
+
+    The bytes are not a real XLSX on purpose: this module tests the purge
+    sweep's path handling, and a real container would only make the
+    sentinel harder to assert on.
+
+    Args:
+        vault: Vault root.
+        name: Staged filename, including its extension.
+
+    Returns:
+        The staged file's path.
+    """
+    staged = vault / UPLOAD_STAGING_RELDIR / name
+    staged.parent.mkdir(parents=True, exist_ok=True)
+    staged.write_text(f"workbook bytes {_WORKBOOK_SECRET}\n", encoding="utf-8")
+    return staged
+
+
+def _write_sheet_fragment(vault: Path, frag_id: str, origin_key: str) -> Path:
+    """Write one sheet fragment whose ``source.origin_key`` is *origin_key*.
+
+    Args:
+        vault: Vault root.
+        frag_id: The fragment's id.
+        origin_key: The vault-relative source key, with or without a unit.
+
+    Returns:
+        The written fragment's path.
+    """
+    path = vault / "01-Fragments" / "Documents" / f"{frag_id}.md"
+    post = frontmatter.Post(
+        content="A rendered sheet table.\n",
+        id=frag_id,
+        title=frag_id,
+        type="fragment",
+        source={
+            "platform": "spreadsheet",
+            "origin_key": origin_key,
+            "original_file": str(vault / UPLOAD_STAGING_RELDIR / "book.xlsx"),
+        },
+        threads=[],
+        eddies=[],
+        privacy_tier="intimate",
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(frontmatter.dumps(post), encoding="utf-8")
+    return path
+
+
+def _survivors(vault: Path) -> list[Path]:
+    """Return every file under *vault* whose text still holds the sentinel.
+
+    Args:
+        vault: Vault root to walk.
+
+    Returns:
+        Offending paths — empty when the purge honoured the request.
+    """
+    return [
+        path
+        for path in sorted(vault.rglob("*"))
+        if path.is_file()
+        and _WORKBOOK_SECRET in path.read_text(encoding="utf-8", errors="ignore")
+    ]
+
+
+def test_purge_follows_a_sub_unit_origin_key_to_the_staged_workbook(
+    tmp_path: Path,
+) -> None:
+    """A ``…/book.xlsx#Budget`` key must still erase ``book.xlsx``.
+
+    RED before the sub-unit fallback lands: the key resolves inside the
+    staging root but names no file, so ``is_file()`` returns early and the
+    workbook survives an RTBF request with ``journal_staged_removed == 0``.
+    """
+    vault = _make_vault(tmp_path)
+    staged = _stage_workbook(vault)
+    key = compose_source_unit(f"{UPLOAD_STAGING_RELDIR.as_posix()}/book.xlsx", "Budget")
+    frag = _write_sheet_fragment(vault, "frag-sheet-budget", key)
+
+    result = PurgeEngine(vault).purge_fragment("frag-sheet-budget")
+
+    assert result.journal_staged_removed == 1
+    assert not frag.exists()
+    assert not staged.exists()
+    assert _survivors(vault) == []
+
+
+def test_purge_of_one_sheet_erases_the_workbook_shared_with_its_siblings(
+    tmp_path: Path,
+) -> None:
+    """Erasing one sheet erases the shared source; siblings stay live.
+
+    This is the semantics every multi-fragment source already has — purging
+    one function fragment deletes the ``.py`` it came from — but it is newly
+    reachable for spreadsheets, so it is pinned rather than left implicit.
+    The sibling fragments are deliberately NOT deleted: this fixes an
+    identity defect, and deciding that one sheet's erasure erases three
+    fragments would be a policy change riding a bugfix.
+    """
+    vault = _make_vault(tmp_path)
+    staged = _stage_workbook(vault)
+    base = f"{UPLOAD_STAGING_RELDIR.as_posix()}/book.xlsx"
+    frag_a = _write_sheet_fragment(vault, "frag-a", compose_source_unit(base, "Budget"))
+    frag_b = _write_sheet_fragment(vault, "frag-b", compose_source_unit(base, "Notes"))
+
+    result = PurgeEngine(vault).purge_fragment("frag-a")
+
+    assert result.journal_staged_removed == 1
+    assert not frag_a.exists()
+    assert frag_b.exists()
+    assert not staged.exists()
+
+
+def test_purge_prefers_a_real_hash_named_file_over_the_unit_split(
+    tmp_path: Path,
+) -> None:
+    """``report#1.xlsx`` is a filename, not a unit, and must be erased as one.
+
+    ``#`` is legal in a POSIX filename, so the split is a hypothesis. The
+    whole key is tried first; only a key that resolves to nothing falls back.
+    Without that ordering this test's file survives while a *different*
+    file named ``report`` would be targeted.
+    """
+    vault = _make_vault(tmp_path)
+    staged = _stage_workbook(vault, name="report#1.xlsx")
+    decoy = _stage_workbook(vault, name="report")
+    key = f"{UPLOAD_STAGING_RELDIR.as_posix()}/report#1.xlsx"
+    _write_sheet_fragment(vault, "frag-hashname", key)
+
+    result = PurgeEngine(vault).purge_fragment("frag-hashname")
+
+    assert result.journal_staged_removed == 1
+    assert not staged.exists()
+    assert decoy.exists(), "the split must not steer the delete at another file"
+
+
+@pytest.mark.parametrize(
+    "origin_key",
+    [
+        "../outside-secret.xlsx#Budget",
+        "01-Fragments/other.md#Budget",
+        f"{UPLOAD_STAGING_RELDIR.as_posix()}/../../../escape.xlsx#Budget",
+    ],
+)
+def test_purge_still_refuses_an_out_of_scope_key_with_a_unit_suffix(
+    tmp_path: Path, origin_key: str
+) -> None:
+    """Both containment guards must be re-applied on the fallback path.
+
+    A sub-unit suffix must not become a way to smuggle a traversal or a
+    non-staging vault path past guards the whole-key attempt enforces. The
+    fallback only ever widens what is deleted *inside* the staging roots.
+    """
+    vault = _make_vault(tmp_path)
+    target = vault / "outside-secret.xlsx"
+    for candidate in (
+        (vault.parent / "outside-secret.xlsx"),
+        (vault / "01-Fragments" / "other.md"),
+        (vault.parent.parent / "escape.xlsx"),
+        target,
+    ):
+        candidate.parent.mkdir(parents=True, exist_ok=True)
+        candidate.write_text(f"decoy {_WORKBOOK_SECRET}\n", encoding="utf-8")
+    frag = _write_sheet_fragment(vault, "frag-escape", origin_key)
+
+    result = PurgeEngine(vault).purge_fragment("frag-escape")
+
+    assert result.journal_staged_removed == 0
+    assert not frag.exists()
+    assert (vault.parent / "outside-secret.xlsx").exists()
+    assert (vault / "01-Fragments" / "other.md").exists()
+    assert (vault.parent.parent / "escape.xlsx").exists()
+    # In-vault but outside every staging root — the second containment
+    # guard's own case, and the one a fallback is most likely to relax.
+    assert target.exists()
+    assert _WORKBOOK_SECRET in target.read_text(encoding="utf-8")
+
+
+def test_split_source_unit_round_trips_and_refuses_a_bare_separator() -> None:
+    """The compose/split pair agrees with itself, including on the empty unit.
+
+    ``compose_source_unit`` never mints a key ending in a bare separator, so
+    ``split_source_unit`` must not invent a unit for one — two spellings of
+    "the whole file" is how one fragment comes to be written twice.
+    """
+    assert split_source_unit(compose_source_unit("a/b.xlsx", "Budget")) == (
+        "a/b.xlsx",
+        "Budget",
+    )
+    assert compose_source_unit("a/b.xlsx", None) == "a/b.xlsx"
+    assert compose_source_unit("a/b.xlsx", "") == "a/b.xlsx"
+    assert split_source_unit("a/b.xlsx") == ("a/b.xlsx", None)
+    assert split_source_unit("a/b.xlsx#") == ("a/b.xlsx#", None)
+    # The LAST separator wins, so a sheet named with a '#' still splits back
+    # to the workbook rather than to a prefix of its own name.
+    assert split_source_unit("a/b.xlsx#Q#3") == ("a/b.xlsx#Q", "3")
+
+
+def test_a_sheet_name_containing_the_separator_is_still_purgeable(
+    tmp_path: Path,
+) -> None:
+    """A sheet named ``Rev#2`` must not mint a key nobody can read back.
+
+    ``#`` is legal in an Excel sheet title (openpyxl round-trips one), so an
+    unsanitised unit composes ``…/book.xlsx#Rev#2``. ``split_source_unit``
+    splits at the LAST separator, yielding base ``…/book.xlsx#Rev`` — a file
+    that does not exist — so the purge sweep finds no staged source, reports
+    ``journal_staged_removed == 0``, and silently leaves the operator's
+    workbook on disk after an erasure request.
+
+    The fix is at mint time (``sanitize_unit``), not in the reader: the unit
+    half of a composed key is now guaranteed separator-free, so exactly one
+    rpartition is exact for every key Creek produces.
+    """
+    vault = _make_vault(tmp_path)
+    staged = _stage_workbook(vault)
+    key = compose_source_unit(f"{UPLOAD_STAGING_RELDIR.as_posix()}/book.xlsx", "Rev#2")
+
+    assert key.count("#") == 1, key
+    assert split_source_unit(key) == (
+        f"{UPLOAD_STAGING_RELDIR.as_posix()}/book.xlsx",
+        "Rev-2",
+    )
+
+    _write_sheet_fragment(vault, "frag-hash-sheet", key)
+    result = PurgeEngine(vault).purge_fragment("frag-hash-sheet")
+
+    assert result.journal_staged_removed == 1
+    assert not staged.exists()
+    assert _survivors(vault) == []
+
+
+def test_separator_bearing_sheet_names_do_not_collide_after_sanitising() -> None:
+    """``Rev#2`` and ``Rev-2`` sanitise alike and must still get distinct units.
+
+    Sanitising *after* de-duplication would map two real sheets onto one
+    unit, one id, and — with first-writer-wins — one surviving fragment:
+    exactly the defect #1305 exists to fix, reintroduced by the fix for it.
+    The de-duplicator therefore counts sanitised names.
+    """
+    from creek.ingest.spreadsheets import SheetData, _sheet_unit_keys
+
+    sheets = [
+        SheetData(name="Rev#2", headers=("a",), rows=(("1",),)),
+        SheetData(name="Rev-2", headers=("a",), rows=(("2",),)),
+    ]
+
+    units = _sheet_unit_keys(sheets)
+
+    assert units == ["Rev-2", "Rev-2~2"]
+    assert len(set(units)) == 2

--- a/creek-tools/tests/test_spreadsheet_presentation_ingestors.py
+++ b/creek-tools/tests/test_spreadsheet_presentation_ingestors.py
@@ -1501,6 +1501,64 @@ class TestMultiSheetWorkbookIdentity:
         assert len({item.fragment.id for item in assembled}) == 3
         assert len(_fragment_files(vault)) == 3
 
+    def test_duplicate_sheet_names_get_distinct_titles_and_headings(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Two sheets named ``Data`` must be tellable apart *on disk*.
+
+        The sibling test above proves the two sheets get distinct ids and
+        two files. That is disambiguation in the index — an operator never
+        reads an index. Both user-visible strings, the ``title`` in
+        frontmatter and the ``# `` heading in the body, were derived from
+        the RAW ``metadata["sheet"]`` name, which is ``Data`` for both
+        sheets. So the fix produced two fragments the operator opens and
+        cannot distinguish: same title, same heading, same rendered table
+        shape, differing only in a ``frag-<12hex>`` id and a ``-1``
+        de-collision suffix the writer had to invent because the computed
+        filenames collided too.
+
+        The deduplicated ``source_unit`` (``Data`` / ``Data~2``) is the
+        string that already resolved this, and is what both surfaces must
+        consume. Asserted against file bytes rather than the assembled
+        model, because the frontmatter round-trip is where the sibling
+        keys ``sheet`` / ``rows`` / ``columns`` are silently dropped
+        (#1392) — an in-memory assertion would not have noticed that the
+        title is the only per-sheet marker left.
+        """
+        source = tmp_path / "book.xlsx"
+        _write_xlsx_placeholder(source)
+        vault = _scaffold_vault(tmp_path)
+        backend = StubSpreadsheetBackend(
+            workbooks={"book.xlsx": _stub_workbook(["Data", "Data"])},
+        )
+
+        assembled = _assemble_all(SpreadsheetIngestor(backend=backend), source)
+        _write_all(vault, assembled)
+
+        files = _fragment_files(vault)
+        assert len(files) == 2
+        loaded = [frontmatter.load(path) for path in files]
+
+        titles = sorted(str(post.metadata["title"]) for post in loaded)
+        assert titles == ["book — Data", "book — Data~2"]
+
+        headings = sorted(
+            line
+            for post in loaded
+            for line in post.content.splitlines()
+            if line.startswith("# ")
+        )
+        assert headings == ["# book.xlsx — Data", "# book.xlsx — Data~2"]
+
+        # Distinct titles mean distinct computed filenames, so the writer
+        # has no name clash to de-collide. A ``-1`` tail is the on-disk
+        # signature of two fragments that both wanted the same name.
+        assert sorted(_title_part(path) for path in files) == [
+            "book--Data",
+            "book--Data2",
+        ]
+
     def test_inserting_a_first_sheet_does_not_re_mint_existing_ids(
         self,
         tmp_path: Path,

--- a/creek-tools/tests/test_spreadsheet_presentation_ingestors.py
+++ b/creek-tools/tests/test_spreadsheet_presentation_ingestors.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import frontmatter
 import pytest
 
+from creek.ingest.base import assemble_ingested_fragment
 from creek.ingest.presentations import (
     PRESENTATION_EXTENSIONS,
     PresentationBackend,
@@ -25,9 +27,12 @@ from creek.ingest.spreadsheets import (
     WorkbookData,
 )
 from creek.models import SourcePlatform
+from creek.vault.writer import VaultWriter
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from creek.ingest.base import IngestedFragment, Ingestor
 
 
 # ---- Stub backends -----------------------------------------------------
@@ -1279,6 +1284,538 @@ class TestModuleExports:
 
         assert INGESTOR_REGISTRY["spreadsheet"] is SpreadsheetIngestor
         assert INGESTOR_REGISTRY["presentation"] is PresentationIngestor
+
+
+# =======================================================================
+# Per-sheet fragment identity (#1305)
+# =======================================================================
+#
+# ``SpreadsheetIngestor.parse`` emits one ``ParsedFragment`` per non-empty
+# sheet, but each one carries ``content=""``, the same hoisted
+# ``file_modified_time(raw.path)`` timestamp and the same ``source_path``.
+# ``generate_fragment_id(source, timestamp, content)`` therefore mints ONE
+# id for all N sheets, and ``VaultWriter._write_model``
+# (``VaultWriter._write_model``) takes the lock, calls
+# ``_find_existing_locked`` and returns the already-written path for a
+# duplicate id — FIRST WRITER WINS. Sheets 2..N are dropped in silence and
+# the one surviving file holds the FIRST sheet.
+#
+# The migration hazard runs the other way: a workbook with exactly ONE
+# non-empty sheet (every CSV, every single-sheet XLSX) and every
+# presentation must keep the byte-identical id and filename they have
+# today, or the fix orphans fragments already sitting in real vaults. The
+# ``_PIN_*`` constants below are that guard.
+
+
+_PINNED_MTIME = 1710500000
+"""Fixed epoch mtime for the pin tests, so the hashed timestamp is constant."""
+
+# Measured at HEAD against a RELATIVE source path (``book.xlsx``) whose
+# mtime is pinned to ``_PINNED_MTIME``, which makes both hash inputs
+# constant across machines and runs. Each value MUST be byte-identical
+# after the sheet discriminator lands; a change means an existing
+# single-unit fragment has been orphaned.
+#
+# The filename pins are the TAIL only: ``_compute_base_name`` prefixes
+# ``{date}-`` from ``Fragment.created`` (i.e. today), which is not a
+# property of this change and would make the pin a calendar flake.
+_PIN_XLSX_SINGLE_SHEET_ID = "frag-2ae23100e7a8"
+"""Fragment id of a one-sheet ``book.xlsx``; a ``frag-<12hex>`` literal."""
+
+_PIN_XLSX_SINGLE_SHEET_FILENAME_TAIL = "-book.md"
+"""Filename tail of a one-sheet ``book.xlsx``; expected ``-book.md``."""
+
+_PIN_CSV_ID = "frag-e2f9d18e46af"
+"""Fragment id of ``book.csv``; a ``frag-<12hex>`` literal."""
+
+_PIN_CSV_FILENAME_TAIL = "-book.md"
+"""Filename tail of ``book.csv``; expected ``-book.md``."""
+
+_PIN_PRESENTATION_ID = "frag-439246060197"
+"""Fragment id of ``deck.pptx``; a ``frag-<12hex>`` literal."""
+
+_PIN_PRESENTATION_FILENAME_TAIL = "-deck.md"
+"""Filename tail of ``deck.pptx``; expected ``-deck.md``."""
+
+
+# ---- Helpers: vault round-trip -----------------------------------------
+
+
+def _scaffold_vault(tmp_path: Path, name: str = "vault") -> Path:
+    """Create the minimum vault tree ``VaultWriter`` refuses to start without.
+
+    ``VaultWriter.__init__`` raises ``FileNotFoundError`` unless both
+    ``00-Creek-Meta/`` and ``01-Fragments/`` already exist; the
+    per-platform subfolder underneath is created by the writer itself.
+    """
+    vault = tmp_path / name
+    for relpart in ("00-Creek-Meta/Processing-Log", "01-Fragments"):
+        (vault / relpart).mkdir(parents=True, exist_ok=True)
+    return vault
+
+
+def _write_real_workbook(path: Path, sheet_names: list[str]) -> None:
+    """Write a genuine openpyxl workbook with one sheet per name.
+
+    Every sheet gets a header row plus one data row so none of them is
+    dropped by the ``sheet.is_empty`` filter in ``parse``.
+    """
+    import openpyxl
+
+    workbook = openpyxl.Workbook()
+    first = workbook.active
+    assert first is not None
+    first.title = sheet_names[0]
+    for name in sheet_names[1:]:
+        workbook.create_sheet(title=name)
+    for index, name in enumerate(sheet_names):
+        worksheet = workbook[name]
+        worksheet.append(["item", "amount"])
+        worksheet.append([f"row-{index}", str(index * 10)])
+    workbook.save(path)
+
+
+def _stub_workbook(sheet_names: list[str]) -> WorkbookData:
+    """Build canned :class:`WorkbookData` with one non-empty sheet per name.
+
+    Used where openpyxl cannot express the case under test — duplicate
+    sheet titles and blank sheet titles are both rejected or silently
+    renamed by the real writer, but a hand-built workbook (and a workbook
+    produced by some other tool) can carry them.
+    """
+    return WorkbookData(
+        sheets=tuple(
+            SheetData(
+                name=name,
+                headers=("item", "amount"),
+                rows=((f"row-{index}", str(index * 10)),),
+            )
+            for index, name in enumerate(sheet_names)
+        ),
+    )
+
+
+def _assemble_all(ingestor: Ingestor, source: Path) -> list[IngestedFragment]:
+    """Run the four-stage pipeline and assemble every fragment it yields."""
+    result = ingestor.ingest(source)
+    assert result.errors == [], result.errors
+    return [assemble_ingested_fragment(parsed) for parsed in result.fragments]
+
+
+def _write_all(vault: Path, assembled: list[IngestedFragment]) -> list[Path]:
+    """Write every assembled fragment through the real ``VaultWriter``."""
+    writer = VaultWriter(vault_path=vault)
+    return [writer.write_fragment(item.fragment, body=item.body) for item in assembled]
+
+
+def _fragment_files(vault: Path) -> list[Path]:
+    """Return every fragment markdown file under ``01-Fragments``, sorted."""
+    return sorted((vault / "01-Fragments").rglob("*.md"))
+
+
+def _title_part(path: Path) -> str:
+    """Return a fragment filename's stem with its ``YYYY-MM-DD-`` prefix removed.
+
+    ``_compute_base_name`` builds ``{date}-{sanitized-title}``; the date
+    is always the 10 characters of an ISO date, so the remainder is the
+    part this change is responsible for.
+    """
+    return path.stem[11:]
+
+
+class TestMultiSheetWorkbookIdentity:
+    """Every non-empty sheet must survive the write as its own fragment (#1305)."""
+
+    def test_multi_sheet_workbook_writes_one_file_per_sheet(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A 3-sheet workbook lands as three fragment files, one per sheet.
+
+        Pre-fix symptom (this is what makes the test RED, and it is *not*
+        what the issue body claims): all three sheets hash to the same
+        ``frag-<12hex>`` because ``parse`` gives each of them
+        ``content=""``, the same hoisted ``file_modified_time`` timestamp
+        and the same ``source_path``. ``VaultWriter._write_model``
+        (``VaultWriter._write_model``) holds the lock, finds the id
+        already indexed via ``_find_existing_locked`` and returns the
+        existing path without writing — so the FIRST writer wins. One file
+        survives and it holds the FIRST sheet (``Budget``); ``Notes`` and
+        ``Q3`` are dropped with no error, no warning and no duplicate.
+        """
+        source = tmp_path / "book.xlsx"
+        _write_real_workbook(source, ["Budget", "Notes", "Q3"])
+        vault = _scaffold_vault(tmp_path)
+
+        assembled = _assemble_all(SpreadsheetIngestor(), source)
+        _write_all(vault, assembled)
+
+        # (a) Three sheets, three distinct identities. No ``frag-`` literal
+        # is pinned here: the id hashes the absolute ``tmp_path``, so any
+        # literal would differ on every run.
+        assert len({item.fragment.id for item in assembled}) == 3
+
+        # (b) Three distinct identities, three files on disk.
+        files = _fragment_files(vault)
+        assert len(files) == 3
+
+        # (c) Each sheet's rendered heading appears in exactly one file.
+        texts = [path.read_text(encoding="utf-8") for path in files]
+        for heading in (
+            "# book.xlsx — Budget",
+            "# book.xlsx — Notes",
+            "# book.xlsx — Q3",
+        ):
+            occurrences = sum(text.count(heading) for text in texts)
+            assert occurrences == 1, f"{heading!r} appeared {occurrences} times"
+
+    def test_duplicate_sheet_names_still_get_distinct_ids(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Sheets named ``Q``, ``Q`` and ``""`` still produce three fragments.
+
+        Excel forbids duplicate sheet titles and openpyxl silently renames
+        the second one, so this workbook is built straight from the
+        backend's ``WorkbookData`` / ``SheetData`` dataclasses through the
+        ``backend`` seam — a file produced by another tool can carry both a
+        duplicate title and a blank one. The discriminator must therefore
+        be a *normalised, de-duplicated* unit key rather than the raw sheet
+        name; a raw-name key collapses the two ``Q`` sheets back into one
+        id and the blank-named sheet into an empty discriminator.
+
+        Pre-fix all three sheets share one id and first-writer-wins leaves
+        a single file behind.
+        """
+        source = tmp_path / "book.xlsx"
+        _write_xlsx_placeholder(source)
+        vault = _scaffold_vault(tmp_path)
+        backend = StubSpreadsheetBackend(
+            workbooks={"book.xlsx": _stub_workbook(["Q", "Q", ""])},
+        )
+
+        assembled = _assemble_all(SpreadsheetIngestor(backend=backend), source)
+        assert len(assembled) == 3
+        _write_all(vault, assembled)
+
+        assert len({item.fragment.id for item in assembled}) == 3
+        assert len(_fragment_files(vault)) == 3
+
+    def test_inserting_a_first_sheet_does_not_re_mint_existing_ids(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Prepending a sheet leaves the other sheets' ids untouched.
+
+        This is the explicit rejection of the "use an empty discriminator
+        for sheet index 0" shortcut. Under that shortcut the workbook's
+        first sheet keeps the bare ``source_path`` identity, so inserting a
+        new sheet at the front hands the newcomer the id that used to
+        belong to the old first sheet. With first-writer-wins in
+        ``VaultWriter._write_model``'s duplicate-id early return, the
+        newcomer is then SILENTLY DROPPED as a duplicate of a fragment it
+        has nothing to do with, and every following sheet shifts one slot
+        and overwrites its neighbour's identity.
+
+        Both parses run against the same ``source_path`` string and the
+        same pinned mtime, so the timestamp and source inputs to
+        ``generate_fragment_id`` are held constant and only the sheet set
+        varies. Pre-fix, every sheet in both runs shares one id, so the
+        distinctness assertions fail first.
+        """
+        import os
+
+        source = tmp_path / "book.xlsx"
+        _write_xlsx_placeholder(source)
+        os.utime(source, (_PINNED_MTIME, _PINNED_MTIME))
+        vault = _scaffold_vault(tmp_path)
+
+        before = _assemble_all(
+            SpreadsheetIngestor(
+                backend=StubSpreadsheetBackend(
+                    workbooks={"book.xlsx": _stub_workbook(["Budget", "Notes"])},
+                ),
+            ),
+            source,
+        )
+        _write_all(vault, before)
+        ids_before = {item.fragment.title: item.fragment.id for item in before}
+        assert len(set(ids_before.values())) == 2
+
+        after = _assemble_all(
+            SpreadsheetIngestor(
+                backend=StubSpreadsheetBackend(
+                    workbooks={
+                        "book.xlsx": _stub_workbook(["Intro", "Budget", "Notes"]),
+                    },
+                ),
+            ),
+            source,
+        )
+        _write_all(vault, after)
+        ids_after = {item.fragment.title: item.fragment.id for item in after}
+        assert len(set(ids_after.values())) == 3
+
+        # The two pre-existing sheets keep the exact ids they were minted
+        # with; only the inserted sheet is new.
+        titles_before = sorted(ids_before)
+        for title in titles_before:
+            assert ids_after[title] == ids_before[title], title
+        new_ids = set(ids_after.values()) - set(ids_before.values())
+        assert len(new_ids) == 1
+
+        # Persisted state: the insert adds exactly one file and re-writing
+        # the two known sheets is a no-op, not a duplicate and not a drop.
+        assert len(_fragment_files(vault)) == 3
+
+    def test_re_ingesting_a_workbook_mints_no_new_files(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A second ingest of an unchanged workbook writes nothing new.
+
+        Idempotency on the default, non-ledgered path: the ids are a pure
+        function of ``(source, timestamp, content)``, so the second run
+        resolves to the same three fragments and ``_write_model`` returns
+        the existing paths. A ``-1`` suffixed stem would mean the writer
+        had to invent a filename because two different ids wanted the same
+        one.
+
+        Pre-fix this test fails on the first run already — one file, not
+        three.
+        """
+        source = tmp_path / "book.xlsx"
+        _write_real_workbook(source, ["Budget", "Notes", "Q3"])
+        vault = _scaffold_vault(tmp_path)
+
+        first = _assemble_all(SpreadsheetIngestor(), source)
+        _write_all(vault, first)
+        assert len(_fragment_files(vault)) == 3
+
+        second = _assemble_all(SpreadsheetIngestor(), source)
+        _write_all(vault, second)
+
+        assert {item.fragment.id for item in second} == {
+            item.fragment.id for item in first
+        }
+        files = _fragment_files(vault)
+        assert len(files) == 3
+        assert [path for path in files if path.stem.endswith("-1")] == []
+
+    def test_multi_sheet_filenames_are_distinct_and_well_formed(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Each sheet's file is named for its sheet, with no collision suffix.
+
+        ``_sanitize_title`` strips the em-dash and turns the two spaces
+        around it into two hyphens, so a title of ``book — Budget``
+        becomes the stem tail ``book--Budget`` (the date prefix comes from
+        ``Fragment.created`` and is stripped by :func:`_title_part`).
+
+        The blank-sheet-name case is checked in its own vault because
+        openpyxl will not create a sheet with an empty title. A blank name
+        must normalise to the literal ``sheet`` — an empty discriminator
+        would render ``book — `` and sanitise down to a bare ``book``,
+        colliding with any other unnamed sheet.
+
+        Pre-fix every sheet is titled ``book`` (``assemble_ingested_fragment``
+        falls back to the source stem because the spreadsheet frontmatter
+        carries no ``title``), and only one file is written at all.
+        """
+        source = tmp_path / "book.xlsx"
+        _write_real_workbook(source, ["Budget", "Notes", "Q3"])
+        vault = _scaffold_vault(tmp_path)
+        _write_all(vault, _assemble_all(SpreadsheetIngestor(), source))
+
+        files = _fragment_files(vault)
+        assert {_title_part(path) for path in files} == {
+            "book--Budget",
+            "book--Notes",
+            "book--Q3",
+        }
+        assert [path for path in files if path.stem.endswith("-")] == []
+        assert [path for path in files if path.stem.endswith("-1")] == []
+
+        blank_vault = _scaffold_vault(tmp_path, name="vault-blank")
+        blank_backend = StubSpreadsheetBackend(
+            workbooks={"book.xlsx": _stub_workbook(["Data", ""])},
+        )
+        blank_source = tmp_path / "blank" / "book.xlsx"
+        blank_source.parent.mkdir()
+        _write_xlsx_placeholder(blank_source)
+        _write_all(
+            blank_vault,
+            _assemble_all(SpreadsheetIngestor(backend=blank_backend), blank_source),
+        )
+        blank_files = _fragment_files(blank_vault)
+        assert {_title_part(path) for path in blank_files} == {
+            "book--Data",
+            "book--sheet",
+        }
+        assert [path for path in blank_files if path.stem.endswith("-")] == []
+
+    def test_sheet_rows_and_columns_do_not_survive_to_disk(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Sheet/rows/columns never reach disk; the title carries the sheet.
+
+        A deliberate, accepted drop rather than an oversight worth
+        widening the model for. ``generate_frontmatter`` emits ``sheet``,
+        ``rows`` and ``columns``, but ``Fragment.model_config``
+        leaves pydantic's default ``extra="ignore"``,
+        so ``Fragment.model_validate`` discards all three and
+        ``_write_model`` serialises only model fields. Per-sheet identity
+        is therefore carried by ``title``, by the filename, by the body
+        heading, and — on the ledgered path — by ``source.origin_key``.
+
+        ``TestSpreadsheetFrontmatter.test_frontmatter_records_platform_and_dimensions``
+        (~line 451) asserts those three keys on the dict the *ingestor*
+        returns. That remains true and is left alone; this test pins the
+        other half of the story, which is that they never reach the vault.
+
+        The frontmatter-key assertions hold before and after the fix; the
+        ``title`` assertion is the RED one, since today every sheet's
+        fragment is titled ``book`` from the source-stem fallback in
+        ``assemble_ingested_fragment``.
+
+        Revisiting the drop is tracked in #1392. If that issue decides to
+        surface the fields, this test is the one to update — deliberately,
+        not incidentally.
+        """
+        source = tmp_path / "book.xlsx"
+        _write_real_workbook(source, ["Budget", "Notes", "Q3"])
+        vault = _scaffold_vault(tmp_path)
+        _write_all(vault, _assemble_all(SpreadsheetIngestor(), source))
+
+        budget = [
+            path
+            for path in _fragment_files(vault)
+            if "# book.xlsx — Budget" in path.read_text(encoding="utf-8")
+        ]
+        assert len(budget) == 1
+        post = frontmatter.load(str(budget[0]))
+        assert "sheet" not in post.metadata
+        assert "rows" not in post.metadata
+        assert "columns" not in post.metadata
+        assert post["title"] == "book — Budget"
+
+
+class TestSingleUnitIdentityIsUnchanged:
+    """The migration carve-out: one-unit sources keep their exact identity.
+
+    Every test in this class is GREEN BEFORE AND AFTER the fix, by
+    construction — that is the point. A workbook with exactly one non-empty
+    sheet (which is every CSV and every single-sheet XLSX) and every
+    presentation must keep the byte-identical ``frag-<12hex>`` and the
+    byte-identical filename they have today. If any of these goes red, the
+    change has orphaned fragments that already exist in real vaults, and no
+    amount of correctness on the multi-sheet path pays for that.
+
+    Each test pins against a RELATIVE source path under a chdir'd
+    ``tmp_path`` and an mtime forced to :data:`_PINNED_MTIME`, so both
+    inputs ``generate_fragment_id`` hashes are constants rather than
+    per-run values.
+    """
+
+    def test_single_sheet_xlsx_id_is_unchanged_by_the_sheet_discriminator(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A one-sheet XLSX keeps its measured id and filename.
+
+        Green before and after. The carve-out under test: the sheet
+        discriminator is set only when a workbook yields two or more
+        non-empty sheets, so a single-sheet workbook keeps
+        ``source_unit=None``, hashes the bare ``source_path``, and titles
+        itself from the plain file stem.
+        """
+        import os
+        from pathlib import Path
+
+        monkeypatch.chdir(tmp_path)
+        source = Path("book.xlsx")
+        _write_real_workbook(source, ["Sheet1"])
+        os.utime(source, (_PINNED_MTIME, _PINNED_MTIME))
+        vault = _scaffold_vault(tmp_path)
+
+        assembled = _assemble_all(SpreadsheetIngestor(), source)
+        assert len(assembled) == 1
+        assert assembled[0].fragment.id == _PIN_XLSX_SINGLE_SHEET_ID
+
+        written = _write_all(vault, assembled)
+        assert len(_fragment_files(vault)) == 1
+        assert written[0].name.endswith(_PIN_XLSX_SINGLE_SHEET_FILENAME_TAIL)
+
+    def test_single_sheet_csv_id_is_unchanged_by_the_sheet_discriminator(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A CSV keeps its measured id and filename.
+
+        Green before and after, and load-bearing: ``_csv_text_to_workbook``
+        (creek/ingest/spreadsheets.py ~336) names a CSV's lone sheet after
+        the file stem, so a discriminator applied unconditionally — even a
+        name-based one — would move the id of every CSV fragment in every
+        vault. This test is what forbids that.
+        """
+        import os
+        from pathlib import Path
+
+        monkeypatch.chdir(tmp_path)
+        source = Path("book.csv")
+        source.write_text("a,b\n1,2\n3,4\n", encoding="utf-8")
+        os.utime(source, (_PINNED_MTIME, _PINNED_MTIME))
+        vault = _scaffold_vault(tmp_path)
+
+        assembled = _assemble_all(SpreadsheetIngestor(), source)
+        assert len(assembled) == 1
+        assert assembled[0].fragment.id == _PIN_CSV_ID
+
+        written = _write_all(vault, assembled)
+        assert len(_fragment_files(vault)) == 1
+        assert written[0].name.endswith(_PIN_CSV_FILENAME_TAIL)
+
+    def test_presentation_fragment_id_is_unchanged_by_the_sheet_discriminator(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A presentation keeps its measured id and filename.
+
+        Green before and after. ``PresentationIngestor.parse``
+        (creek/ingest/presentations.py ~310) has the identical
+        ``content=""`` shape as the spreadsheet ingestor, so it is the
+        obvious place for a sheet-discriminator refactor to leak into. It
+        must be provably untouched: a deck is one unit and stays one unit.
+        """
+        import os
+        from pathlib import Path
+
+        monkeypatch.chdir(tmp_path)
+        source = Path("deck.pptx")
+        _write_pptx_placeholder(source)
+        os.utime(source, (_PINNED_MTIME, _PINNED_MTIME))
+        vault = _scaffold_vault(tmp_path)
+        backend = StubPresentationBackend(
+            presentations={
+                "deck.pptx": PresentationData(
+                    title=None,
+                    slides=(SlideData(index=1, title="Hello", body="World"),),
+                ),
+            },
+        )
+
+        assembled = _assemble_all(PresentationIngestor(backend=backend), source)
+        assert len(assembled) == 1
+        assert assembled[0].fragment.id == _PIN_PRESENTATION_ID
+
+        written = _write_all(vault, assembled)
+        assert len(_fragment_files(vault)) == 1
+        assert written[0].name.endswith(_PIN_PRESENTATION_FILENAME_TAIL)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Every sheet of a multi-sheet workbook derived the same fragment id, so all but one were silently dropped. This gives each sheet its own identity — and closes the three ratchets that opening that door creates.

**The issue body is wrong about the symptom, and correcting it matters.** It says twice that "only the last sheet survives". It is the **first**. `VaultWriter._write_model` takes the lock, calls `_find_existing_locked` and returns the existing path, so writes 2..N are silent no-ops. A test written to the body's wording is red before *and* after the fix and certifies nothing.

### The four-combination matrix, re-measured at this branch's base

```
                                    run  created updated unchanged  files  headings on disk
HEAD,  unledgered (creek ingest)    1      3       0        0         1    Budget
HEAD,  ledgered  (creek.upload)     1      1       0        2         1    Budget
                                    2      0       0        3         1    Budget
FIXED, unledgered (creek ingest)    1      3       0        0         3    Budget, Notes, Q3
FIXED, ledgered  (creek.upload)     1      3       0        0         3    Budget, Notes, Q3
                                    2      0       0        3         3    Budget, Notes, Q3
```

The `FIXED, ledgered` row is the one that needed work. A per-sheet **fragment id alone does not produce it** — `derive_source_key` keys on the file, so all N sheets share one `origin_key` and one `LedgerRecord`, and `write_fragment_idempotent` then reassigns `fragment.id = record.fragment_id` and overwrites sheet 1 with sheet 2 and then sheet 3. That intermediate state reports `created=1 updated=2`: two of three sheets still lost, wearing a success message. Closing it needs a per-sheet **source key** as well.

### What changed

1. **`creek/ingest/source_unit.py`** (new) — `SOURCE_UNIT_SEPARATOR`, `compose_source_unit`, `split_source_unit`. One spelling, shared by the ingest derivation, the ledger, and the purge engine. No heavy imports, so `creek.purge` can take it without pulling `creek.classify`.

2. **`ParsedFragment.source_unit` + `identity_key`** — the discriminator rides on a new optional field, and `identity_key` is the single string every identity derivation reads. `source_path` is left as the whole file. That is a deliberate departure from the planned design, and the reason is below.

3. **`SpreadsheetIngestor.parse`** sets a per-sheet unit **only when the workbook yields two or more non-empty sheets**, plus an explicit per-sheet `title` in `generate_frontmatter`.

4. **The ledgered path** — `attach_origin_key` composes the unit into `source.origin_key`; `SourceLedger.records_for` enumerates a base key's units; `creek_mcp/tools/upload.py`'s `_resolve_fragment_id` becomes `_resolve_fragment_ids` and all four consumers are updated.

5. **The purge sweep** — `PurgeEngine._resolve_staged_source` tries the whole key, then its path half, re-applying both containment guards.

### The design departs from the plan, because the plan predates `routing.py`

The judged plan put the discriminator directly in `ParsedFragment.source_path`. That was correct against the tree it was written for. It is not correct against this one.

`creek/ingest/routing.py` was added by #1387 (issue #1304) and **did not exist** at the commit the plan was written against — `git cat-file -e fdfc39f:creek-tools/creek/ingest/routing.py` returns `ABSENT`. `arbitrate` decides which ingestor owns a source file by grouping fragments on `fragment.source_path`. Overloading that string would give a 3-sheet workbook three distinct "source files", so a contested extension would no longer be arbitrated at all — both the specialist's fragments *and* the generic fallback's would survive, which is precisely the double-writing #1304 had just fixed.

Two further hazards the overload carries, both measured rather than reasoned: `Path("book.xlsx#Budget").suffix` is `'.xlsx#Budget'`, so any suffix dispatch on the string mis-routes; and five production consumers of `.source_path` (`creek/fragment.py:213/252/290/302/362`) were outside the plan's stated audit.

Putting the unit on its own field gets everything the overload got — per-sheet fragment id, per-sheet provenance, per-sheet ledger key — with none of that. `arbitrate` needed no change at all. This is **not** the rejected `FragmentSource.unit` approach: `ParsedFragment` is an in-memory parse-stage model that is never serialised, so no `unit: null` appears in any vault file.

### Migration: the #1304 answer, reused

Two populations were at risk.

**Every existing CSV and single-sheet XLSX** — pinned **by construction**. A workbook with exactly one non-empty sheet emits no unit, so it hashes exactly what it hashed before. A ledger backfill was unavailable (`ledger_for_source` returns `None` for every source type but markdown, and #1368's `pin_ids.py` is markdown-only by construction), so the pin had to be in the derivation. Proven, not asserted: `git archive HEAD` into a scratch tree, verified to import pre-fix code, then the same scenarios run there —

| source | pre-fix id | post-fix id |
|---|---|---|
| one-sheet `book.xlsx` | `frag-2ae23100e7a8` | `frag-2ae23100e7a8` |
| `book.csv` | `frag-e2f9d18e46af` | `frag-e2f9d18e46af` |
| `deck.pptx` | `frag-439246060197` | `frag-439246060197` |

The **filename** is pinned too, which is why `generate_frontmatter` emits the bare stem when there is no unit rather than naming the lone sheet: an id pin that lets the filename churn is only half a pin.

**The one collapsed fragment per multi-sheet workbook** — **detected, named, and left alone**, which is the answer #1304 gave the same shape of problem (`contested_sources`: name the strays, point at the read-only `creek purge source --dry-run` recipe, delete nothing). `collapsed_unit_warning` recomputes the superseded id — exactly what the fragment in hand hashes to with no unit — and looks it up in the writer's id index. It rides the existing `IngestRunResult.warnings` + `on_warning` channel #1329 built, so `creek ingest` prints it with no new CLI surface.

That detector is strictly better than the frontmatter-recomputation one the plan proposed: no vault walk, no `platform` scoping heuristic, no sibling check, and it sidesteps both frontmatter traps (`ingested` reads back as a `str`; its trailing `Z` hashes differently from `+00:00`) by never reading frontmatter. It is self-clearing and silent on unit-less sources.

I did **not** ship a tombing migration. Deleting operator vault content on the strength of a heuristic is the one-way operation this repo has now twice declined to automate, and I saw no reason #1305 differs.

### Two ratchets this fix opens, both closed here

Neither is optional; `SpreadsheetIngestor.parse` alone would be two privacy regressions.

- **RTBF purge.** A sub-unit `origin_key` resolves inside the staging root but names no file, so `is_file()` returned early and the staged workbook **survived an erasure request**. `_resolve_staged_source` now falls back to the path half — re-applying *both* guards, and only ever widening deletion inside the staging roots. Whole-key-first means a genuinely `#`-named file (`report#1.xlsx`) still resolves to itself.
- **The #970 tier gate.** `_resolve_fragment_id` looked up the bare staged key and returned `None`, which every caller reads as "this id owns nothing": the gate would compute `existing=None` and **admit a caller at `ceiling=open` to overwrite intimate content**; `_discard_unreferenced` would **unlink a workbook three live fragments still reference**; `_refuse_extension_conflict` would fork one `external_id` onto two fragments. All four now read the id list.

### The two surfaces that bypass `run_ingest`

Both were named in the issue's blast radius and neither is reachable by a `run_ingest` test, so both got their own:

- The **`creek.ingest` MCP tool** audit-logged the same id three times in `affected_fragment_ids` — a false audit record, and audit records are what an RTBF request is answered from. Now three distinct ids. Fixed (upstream in `parse`) **and asserted**.
- **`creek process`** classified all N fragments and then discarded N−1 when the writer deduped, paying N−1 LLM calls for nothing. That waste is gone as a side effect; flagging it for #1303/#1304 so nobody re-plans around a number that has already moved.

## Test plan

**RED, correctly stated.** `test_multi_sheet_workbook_writes_one_file_per_sheet` asserts persisted vault state — three files, and each of `# book.xlsx — Budget` / `— Notes` / `— Q3` in exactly one file — not a returned id. Its docstring states the *first*-sheet symptom. No `frag-<12hex>` literal appears in any multi-sheet test: ids hash the absolute `tmp_path`, so the issue body's `frag-095913511f6c` is unreproducible (three runs gave three different values). Literals appear only in the pin tests, under `monkeypatch.chdir` with a relative path and a forced mtime.

**Each hunk proven load-bearing** by reverting only it:

| reverted | result |
|---|---|
| `parse` emits no unit | 19 failures across all four surfaces |
| `attach_origin_key` drops the unit | 9 failures — ledgered path only, the piece a per-sheet id does not give you |
| purge sub-unit fallback | 2 failures — the workbook survives RTBF |
| upload plural resolution | 4 failures, incl. `fragment_id is None` (gate ratchet) and a destroyed staged workbook |
| advisory | 1 failure |
| *(restored)* | 120 passed |

**Mutation battery: 26 mutants at first pass** (extended to 33 after review — see below). The first run reported 26/26 with a scope list containing a filename that does not exist — pytest exited 4 on every run, so every "kill" was false. Fixed the scope, added a fail-fast baseline-green guard, and re-ran: **4 real survivors**, all genuine coverage gaps rather than equivalent mutants, each closed with a new test:

- `M9` provenance id reverted to `source_path` — the second, independent `generate_fragment_id` call site was unasserted. → `test_each_sheet_gets_its_own_provenance_entry`.
- `M15` `records_for` unordered — `fragment_id` reduces N ids to one, and insertion order is not a promise the ledger makes. → `test_multi_sheet_fragment_id_is_stable_under_sheet_order`, with anti-alphabetical sheet names so the two orders disagree.
- `M23` advisory dedup removed — would overstate stray content by a factor of N. → `test_collapsed_advisory_names_each_superseded_id_once`.
- `M24` advisory fires for unit-less fragments — would accuse the operator on **every** re-ingest of every CSV. → `test_single_sheet_re_ingest_raises_no_collapsed_advisory`.

**Gate 2:** `./scripts/check-all.sh` exit code **0**, 12/12 checks. Aggregate branch coverage 94.43%; `creek/ingest/spreadsheets.py` 89.77% (up from 89.50%, floor 80%); `source_unit.py` and `ingest/base.py` 100%. Integration + e2e: 380 passed, including #1304's `test_mixed_extension_tree_routes_one_ingestor_per_file` — its `sheet.csv` is single-sheet, so the carve-out keeps it at one fragment and the one-ingestor-per-file invariant intact.

### Gate 2.5 found two real security defects, both fixed

Self-review returned `BLOCKERS`. Both were genuine, both were introduced by this change, and both are now fixed at the root with a regression test proven to catch them.

**1. A sheet name containing `#` minted an unreadable key.** Excel permits `#` in a sheet title (openpyxl round-trips one), so `Rev#2` composed `…/book.xlsx#Rev#2`. `split_source_unit` splits at the *last* separator, giving base `…/book.xlsx#Rev` — a file that does not exist — so the RTBF purge deleted the fragment and **silently left the staged workbook on disk**, `journal_staged_removed == 0`, no error. A regression versus pre-#1305, where no unit existed and the whole-key lookup matched.

Fixed at mint time, not in the reader: `sanitize_unit` rewrites the separator, so "the unit half of a composed key never contains a separator" is an invariant of the key space rather than something each reader must rediscover. Applied **before** de-duplication — sanitising after would map `Rev#2` and `Rev-2` onto one unit and one id, reintroducing this issue's own defect (pinned by `test_separator_bearing_sheet_names_do_not_collide_after_sanitising`).

**2. Purge one sheet, then re-upload at `ceiling=open`, and the tier gate opened.** Purging one sheet of an N-sheet intimate upload deletes the shared staged workbook (that is the RTBF contract) while the other N−1 fragments stay live, intimate, and ledgered. The #970 gate surveyed the staging *directory*, saw it empty, concluded the `external_id` owned nothing, and admitted the caller as a **creation**. The re-upload restaged to the same deterministic path, `write_fragment_idempotent` matched the survivors by their intact ledger keys, and overwrote intimate content with the low-ceiling caller's bytes — **a privacy-tier bypass reachable through two individually legitimate operations.**

Fixed by surveying the **ledger** (`_ledgered_names_for_id`), which outlives the file it points at, for both the tier gate and the extension-conflict check. Uses `all_keys()` rather than `live_keys()`: a soft-tombed fragment still exists under `10-Liminal/Orphaned/`, and for a gate whose failure mode is *admitting*, over-counting is the safe error.

Reverting either fix turns `refused` back into `ok` on the new tests — verified.

Also from the review, all applied: five stale `path:line` citations in the new tests replaced with symbol references (`writer.py:1258-1261` had drifted into docstring `Args:` text; `pipeline.py:336` likewise — ironic in a change whose own docstring true-up was about exactly this); an unasserted in-vault decoy in the purge traversal test now asserted; and `no_llm=True` on the `creek process` e2e so it cannot reach a live model on a machine with ollama up.

**Mutation battery re-run and extended to 33 mutants** covering both fixes and the two defensive branches they introduced: **33/33 killed, zero survivors.** The two that initially survived (`all_keys` vs `live_keys`; the staging-dir scope filter) are unreachable-today defensive branches — rather than delete them or assert equivalence, both now have a direct ledger-seeding test, so the safety property is pinned for the day it becomes reachable.

**No existing assertion was weakened.** `git diff` over all three modified test files shows **zero removed lines**; they are pure additions. `test_frontmatter_records_platform_and_dimensions` is untouched — it asserts `sheet`/`rows`/`columns` on the dict the *ingestor returns*, which is true. The new `test_sheet_rows_and_columns_do_not_survive_to_disk` pins the other half: those keys never reach a file.

**Decision recorded:** `sheet`/`rows`/`columns` are dropped by `Fragment.model_validate` (pydantic's default `extra="ignore"`). Accepted, pinned by test, tracked in #1392 — widening what survives validation is a repo-wide frontmatter change, not a bugfix. `FragmentSource.unit` was rejected outright: `_write_model` dumps with no `exclude_none`, so a nullable field there appends `unit: null` to every fragment from every ingestor.

**Docstring true-up.** `assemble_ingested_fragment` cited four `path:line` callers; **all four had rotted** (`creek/pipeline.py:498` had drifted into `_scan_for_redaction`) and a real caller, the `creek.ingest` MCP tool, was missing. Replaced with symbol references, which cannot rot.

## Follow-ups filed

- #1392 — `Fragment` silently discards ingestor frontmatter it does not model.
- #1393 — an edited spreadsheet is never detected as changed, because `parsed.content` is `""` so the ledger's content hash is constant. **Pre-existing**; this change neither causes nor cures it, and it must specifically **not** be "fixed" by moving the discriminator into `content` — that is exactly what produces the `created=1 updated=2` data loss above.

## Not done

- No tombing/cleanup CLI migration (see *Migration* above — detect-and-report instead, deliberately).
- `creek/fragment.py`'s `FragmentSplitter` still *groups* by `source_path` (grouping by file is arguably right there, and it has no production caller). Its parent-id derivation now uses `identity_key`, which removes a latent sibling collision and is a no-op for every fragment without a unit.

Closes #1305
Refs #1304, #1329, #1392, #1393
