### PR TITLE
fix(skills): guard medium contracts from silent overwrite, at the primitive

### DIFF
--- a/creek-tools/CHANGELOG.md
+++ b/creek-tools/CHANGELOG.md
@@ -69,3 +69,17 @@ to locate the originating commit for any reference below.
   `01-Fragments/` … `10-Liminal/` or `00-Creek-Meta/`. User vault
   content lives outside this repository (default suggested location:
   `~/Obsidian/Creek-Vault/`, scaffolded by `creek init`).
+
+### Fixed
+
+- **The drift guard that refuses to overwrite a hand-edited skill file
+  now covers medium contracts too, not just schema skills, and it now
+  lives inside the shared deployment primitive itself** (#1306).
+  `<vault>/00-Creek-Meta/Skills/mediums/*.MEDIUM.md` is refused on
+  divergence exactly like `*.SKILL.md`; because the guard moved into
+  the deploy primitive, `creek init --refresh` is covered by the same
+  check, and a refusal there is atomic — nothing at all is deployed,
+  not just the skill tree. `--force` no longer silently discards the
+  operator's edits: it now preserves the local version alongside as
+  `<name>.bak` (e.g. `mediums/essay.MEDIUM.md.bak`) before
+  overwriting.

--- a/creek-tools/README.md
+++ b/creek-tools/README.md
@@ -118,7 +118,7 @@ Every command is also documented under [`docs/`](docs/) with end-to-end examples
 | Command | Purpose | Doc |
 |---------|---------|-----|
 | `creek skills generate` | Generate the **Voice Skill Tree** under `<vault>/creek-skills/` (one `SKILL.md` per frequency, phase, mode, register, plus thread/eddy/meta skills). Previously `creek skills`; see [`CHANGELOG.md`](CHANGELOG.md) for the FEAT-019 rename. | [generation](docs/generation.md#voice-skill-tree) |
-| `creek skills sync` | Re-deploy the canonical schema-skill tree from `creek-tools/creek/templates/skills/` into `<vault>/00-Creek-Meta/Skills/`. Refuses to overwrite locally-modified skill files unless `--force` is passed. | [generation](docs/generation.md#voice-skill-tree) |
+| `creek skills sync` | Re-deploy the canonical schema-skill tree and medium contracts from `creek-tools/creek/templates/skills/` into `<vault>/00-Creek-Meta/Skills/` (including `mediums/*.MEDIUM.md`). Refuses to overwrite a locally-modified *canonical* file of either class unless `--force` is passed, in which case the local version is preserved alongside as `<name>.bak`. Files you authored yourself are never deployed over or reported as drift. | [generation](docs/generation.md#voice-skill-tree) |
 | `creek mine`     | Mine blog/essay seed ideas from the vault using four discovery strategies (liminal cross-eddy, thread terminus, resonance chain, wavelength-phase window). | [generation](docs/generation.md#mining) |
 | `creek draft`    | Draft an essay from a mined idea using the activated skill stack. Saves to `07-Voice/Drafts/` with full provenance. | [generation](docs/generation.md#drafting) |
 

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Sequence
 
     from creek.author.conductor import VoiceClientFactory
     from creek.author.models import AuthoredDraft
@@ -569,21 +569,95 @@ def _guard_vault_path(vault: Path, allow_in_repo: bool) -> None:
     )
 
 
+def _print_skill_drift_refusal(
+    labels: Sequence[str],
+    *,
+    verb: str,
+    remedy: str,
+    whole_deployment: bool,
+) -> None:
+    """Explain a refused canonical-skill deployment and the way past it.
+
+    ``creek skills sync`` and ``creek init`` reach the same destructive
+    primitive, so they owe the operator the same explanation (issue
+    #1306). Each label gets its own line: Rich hard-wraps at the console
+    width, and a path folded across a wrap is both unreadable and
+    unsearchable. The labels are vault-relative on purpose — the bare
+    filename this used to print could not tell
+    ``mediums/essay.MEDIUM.md`` apart from a top-level skill.
+
+    Both the verb and the suggested command are supplied by the caller
+    rather than derived here. Printing a fixed menu of escapes is how a
+    refusal ends up advising ``--refresh`` to someone who never typed
+    it — which for a plain ``creek init`` would also skip seeding
+    ``creek_config.yaml``, so the "fix" would quietly do less than the
+    command it replaced.
+
+    Args:
+        labels: Vault-relative paths of the drifted files, as
+            ``creek.scaffold.DriftedSkillsError.labels`` renders them.
+            Plain strings so this module needs no import of the
+            exception type (``creek.scaffold`` is imported lazily inside
+            the commands that use it).
+        verb: What this invocation was trying to do, for the first line.
+        remedy: The exact command to re-run, already ``--force``-bearing
+            and matching the flags the operator actually passed.
+        whole_deployment: Whether the refusal aborted more than the skill
+            tree. An explicit flag, not a test on *verb*: what the
+            operator is told must not depend on how a word was spelled.
+    """
+    console.print(
+        f"[red]Refusing to {verb}: local changes detected in "
+        f"{len(labels)} skill file(s):[/red]",
+        highlight=False,
+    )
+    for label in labels:
+        console.print(f"[red]  - {escape(label)}[/red]", highlight=False)
+    if whole_deployment:
+        # A drifted skill aborts the *whole* canonical deployment, not
+        # just the skill tree. Say so, or the operator is left guessing
+        # whether the ontology spec and AGENTS.md landed.
+        console.print(
+            "[red]Nothing at all was deployed: no folders, no ontology "
+            "spec, no AGENTS.md.[/red]",
+            highlight=False,
+        )
+    console.print(
+        "[yellow]Revert the edit, or re-run to overwrite it:\n"
+        f"  {escape(remedy)}[/yellow]",
+        highlight=False,
+    )
+    console.print(
+        "[dim]--force keeps your version alongside the canonical file as "
+        "<name>.bak, replacing anything already at that path; a later "
+        "--force overwrites it again.[/dim]",
+        highlight=False,
+    )
+
+
 @app.command()
 def init(
     vault: Path = typer.Option(..., "--vault", help="Vault root to initialise"),
     force: bool = typer.Option(
         False,
         "--force",
-        help="Overwrite an existing creek_config.yaml.",
+        help=(
+            "Overwrite an existing creek_config.yaml, and overwrite "
+            "locally-modified canonical skill files (your version is kept "
+            "alongside as <name>.bak; a later --force overwrites that "
+            "backup)."
+        ),
     ),
     refresh: bool = typer.Option(
         False,
         "--refresh",
         help=(
-            "Re-copy canonical templates (ontology, AGENTS.md, schema "
-            "skills, scaffold) into an existing vault. User data and "
-            "creek_config.yaml are preserved."
+            "Re-copy canonical material (folder scaffold, ontology spec, "
+            "AGENTS.md, schema skills, medium contracts) into an existing "
+            "vault without seeding a fresh creek_config.yaml. AGENTS.md is "
+            "always overwritten; a locally-edited skill or medium contract "
+            "makes the command refuse unless --force. User content "
+            "elsewhere in the vault is untouched."
         ),
     ),
     allow_in_repo: bool = typer.Option(
@@ -609,11 +683,19 @@ def init(
     By default ``creek init`` refuses to scaffold inside a git repo;
     pass ``--allow-in-repo`` to override.
 
-    ``--refresh`` re-copies canonical material into an existing vault
-    without touching user-edited content or ``creek_config.yaml``.
+    Every run — with or without ``--refresh`` — restores the canonical
+    material: the folder scaffold, the ontology spec, ``AGENTS.md``, the
+    schema skills and the medium contracts. ``AGENTS.md`` is *always*
+    overwritten; it is the machine-facing agent contract, not
+    operator-authored content. A locally-edited skill or medium contract
+    makes the command refuse outright — deploying nothing — unless
+    ``--force`` is passed, which keeps the operator's bytes alongside as
+    ``<name>.bak``. ``--refresh`` differs from a plain run only in that
+    it leaves ``creek_config.yaml`` alone instead of seeding a fresh
+    one. User content elsewhere in the vault is never touched.
     """
     from creek.config import generate_default_config
-    from creek.scaffold import deploy_canonical
+    from creek.scaffold import DriftedSkillsError, deploy_canonical
 
     _guard_vault_path(vault, allow_in_repo)
 
@@ -627,7 +709,21 @@ def init(
         )
         raise typer.Exit(code=1)
 
-    result = deploy_canonical(vault)
+    try:
+        result = deploy_canonical(vault, force=force)
+    except DriftedSkillsError as exc:
+        # Name the invocation the operator actually made. A plain ``creek
+        # init`` can reach here too (existing skills, deleted config), and
+        # telling that operator to re-run with ``--refresh`` would skip the
+        # ``generate_default_config`` step they were owed.
+        refresh_flag = " --refresh" if refresh else ""
+        _print_skill_drift_refusal(
+            exc.labels,
+            verb="refresh" if refresh else "initialise",
+            remedy=f"creek init --vault {vault}{refresh_flag} --force",
+            whole_deployment=True,
+        )
+        raise typer.Exit(code=1) from exc
 
     if not refresh:
         generate_default_config(config_path)
@@ -4235,33 +4331,40 @@ def skills_sync(
     force: bool = typer.Option(
         False,
         "--force",
-        help="Overwrite locally-modified skill files.",
+        help=(
+            "Overwrite locally-modified skill files, keeping your version "
+            "alongside as <name>.bak. A later --force overwrites that "
+            "backup."
+        ),
     ),
 ) -> None:
     """Re-deploy the canonical schema-skill tree into ``<vault>/00-Creek-Meta/Skills/``.
 
-    Pulls upstream changes from
-    ``creek-tools/creek/templates/skills/*.SKILL.md`` after upgrading
-    ``creek-tools``. Local edits to deployed skill files block the
-    overwrite unless ``--force`` is passed.
+    Pulls upstream changes to both classes of canonical skill file after
+    upgrading ``creek-tools``: the flat schema skills
+    (``creek/templates/skills/*.SKILL.md``) and the medium contracts
+    (``creek/templates/skills/mediums/*.MEDIUM.md``). Local edits to
+    either class block the overwrite unless ``--force`` is passed.
     """
-    from creek.scaffold import deploy_skills, detect_drifted_skills
+    from creek.scaffold import DriftedSkillsError, deploy_skills
 
-    drifted = detect_drifted_skills(vault)
-    if drifted and not force:
-        names = ", ".join(p.name for p in drifted)
-        console.print(
-            f"[red]Refusing to sync: local changes detected in "
-            f"{len(drifted)} skill file(s): {names}. "
-            "Pass --force to overwrite.[/red]",
+    try:
+        deployment = deploy_skills(vault, force=force)
+    except DriftedSkillsError as exc:
+        _print_skill_drift_refusal(
+            exc.labels,
+            verb="sync",
+            remedy=f"creek skills sync --vault {vault} --force",
+            whole_deployment=False,
         )
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from exc
 
-    synced = deploy_skills(vault)
     console.print(
-        f"[bold green]Synced {synced} skill file(s) to "
+        f"[bold green]Synced {deployment.written} skill file(s) to "
         f"{vault / '00-Creek-Meta' / 'Skills'}.[/bold green]",
     )
+    for backup in deployment.preserved:
+        console.print(f"[yellow]Kept your previous version at {backup}.[/yellow]")
 
 
 def _warn_bypass_compiled(verb: str) -> None:

--- a/creek-tools/creek/scaffold.py
+++ b/creek-tools/creek/scaffold.py
@@ -12,12 +12,29 @@ from __future__ import annotations
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 PACKAGE_DIR = Path(__file__).resolve().parent
 TEMPLATES_DIR = PACKAGE_DIR / "templates"
 VAULT_TEMPLATE_DIR = TEMPLATES_DIR / "vault"
 SKILLS_TEMPLATE_DIR = TEMPLATES_DIR / "skills"
 AGENTS_TEMPLATE_FILE = TEMPLATES_DIR / "AGENTS.md"
+
+MEDIUMS_DIRNAME: Final = "mediums"
+"""Sub-directory of the skill tree holding the ``*.MEDIUM.md`` contracts."""
+
+BACKUP_SUFFIX: Final = ".bak"
+"""Suffix appended to a locally-edited skill file preserved by ``--force``.
+
+Deliberately *appended* rather than substituted: ``essay.MEDIUM.md.bak``
+still reads as the file it came from, and — because it no longer ends in
+``.SKILL.md`` or ``.MEDIUM.md`` — it is invisible to every glob that
+enumerates skills, including drift detection and the ``skill-size`` lint
+check.
+"""
 
 # The ontology spec lives at repo-level ``docs/Ontology/`` per FEAT-019's
 # pre-decided choice. We resolve it via the package's parents so editable
@@ -35,6 +52,134 @@ class ScaffoldResult:
     skills_synced: int
     ontology_deployed: bool
     agents_deployed: bool
+
+
+@dataclass(frozen=True)
+class SkillDeployment:
+    """Summary of one canonical skill-tree deployment.
+
+    Attributes:
+        written: How many canonical skill files were copied into the vault.
+        preserved: The ``.bak`` sidecars created to hold the operator's
+            pre-existing bytes. Empty unless ``force`` overrode drift.
+    """
+
+    written: int
+    preserved: tuple[Path, ...]
+
+
+class DriftedSkillsError(RuntimeError):
+    """Raised when deploying canonical skills would clobber local edits.
+
+    Carries the *deployed* paths (not the template ones) so a caller can
+    hand the operator something they can open, and the skills root they
+    hang off so :attr:`labels` can render them unambiguously.
+    """
+
+    def __init__(self, drifted: Sequence[Path], skills_root: Path) -> None:
+        """Record the drifted deployed paths and the root they live under.
+
+        Args:
+            drifted: Deployed skill paths whose bytes diverge from canon,
+                in the order :func:`detect_drifted_skills` returned them.
+            skills_root: ``<vault>/00-Creek-Meta/Skills``.
+        """
+        self.drifted: tuple[Path, ...] = tuple(drifted)
+        self.skills_root = skills_root
+        joined = ", ".join(self.labels)
+        super().__init__(
+            f"{len(self.drifted)} canonical skill file(s) have local changes: {joined}",
+        )
+
+    @property
+    def labels(self) -> tuple[str, ...]:
+        """Return each drifted path rendered relative to the skills root.
+
+        Returns:
+            Vault-relative POSIX labels such as
+            ``"mediums/essay.MEDIUM.md"``. The bare filename would be
+            ambiguous — the two skill classes live at different depths,
+            and only the relative path says which file to go and look at.
+        """
+        return tuple(
+            path.relative_to(self.skills_root).as_posix() for path in self.drifted
+        )
+
+
+def _skills_root(vault: Path) -> Path:
+    """Return the vault directory the canonical skill tree deploys into.
+
+    Args:
+        vault: Target vault root.
+
+    Returns:
+        ``<vault>/00-Creek-Meta/Skills`` — the single spelling of that
+        location for this module.
+    """
+    return vault / "00-Creek-Meta" / "Skills"
+
+
+def _canonical_skill_pairs(vault: Path) -> list[tuple[Path, Path]]:
+    """Enumerate every canonical skill file and where it deploys to.
+
+    This is the module's *only* answer to "what is a skill file". Drift
+    detection and deployment both read it, so the two can no longer
+    disagree — issue #1306 was exactly that disagreement: deployment
+    wrote ``mediums/*.MEDIUM.md`` while the guard globbed only
+    ``*.SKILL.md``, leaving hand-edited medium contracts unprotected.
+
+    The two globs are deliberately explicit rather than an ``rglob``
+    sweep: a stray ``.md`` file dropped into the template tree must not
+    become something every user vault silently receives.
+
+    Args:
+        vault: Target vault root.
+
+    Returns:
+        ``(canonical_template_path, deployed_vault_path)`` pairs sorted
+        once, globally, by the deployed path relative to the skills root
+        — so ``lint.SKILL.md`` sorts before ``mediums/book-report.MEDIUM.md``
+        sorts before ``paradox.SKILL.md``. Per-glob sorting would
+        interleave wrongly and make the reported order a lie.
+    """
+    root = _skills_root(vault)
+    pairs: list[tuple[Path, Path]] = [
+        (canonical, root / canonical.name)
+        for canonical in SKILLS_TEMPLATE_DIR.glob("*.SKILL.md")
+    ]
+    # Stripped-wheel installs ship no ``mediums/``; absence is not an error.
+    mediums_src = SKILLS_TEMPLATE_DIR / MEDIUMS_DIRNAME
+    if mediums_src.is_dir():
+        pairs.extend(
+            (canonical, root / MEDIUMS_DIRNAME / canonical.name)
+            for canonical in mediums_src.glob("*.MEDIUM.md")
+        )
+    return sorted(pairs, key=lambda pair: pair[1].relative_to(root).as_posix())
+
+
+def _preserve_local_edits(drifted: Sequence[Path]) -> tuple[Path, ...]:
+    """Copy each drifted file aside before it is overwritten.
+
+    Args:
+        drifted: Deployed skill paths about to be replaced by canon.
+
+    Returns:
+        The ``.bak`` sidecars written, in the same order. *Whatever* sits
+        at that path is replaced — normally a backup from an earlier
+        ``--force``, but an operator's own unrelated ``<name>.bak`` would
+        go with it. That is the accepted cost of a single guessable
+        name: numbered sidecars would accumulate in a browsed Obsidian
+        vault with nothing in creek to ever list or remove them. The
+        CLI's refusal message discloses it before the operator reaches
+        for ``--force``. The sidecar always ends up holding the edit
+        this deploy is about to discard, never an older one.
+    """
+    backups: list[Path] = []
+    for deployed in drifted:
+        backup = deployed.with_name(deployed.name + BACKUP_SUFFIX)
+        shutil.copy2(deployed, backup)
+        backups.append(backup)
+    return tuple(backups)
 
 
 def find_enclosing_git_repo(path: Path) -> Path | None:
@@ -80,32 +225,45 @@ def scaffold_vault(vault: Path) -> int:
     return sum(1 for entry in VAULT_TEMPLATE_DIR.rglob("*") if entry.is_dir())
 
 
-def deploy_skills(vault: Path) -> int:
+def deploy_skills(vault: Path, *, force: bool = False) -> SkillDeployment:
     """Copy the canonical skill tree into ``<vault>/00-Creek-Meta/Skills/``.
 
     Deploys both the flat schema skills (``*.SKILL.md``) and the medium
     contracts under ``mediums/`` (``*.MEDIUM.md``, FEAT-041 §5).
 
+    The drift guard lives *here*, in the destructive primitive, rather
+    than in each caller: ``force`` defaults to ``False`` so a future
+    caller that forgets to check is safe by construction (issue #1306,
+    where ``creek init --refresh`` reached this function with no guard
+    at all and destroyed hand-edited contracts).
+
     Args:
         vault: Target vault root.
+        force: Overwrite locally-modified files instead of refusing.
+            Each one is copied aside to ``<name>.bak`` first.
 
     Returns:
-        The number of skill files written.
+        A :class:`SkillDeployment` recording how many files were written
+        and which ``.bak`` sidecars were created.
+
+    Raises:
+        DriftedSkillsError: If any deployed skill file has local changes
+            and *force* is not set. Nothing is written in that case.
     """
-    target = vault / "00-Creek-Meta" / "Skills"
-    target.mkdir(parents=True, exist_ok=True)
-    written = 0
-    for skill in sorted(SKILLS_TEMPLATE_DIR.glob("*.SKILL.md")):
-        shutil.copy2(skill, target / skill.name)
-        written += 1
-    mediums_src = SKILLS_TEMPLATE_DIR / "mediums"
-    if mediums_src.is_dir():
-        mediums_target = target / "mediums"
-        mediums_target.mkdir(parents=True, exist_ok=True)
-        for contract in sorted(mediums_src.glob("*.MEDIUM.md")):
-            shutil.copy2(contract, mediums_target / contract.name)
-            written += 1
-    return written
+    root = _skills_root(vault)
+    drifted = detect_drifted_skills(vault)
+    if drifted and not force:
+        raise DriftedSkillsError(drifted, root)
+
+    # The root is ensured even when the template tree is empty, so a vault
+    # always has a Skills/ directory to drop operator-authored skills into.
+    root.mkdir(parents=True, exist_ok=True)
+    preserved = _preserve_local_edits(drifted)
+    pairs = _canonical_skill_pairs(vault)
+    for canonical, deployed in pairs:
+        deployed.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(canonical, deployed)
+    return SkillDeployment(written=len(pairs), preserved=preserved)
 
 
 def detect_drifted_skills(vault: Path) -> list[Path]:
@@ -113,8 +271,10 @@ def detect_drifted_skills(vault: Path) -> list[Path]:
 
     A skill file is considered *drifted* when it exists in the user's
     vault but its bytes differ from the canonical template. Missing
-    files are not drift — they are simply pending sync. The returned
-    paths point at the *deployed* copies (under
+    files are not drift — they are simply pending sync. Files the
+    operator authored themselves are not drift either: only the
+    canonical set from :func:`_canonical_skill_pairs` is compared. The
+    returned paths point at the *deployed* copies (under
     ``<vault>/00-Creek-Meta/Skills/``) so callers can surface them
     directly to the operator.
 
@@ -122,17 +282,20 @@ def detect_drifted_skills(vault: Path) -> list[Path]:
         vault: Target vault root.
 
     Returns:
-        The list of drifted *deployed* skill paths (sorted by name).
+        The list of drifted *deployed* skill paths, in one global sort
+        over the path each holds relative to
+        ``<vault>/00-Creek-Meta/Skills/`` — so ``lint.SKILL.md`` precedes
+        ``mediums/book-report.MEDIUM.md`` precedes ``paradox.SKILL.md``.
+        Sorting each glob separately would interleave them wrongly.
     """
-    target = vault / "00-Creek-Meta" / "Skills"
-    if not target.exists():
+    root = _skills_root(vault)
+    if not root.exists():
         return []
-    drifted: list[Path] = []
-    for canonical in sorted(SKILLS_TEMPLATE_DIR.glob("*.SKILL.md")):
-        deployed = target / canonical.name
-        if deployed.exists() and deployed.read_bytes() != canonical.read_bytes():
-            drifted.append(deployed)
-    return drifted
+    return [
+        deployed
+        for canonical, deployed in _canonical_skill_pairs(vault)
+        if deployed.exists() and deployed.read_bytes() != canonical.read_bytes()
+    ]
 
 
 def deploy_ontology(vault: Path) -> bool:
@@ -171,21 +334,50 @@ def deploy_agents_md(vault: Path) -> bool:
     return True
 
 
-def deploy_canonical(vault: Path) -> ScaffoldResult:
+def deploy_canonical(vault: Path, *, force: bool = False) -> ScaffoldResult:
     """Apply the full canonical deployment to *vault*.
 
     Wraps :func:`scaffold_vault`, :func:`deploy_skills`,
     :func:`deploy_ontology`, and :func:`deploy_agents_md` in one call.
     Safe to re-run; user data outside the canonical targets is never
     touched.
+
+    The drift check is a *pre-flight*, not a step: refusing halfway
+    through would leave the operator with a freshly-overwritten
+    ``AGENTS.md`` and an error message, unable to tell what landed. So
+    the check runs before the first write, which makes a *drift
+    refusal* all-or-nothing — it deploys nothing at all.
+
+    That guarantee is scoped to the refusal, and deliberately not
+    claimed more broadly: once past the pre-flight the four deployment
+    steps are sequential, so an I/O error partway through (a full disk,
+    a permission denial) can still leave a partial deployment behind.
+    Making that atomic would need a staging directory and is out of
+    scope here; saying so is not.
+
+    Args:
+        vault: Target vault root.
+        force: Overwrite locally-modified canonical skill files,
+            preserving each as ``<name>.bak``.
+
+    Returns:
+        A :class:`ScaffoldResult` summarising the deployment.
+
+    Raises:
+        DriftedSkillsError: If any deployed skill file has local changes
+            and *force* is not set. Nothing at all is deployed.
     """
+    drifted = detect_drifted_skills(vault)
+    if drifted and not force:
+        raise DriftedSkillsError(drifted, _skills_root(vault))
+
     folders = scaffold_vault(vault)
-    synced = deploy_skills(vault)
+    deployment = deploy_skills(vault, force=force)
     ontology = deploy_ontology(vault)
     agents = deploy_agents_md(vault)
     return ScaffoldResult(
         folders_ensured=folders,
-        skills_synced=synced,
+        skills_synced=deployment.written,
         ontology_deployed=ontology,
         agents_deployed=agents,
     )

--- a/creek-tools/docs/getting-started.md
+++ b/creek-tools/docs/getting-started.md
@@ -33,7 +33,7 @@ The scaffold materialises the canonical folder topology, copies the ontology spe
 └── AGENTS.md
 ```
 
-After upgrading `creek-tools`, re-deploy upstream schema-skill changes with `creek skills sync --vault <path>` (add `--force` to overwrite local edits). To re-copy templates without touching user content, run `creek init --vault <path> --refresh`.
+After upgrading `creek-tools`, re-deploy upstream schema-skill and medium-contract changes with `creek skills sync --vault <path>`. `creek init --vault <path> --refresh` does the same for the whole scaffold — folder topology, ontology spec, schema-skill tree, and medium contracts — and always overwrites `AGENTS.md` with the canonical copy (it's the machine-facing agent contract, not operator-authored content, so it isn't protected). If a deployed skill or medium file has been hand-edited since the last deploy, both commands refuse rather than clobber it — for `--refresh` that refusal is atomic, so nothing at all is deployed, not just the skill tree. Pass `--force` to overwrite anyway; the operator's version is preserved alongside as `<name>.bak` (e.g. `mediums/essay.MEDIUM.md.bak`) before being replaced.
 
 A minimal starter `creek_config.yaml` (already written by `creek init`):
 

--- a/creek-tools/docs/wiring-contract.md
+++ b/creek-tools/docs/wiring-contract.md
@@ -80,6 +80,15 @@ Field by field:
   documented reason appears *and* the vault is byte-identical. The entry's
   primary invocation supplies the open-gate half. One half alone is passed by a
   surface that refuses everything.
+- **`refusal.mutate`** — vault-relative path → content, written before the
+  refusal run. Some gates trigger on *pre-existing local state* rather than on
+  a flag or a missing token: `skills sync` refuses on **drift**, which by
+  definition cannot exist in a vault straight from `creek init`. Without
+  `mutate` such a gate is undeclarable, and an undeclarable gate is an
+  unwatched one — that is precisely how #1306 (the drift guard covering
+  `*.SKILL.md` but not `mediums/*.MEDIUM.md`) survived here unseen. The write
+  lands before the harness snapshots its baseline digest, so the mutated bytes
+  become the "untouched" reference and a refusal that reverts them fails.
 - **`strip`** — vault-relative globs the fixture deletes before the run, for a
   surface whose artefacts `creek init` already deploys (`skills sync`).
 - **`prepare`** — CLI invocations to run first, for chained preconditions

--- a/creek-tools/tests/test_vault_sovereignty.py
+++ b/creek-tools/tests/test_vault_sovereignty.py
@@ -13,16 +13,46 @@ sync`` re-deploys canonical skills.
 
 from __future__ import annotations
 
+import hashlib
+import shutil
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
+import creek.scaffold
 from creek.cli import app
+from creek.lint.checks import skill_size_budget
+from creek.scaffold import DriftedSkillsError, deploy_skills, detect_drifted_skills
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TEMPLATES_DIR = REPO_ROOT / "creek-tools" / "creek" / "templates"
 
 runner = CliRunner()
+
+
+def _digest_tree(root: Path) -> dict[Path, str]:
+    """Map every file under *root* to the SHA-256 hex digest of its bytes.
+
+    Used to prove a command wrote *nothing*: capture the mapping before
+    the command, compare after. Keys are paths relative to *root* so the
+    mapping is independent of the temporary directory it lives in.
+
+    Args:
+        root: Directory to walk recursively. A missing directory yields
+            an empty mapping.
+
+    Returns:
+        A dict keyed by the file's path relative to *root*, valued by the
+        hex SHA-256 digest of that file's bytes.
+    """
+    if not root.is_dir():
+        return {}
+    return {
+        path.relative_to(root): hashlib.sha256(path.read_bytes()).hexdigest()
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
 
 
 # ---------- repo topology ----------
@@ -260,6 +290,270 @@ def test_skills_sync_is_idempotent(tmp_path: Path) -> None:
     assert second.exit_code == 0
 
 
+# ---------- issue #1306: mediums/*.MEDIUM.md are skills too ----------
+
+
+def test_skills_sync_refuses_a_drifted_medium_contract_and_writes_nothing(
+    tmp_path: Path,
+) -> None:
+    """A hand-edited medium contract blocks sync and survives byte-for-byte.
+
+    Issue #1306: the drift guard only globbed ``*.SKILL.md``, so an
+    operator's ``mediums/*.MEDIUM.md`` edits were silently overwritten by
+    a plain ``creek skills sync``. The refusal must name the file, exit
+    non-zero, and leave the whole Skills tree untouched.
+    """
+    vault = tmp_path / "vault"
+    init_result = runner.invoke(app, ["init", "--vault", str(vault)])
+    assert init_result.exit_code == 0, init_result.output
+
+    skills_dir = vault / "00-Creek-Meta" / "Skills"
+    before = _digest_tree(skills_dir)
+
+    essay = skills_dir / "mediums" / "essay.MEDIUM.md"
+    essay.write_text("# my house style\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["skills", "sync", "--vault", str(vault)])
+
+    assert result.exit_code == 1, result.output
+    assert "mediums/essay.MEDIUM.md" in result.output
+    assert essay.read_text(encoding="utf-8") == "# my house style\n"
+
+    edited = Path("mediums/essay.MEDIUM.md")
+    after = _digest_tree(skills_dir)
+    assert {k: v for k, v in after.items() if k != edited} == {
+        k: v for k, v in before.items() if k != edited
+    }
+
+
+def test_detect_drifted_skills_reports_a_drifted_medium_contract(
+    tmp_path: Path,
+) -> None:
+    """A single edited ``mediums/*.MEDIUM.md`` is reported as drift."""
+    vault = tmp_path / "vault"
+    init_result = runner.invoke(app, ["init", "--vault", str(vault)])
+    assert init_result.exit_code == 0, init_result.output
+
+    skills_dir = vault / "00-Creek-Meta" / "Skills"
+    essay = skills_dir / "mediums" / "essay.MEDIUM.md"
+    essay.write_text("# my house style\n", encoding="utf-8")
+
+    assert detect_drifted_skills(vault) == [skills_dir / "mediums" / "essay.MEDIUM.md"]
+
+
+def test_detect_drifted_skills_still_reports_a_drifted_schema_skill(
+    tmp_path: Path,
+) -> None:
+    """The already-covered ``*.SKILL.md`` class must not regress."""
+    vault = tmp_path / "vault"
+    init_result = runner.invoke(app, ["init", "--vault", str(vault)])
+    assert init_result.exit_code == 0, init_result.output
+
+    skills_dir = vault / "00-Creek-Meta" / "Skills"
+    (skills_dir / "lint.SKILL.md").write_text("# my lint rules\n", encoding="utf-8")
+
+    assert detect_drifted_skills(vault) == [skills_dir / "lint.SKILL.md"]
+
+
+def test_detect_drifted_skills_sorts_globally_not_per_glob(tmp_path: Path) -> None:
+    """Drifted paths come back in one global sort over vault-relative posix paths.
+
+    ``lint.SKILL.md`` < ``mediums/book-report.MEDIUM.md`` < ``paradox.SKILL.md``.
+    A naive ``[*sorted(skill_glob), *sorted(medium_glob)]`` concatenation
+    yields ``lint, paradox, mediums/book-report`` instead, so this must be a
+    list equality — not a set, not a length.
+    """
+    vault = tmp_path / "vault"
+    init_result = runner.invoke(app, ["init", "--vault", str(vault)])
+    assert init_result.exit_code == 0, init_result.output
+
+    skills_dir = vault / "00-Creek-Meta" / "Skills"
+    (skills_dir / "lint.SKILL.md").write_text("# my lint rules\n", encoding="utf-8")
+    (skills_dir / "paradox.SKILL.md").write_text("# my paradoxes\n", encoding="utf-8")
+    (skills_dir / "mediums" / "book-report.MEDIUM.md").write_text(
+        "# my book reports\n",
+        encoding="utf-8",
+    )
+
+    assert detect_drifted_skills(vault) == [
+        skills_dir / "lint.SKILL.md",
+        skills_dir / "mediums" / "book-report.MEDIUM.md",
+        skills_dir / "paradox.SKILL.md",
+    ]
+
+
+def test_detect_drifted_skills_returns_deployed_paths_never_template_paths(
+    tmp_path: Path,
+) -> None:
+    """Reported paths live in the vault so the operator can open them."""
+    vault = tmp_path / "vault"
+    init_result = runner.invoke(app, ["init", "--vault", str(vault)])
+    assert init_result.exit_code == 0, init_result.output
+
+    skills_dir = vault / "00-Creek-Meta" / "Skills"
+    (skills_dir / "lint.SKILL.md").write_text("# my lint rules\n", encoding="utf-8")
+    (skills_dir / "mediums" / "essay.MEDIUM.md").write_text(
+        "# my house style\n",
+        encoding="utf-8",
+    )
+
+    drifted = detect_drifted_skills(vault)
+    assert len(drifted) == 2, drifted
+    template_skills = TEMPLATES_DIR / "skills"
+    for path in drifted:
+        assert path.is_relative_to(skills_dir), path
+        assert not path.is_relative_to(template_skills), path
+
+
+def test_detect_drifted_skills_tolerates_missing_directories(tmp_path: Path) -> None:
+    """A vault missing ``mediums/`` — or ``Skills/`` entirely — is not an error."""
+    vault = tmp_path / "vault"
+    init_result = runner.invoke(app, ["init", "--vault", str(vault)])
+    assert init_result.exit_code == 0, init_result.output
+
+    skills_dir = vault / "00-Creek-Meta" / "Skills"
+    shutil.rmtree(skills_dir / "mediums")
+    assert detect_drifted_skills(vault) == []
+
+    shutil.rmtree(skills_dir)
+    assert detect_drifted_skills(vault) == []
+
+
+def test_deploy_skills_handles_a_template_tree_with_no_mediums_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stripped wheel whose template tree has no ``mediums/`` still deploys.
+
+    Neither deployment nor drift detection may assume the medium
+    contracts exist on disk.
+    """
+    stripped = tmp_path / "stripped-templates"
+    stripped.mkdir()
+    (stripped / "solo.SKILL.md").write_text("# solo\n", encoding="utf-8")
+    monkeypatch.setattr(creek.scaffold, "SKILLS_TEMPLATE_DIR", stripped)
+
+    vault = tmp_path / "vault"
+    assert deploy_skills(vault, force=True).written == 1
+    assert detect_drifted_skills(vault) == []
+
+
+def test_deploy_skills_preserves_operator_authored_extra_files(tmp_path: Path) -> None:
+    """Operator-authored skills the templates never shipped survive a deploy.
+
+    Pins against a ``copytree``-style "fix" that would mirror the template
+    tree and delete everything the operator added.
+    """
+    vault = tmp_path / "vault"
+    init_result = runner.invoke(app, ["init", "--vault", str(vault)])
+    assert init_result.exit_code == 0, init_result.output
+
+    skills_dir = vault / "00-Creek-Meta" / "Skills"
+    mine = skills_dir / "mine.SKILL.md"
+    mine.write_text("# my own schema skill\n", encoding="utf-8")
+    custom = skills_dir / "mediums" / "custom.MEDIUM.md"
+    custom.write_text("# my own medium contract\n", encoding="utf-8")
+
+    assert detect_drifted_skills(vault) == []
+
+    deploy_skills(vault, force=True)
+
+    assert mine.read_text(encoding="utf-8") == "# my own schema skill\n"
+    assert custom.read_text(encoding="utf-8") == "# my own medium contract\n"
+    assert detect_drifted_skills(vault) == []
+
+
+def test_deploy_skills_refuses_drift_and_labels_paths_under_the_skills_root(
+    tmp_path: Path,
+) -> None:
+    """Without ``force`` the API raises, labelling both drifted classes."""
+    vault = tmp_path / "vault"
+    init_result = runner.invoke(app, ["init", "--vault", str(vault)])
+    assert init_result.exit_code == 0, init_result.output
+
+    skills_dir = vault / "00-Creek-Meta" / "Skills"
+    (skills_dir / "lint.SKILL.md").write_text("# my lint rules\n", encoding="utf-8")
+    essay = skills_dir / "mediums" / "essay.MEDIUM.md"
+    essay.write_text("# my house style\n", encoding="utf-8")
+
+    with pytest.raises(DriftedSkillsError) as excinfo:
+        deploy_skills(vault)
+
+    assert list(excinfo.value.labels) == [
+        "lint.SKILL.md",
+        "mediums/essay.MEDIUM.md",
+    ]
+    assert essay.read_text(encoding="utf-8") == "# my house style\n"
+
+
+def test_skills_sync_force_restores_both_classes_and_backs_up_operator_bytes(
+    tmp_path: Path,
+) -> None:
+    """``--force`` re-deploys both skill classes, keeping ``.bak`` sidecars."""
+    vault = tmp_path / "vault"
+    init_result = runner.invoke(app, ["init", "--vault", str(vault)])
+    assert init_result.exit_code == 0, init_result.output
+
+    skills_dir = vault / "00-Creek-Meta" / "Skills"
+    lint = skills_dir / "lint.SKILL.md"
+    lint.write_text("# my lint rules\n", encoding="utf-8")
+    essay = skills_dir / "mediums" / "essay.MEDIUM.md"
+    essay.write_text("# my house style\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["skills", "sync", "--vault", str(vault), "--force"])
+    assert result.exit_code == 0, result.output
+
+    canonical_skills = TEMPLATES_DIR / "skills"
+    assert lint.read_bytes() == (canonical_skills / "lint.SKILL.md").read_bytes()
+    assert (
+        essay.read_bytes()
+        == (canonical_skills / "mediums" / "essay.MEDIUM.md").read_bytes()
+    )
+
+    lint_backup = skills_dir / "lint.SKILL.md.bak"
+    essay_backup = skills_dir / "mediums" / "essay.MEDIUM.md.bak"
+    assert lint_backup.read_text(encoding="utf-8") == "# my lint rules\n"
+    assert essay_backup.read_text(encoding="utf-8") == "# my house style\n"
+
+
+def test_backup_sidecars_are_invisible_to_drift_detection_and_lint(
+    tmp_path: Path,
+) -> None:
+    """``.bak`` sidecars must not be mistaken for skill files by anything.
+
+    The operator's saved versions are deliberately over the size budget so
+    a glob that accidentally swept them in (``*.md``, ``*.SKILL.md*``)
+    would surface as a ``skill-size`` finding.
+    """
+    vault = tmp_path / "vault"
+    init_result = runner.invoke(app, ["init", "--vault", str(vault)])
+    assert init_result.exit_code == 0, init_result.output
+
+    bloated = "word " * (skill_size_budget.SKILL_BUDGET_WORDS + 100)
+    skills_dir = vault / "00-Creek-Meta" / "Skills"
+    (skills_dir / "lint.SKILL.md").write_text(bloated, encoding="utf-8")
+    (skills_dir / "mediums" / "essay.MEDIUM.md").write_text(bloated, encoding="utf-8")
+
+    result = runner.invoke(app, ["skills", "sync", "--vault", str(vault), "--force"])
+    assert result.exit_code == 0, result.output
+
+    lint_backup = skills_dir / "lint.SKILL.md.bak"
+    essay_backup = skills_dir / "mediums" / "essay.MEDIUM.md.bak"
+    assert lint_backup.read_text(encoding="utf-8") == bloated
+    assert essay_backup.read_text(encoding="utf-8") == bloated
+
+    assert detect_drifted_skills(vault) == []
+
+    globbed = [
+        *sorted(skills_dir.glob("*.SKILL.md")),
+        *sorted(skills_dir.glob("mediums/*.MEDIUM.md")),
+    ]
+    assert [p for p in globbed if p.name.endswith(".bak")] == []
+
+    findings = skill_size_budget.run(vault).findings
+    assert [f for f in findings if ".bak" in f] == []
+
+
 # ---------- init idempotency / refresh ----------
 
 
@@ -314,3 +608,104 @@ def test_init_does_not_overwrite_user_config_without_force(tmp_path: Path) -> No
     result = runner.invoke(app, ["init", "--vault", str(vault)])
     assert result.exit_code != 0
     assert config.read_text(encoding="utf-8") == "# operator-edited\n"
+
+
+def test_init_refresh_refuses_a_drifted_medium_and_deploys_nothing(
+    tmp_path: Path,
+) -> None:
+    """``init --refresh`` pre-flights the drift check and aborts atomically.
+
+    Issue #1306: ``--refresh`` overwrote hand-edited medium contracts. The
+    refusal has to happen *before* any deployment, so not one byte of the
+    vault — folders, ontology, AGENTS.md included — may change.
+    """
+    vault = tmp_path / "vault"
+    init_result = runner.invoke(app, ["init", "--vault", str(vault)])
+    assert init_result.exit_code == 0, init_result.output
+
+    user_note = vault / "01-Fragments" / "Journal" / "mine.md"
+    user_note.write_text("dear diary\n", encoding="utf-8")
+    essay = vault / "00-Creek-Meta" / "Skills" / "mediums" / "essay.MEDIUM.md"
+    essay.write_text("# my house style\n", encoding="utf-8")
+
+    before = _digest_tree(vault)
+
+    refresh = runner.invoke(app, ["init", "--vault", str(vault), "--refresh"])
+
+    assert refresh.exit_code == 1, refresh.output
+    assert "mediums/essay.MEDIUM.md" in refresh.output
+    assert essay.read_text(encoding="utf-8") == "# my house style\n"
+    assert user_note.read_text(encoding="utf-8") == "dear diary\n"
+    assert _digest_tree(vault) == before
+
+
+def test_init_refresh_refusal_precedes_the_folder_scaffold(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The drift pre-flight must precede ``scaffold_vault``, not just the copy.
+
+    Its sibling test above cannot see the difference: re-scaffolding an
+    already-initialised vault rewrites byte-identical content, so a
+    whole-vault digest stays equal even if the folder step ran. Deleting
+    the pre-flight in ``deploy_canonical`` as "redundant" — the guard
+    inside ``deploy_skills`` would still protect the skill bytes — would
+    therefore break nothing visible, while quietly letting a refused
+    refresh create canonical folders. Pin it with a template tree that
+    ships a directory the vault does not have yet.
+    """
+    vault = tmp_path / "vault"
+    init_result = runner.invoke(app, ["init", "--vault", str(vault)])
+    assert init_result.exit_code == 0, init_result.output
+
+    upgraded_templates = tmp_path / "upgraded-vault-template"
+    (upgraded_templates / "99-Brand-New").mkdir(parents=True)
+    (upgraded_templates / "99-Brand-New" / ".gitkeep").write_text(
+        "",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(creek.scaffold, "VAULT_TEMPLATE_DIR", upgraded_templates)
+
+    essay = vault / "00-Creek-Meta" / "Skills" / "mediums" / "essay.MEDIUM.md"
+    essay.write_text("# my house style\n", encoding="utf-8")
+
+    refresh = runner.invoke(app, ["init", "--vault", str(vault), "--refresh"])
+    assert refresh.exit_code == 1, refresh.output
+    assert not (vault / "99-Brand-New").exists(), (
+        "a refused refresh deployed the new canonical folder: the drift "
+        "pre-flight ran after scaffold_vault instead of before it"
+    )
+
+    forced = runner.invoke(
+        app,
+        ["init", "--vault", str(vault), "--refresh", "--force"],
+    )
+    assert forced.exit_code == 0, forced.output
+    assert (vault / "99-Brand-New").is_dir(), (
+        "the control half failed: --force did not deploy the folder either, "
+        "so the assertion above proves nothing"
+    )
+
+
+def test_init_refresh_force_restores_canonical_bytes_and_keeps_a_backup(
+    tmp_path: Path,
+) -> None:
+    """``init --refresh --force`` overwrites drift but preserves a ``.bak``."""
+    vault = tmp_path / "vault"
+    init_result = runner.invoke(app, ["init", "--vault", str(vault)])
+    assert init_result.exit_code == 0, init_result.output
+
+    essay = vault / "00-Creek-Meta" / "Skills" / "mediums" / "essay.MEDIUM.md"
+    essay.write_text("# my house style\n", encoding="utf-8")
+
+    refresh = runner.invoke(
+        app,
+        ["init", "--vault", str(vault), "--refresh", "--force"],
+    )
+    assert refresh.exit_code == 0, refresh.output
+
+    canonical = TEMPLATES_DIR / "skills" / "mediums" / "essay.MEDIUM.md"
+    assert essay.read_bytes() == canonical.read_bytes()
+
+    backup = essay.with_name("essay.MEDIUM.md.bak")
+    assert backup.read_text(encoding="utf-8") == "# my house style\n"

--- a/creek-tools/tests/test_wiring_contract.py
+++ b/creek-tools/tests/test_wiring_contract.py
@@ -304,12 +304,20 @@ class Refusal:
         reason: Substring of the documented refusal message.
         argv: CLI arguments that leave the gate closed.
         kwargs: MCP arguments that leave the gate closed.
+        mutate: Vault-relative path -> content, written *before* the run so a
+            gate whose trigger is pre-existing local state can be declared at
+            all. ``skills sync`` refuses on *drift*, which cannot exist in a
+            vault straight from ``creek init``; without this the drift gate
+            would be undeclarable and #1306 would have stayed invisible here.
+            The write lands before the harness takes its baseline digest, so
+            the mutated bytes become the "untouched" reference.
         exit_code: Expected CLI exit status.
     """
 
     reason: str
     argv: tuple[str, ...] = ()
     kwargs: Mapping[str, Any] = field(default_factory=dict)
+    mutate: Mapping[str, str] = field(default_factory=dict)
     exit_code: int = 1
 
 
@@ -1374,10 +1382,29 @@ CLI_CONTRACT: Final[Mapping[str, Surface]] = {
             "#460: the canonical skills shipped in the package but never "
             "reached a vault"
         ),
-        derived_from=("creek.scaffold:VAULT_TEMPLATE_DIR",),
+        derived_from=(
+            "creek.scaffold:SKILLS_TEMPLATE_DIR",
+            "creek.scaffold:deploy_skills",
+        ),
         argv=("--vault", "{vault}", "--force"),
         strip=("00-Creek-Meta/Skills/**/*.md",),
-        effect=Effect(writes=("00-Creek-Meta/Skills/*.SKILL.md",)),
+        effect=Effect(
+            writes=(
+                "00-Creek-Meta/Skills/*.SKILL.md",
+                # #1306: the medium contracts are the *other* half of what
+                # this command deploys. Declaring only the flat schema skills
+                # is what let the drift guard cover one class for a whole
+                # release without a single test noticing.
+                "00-Creek-Meta/Skills/mediums/*.MEDIUM.md",
+            )
+        ),
+        refusal=Refusal(
+            reason="local changes",
+            argv=("--vault", "{vault}"),
+            mutate={
+                "00-Creek-Meta/Skills/mediums/essay.MEDIUM.md": "# my house style\n",
+            },
+        ),
     ),
     "purge fragment": Surface(
         shape=Shape.REMOVES,
@@ -2274,6 +2301,10 @@ def test_declared_gate_refuses_and_leaves_the_vault_untouched(
     refusal = surface.refusal
     assert refusal is not None
     vault = bench.seeded_vault()
+    for relative, content in refusal.mutate.items():
+        seeded = vault / relative
+        seeded.parent.mkdir(parents=True, exist_ok=True)
+        seeded.write_text(content, encoding="utf-8")
 
     if name in MCP_CONTRACT:
         outcome = bench.run_mcp(name, refusal.kwargs, vault=vault)


### PR DESCRIPTION
## Summary

`creek skills sync` silently destroyed hand-edited `<vault>/00-Creek-Meta/Skills/mediums/*.MEDIUM.md`. `deploy_skills` wrote 14 files — 8 `*.SKILL.md` **and** 6 `mediums/*.MEDIUM.md` — while `detect_drifted_skills` globbed only the first class. Two enumerations of "what is a skill file" had diverged, and the guard was watching one of them.

Scoping the fix to that glob would have left the destruction half-closed, so this PR goes further. Four things were verified broken **by execution**, not by reading:

1. A hand-edited `mediums/essay.MEDIUM.md` yielded `detect_drifted_skills(vault) -> []`; `creek skills sync` exited **0**, printed `Synced 14 skill file(s)`, and replaced the operator's bytes. (Control: editing `lint.SKILL.md` *was* detected.)
2. `creek init --refresh` reached `deploy_skills` through a **second, entirely unguarded call site** (`deploy_canonical`) and destroyed **both** classes plus `AGENTS.md` — including the `*.SKILL.md` class the guard supposedly already covered. Measured: `SKILL survived refresh? False / MEDIUM survived refresh? False / AGENTS survived refresh? False`.
3. `docs/getting-started.md` actively recommended that path with the words "without touching user content". False.
4. `README.md` claimed sync already "refuses to overwrite locally-modified skill files". False for the medium class.

### The fix

- **One enumeration.** `_canonical_skill_pairs()` is now the module's only answer to "what is a skill file"; drift detection and deployment both read it, so they cannot disagree again. That divergence *was* this bug.
- **The guard moved into the destructive primitive.** `deploy_skills(vault, *, force: bool = False)` raises `DriftedSkillsError` itself. `force=False` is the default, so a future third caller is safe by construction rather than by convention. Leaving the guard in the CLI would have re-created the exact defect one layer up.
- **`deploy_canonical` pre-flights the check**, so a refused `creek init --refresh` deploys *nothing* — no folders, no ontology spec, no `AGENTS.md`. A refusal that had already overwritten `AGENTS.md` would leave the operator unable to tell what landed.
- **The refusal names the file unambiguously**, as a path relative to the Skills root (`mediums/essay.MEDIUM.md`), one per line. It previously printed a bare `p.name`, which could not distinguish a medium contract from a top-level skill.

## The `--force` policy — decided deliberately, not inherited

The question this issue forces is *what happens to an edit `--force` cannot preserve*. Silent discard is what `*.SKILL.md` did before this PR. For a data-loss issue that is the wrong default to leave unexamined, so it is changed:

> Canonical skill deployment **refuses** when a deployed skill file's bytes diverge from its canonical template. `--force` overwrites, but **preserves the operator's version alongside as `<name>.bak`** before the canonical bytes land. A later `--force` overwrites that backup. The policy is **identical for `*.SKILL.md` and `mediums/*.MEDIUM.md`**, and **identical for `creek skills sync` and `creek init`**, because the guard lives inside `deploy_skills`.

That policy is recorded in four places that the operator can actually reach: the `--force` help on both commands, the `creek init` docstring, the refusal message itself, and `docs/getting-started.md` + `README.md`.

**Honest limits of the `.bak` scheme** (probed by execution, not assumed):
- A pre-existing operator-authored `essay.MEDIUM.md.bak` **is** overwritten by the first `--force` — not just a backup from an earlier `--force`. The single deterministic name is the trade: numbered backups were rejected because unbounded `.bak.1`, `.bak.2` litter in a browsed Obsidian vault has no lifecycle and nothing in creek ever lists or cleans it. This is now disclosed in the refusal message itself ("replacing anything already at that path") and in `_preserve_local_edits`'s docstring, rather than left for someone to discover.
- Verified non-interference three ways by test: after a forced sync `detect_drifted_skills(vault) == []`; neither `*.SKILL.md` nor `mediums/*.MEDIUM.md` globs match a `.bak`; and `creek lint`'s skill-size-budget sweep produces no finding naming one. The sidecar is deliberately named so it cannot re-enter `creek/lint/checks/skill_size_budget.py` or `creek/author/contracts.py:_resolve_contract_path`.

## `AGENTS.md` is intentionally forfeit — and the pin is left alone

`tests/test_vault_sovereignty.py::test_init_refresh_overwrites_canonical_material` pins the *opposite* doctrine: it hand-edits `AGENTS.md` and asserts the canonical bytes win. **That test is deliberately untouched and still green.** `AGENTS.md` is the machine-facing agent contract whose canonical version is the intended one; a vault `MEDIUM` contract, by contrast, changes what `creek author` actually emits (`creek/author/contracts.py` prefers the vault copy over the template), so an edit there is load-bearing on output. The two are not the same kind of file and do not get the same guarantee. Every `creek init` run still overwrites `AGENTS.md`, and the help text and docs now say so instead of claiming user content is untouched.

## Consequence for #1354 — stated plainly

[#1354](https://github.com/Geoffe-Ga/Creek-Vault/issues/1354) reports that a vault-deployed medium contract can raise the privacy ceiling and disarm the HARD leak gate. Today a tampered `mediums/*.MEDIUM.md` is *incidentally* reverted the next time anyone runs `creek skills sync`. **After this change, sync refuses and the tampered contract persists.**

This PR therefore **strictly increases the persistence of a ceiling-widening contract**, and makes #1354's independent, config-sourced floor more load-bearing, not less. That is accepted: a bug that sometimes clobbers tampering is not a security control, and the new refusal actually *names the drifted file*, which is better detection than silent reversion. **Nothing anywhere should now cite "sync will restore the canonical contract" as a mitigation for #1354 — after this merges it is no longer true.**

## Two smaller decisions worth surfacing

- **Two explicit globs, not an `rglob` walk.** A whole-tree sweep would ship any stray `.md` dropped into `creek/templates/skills/` into every user vault *and* silently promote it into the watched set. It would also discard the stripped-wheel `is_dir()` guard, whose behaviour depends on pathlib globbing that changed in 3.13 — and CI runs 3.11/3.12/3.13. The two-glob form mirrors the correct in-tree precedent at `creek/lint/checks/skill_size_budget.py`.
- **`Refusal.mutate` added to the wiring-contract harness.** A drift gate could not be declared at all before: `Refusal` had no way to create pre-existing local state, and a vault fresh from `creek init` has no drift by definition. An undeclarable gate is an unwatched one — that is precisely how this bug survived in a suite whose job is to catch unwired surfaces. The `skills sync` surface also gains `00-Creek-Meta/Skills/mediums/*.MEDIUM.md` in `effect.writes`; declaring only the schema skills is what let the guard cover one class for a whole release unnoticed.

## Gate 2.5 self-review: verdict CLEAN, four non-blocking findings fixed anyway

- **The refusal named the wrong command.** `creek init` printed "Refusing to **refresh**" even without `--refresh` (reachable when the config file is missing but a drifted skill tree exists), and then advised re-running with `--refresh --force` — which would have silently skipped `generate_default_config`, so the suggested "fix" would have done *less* than the command it replaced. The verb and the remedy are now supplied by the caller and match the flags actually passed.
- **`.bak` collision disclosed** (above) rather than left implicit.
- **An overstated atomicity claim retracted.** `deploy_canonical`'s docstring said "the whole deployment is all-or-nothing". True of a *drift refusal*; not true of an I/O error partway through the four sequential steps. Scoped to what is actually guaranteed — the point of this PR is to stop shipping prose that overpromises.
- **A test-hardening gap closed.** The whole-vault digest assertion could not distinguish "the pre-flight ran before `scaffold_vault`" from "`scaffold_vault` ran but was a no-op on an already-scaffolded vault". So deleting `deploy_canonical`'s seemingly-redundant pre-flight would have broken *no test* while quietly letting a refused refresh create canonical folders. `test_init_refresh_refusal_precedes_the_folder_scaffold` now pins it with a template tree shipping a folder the vault lacks, and carries a control half so the assertion cannot pass vacuously. Verified: deleting the pre-flight reddens exactly that one test.

One finding accepted and not fixed: `deploy_canonical` computes `detect_drifted_skills` and `deploy_skills` recomputes it, a duplicate glob+hash pass per `init`. Harmless at 14 files, and keeping the primitive self-guarding is the entire point of the design.

## Test plan

**Gate 1 RED, proven by running it — not asserted.** Before any production change, the lead test failed on real behaviour, not a missing symbol:

```
FAILED test_skills_sync_refuses_a_drifted_medium_contract_and_writes_nothing
  AssertionError: Synced 14 skill file(s) to .../vault/00-Creek-Meta/Skills.
  assert 0 == 1
```

11 of the 13 tests written at that point were red (10 behavioural, 1 on the genuinely-absent `DriftedSkillsError`). The other 2 are guard rails against the *fix* — the `*.SKILL.md` no-regression control and the missing-directory tolerance — and cannot be red without changing what they assert. A 14th test came out of self-review.

**Mutation-tested, three ways.** Reintroducing exactly this bug into the fixed code (blinding the detector to the mediums class, every new symbol still present) turns **9 of the new tests red**, plus the new wiring-contract refusal gate:

```
FAILED test_declared_gate_refuses_and_leaves_the_vault_untouched[skills sync-surface14]
  AssertionError: skills sync: refusal expected exit 1, got 0
```

Restoring the fix returns green. The tests that stay green under that mutation are the ones not about the mediums class. Separately, deleting `deploy_canonical`'s pre-flight reddens exactly the new folder-scaffold pin and nothing else.

**Coverage of the behaviour, not just the line:**
- refusal exits 1, names `mediums/essay.MEDIUM.md`, operator bytes intact, **and every other skill file byte-identical** — the reason-printed half alone is passed by a surface that refuses everything
- no regression on the `*.SKILL.md` class (which had **zero** test coverage before this PR — the existing guard was itself untested)
- both classes in one call, asserted as an **exact ordered list** (`lint.SKILL.md`, `mediums/book-report.MEDIUM.md`, `paradox.SKILL.md`) — the assertion a naive two-glob concatenation fails, where a set or a count would not
- operator-authored extras (`mine.SKILL.md`, `mediums/custom.MEDIUM.md`) survive and are never reported as drift — the pin against a `copytree`-style "fix"
- stripped wheel with no `mediums/` template dir; missing `mediums/`; missing `Skills/`
- `init --refresh` refusal is atomic: the **whole-vault digest map** is identical afterwards
- `.bak` sidecar non-interference, three ways
- the `init --refresh` refusal precedes the *folder scaffold*, not merely the skill copy

**Gate 2:** `./scripts/check-all.sh` — literal exit code **0**, 12/12 checks. 9145 passed, 5 skipped (env-gated live smokes). Aggregate coverage 94.46%; `creek/scaffold.py` 95.28% and complexity grade A; per-file gate 259 files ≥80%. Integration + e2e lanes pass (24). Ruff re-verified with `--no-cache`. No `# noqa`, `# type: ignore`, `skip`, or threshold change anywhere in the diff — swept, test files included.

Closes #1306
