### PR TITLE
fix(classify): give the weighted path the confidence axis, and stop it erasing the evidence

### DIFF
--- a/creek-tools/creek/classify/classify_engine.py
+++ b/creek-tools/creek/classify/classify_engine.py
@@ -170,6 +170,15 @@ voice-proxy generation, the Writing Desk), which is a strict improvement
 on the prior behaviour where 100% of intimate content routed to the
 cloud, every time. Fixing the residual properly needs a local
 pre-classification pass, which is out of scope here.
+
+That "once, not every time" promise was true only of the single-pick
+path until #1309. The weighted path could not keep it: it had no
+author-stance axis to detect ``conviction`` with, and it overwrote
+``voice.confidence`` with ``None`` on every run — so the escalation
+never fired, and even a tier escalated by some other route lost the
+evidence explaining it. Both paths now reach the same tier for the
+same model verdict, and both leave the evidence in place across
+re-runs, so the residual above is genuinely one egress on either.
 """
 
 from __future__ import annotations
@@ -1489,10 +1498,11 @@ def _classify_one(
             dispatches through
             :func:`creek.classify.weighted.classify_weighted`, persists
             the resulting weighted profile to
-            :attr:`Fragment.weighted`, and derives the legacy
-            single-pick fields via
-            :meth:`WeightedFragmentClassification.to_legacy` so
-            downstream consumers stay synchronised. Has no effect on
+            :attr:`Fragment.weighted`, and merges the derived legacy
+            single-pick fields over the fragment via
+            :meth:`WeightedFragmentClassification.merge_onto` — a
+            dimension the profile is silent about keeps its prior
+            value rather than being reset. Has no effect on
             the rules path or on ``--method llm`` runs where the rule
             classifier already cleared the confidence floor; for those
             fragments :attr:`Fragment.weighted` stays ``None``.
@@ -1540,10 +1550,16 @@ def _classify_one_weighted(
     :attr:`ClassificationConfig.weighted_classification` is set.
     Populates :attr:`Fragment.weighted` with the full weighted
     profile and derives the legacy single-pick fields from the
-    profile's top entries via
-    :meth:`WeightedFragmentClassification.to_legacy` so existing
-    consumers (lint, compile, voice-skill generation) stay
-    synchronised. When the underlying call fails soft to an empty
+    profile's top entries, so existing consumers (lint, compile,
+    voice-skill generation) keep reading a canonical pick.
+
+    Those derived fields **merge** over the fragment's existing
+    classification rather than replacing it wholesale — a dimension
+    the profile is silent about leaves the prior value standing. The
+    merge rule, and why the wholesale form was a privacy defect, live
+    on :meth:`WeightedFragmentClassification.merge_onto` (#1309).
+
+    When the underlying call fails soft to an empty
     profile (whitespace-only body, provider unavailable, transport
     error, malformed YAML) nothing is derived from it: the input
     fragment is handed back untouched — rule verdict intact,
@@ -1581,15 +1597,7 @@ def _classify_one_weighted(
         # ``_record_if_preserved`` forever (#744, #1330).
         return fragment, True, ""
     weighted = result.classification
-    freq, wave, voice = weighted.to_legacy()
-    updated = fragment.model_copy(
-        update={
-            "weighted": weighted,
-            "frequency": freq,
-            "wavelength": wave,
-            "voice": voice,
-        },
-    )
+    updated = weighted.merge_onto(fragment)
     return updated, False, weighted.reasoning
 
 

--- a/creek-tools/creek/classify/holonic.py
+++ b/creek-tools/creek/classify/holonic.py
@@ -72,6 +72,7 @@ from creek.classify.weighted import (
     WeightedFragmentClassification,
 )
 from creek.models import (
+    Confidence,
     Dosage,
     Frequency,
     Mode,
@@ -189,6 +190,11 @@ def combine(
             effective_weights,
             top_k=top_k,
         ),
+        confidences=_combine_dimension(
+            [c.confidences for c in children],
+            effective_weights,
+            top_k=top_k,
+        ),
         overall_confidence=confidence,
         reasoning=reasoning,
     )
@@ -235,6 +241,7 @@ def decompose_prior(
         orientations=parent.orientations,
         dosages=parent.dosages,
         voice_registers=parent.voice_registers,
+        confidences=parent.confidences,
         overall_confidence=parent.overall_confidence * 0.5,
         reasoning=parent.reasoning,
     )
@@ -387,6 +394,12 @@ def _mean_normalised_jsd(
         ("orientations", Orientation),
         ("dosages", Dosage),
         ("voice_registers", VoiceRegister),
+        # Author stance counts toward the divergence penalty like any
+        # other dimension. Omitting it would let children that disagree
+        # maximally about how firmly the writer holds their claim
+        # contribute zero divergence, silently overstating the bubbled-up
+        # parent's ``overall_confidence`` (#1309).
+        ("confidences", Confidence),
     )
     divergences: list[float] = []
     for attr, enum_type in dimension_accessors:

--- a/creek-tools/creek/classify/prompt.py
+++ b/creek-tools/creek/classify/prompt.py
@@ -291,6 +291,17 @@ def parse_prompt_ontology_response(
     # Parsing lives on :func:`creek.classify.weighted.parse_weighted_yaml`
     # so the prompt-level and fragment-level paths share one source of
     # truth; this wrapper only adds the ``prompt`` echo onto the result.
+    #
+    # One dimension is intentionally not copied across. #1309 gave the
+    # fragment-level profile a ``confidences`` axis — the *author's*
+    # stance toward their own claim — and :class:`PromptOntology`
+    # deliberately does not gain it: an operator-supplied essay seed has
+    # no author whose stance could be detected, so the axis is undefined
+    # rather than merely unmeasured, and inventing a value for it would
+    # feed a privacy control (the INTIMATE escalation) a fabricated
+    # reading. The shared parser tolerating the extra key costs nothing
+    # here precisely because this field copy is hand-written: an axis
+    # this path has no meaning for is simply left behind.
     parsed = parse_weighted_yaml(response)
     return PromptOntology(
         prompt=prompt,

--- a/creek-tools/creek/classify/weighted.py
+++ b/creek-tools/creek/classify/weighted.py
@@ -19,7 +19,10 @@ The legacy single-pick fields on :class:`creek.models.Fragment`
 downstream consumers (compile, lint, voice-skill generation). When
 ``weighted`` is populated, the two stay synchronised via the
 :meth:`WeightedFragmentClassification.from_single_pick` and
-:meth:`WeightedFragmentClassification.to_legacy` adapters.
+:meth:`WeightedFragmentClassification.to_legacy` adapters — or, on a
+real classification run,
+:meth:`WeightedFragmentClassification.merge_onto`, which layers the
+collapse over the fragment instead of replacing it.
 """
 
 from __future__ import annotations
@@ -52,6 +55,7 @@ from creek.classify.llm.prompts import (
 )
 from creek.models import (
     Color,
+    Confidence,
     Dosage,
     Frequency,
     FrequencyClassification,
@@ -110,6 +114,14 @@ class WeightedDimension(Generic[_DimT]):
 # classifier so the schema is enforced from one place. ``reasoning``
 # is populated outside the YAML path (via :func:`_split_reasoning_and_yaml`)
 # and therefore is not a permitted top-level YAML key here.
+#
+# This set is the SEC-004 injection boundary: it is what stops a model —
+# or a prompt injection riding in on fragment text — from writing an
+# arbitrary :class:`~creek.models.Fragment` field, ``privacy_tier`` above
+# all, straight out of an LLM response. Widening it is always a deliberate
+# act; #1309 added exactly one key, ``confidences``, and like every other
+# member it is named after the *dimension* rather than the Fragment field
+# it eventually feeds (``voice.confidence``).
 _ALLOWED_TOP_LEVEL_KEYS: frozenset[str] = frozenset(
     {
         "frequencies",
@@ -118,6 +130,7 @@ _ALLOWED_TOP_LEVEL_KEYS: frozenset[str] = frozenset(
         "orientations",
         "dosages",
         "voice_registers",
+        "confidences",
         "overall_confidence",
     },
 )
@@ -296,17 +309,27 @@ class WeightedFragmentClassification(BaseModel):
     """Weighted ontology profile attached to a :class:`Fragment`.
 
     Mirrors :class:`creek.classify.prompt.PromptOntology` minus the
-    ``prompt`` field. Each dimension is a tuple of
-    :class:`WeightedDimension` entries sorted weight-descending so the
-    heaviest signal sits at index 0.
+    ``prompt`` field, plus :attr:`confidences` — author stance is
+    undefined for an operator-supplied essay seed, so the prompt-level
+    twin deliberately stops one dimension short (see
+    :func:`creek.classify.prompt.parse_prompt_ontology_response`).
+    Each dimension is a tuple of :class:`WeightedDimension` entries
+    sorted weight-descending so the heaviest signal sits at index 0.
+
+    Every dimension defaults to the empty tuple, which is what lets a
+    profile written by an older release round-trip: a ``weighted:``
+    frontmatter block persisted before :attr:`confidences` existed
+    still validates, and reads back as "the model said nothing about
+    author stance" (#1309).
 
     Lives on :attr:`Fragment.weighted` as ``WeightedFragmentClassification |
     None``; ``None`` means "no weighted detection ran" (legacy
     fragments). When set, the legacy single-pick fields
     (:attr:`Fragment.frequency`, :attr:`Fragment.wavelength`,
     :attr:`Fragment.voice`) can be derived from the top weighted pick
-    per dimension via :meth:`to_legacy`; the reverse widening lives in
-    :meth:`from_single_pick`.
+    per dimension via :meth:`to_legacy`, or merged over a fragment's
+    existing classification via :meth:`merge_onto`; the reverse
+    widening lives in :meth:`from_single_pick`.
 
     Pydantic BaseModel rather than a frozen dataclass (the
     :class:`PromptOntology` shape) so the field plugs into
@@ -324,6 +347,7 @@ class WeightedFragmentClassification(BaseModel):
     orientations: tuple[WeightedDimension[Orientation], ...] = ()
     dosages: tuple[WeightedDimension[Dosage], ...] = ()
     voice_registers: tuple[WeightedDimension[VoiceRegister], ...] = ()
+    confidences: tuple[WeightedDimension[Confidence], ...] = ()
     overall_confidence: float = 0.0
     reasoning: str = ""
 
@@ -341,6 +365,11 @@ class WeightedFragmentClassification(BaseModel):
         dropped so :meth:`to_legacy` can distinguish "unset" from
         "explicitly classified as unclassified".
 
+        :attr:`VoiceClassification.confidence` round-trips since
+        #1309: it widens onto :attr:`confidences` and collapses back
+        out of it, so the author-stance evidence the INTIMATE privacy
+        escalation reads survives a weighted pass.
+
         The following legacy state does **not** round-trip back via
         :meth:`to_legacy` (documented limitations):
 
@@ -350,9 +379,14 @@ class WeightedFragmentClassification(BaseModel):
         * :attr:`WavelengthClassification.descriptor` is a free-form
           string with no weighted analogue; :meth:`to_legacy` returns
           ``""``.
-        * :attr:`VoiceClassification.confidence` is a
-          :class:`Confidence` enum with no weighted analogue;
-          :meth:`to_legacy` returns ``None``.
+
+        Both limitations are properties of :meth:`to_legacy`, which is
+        a *pure collapse* of this profile and knows nothing of the
+        fragment it came from. On a real classification run the loss
+        does not occur, because the engine goes through
+        :meth:`merge_onto`, which layers the collapse over the
+        fragment's existing classification and so leaves a descriptor
+        (or any other field the profile is silent about) standing.
 
         Args:
             fragment: A Pydantic ``Fragment`` instance.
@@ -366,7 +400,8 @@ class WeightedFragmentClassification(BaseModel):
         modes = _widen_single(fragment.wavelength.mode, Mode)
         orientations = _widen_single(fragment.wavelength.orientation, Orientation)
         dosages = _widen_single(fragment.wavelength.dosage, Dosage)
-        voice_registers = _widen_voice_register(fragment.voice.voice_register)
+        voice_registers = _widen_optional(fragment.voice.voice_register, VoiceRegister)
+        confidences = _widen_optional(fragment.voice.confidence, Confidence)
 
         return cls(
             frequencies=frequencies,
@@ -375,6 +410,7 @@ class WeightedFragmentClassification(BaseModel):
             orientations=orientations,
             dosages=dosages,
             voice_registers=voice_registers,
+            confidences=confidences,
         )
 
     def to_legacy(
@@ -388,9 +424,19 @@ class WeightedFragmentClassification(BaseModel):
         :class:`WeightedFragmentClassification` round-trips to the
         same default-empty legacy classifications.
 
+        This is a **pure collapse**: it sees only this profile, so
+        every dimension the profile is silent about comes back as that
+        field's "not determined" default. Assigning the result onto a
+        fragment wholesale therefore erases whatever that fragment
+        already knew — use :meth:`merge_onto` instead, which is the
+        operation the classify engine actually performs (#1309).
+
         See :meth:`from_single_pick` for the documented limitations
-        (color is recomputed; descriptor and voice confidence are
-        dropped).
+        (color is recomputed; descriptor is dropped). Voice confidence
+        is **not** among them any more: it collapses out of
+        :attr:`confidences`, so the evidence the INTIMATE privacy
+        escalation reads survives the weighted path exactly as it does
+        the single-pick one.
 
         Returns:
             A 3-tuple of ``(FrequencyClassification,
@@ -403,6 +449,11 @@ class WeightedFragmentClassification(BaseModel):
         orientation = _top_value(self.orientations, Orientation.UNCLASSIFIED)
         dosage = _top_value(self.dosages, Dosage.UNCLASSIFIED)
         voice_register = _top_value_optional(self.voice_registers)
+        # No weight floor, deliberately: the single-pick path applies
+        # none, so a floor here would make the weighted path *less*
+        # likely to surface a confessional+conviction verdict than the
+        # legacy one — the forbidden direction for a privacy control.
+        confidence = _top_value_optional(self.confidences)
         color = _FREQUENCY_TO_COLOR.get(primary, Color.UNCLASSIFIED)
 
         return (
@@ -417,9 +468,70 @@ class WeightedFragmentClassification(BaseModel):
             ),
             VoiceClassification(
                 voice_register=voice_register,
-                confidence=None,
+                confidence=confidence,
             ),
         )
+
+    def merge_onto(self, fragment: Fragment) -> Fragment:
+        """Layer this profile's derived legacy fields over a fragment.
+
+        The operation the classify engine performs when a weighted run
+        succeeds: persist the profile itself to
+        :attr:`Fragment.weighted`, and update the legacy single-pick
+        fields *only where the profile actually spoke*. Replacing them
+        wholesale from :meth:`to_legacy` — which this method
+        deliberately does not do — destroys the fragment's prior
+        ``voice.confidence`` and ``wavelength.descriptor``/``mode``,
+        which on the privacy path means erasing the very evidence the
+        INTIMATE escalation reads (#1309).
+
+        Precondition: this is only ever reached with a profile the model
+        genuinely produced. Every soft-failure mode — whitespace-only
+        body, provider unavailable, transport error, malformed YAML —
+        returns before the call site is reached
+        (:func:`~creek.classify.classify_engine._classify_one_weighted`,
+        #1330/#1358). That is what licenses the rule below: a dimension
+        this profile is silent about means "the model detected nothing
+        here", never "the call died", so deferring to the fragment's
+        prior evidence is always the right reading.
+
+        Args:
+            fragment: The fragment being classified, carrying whatever
+                classification a previous run or the rule classifier
+                already established.
+
+        Returns:
+            A copy of ``fragment`` with ``weighted`` set to this
+            profile and its legacy classification merged, not replaced.
+        """
+        freq, wave, voice = self.to_legacy()
+        # THE ``exclude_defaults`` INVARIANT that makes this a merge:
+        # every legacy classification field's default *is* its "not
+        # determined" sentinel (``UNCLASSIFIED`` / ``""`` / ``None``).
+        # So dumping the collapse with ``exclude_defaults=True`` yields
+        # exactly the subset of fields the model actually spoke to, and
+        # anything it was silent about is simply absent from the update
+        # — leaving the fragment's prior evidence standing.
+        update: dict[str, object] = {
+            "weighted": self,
+            "wavelength": fragment.wavelength.model_copy(
+                update=wave.model_dump(exclude_defaults=True),
+            ),
+            "voice": fragment.voice.model_copy(
+                update=voice.model_dump(exclude_defaults=True),
+            ),
+        }
+        # THE FREQUENCY ASYMMETRY: frequency is replaced wholesale when
+        # the profile has any frequencies (so stale secondaries from an
+        # earlier verdict are cleared rather than accumulating), and
+        # skipped entirely when it has none (so a signal-free profile
+        # does not wipe the rule classifier's output). The asymmetry is
+        # deliberate: ``FrequencyClassification.secondary`` is a list,
+        # and a list cannot be merged field-wise the way the scalar
+        # wavelength and voice axes can.
+        if self.frequencies:
+            update["frequency"] = freq
+        return fragment.model_copy(update=update)
 
 
 # ---- Adapter helpers -------------------------------------------------------
@@ -508,25 +620,34 @@ def _widen_single(
     return (WeightedDimension(value=member, weight=_LEGACY_SINGLE_WEIGHT),)
 
 
-def _widen_voice_register(
-    legacy: VoiceRegister | str | None,
-) -> tuple[WeightedDimension[VoiceRegister], ...]:
-    """Widen :attr:`VoiceClassification.voice_register` into weighted form.
+def _widen_optional(
+    legacy: _DimT | str | None,
+    enum_type: type[_DimT],
+) -> tuple[WeightedDimension[_DimT], ...]:
+    """Widen an optional legacy enum field into a one-entry weighted tuple.
 
-    Voice register has no ``UNCLASSIFIED`` sentinel; its absence is
-    modelled as ``None``. ``None`` widens to the empty tuple so the
-    round-trip distinguishes "no voice signal" from "explicitly the
-    confessional register".
+    The counterpart to :func:`_widen_single` for the two
+    :class:`VoiceClassification` axes — ``voice_register`` and
+    ``confidence`` — whose enums have **no** ``UNCLASSIFIED`` member:
+    absence is modelled as ``None`` instead. ``_widen_single`` cannot
+    serve them because it calls ``enum_type("unclassified")``, which
+    raises :class:`ValueError` on :class:`Confidence` and
+    :class:`VoiceRegister`. ``None`` widens to the empty tuple so the
+    round-trip distinguishes "no signal on this axis" from "explicitly
+    the confessional register" / "explicitly conviction".
 
     Args:
-        legacy: The voice register, possibly ``None``.
+        legacy: The legacy enum value, possibly serialised as a string
+            (Pydantic's ``use_enum_values=True``) or absent (``None``).
+        enum_type: The target :class:`StrEnum` subclass.
 
     Returns:
-        A single-entry tuple at weight 1.0, or empty when ``None``.
+        A single-entry tuple at weight 1.0, or empty when the input is
+        ``None`` / unresolvable.
     """
     if legacy is None:
         return ()
-    member = _coerce_enum(legacy, VoiceRegister)
+    member = _coerce_enum(legacy, enum_type)
     if member is None:
         return ()
     return (WeightedDimension(value=member, weight=_LEGACY_SINGLE_WEIGHT),)
@@ -639,6 +760,13 @@ bottoming_out, restoration
 6. **Voice Register**: confessional, analytical, playful, prophetic, \
 instructional, raw, conversational
 
+7. **Confidence**: musing, exploring, forming, settled, conviction
+   — the AUTHOR'S STANCE TOWARD THEIR OWN CLAIM, as evidenced in the
+   text. Score how firmly the writer holds what they are saying
+   ("maybe I'm just tired" is musing; "this is who I am" is
+   conviction). This is NOT your certainty about the classification —
+   see ``overall_confidence`` below for that.
+
 Wavelength Color (Spiral Dynamics) is anchored to the primary
 frequency for downstream visualisation only — you do not need to
 score it here. Canonical vocabulary, for reference: __COLOR_BLOCK__.
@@ -648,8 +776,8 @@ __FREQUENCY_COLOR_BLOCK__
 PROTOCOL:
 
 Step 1 — Reason briefly. Walk through which frequencies the fragment
-activates and why, then phases, modes, orientation, dosage, register.
-Two to four sentences.
+activates and why, then phases, modes, orientation, dosage, register,
+and the author's confidence in their own claim. Two to four sentences.
 
 Step 2 — Emit your classification as YAML inside a fenced ```yaml ... ```
 block. Only list dimension values you genuinely detect; omit entries
@@ -679,6 +807,9 @@ dosages:
 voice_registers:
   - value: analytical
     weight: 0.5
+confidences:
+  - value: exploring
+    weight: 0.6
 overall_confidence: 0.7
 ```
 
@@ -687,6 +818,16 @@ classification. Calibrate to the FEAT-017 threshold of {threshold:.2f}
 — above it means "I would stand behind this classification", below
 means "I would defer to a human." Per-dimension weights below this
 threshold will be ignored by downstream composition by default.
+
+``overall_confidence`` and ``confidences`` are DIFFERENT QUANTITIES
+and must be scored independently: ``overall_confidence`` is how sure
+YOU are of this classification, while ``confidences`` is how sure the
+AUTHOR is of what they wrote. A hesitant author described with total
+certainty is a high ``overall_confidence`` on a ``musing``
+``confidences`` entry, and a confident author you can barely read is
+the reverse. Never copy one into the other: downstream, a
+``conviction`` stance can permanently reclassify a fragment as
+private, and that decision is never revisited.
 
 FRAGMENT LEVEL: {level}
 FRAGMENT TITLE: {title}
@@ -790,6 +931,7 @@ def parse_weighted_yaml(response: str) -> WeightedFragmentClassification:
         orientations=_parse_dimension(data, "orientations", Orientation),
         dosages=_parse_dimension(data, "dosages", Dosage),
         voice_registers=_parse_dimension(data, "voice_registers", VoiceRegister),
+        confidences=_parse_dimension(data, "confidences", Confidence),
         overall_confidence=_coerce_weight(data.get("overall_confidence")),
         reasoning=reasoning,
     )

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -686,10 +686,19 @@ class ClassificationConfig(BaseModel):
     actually reaches the LLM also gets a
     :class:`~creek.classify.weighted.WeightedFragmentClassification`
     persisted to :attr:`Fragment.weighted`; the legacy single-pick
-    fields are derived from the top weighted entries via
-    :meth:`WeightedFragmentClassification.to_legacy` so downstream
-    consumers (lint, compile, voice-skill generation) keep working
-    unchanged.
+    fields are derived from the top weighted entries so downstream
+    consumers (lint, compile, voice-skill generation) keep reading a
+    canonical pick.
+
+    Those derived fields are **merged** over the fragment via
+    :meth:`WeightedFragmentClassification.merge_onto`, not written over
+    it: a dimension the model said nothing about keeps whatever value
+    the fragment already carried. That, plus the author-stance
+    (``confidences``) axis added alongside it, is what makes the
+    weighted path reach the **same privacy tier as the single-pick
+    path for the same model verdict** — before #1309 a
+    confessional+conviction verdict escalated to INTIMATE on the
+    single-pick path and stayed OPEN here.
 
     Rule-confident fragments are NOT re-classified —
     :attr:`Fragment.weighted` stays ``None`` for those even with this

--- a/creek-tools/tests/test_classify_weighted_evidence_on_disk.py
+++ b/creek-tools/tests/test_classify_weighted_evidence_on_disk.py
@@ -1,0 +1,423 @@
+"""On-disk evidence survival across a weighted classify run (issue #1309).
+
+The in-memory merge is covered by ``tests/test_weighted.py``. This module
+asserts the half that only a real ``run_classify`` over a real vault can
+show: that the restored ``voice.confidence`` actually reaches the written
+frontmatter, and that the INTIMATE escalation it triggers is durable across
+re-runs.
+
+Why the written file and not the returned ``Fragment``: the write path is
+``new_metadata.update(fragment.model_dump(mode="json"))`` with **no**
+``exclude_none``, so a nulled confidence really does land on disk as
+``confidence: null``. An in-memory assertion cannot see that.
+
+A deliberate limitation is encoded in every test here, and it is the reason
+for the ``_RULE_INERT_BODY`` constant and the explicit precondition
+assertions. ``RuleClassifier._build_updates`` rebuilds ``VoiceClassification``
+from scratch under an ``OR`` guard, so for any body its voice matcher fires
+on, a persisted ``confidence`` is destroyed *before* the weighted classifier
+is ever called and no downstream merge can recover it. That is a separate
+defect at the rules layer, filed as issue #1400 and out of scope here. These
+tests therefore prove the weighted path closes completely **for the fragments
+the rule pass leaves alone**, and they assert that precondition rather than
+quietly depending on it.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final
+from unittest.mock import patch
+
+import frontmatter
+import pytest
+
+from creek.classify.classify_engine import run_classify
+from creek.classify.privacy import PrivacyClassifier
+from creek.classify.rules import RuleClassifier
+from creek.config import (
+    ClassificationConfig,
+    CreekConfig,
+    LLMConfig,
+    LLMRoutingConfig,
+)
+from creek.models import (
+    Authorship,
+    Color,
+    Confidence,
+    Fragment,
+    FragmentSource,
+    Mode,
+    Phase,
+    PrivacyTier,
+    SourcePlatform,
+    VoiceClassification,
+    VoiceRegister,
+    WavelengthClassification,
+)
+from tests.helpers import write_fragment_file
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_AVAILABILITY: Final[str] = "creek.classify.llm.LLMClassifier._check_availability"
+"""Availability hook on the class ``classify_weighted`` builds itself."""
+
+_INVOKE: Final[str] = "creek.classify.llm.LLMClassifier.invoke_prompt"
+"""Transport hook on the class ``classify_weighted`` builds itself."""
+
+_FRAGMENT_ID: Final[str] = "frag-1309-on-disk"
+
+_RULE_INERT_BODY: Final[str] = (
+    "A plain paragraph about gardening tools and afternoon light."
+)
+"""A body the rule classifier has no opinion about.
+
+Load-bearing: see the module docstring. Verified by an explicit precondition
+assertion in every test below rather than trusted.
+"""
+
+_RULE_INERT_TITLE: Final[str] = "A quiet note"
+"""A title the rule classifier has no opinion about either.
+
+The rule matchers read the title as well as the body, and that bites. An
+earlier draft titled this fragment "Evidence bearing fragment"; the word
+"evidence" trips ``_match_voice_register`` into an ``analytical`` verdict,
+which fires the ``OR`` guard at ``rules.py:791`` and destroys the persisted
+``confidence`` before the weighted classifier is reached (#1400) — turning
+these tests red for a reason that has nothing to do with what they measure.
+The precondition assertions caught it.
+"""
+
+_CONFESSIONAL_CONVICTION_RESPONSE: Final[str] = """\
+The author is disclosing something personal and holds it firmly.
+
+```yaml
+frequencies:
+  - value: F6
+    weight: 0.8
+voice_registers:
+  - value: confessional
+    weight: 0.9
+confidences:
+  - value: conviction
+    weight: 0.9
+overall_confidence: 0.7
+```
+"""
+
+_SILENT_ON_VOICE_RESPONSE: Final[str] = """\
+Only a frequency reading here.
+
+```yaml
+frequencies:
+  - value: F6
+    weight: 0.8
+overall_confidence: 0.7
+```
+"""
+
+
+def _respond(payload: str) -> object:
+    """Build an ``invoke_prompt`` replacement returning *payload*.
+
+    Args:
+        payload: The canned model response.
+
+    Returns:
+        A function suitable for ``patch(..., new=...)``.
+    """
+
+    def _fake(self: object, prompt: str) -> str:
+        del self, prompt
+        return payload
+
+    return _fake
+
+
+def _weighted_config() -> CreekConfig:
+    """Build a local-provider config that forces the weighted LLM path.
+
+    ``confidence_threshold=1.0`` is above anything the rule classifier can
+    score, so the fragment always reaches the LLM branch; ``ollama`` keeps
+    every route local so the run needs no credentials.
+
+    Returns:
+        The assembled :class:`CreekConfig`.
+    """
+    return CreekConfig(
+        llm=LLMRoutingConfig(
+            default=LLMConfig(provider="ollama", model="qwen3:8b"),
+            classification=LLMConfig(provider="ollama", model="qwen3:8b"),
+            intimate=LLMConfig(provider="ollama", model="qwen3:8b"),
+        ),
+        classification=ClassificationConfig(
+            weighted_classification=True,
+            confidence_threshold=1.0,
+        ),
+    )
+
+
+def _seed_with_evidence(vault: Path) -> Path:
+    """Write one fragment already carrying voice and wavelength evidence.
+
+    Args:
+        vault: Vault root (created on demand).
+
+    Returns:
+        Path to the freshly-written fragment file.
+    """
+    return write_fragment_file(
+        vault=vault,
+        fragment=Fragment(
+            id=_FRAGMENT_ID,
+            title=_RULE_INERT_TITLE,
+            source=FragmentSource(
+                platform=SourcePlatform.ESSAY, author=Authorship.SELF
+            ),
+            voice=VoiceClassification(
+                voice_register=VoiceRegister.ANALYTICAL,
+                confidence=Confidence.CONVICTION,
+            ),
+            wavelength=WavelengthClassification(
+                phase=Phase.RISING,
+                mode=Mode.EXPRESS,
+                color=Color.GREEN,
+                descriptor="Social Anxiety",
+            ),
+        ),
+        body=_RULE_INERT_BODY,
+    )
+
+
+def _assert_rule_pass_preserves_evidence(fragment: Fragment) -> None:
+    """Assert the rules layer leaves this fragment's evidence intact.
+
+    The visible boundary of this PR. If this ever fails, the rules-layer
+    twin (#1400) has started firing on the test body and the assertions
+    downstream would be measuring the wrong defect.
+
+    Args:
+        fragment: The seeded fragment, before classification.
+    """
+    pre = RuleClassifier().classify(fragment, content=_RULE_INERT_BODY)
+    assert pre.voice.confidence == Confidence.CONVICTION
+    assert pre.wavelength.descriptor == "Social Anxiety"
+    assert pre.wavelength.mode == Mode.EXPRESS
+
+
+def _seeded_fragment() -> Fragment:
+    """Return the in-memory twin of the seeded fragment.
+
+    Returns:
+        A :class:`Fragment` matching what :func:`_seed_with_evidence` writes.
+    """
+    return Fragment(
+        id=_FRAGMENT_ID,
+        title=_RULE_INERT_TITLE,
+        source=FragmentSource(platform=SourcePlatform.ESSAY, author=Authorship.SELF),
+        voice=VoiceClassification(
+            voice_register=VoiceRegister.ANALYTICAL,
+            confidence=Confidence.CONVICTION,
+        ),
+        wavelength=WavelengthClassification(
+            phase=Phase.RISING,
+            mode=Mode.EXPRESS,
+            color=Color.GREEN,
+            descriptor="Social Anxiety",
+        ),
+    )
+
+
+def test_persisted_confidence_survives_a_weighted_run_on_disk(
+    tmp_path: Path,
+) -> None:
+    """A frontmatter ``confidence: conviction`` is still there afterwards.
+
+    At HEAD the weighted run replaced ``voice`` wholesale from ``to_legacy``,
+    and because the write does no ``exclude_none`` the frontmatter came back
+    carrying a literal ``confidence: null``.
+
+    Args:
+        tmp_path: Pytest-provided scratch directory.
+    """
+    _assert_rule_pass_preserves_evidence(_seeded_fragment())
+    vault = tmp_path / "vault"
+    md = _seed_with_evidence(vault)
+
+    with (
+        patch(_AVAILABILITY, return_value=True),
+        patch(_INVOKE, new=_respond(_SILENT_ON_VOICE_RESPONSE)),
+    ):
+        summary = run_classify(
+            vault_path=vault,
+            config=_weighted_config(),
+            method="llm",
+            force=True,
+        )
+
+    assert summary.classified == 1
+    meta = frontmatter.load(md).metadata
+    # The model said nothing about voice or wavelength, so the fragment's
+    # own evidence stands — on disk, not merely in memory.
+    assert meta["voice"]["confidence"] == "conviction"
+    assert meta["voice"]["voice_register"] == "analytical"
+    assert meta["wavelength"]["descriptor"] == "Social Anxiety"
+    assert meta["wavelength"]["mode"] == "express"
+    # What the model DID say is applied.
+    assert meta["frequency"]["primary"] == "F6"
+
+
+def test_weighted_run_escalates_to_intimate_on_disk(tmp_path: Path) -> None:
+    """A confessional+conviction verdict reaches ``privacy_tier: intimate``.
+
+    Asserted as an escalation UP from the ESSAY baseline of ``open``, not as
+    "the tier did not go down" — every writer of ``privacy_tier`` is already
+    escalate-only, so a no-downgrade assertion passes at HEAD and proves
+    nothing.
+
+    Args:
+        tmp_path: Pytest-provided scratch directory.
+    """
+    fragment = _seeded_fragment()
+    _assert_rule_pass_preserves_evidence(fragment)
+    # The test proves its own baseline: without the model's verdict this
+    # fragment is OPEN, so INTIMATE below is a real escalation.
+    assert (
+        PrivacyClassifier().classify_tier(fragment, content=_RULE_INERT_BODY)
+        == PrivacyTier.OPEN
+    )
+
+    vault = tmp_path / "vault"
+    md = _seed_with_evidence(vault)
+
+    with (
+        patch(_AVAILABILITY, return_value=True),
+        patch(_INVOKE, new=_respond(_CONFESSIONAL_CONVICTION_RESPONSE)),
+    ):
+        run_classify(
+            vault_path=vault,
+            config=_weighted_config(),
+            method="llm",
+            force=True,
+        )
+
+    meta = frontmatter.load(md).metadata
+    assert meta["voice"]["voice_register"] == "confessional"
+    assert meta["voice"]["confidence"] == "conviction"
+    assert meta["privacy_tier"] == "intimate"
+
+
+def test_second_weighted_run_keeps_the_tier_and_its_evidence(
+    tmp_path: Path,
+) -> None:
+    """Re-running does not undo the escalation or erase what justifies it.
+
+    ``classify_engine``'s stated invariant is that the escalation "prevents
+    every *future* egress" for a fragment. On the weighted path at HEAD it
+    prevented none of them: every re-run nulled the confidence again, so the
+    fragment routed to the cloud on every run rather than once.
+
+    Args:
+        tmp_path: Pytest-provided scratch directory.
+    """
+    _assert_rule_pass_preserves_evidence(_seeded_fragment())
+    vault = tmp_path / "vault"
+    md = _seed_with_evidence(vault)
+    config = _weighted_config()
+
+    for _ in range(2):
+        with (
+            patch(_AVAILABILITY, return_value=True),
+            patch(_INVOKE, new=_respond(_CONFESSIONAL_CONVICTION_RESPONSE)),
+        ):
+            run_classify(
+                vault_path=vault,
+                config=config,
+                method="llm",
+                force=True,
+            )
+
+    meta = frontmatter.load(md).metadata
+    assert meta["privacy_tier"] == "intimate"
+    assert meta["voice"]["confidence"] == "conviction"
+    assert meta["voice"]["voice_register"] == "confessional"
+
+
+def test_pre_fix_frontmatter_without_confidences_still_classifies(
+    tmp_path: Path,
+) -> None:
+    """A vault written by the pre-#1309 pipeline still runs (#1309).
+
+    The new axis adds a key to every fragment's ``weighted:`` block, so a
+    fragment persisted before the change must still validate on read.
+
+    Args:
+        tmp_path: Pytest-provided scratch directory.
+    """
+    vault = tmp_path / "vault"
+    folder = vault / "01-Fragments" / "Markdown"
+    folder.mkdir(parents=True)
+    (vault / "00-Creek-Meta").mkdir(parents=True, exist_ok=True)
+    md = folder / "frag-prefix.md"
+    md.write_text(
+        "---\ntype: fragment\nid: frag-prefix\ntitle: Pre-fix fragment\n"
+        "source:\n  platform: markdown\n"
+        "weighted:\n"
+        "  frequencies:\n    - value: F3\n      weight: 0.8\n"
+        "  voice_registers:\n    - value: analytical\n      weight: 0.5\n"
+        "  overall_confidence: 0.7\n"
+        f"---\n{_RULE_INERT_BODY}\n",
+        encoding="utf-8",
+    )
+
+    with (
+        patch(_AVAILABILITY, return_value=True),
+        patch(_INVOKE, new=_respond(_SILENT_ON_VOICE_RESPONSE)),
+    ):
+        summary = run_classify(
+            vault_path=vault,
+            config=_weighted_config(),
+            method="llm",
+            force=True,
+        )
+
+    assert summary.classified == 1
+    meta = frontmatter.load(md).metadata
+    assert meta["weighted"]["confidences"] == []
+
+
+@pytest.mark.parametrize("stance", ["musing", "exploring"])
+def test_a_tentative_confessional_is_not_buried_on_disk(
+    tmp_path: Path,
+    stance: str,
+) -> None:
+    """A tentative stance must not reach INTIMATE (#1309).
+
+    Under the escalate-only ratchet a manufactured escalation is permanent,
+    so over-burying is as much a defect as under-burying.
+
+    Args:
+        tmp_path: Pytest-provided scratch directory.
+        stance: The non-conviction stance the model reports.
+    """
+    vault = tmp_path / "vault"
+    md = _seed_with_evidence(vault)
+    payload = _CONFESSIONAL_CONVICTION_RESPONSE.replace("conviction", stance)
+
+    with (
+        patch(_AVAILABILITY, return_value=True),
+        patch(_INVOKE, new=_respond(payload)),
+    ):
+        run_classify(
+            vault_path=vault,
+            config=_weighted_config(),
+            method="llm",
+            force=True,
+        )
+
+    meta = frontmatter.load(md).metadata
+    # The stance really did round-trip, so this is not passing vacuously
+    # because the axis was dropped...
+    assert meta["voice"]["confidence"] == stance
+    # ...and it did not trigger the burial.
+    assert meta["privacy_tier"] != "intimate"

--- a/creek-tools/tests/test_holonic.py
+++ b/creek-tools/tests/test_holonic.py
@@ -25,6 +25,7 @@ from creek.classify.weighted import (
     WeightedFragmentClassification,
 )
 from creek.models import (
+    Confidence,
     Dosage,
     Frequency,
     Mode,
@@ -44,6 +45,7 @@ def _wfc(
     orientations: tuple[tuple[Orientation, float], ...] = (),
     dosages: tuple[tuple[Dosage, float], ...] = (),
     voice_registers: tuple[tuple[VoiceRegister, float], ...] = (),
+    confidences: tuple[tuple[Confidence, float], ...] = (),
     overall_confidence: float = 0.7,
     reasoning: str = "",
 ) -> WeightedFragmentClassification:
@@ -65,6 +67,7 @@ def _wfc(
         voice_registers=tuple(
             WeightedDimension(value=v, weight=w) for v, w in voice_registers
         ),
+        confidences=tuple(WeightedDimension(value=v, weight=w) for v, w in confidences),
         overall_confidence=overall_confidence,
         reasoning=reasoning,
     )
@@ -589,3 +592,56 @@ class TestDefensiveBranches:
         # skipped and parent confidence equals the mean.
         assert parent.frequencies[0].value is Frequency.F3
         assert parent.overall_confidence == pytest.approx(0.7)
+
+
+class TestConfidencesDimension:
+    """The author-stance axis is threaded through every holonic path (#1309)."""
+
+    def test_combine_rolls_up_children_confidences(self) -> None:
+        """A bubbled-up parent carries the children's author stance."""
+        agreeing = _wfc(
+            confidences=((Confidence.CONVICTION, 0.9),),
+            overall_confidence=0.8,
+        )
+        parent = combine([agreeing, agreeing])
+        assert parent.confidences != ()
+        assert parent.confidences[0].value is Confidence.CONVICTION
+
+    def test_decompose_prior_carries_confidences_down(self) -> None:
+        """A decomposed prior hands the parent's stance to its children."""
+        parent = _wfc(
+            confidences=((Confidence.SETTLED, 0.8),),
+            overall_confidence=0.8,
+        )
+        assert decompose_prior(parent, n_atoms=3).confidences == parent.confidences
+
+    def test_opposed_confidences_dampen_parent_confidence(self) -> None:
+        """Disagreement about author stance contributes to the JSD penalty.
+
+        The regression guard for a hole that nothing else catches.
+        ``_mean_normalised_jsd`` walks a hard-coded ``dimension_accessors``
+        table; ``confidences`` has to be listed there explicitly. If it is
+        omitted, ``combine`` and ``decompose_prior`` still thread the axis, so
+        every other test in this class stays green — but two children that
+        disagree maximally about how firmly the writer holds their claim
+        contribute ZERO divergence, and the parent's ``overall_confidence`` is
+        silently overstated.
+
+        Verified to be a real binding: deleting the ``("confidences",
+        Confidence)`` accessor turns this test, and only this test, red.
+        """
+        musing = _wfc(
+            confidences=((Confidence.MUSING, 0.9),),
+            overall_confidence=0.8,
+        )
+        conviction = _wfc(
+            confidences=((Confidence.CONVICTION, 0.9),),
+            overall_confidence=0.8,
+        )
+        opposed = combine([musing, conviction])
+        agreed = combine([musing, musing])
+
+        # Same per-child confidence in both cases, so any difference is
+        # attributable to the divergence penalty alone.
+        assert agreed.overall_confidence == pytest.approx(0.8)
+        assert opposed.overall_confidence < agreed.overall_confidence

--- a/creek-tools/tests/test_prompt_ontology.py
+++ b/creek-tools/tests/test_prompt_ontology.py
@@ -244,6 +244,47 @@ class TestBuildPromptOntologyPrompt:
 # ---- Response parser ----
 
 
+class TestConfidencesIsDeliberatelyNotDetected:
+    """The prompt-level twin drops the author-stance axis on purpose (#1309)."""
+
+    def test_template_does_not_request_confidences(self) -> None:
+        """The operator-seed prompt must not ask for an author stance.
+
+        Issue #1309 added a ``confidences`` axis to the *fragment* classifier,
+        whose YAML schema this module shares. It was deliberately NOT added
+        here: ``Confidence`` is ontology axis 9, the stance an author takes
+        toward their own claim, and an operator-supplied essay seed has no
+        author whose stance could be detected.
+
+        This half of the test is what stops the pair being vacuous. The field
+        copy in ``parse_prompt_ontology_response`` is hand-written, so the
+        dropping below is structural and cannot regress on its own — but
+        nothing structural stops a future edit adding ``confidences:`` to this
+        template and quietly asking the model for a value nobody consumes.
+        """
+        assert "confidences" not in PROMPT_ONTOLOGY_TEMPLATE
+
+    def test_a_confidences_section_is_dropped_not_rejected(self) -> None:
+        """A response carrying the shared key parses cleanly and ignores it.
+
+        The two modules share ``_ALLOWED_TOP_LEVEL_KEYS``, so widening it for
+        the fragment classifier necessarily makes ``confidences:`` legal here
+        too. That must be tolerated rather than fatal: a model that volunteers
+        the section should not take the whole detection down with it.
+        """
+        payload = _yaml_payload().replace(
+            "overall_confidence:",
+            "confidences:\n  - value: conviction\n    weight: 0.9\noverall_confidence:",
+        )
+        ontology = parse_prompt_ontology_response(payload, prompt="seed")
+        # Parsed, not rejected — the other dimensions still land.
+        assert ontology.frequencies == (
+            WeightedDimension(value=Frequency.F3, weight=0.8),
+        )
+        # And the volunteered axis is simply not carried onto PromptOntology.
+        assert not hasattr(ontology, "confidences")
+
+
 class TestParsePromptOntologyResponse:
     """Tests for parsing the LLM's YAML response into :class:`PromptOntology`."""
 

--- a/creek-tools/tests/test_weighted.py
+++ b/creek-tools/tests/test_weighted.py
@@ -25,7 +25,8 @@ Three concerns get exercised here:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+import re
+from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import patch
 
 import pytest
@@ -33,7 +34,11 @@ from pydantic import ValidationError
 
 from creek.classify import prompt as prompt_module
 from creek.classify import weighted as weighted_module
+from creek.classify.privacy import PrivacyClassifier
+from creek.classify.privacy_pass import reassess
+from creek.classify.rules import RuleClassifier
 from creek.classify.weighted import (
+    _ALLOWED_TOP_LEVEL_KEYS,
     _FREQUENCY_TO_COLOR,
     _LEGACY_SECONDARY_WEIGHT,
     _LEGACY_SINGLE_WEIGHT,
@@ -51,6 +56,7 @@ from creek.classify.weighted import (
 from creek.config import LLMConfig
 from creek.ingest.base import IngestedFragment
 from creek.models import (
+    Authorship,
     Color,
     Confidence,
     Dosage,
@@ -62,6 +68,7 @@ from creek.models import (
     Mode,
     Orientation,
     Phase,
+    PrivacyTier,
     SourcePlatform,
     VoiceClassification,
     VoiceRegister,
@@ -70,6 +77,8 @@ from creek.models import (
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+
+    from creek.classify.llm.orchestrator import LLMClassifier
 
 # ---- Fixtures --------------------------------------------------------------
 
@@ -201,10 +210,63 @@ class TestLoadYamlDict:
             "orientations: []\n"
             "dosages: []\n"
             "voice_registers: []\n"
+            "confidences: []\n"
             "overall_confidence: 0.5\n"
         )
         parsed = _load_yaml_dict(text)
         assert parsed["overall_confidence"] == 0.5
+
+    def test_allow_list_is_exactly_these_eight_keys(self) -> None:
+        """SEC-004: the allow-list is pinned exactly, as a forcing function.
+
+        ``_ALLOWED_TOP_LEVEL_KEYS`` is the boundary that stops a model (or a
+        prompt injection carried in fragment text) from writing arbitrary
+        Fragment fields — ``privacy_tier`` above all — straight out of an LLM
+        response. An equality assertion rather than a membership one means
+        widening the schema is always a deliberate, reviewed act: #1309 added
+        exactly one key and this test is where that has to be admitted.
+        """
+        assert (
+            frozenset(
+                {
+                    "frequencies",
+                    "phases",
+                    "modes",
+                    "orientations",
+                    "dosages",
+                    "voice_registers",
+                    "confidences",
+                    "overall_confidence",
+                },
+            )
+            == _ALLOWED_TOP_LEVEL_KEYS
+        )
+
+    def test_singular_confidence_key_still_rejected(self) -> None:
+        """The Fragment field spelling ``confidence:`` is not the new axis.
+
+        The weighted axis is the PLURAL ``confidences``. The singular is the
+        name of the Fragment's own field, and accepting it would let a
+        response address Fragment state directly.
+        """
+        with pytest.raises(ValueError, match="unexpected top-level keys"):
+            _load_yaml_dict("frequencies: []\nconfidence: conviction")
+
+    def test_privacy_tier_rejected_alongside_a_legal_confidences_section(
+        self,
+    ) -> None:
+        """A legal new key does not smuggle an illegal one past the validator.
+
+        The realistic injection shape after #1309: a payload that looks
+        well-formed because it carries the newly-legal ``confidences:``
+        section, with ``privacy_tier`` riding along. Downgrading a tier from
+        an LLM response is exactly what SEC-004 exists to prevent.
+        """
+        with pytest.raises(ValueError, match="unexpected top-level keys"):
+            _load_yaml_dict(
+                "confidences:\n  - value: conviction\n    weight: 0.9\n"
+                "privacy_tier: open\n",
+            )
 
     def test_non_dict_entry_dropped(self) -> None:
         """``_parse_dimension`` skips non-dict entries silently."""
@@ -222,9 +284,26 @@ class TestLoadYamlDict:
         # Bypass Pydantic's enum coercion by going through ``model_validate``
         # with a typo — Pydantic would raise; we hand-roll the legacy
         # widening helper directly to exercise the defensive branch.
-        from creek.classify.weighted import _widen_voice_register
+        from creek.classify.weighted import _widen_optional
 
-        assert _widen_voice_register("not-a-register") == ()
+        assert _widen_optional("not-a-register", VoiceRegister) == ()
+
+    def test_widen_optional_is_enum_generic(self) -> None:
+        """``_widen_optional`` handles ``Confidence`` as well as ``VoiceRegister``.
+
+        ``Confidence`` has no ``unclassified`` member (``Confidence(
+        "unclassified")`` raises), which is why the optional-aware helper
+        rather than ``_widen_single`` is the right widener for it.
+        """
+        from creek.classify.weighted import _widen_optional
+
+        assert _widen_optional(None, Confidence) == ()
+        assert _widen_optional("garbage", Confidence) == ()
+        assert _widen_optional(Confidence.CONVICTION, Confidence) == (
+            WeightedDimension(
+                value=Confidence.CONVICTION, weight=_LEGACY_SINGLE_WEIGHT
+            ),
+        )
 
 
 class TestCoerceEnumEdgeCases:
@@ -555,8 +634,19 @@ class TestRoundTrip:
         assert wave_out.color == Color.RED  # recomputed from primary, matches original
         assert voice_out.voice_register == VoiceRegister.ANALYTICAL
 
-    def test_widen_drops_voice_confidence(self) -> None:
-        """``VoiceClassification.confidence`` does not round-trip (documented)."""
+    def test_widen_round_trips_voice_confidence(self) -> None:
+        """``VoiceClassification.confidence`` now round-trips (#1309).
+
+        DELIBERATELY INVERTED, not deleted. This test was previously named
+        ``test_widen_drops_voice_confidence`` and asserted
+        ``voice_out.confidence is None`` — it pinned the defect in place. The
+        dropped confidence is the third INTIMATE trigger in
+        ``PrivacyClassifier.classify_tier`` (``confessional`` +
+        ``conviction``), so "confidence does not round-trip" was not a benign
+        documented limitation; it was a fail-open privacy hole with a test
+        holding it open. Confidence is now a real weighted axis, so the
+        round-trip is lossless and the assertion is reversed.
+        """
         original = _make_fragment(
             voice=VoiceClassification(
                 voice_register=VoiceRegister.PROPHETIC,
@@ -565,9 +655,8 @@ class TestRoundTrip:
         )
         widened = WeightedFragmentClassification.from_single_pick(original)
         _freq, _wave, voice_out = widened.to_legacy()
-        # voice_register survives; confidence is dropped to None.
         assert voice_out.voice_register == VoiceRegister.PROPHETIC
-        assert voice_out.confidence is None
+        assert voice_out.confidence == Confidence.SETTLED
 
     def test_widen_drops_descriptor(self) -> None:
         """``WavelengthClassification.descriptor`` does not round-trip."""
@@ -708,10 +797,16 @@ def _weighted_yaml_payload(
     orientations: str = "  - value: do_feel\n    weight: 0.5",
     dosages: str = "  - value: medicine\n    weight: 0.6",
     voice_registers: str = "  - value: analytical\n    weight: 0.5",
+    confidences: str = "",
     overall_confidence: float = 0.7,
     reasoning: str = "The fragment lands at F3 / Red, rising into expression.",
 ) -> str:
-    """Render a canned LLM response with controllable per-section content."""
+    """Render a canned LLM response with controllable per-section content.
+
+    ``confidences`` defaults to empty rather than to a canned entry (unlike
+    every sibling section) so the pre-#1309 payloads every other test in this
+    module renders stay byte-identical — the new axis is opt-in per test.
+    """
     sections: list[str] = [reasoning, "", "```yaml"]
     if frequencies:
         sections.extend(("frequencies:", frequencies))
@@ -725,6 +820,8 @@ def _weighted_yaml_payload(
         sections.extend(("dosages:", dosages))
     if voice_registers:
         sections.extend(("voice_registers:", voice_registers))
+    if confidences:
+        sections.extend(("confidences:", confidences))
     sections.extend((f"overall_confidence: {overall_confidence}", "```"))
     return "\n".join(sections)
 
@@ -741,6 +838,96 @@ class TestBuildWeightedClassificationPrompt:
         assert "{level}" in WEIGHTED_CLASSIFICATION_TEMPLATE
         assert "{title}" in WEIGHTED_CLASSIFICATION_TEMPLATE
         assert "{content}" in WEIGHTED_CLASSIFICATION_TEMPLATE
+
+    def test_every_key_the_prompt_requests_is_on_the_allow_list(self) -> None:
+        """The prompt skeleton and the schema validator cannot drift (#1309).
+
+        This is a structural guard, not a hand-maintained list, and it exists
+        because PR #1358 changed the *consequence* of drift from loud to
+        silent. The two halves of a schema widening are the YAML skeleton in
+        ``WEIGHTED_CLASSIFICATION_TEMPLATE`` and
+        ``_ALLOWED_TOP_LEVEL_KEYS``. Add a key to the prompt but not the
+        allow-list and:
+
+        * before #1358, ``_load_yaml_dict`` raised, the profile failed soft to
+          empty, and every legacy field on every fragment was blanked to
+          ``unclassified`` on disk — catastrophic, but obvious at a glance;
+        * after #1358, the same raise is caught, ``succeeded`` is ``False``,
+          and the engine hands the fragment back untouched with an honest
+          ``classification_method: rules``. The run reports zero errors and a
+          full classified count. **The weighted feature is dead on every
+          fragment and nothing anywhere says so** except one log warning that
+          no gate asserts on.
+
+        A hand-written key list (``test_known_keys_pass``) cannot catch this,
+        because the person adding the key updates the list they can see.
+        """
+        prompt = build_weighted_classification_prompt(
+            body="A body",
+            title="A title",
+            unclassified_threshold=0.6,
+        )
+        # Pull the fenced YAML skeleton out of the built prompt and read its
+        # top-level keys — column-zero ``key:`` lines only, so nested list
+        # entries and prose are ignored.
+        fences = re.findall(r"```yaml\n(.*?)```", prompt, re.DOTALL)
+        assert fences, "the prompt must contain a fenced YAML skeleton"
+        requested = {
+            match.group(1)
+            for fence in fences
+            for match in re.finditer(r"^([a-z_]+):", fence, re.MULTILINE)
+        }
+        assert requested, "no top-level keys found in the YAML skeleton"
+        assert requested <= _ALLOWED_TOP_LEVEL_KEYS, (
+            "the prompt asks the model for keys the validator will reject, "
+            "which silently kills the whole weighted path: "
+            f"{sorted(requested - _ALLOWED_TOP_LEVEL_KEYS)}"
+        )
+        # And specifically: the new axis really is being requested, so this
+        # test cannot pass vacuously by the prompt asking for nothing.
+        assert "confidences" in requested
+
+    def test_a_response_shaped_like_the_prompt_skeleton_is_accepted(
+        self,
+    ) -> None:
+        """End-to-end: an obedient model's response actually parses (#1309).
+
+        The mirror of the drift guard above, from the other side — a payload
+        carrying every section the prompt requests must survive
+        ``_load_yaml_dict`` rather than being rejected and failed soft.
+        """
+        payload = _weighted_yaml_payload(
+            confidences="  - value: conviction\n    weight: 0.9",
+        )
+        parsed = parse_weighted_yaml(payload)
+        assert parsed.confidences == (
+            WeightedDimension(value=Confidence.CONVICTION, weight=0.9),
+        )
+
+    def test_prompt_distinguishes_author_stance_from_model_certainty(
+        self,
+    ) -> None:
+        """The prompt must not let the model conflate the two confidences.
+
+        ``overall_confidence`` is the model's self-rating of its own work;
+        ``confidences`` is ontology axis 9, the author's stance toward their
+        own claim. Conflating them would manufacture INTIMATE escalations at
+        scale, and under the escalate-only ratchet those are permanent. The
+        disambiguation is therefore a privacy control and is asserted, not
+        left to the prompt author's memory.
+        """
+        prompt = build_weighted_classification_prompt(
+            body="A body",
+            unclassified_threshold=0.6,
+        )
+        lowered = prompt.lower()
+        assert "confidences" in lowered
+        assert "overall_confidence" in lowered
+        # The axis is glossed as the AUTHOR's stance...
+        assert "author" in lowered
+        # ...and the five ontology stance values are offered verbatim.
+        for stance in Confidence:
+            assert stance.value in lowered
 
     def test_body_and_title_appear(self) -> None:
         """The fragment body and title are substituted into the template."""
@@ -1123,3 +1310,646 @@ class TestClassifyEngineWiring:
         assert reasoning == ""
         # And the weighted LLM stub was never called.
         assert stub_llm.dispatched is False
+
+
+# ---- #1309: the weighted path must not void the INTIMATE escalation --------
+#
+# Framing, because it decides what these tests may assert. This is NOT a
+# ratchet violation in the "a stored tier gets lowered" sense: every writer
+# of ``privacy_tier`` is escalate-only (``privacy_pass.escalate``,
+# ``apply_tier``, ``reassess``, and ``vault/writer.py``'s re-ingest merge all
+# take the max). The defect is a MISSED escalation — fail-open — plus the
+# destruction of the on-disk evidence that escalation reads.
+#
+# Consequence: an assertion of the form "the tier did not go down" PASSES at
+# HEAD and proves nothing. Every test below asserts the tier goes UP, at
+# parity with the single-pick path.
+
+# A body the rule classifier has no opinion about: no recovery keyword, no
+# voice-register trigger, no frequency keyword. Verified at HEAD —
+# ``RuleClassifier.classify`` returns the fragment with voice and wavelength
+# untouched and ``frequency.primary == UNCLASSIFIED``, so ``_classify_one``
+# cannot short-circuit on rule confidence and is forced down the LLM path.
+#
+# This body is load-bearing, not incidental. ``RuleClassifier._build_updates``
+# rebuilds ``VoiceClassification`` from scratch under an OR guard, so a body
+# the voice matcher DOES fire on (e.g. "I confess ...") arrives at the
+# weighted classifier with ``confidence`` already destroyed — before any code
+# under test here runs. That is a separate, out-of-scope defect (see the
+# follow-up issue referenced in the PR body); each test below pins the
+# precondition explicitly so the boundary is visible rather than implied.
+_RULE_INERT_BODY = "A plain paragraph about gardening tools and afternoon light."
+
+# The single-pick wire format: top-level ``frequency:``/``wavelength:``/
+# ``voice:`` blocks parsed by ``creek.classify.llm.parsing``. Same model
+# verdict as the weighted payloads below, down the legacy path.
+_SINGLE_PICK_CONFESSIONAL_RESPONSE = """\
+frequency:
+  primary: F6
+wavelength:
+  phase: rising
+  mode: express
+voice:
+  voice_register: confessional
+  confidence: conviction
+"""
+
+
+class _WeightedOnlyLLM:
+    """LLMClassifier stand-in exposing only what the weighted path needs.
+
+    ``_classify_one_weighted`` reads ``.config`` and nothing else. The
+    ``classify_with_reasoning`` override raises so a test that accidentally
+    routes down the single-pick path fails loudly instead of silently
+    asserting the wrong code path.
+    """
+
+    def __init__(self, config: LLMConfig) -> None:
+        """Capture the config the weighted classifier will be handed."""
+        self.config = config
+
+    def classify_with_reasoning(
+        self,
+        fragment: Fragment,
+        content: str = "",
+    ) -> object:
+        """Raise: the weighted path must never fall back to single-pick."""
+        del fragment, content
+        msg = "legacy classify_with_reasoning should not be invoked"
+        raise AssertionError(msg)
+
+
+def _essay_fragment(**overrides: Any) -> Fragment:
+    """Build a self-authored ESSAY-platform fragment.
+
+    ESSAY (not JOURNAL) and ``author="self"`` is the combination that makes
+    the confessional+conviction trigger the *only* route to INTIMATE:
+    ``PrivacyClassifier.classify_tier`` checks a recovery keyword first, then
+    ``platform == JOURNAL``, and only then the high-confidence-confessional
+    rule. A journal fragment would reach INTIMATE regardless and the test
+    would prove nothing about voice evidence.
+
+    Args:
+        **overrides: Field values spliced onto the default fragment.
+
+    Returns:
+        A constructed :class:`Fragment` on the ESSAY platform.
+    """
+    return _make_fragment(
+        id=overrides.pop("id", "frag-1309000001"),
+        source=FragmentSource(platform=SourcePlatform.ESSAY, author=Authorship.SELF),
+        **overrides,
+    )
+
+
+def _run_weighted(
+    fragment: Fragment,
+    config: LLMConfig,
+    body: str = _RULE_INERT_BODY,
+) -> Fragment:
+    """Drive ``_classify_one`` down the weighted path and return the result.
+
+    Args:
+        fragment: The fragment to classify.
+        config: LLM config handed to the weighted classifier.
+        body: Fragment body; defaults to the rule-inert body.
+
+    Returns:
+        The updated :class:`Fragment`.
+    """
+    from creek.classify.classify_engine import _classify_one
+
+    updated, _skipped, _reasoning = _classify_one(
+        fragment=fragment,
+        body=body,
+        method="llm",
+        rules=RuleClassifier(),
+        llm=cast("LLMClassifier", _WeightedOnlyLLM(config)),
+        confidence_threshold=1.0,
+        weighted_classification=True,
+    )
+    return updated
+
+
+class TestWeightedPreservesEvidence:
+    """A weighted run merges over prior classification instead of erasing it."""
+
+    def test_weighted_run_does_not_erase_persisted_voice_and_wavelength(
+        self,
+        llm_config: LLMConfig,
+        fake_invoke: list[str],
+    ) -> None:
+        """Persisted voice confidence and wavelength descriptor survive (#1309).
+
+        The isolating red for the merge half: the stubbed response carries
+        ONLY keys the pre-fix schema already accepts, so nothing here depends
+        on the new ``confidences`` axis. At HEAD ``_classify_one_weighted``
+        replaces ``voice`` and ``wavelength`` wholesale from ``to_legacy()``,
+        which yields ``confidence=None``, ``descriptor=""`` and
+        ``mode=UNCLASSIFIED`` for a profile that said nothing about them.
+        """
+        fragment = _essay_fragment(
+            voice=VoiceClassification(
+                voice_register=VoiceRegister.ANALYTICAL,
+                confidence=Confidence.CONVICTION,
+            ),
+            wavelength=WavelengthClassification(
+                phase=Phase.RISING,
+                mode=Mode.EXPRESS,
+                color=Color.GREEN,
+                descriptor="Social Anxiety",
+            ),
+        )
+
+        # PRECONDITION, asserted rather than assumed: the rule classifier
+        # leaves all three values intact for this body, so a failure below is
+        # attributable to the weighted merge and not to rules.py destroying
+        # the evidence first.
+        pre = RuleClassifier().classify(fragment, content=_RULE_INERT_BODY)
+        assert pre.voice.confidence == Confidence.CONVICTION
+        assert pre.wavelength.descriptor == "Social Anxiety"
+        assert pre.wavelength.mode == Mode.EXPRESS
+
+        fake_invoke[0] = _weighted_yaml_payload(
+            frequencies="  - value: F6\n    weight: 0.8",
+            phases="",
+            modes="",
+            orientations="",
+            dosages="",
+            voice_registers="  - value: analytical\n    weight: 0.5",
+        )
+        updated = _run_weighted(fragment, llm_config)
+
+        # The model did say something about frequency and voice register, so
+        # those are the model's now.
+        assert updated.frequency.primary == Frequency.F6
+        assert updated.voice.voice_register == VoiceRegister.ANALYTICAL
+        # It said nothing about confidence, descriptor or mode — so the
+        # fragment's own evidence stands. At HEAD: None, "", "unclassified".
+        assert updated.voice.confidence == Confidence.CONVICTION
+        assert updated.wavelength.descriptor == "Social Anxiety"
+        assert updated.wavelength.mode == Mode.EXPRESS
+
+
+class TestWeightedPrivacyParity:
+    """One model verdict reaches one privacy tier on both classifier paths."""
+
+    def test_weighted_verdict_reaches_intimate_like_single_pick(
+        self,
+        llm_config: LLMConfig,
+        fake_invoke: list[str],
+    ) -> None:
+        """confessional+conviction reaches INTIMATE on both paths (#1309).
+
+        The primary red. Same model verdict, two code paths, one tier. At
+        HEAD the weighted arm yields OPEN for two independent reasons: the
+        schema validator rejects ``confidences:`` outright (so the call fails
+        soft and, post-#1358, hands the fragment back untouched), and even a
+        profile that carried it would be flattened by ``to_legacy``'s
+        hard-coded ``confidence=None``.
+        """
+        from creek.classify.llm.orchestrator import LLMClassifier
+
+        fragment = _essay_fragment()
+
+        # The test proves its own baseline: an essay fragment with no voice
+        # evidence is OPEN, so any INTIMATE below is a genuine escalation and
+        # not a pre-existing tier the run merely failed to lower.
+        baseline = PrivacyClassifier().classify_tier(
+            fragment,
+            content=_RULE_INERT_BODY,
+        )
+        assert baseline == PrivacyTier.OPEN
+
+        # Precondition: the rule pass contributes no voice evidence here, so
+        # both arms start from the same empty state.
+        pre = RuleClassifier().classify(fragment, content=_RULE_INERT_BODY)
+        assert pre.voice.confidence is None
+        assert pre.voice.voice_register is None
+
+        # --- weighted arm -------------------------------------------------
+        fake_invoke[0] = _weighted_yaml_payload(
+            frequencies="  - value: F6\n    weight: 0.8",
+            phases="",
+            modes="",
+            orientations="",
+            dosages="",
+            voice_registers="  - value: confessional\n    weight: 0.9",
+            confidences="  - value: conviction\n    weight: 0.9",
+        )
+        weighted_out = _run_weighted(fragment, llm_config)
+        weighted_tier = reassess(
+            weighted_out,
+            _RULE_INERT_BODY,
+            baseline=baseline,
+            classifier=PrivacyClassifier(),
+        ).privacy_tier
+
+        # --- single-pick arm, identical verdict ---------------------------
+        # The legacy path dispatches through ``_invoke_llm``, not the
+        # ``invoke_prompt`` seam the weighted path (and the ``fake_invoke``
+        # fixture) uses, so it needs its own stub.
+        from creek.classify.classify_engine import _classify_one
+
+        with patch(
+            "creek.classify.llm.LLMClassifier._invoke_llm",
+            new=lambda self, prompt: _SINGLE_PICK_CONFESSIONAL_RESPONSE,
+        ):
+            single_out, _skipped, _reasoning = _classify_one(
+                fragment=fragment,
+                body=_RULE_INERT_BODY,
+                method="llm",
+                rules=RuleClassifier(),
+                llm=LLMClassifier(config=llm_config),
+                confidence_threshold=1.0,
+                weighted_classification=False,
+            )
+        single_tier = reassess(
+            single_out,
+            _RULE_INERT_BODY,
+            baseline=baseline,
+            classifier=PrivacyClassifier(),
+        ).privacy_tier
+
+        # The escalation actually happened — asserted UP from OPEN, not
+        # merely "not lowered" (which passes at HEAD and proves nothing).
+        assert single_tier == PrivacyTier.INTIMATE
+        assert weighted_tier == PrivacyTier.INTIMATE
+        assert weighted_tier == single_tier
+        assert weighted_out.voice.confidence == Confidence.CONVICTION
+
+    @pytest.mark.parametrize(
+        "stance",
+        [Confidence.MUSING, Confidence.EXPLORING],
+    )
+    def test_tentative_confessional_does_not_reach_intimate(
+        self,
+        llm_config: LLMConfig,
+        fake_invoke: list[str],
+        stance: Confidence,
+    ) -> None:
+        """A tentative confessional stance must NOT be buried (#1309).
+
+        The escalate-only ratchet makes over-burying as much a defect as
+        under-burying: nothing ever lowers a stored tier, so a manufactured
+        INTIMATE is permanent. Only ``conviction`` is the trigger.
+        """
+        fragment = _essay_fragment()
+        fake_invoke[0] = _weighted_yaml_payload(
+            frequencies="  - value: F6\n    weight: 0.8",
+            phases="",
+            modes="",
+            orientations="",
+            dosages="",
+            voice_registers="  - value: confessional\n    weight: 0.9",
+            confidences=f"  - value: {stance.value}\n    weight: 0.9",
+        )
+        updated = _run_weighted(fragment, llm_config)
+
+        # The stance round-trips (so this is not vacuously passing because
+        # the axis was dropped)...
+        assert updated.voice.confidence == stance
+        # ...and it does not trigger the burial.
+        assert (
+            PrivacyClassifier().classify_tier(updated, content=_RULE_INERT_BODY)
+            == PrivacyTier.OPEN
+        )
+
+    def test_overall_confidence_is_not_a_confidence_axis(
+        self,
+        llm_config: LLMConfig,
+        fake_invoke: list[str],
+    ) -> None:
+        """``overall_confidence`` is never coerced into a ``Confidence`` (#1309).
+
+        They are different quantities: ``overall_confidence`` is the model's
+        self-rating of the whole classification; ``Confidence`` is ontology
+        axis 9, the *author's* stance. Conflating them would manufacture
+        intimate escalations at scale, and under the one-way ratchet that is
+        permanent burial.
+        """
+        fragment = _essay_fragment(
+            voice=VoiceClassification(
+                voice_register=VoiceRegister.CONFESSIONAL,
+                confidence=Confidence.MUSING,
+            ),
+        )
+        fake_invoke[0] = _weighted_yaml_payload(
+            frequencies="  - value: F6\n    weight: 0.8",
+            phases="",
+            modes="",
+            orientations="",
+            dosages="",
+            voice_registers="  - value: confessional\n    weight: 0.9",
+            confidences="",
+            overall_confidence=0.99,
+        )
+        updated = _run_weighted(fragment, llm_config)
+
+        # A 0.99 self-rating with no ``confidences:`` section leaves the
+        # author's stance exactly as it was — it never becomes CONVICTION.
+        assert updated.voice.confidence == Confidence.MUSING
+        assert (
+            PrivacyClassifier().classify_tier(updated, content=_RULE_INERT_BODY)
+            == PrivacyTier.OPEN
+        )
+
+    def test_rerun_is_idempotent_over_an_intimate_fragment(
+        self,
+        llm_config: LLMConfig,
+        fake_invoke: list[str],
+    ) -> None:
+        """A second weighted run preserves both the tier and its evidence.
+
+        ``classify_engine``'s stated invariant is that the escalation
+        "prevents every *future* egress" for a fragment. On the weighted path
+        at HEAD it prevents none of them: every re-run nulls the confidence
+        again, so the fragment routes to the cloud on every run rather than
+        once.
+        """
+        payload = _weighted_yaml_payload(
+            frequencies="  - value: F6\n    weight: 0.8",
+            phases="",
+            modes="",
+            orientations="",
+            dosages="",
+            voice_registers="  - value: confessional\n    weight: 0.9",
+            confidences="  - value: conviction\n    weight: 0.9",
+        )
+        fake_invoke[0] = payload
+        first = _run_weighted(_essay_fragment(), llm_config)
+        first = reassess(
+            first,
+            _RULE_INERT_BODY,
+            baseline=PrivacyTier.OPEN,
+            classifier=PrivacyClassifier(),
+        )
+        assert first.privacy_tier == PrivacyTier.INTIMATE
+
+        fake_invoke[0] = payload
+        second = _run_weighted(first, llm_config)
+        second = reassess(
+            second,
+            _RULE_INERT_BODY,
+            baseline=first.privacy_tier,
+            classifier=PrivacyClassifier(),
+        )
+
+        # Tier holds AND the evidence that justifies it is still on the
+        # fragment — a tier with its evidence erased is one re-ingest away
+        # from being unexplainable.
+        assert second.privacy_tier == PrivacyTier.INTIMATE
+        assert second.voice.confidence == Confidence.CONVICTION
+        assert second.voice.voice_register == VoiceRegister.CONFESSIONAL
+
+
+class TestMergeOnto:
+    """``merge_onto`` overlays only what the profile actually determined."""
+
+    def test_exclude_defaults_delta_is_exactly_the_determined_subset(self) -> None:
+        """Pin the delta dict that makes the whole merge correct (#1309).
+
+        ``merge_onto`` rests on one invariant: every legacy classification
+        field's default IS its "not determined" sentinel (``UNCLASSIFIED`` /
+        ``""`` / ``None``), so ``model_dump(exclude_defaults=True)`` yields
+        exactly the fields the model spoke to. If a future field lands with a
+        non-sentinel default, that invariant breaks silently and the merge
+        starts overwriting prior evidence again — so the delta is asserted
+        here explicitly rather than trusted.
+        """
+        partial = WeightedFragmentClassification(
+            phases=(WeightedDimension(value=Phase.PEAKING, weight=0.9),),
+            frequencies=(WeightedDimension(value=Frequency.F3, weight=0.9),),
+        )
+        _freq, wave, voice = partial.to_legacy()
+        assert wave.model_dump(exclude_defaults=True) == {
+            "phase": "peaking",
+            "color": "red",
+        }
+        assert voice.model_dump(exclude_defaults=True) == {}
+
+    def test_empty_profile_is_a_no_op(self) -> None:
+        """A signal-free profile overwrites nothing but ``weighted`` itself."""
+        fragment = _make_fragment(
+            frequency=FrequencyClassification(primary=Frequency.F3),
+            wavelength=WavelengthClassification(
+                phase=Phase.RISING,
+                mode=Mode.EXPRESS,
+                descriptor="Social Anxiety",
+            ),
+            voice=VoiceClassification(
+                voice_register=VoiceRegister.ANALYTICAL,
+                confidence=Confidence.CONVICTION,
+            ),
+        )
+        merged = WeightedFragmentClassification().merge_onto(fragment)
+        assert merged.frequency.primary == Frequency.F3
+        assert merged.wavelength.phase == Phase.RISING
+        assert merged.wavelength.mode == Mode.EXPRESS
+        assert merged.wavelength.descriptor == "Social Anxiety"
+        assert merged.voice.voice_register == VoiceRegister.ANALYTICAL
+        assert merged.voice.confidence == Confidence.CONVICTION
+
+    def test_determined_dimensions_win_over_prior(self) -> None:
+        """What the model DID determine replaces the prior value."""
+        fragment = _make_fragment(
+            wavelength=WavelengthClassification(phase=Phase.RISING),
+            voice=VoiceClassification(voice_register=VoiceRegister.ANALYTICAL),
+        )
+        merged = WeightedFragmentClassification(
+            phases=(WeightedDimension(value=Phase.PEAKING, weight=0.9),),
+            voice_registers=(
+                WeightedDimension(value=VoiceRegister.CONFESSIONAL, weight=0.9),
+            ),
+        ).merge_onto(fragment)
+        assert merged.wavelength.phase == Phase.PEAKING
+        assert merged.voice.voice_register == VoiceRegister.CONFESSIONAL
+
+    def test_frequencies_replace_wholesale_so_stale_secondaries_clear(self) -> None:
+        """Frequency is replaced, not merged — secondaries are a list."""
+        fragment = _make_fragment(
+            frequency=FrequencyClassification(
+                primary=Frequency.F3,
+                secondary=[Frequency.F5, Frequency.F7],
+            ),
+        )
+        merged = WeightedFragmentClassification(
+            frequencies=(WeightedDimension(value=Frequency.F6, weight=0.9),),
+        ).merge_onto(fragment)
+        assert merged.frequency.primary == Frequency.F6
+        assert merged.frequency.secondary == []
+
+
+class TestSucceededButEmptyProfile:
+    """The one destruction path #1358 did not close, and its honest stamp."""
+
+    def test_a_signal_free_verdict_preserves_the_rule_classification(
+        self,
+        llm_config: LLMConfig,
+        fake_invoke: list[str],
+    ) -> None:
+        """A model that ran and detected nothing must not erase prior work.
+
+        This case is distinct from every failure mode PR #1358 handled, and
+        it is easy to believe it was covered: ``_load_yaml_dict`` accepts a
+        payload whose keys are all allow-listed but whose sections are all
+        empty, so ``classify_weighted`` returns ``succeeded=True`` with an
+        all-default profile and sails straight past #1358's guard. Before
+        this fix that wiped every legacy field; now it is a no-op.
+
+        The ``llm`` stamp stays correct here and that is deliberate — the
+        provider really did run and really did return a parseable verdict,
+        so claiming ``rules`` would be a different lie.
+        """
+        fragment = _essay_fragment(
+            frequency=FrequencyClassification(primary=Frequency.F3),
+            wavelength=WavelengthClassification(
+                phase=Phase.RISING,
+                mode=Mode.EXPRESS,
+                descriptor="Social Anxiety",
+            ),
+            voice=VoiceClassification(
+                voice_register=VoiceRegister.ANALYTICAL,
+                confidence=Confidence.CONVICTION,
+            ),
+        )
+        fake_invoke[0] = _weighted_yaml_payload(
+            frequencies="",
+            phases="",
+            modes="",
+            orientations="",
+            dosages="",
+            voice_registers="",
+            confidences="",
+        )
+
+        from creek.classify.classify_engine import _classify_one
+
+        updated, was_skipped, _reasoning = _classify_one(
+            fragment=fragment,
+            body=_RULE_INERT_BODY,
+            method="llm",
+            rules=RuleClassifier(),
+            llm=cast("LLMClassifier", _WeightedOnlyLLM(llm_config)),
+            confidence_threshold=1.0,
+            weighted_classification=True,
+        )
+
+        # Every prior field stands.
+        assert updated.frequency.primary == Frequency.F3
+        assert updated.wavelength.phase == Phase.RISING
+        assert updated.wavelength.mode == Mode.EXPRESS
+        assert updated.wavelength.descriptor == "Social Anxiety"
+        assert updated.voice.voice_register == VoiceRegister.ANALYTICAL
+        assert updated.voice.confidence == Confidence.CONVICTION
+        # The empty-but-real verdict is still recorded, and the run is NOT a
+        # skip: the LLM was genuinely invoked.
+        assert updated.weighted == WeightedFragmentClassification(
+            overall_confidence=0.7,
+            reasoning="The fragment lands at F3 / Red, rising into expression.",
+        )
+        assert was_skipped is False
+
+
+class TestWeightedBackwardCompatibility:
+    """Fragments written by the pre-#1309 pipeline still load."""
+
+    def test_pre_fix_weighted_block_validates_with_empty_confidences(self) -> None:
+        """An on-disk ``weighted:`` block with no ``confidences`` key loads."""
+        pre_fix: dict[str, object] = {
+            "frequencies": [{"value": "F3", "weight": 0.8}],
+            "phases": [{"value": "rising", "weight": 0.7}],
+            "modes": [{"value": "express", "weight": 0.6}],
+            "orientations": [],
+            "dosages": [],
+            "voice_registers": [{"value": "analytical", "weight": 0.5}],
+            "overall_confidence": 0.7,
+            "reasoning": "written before the confidences axis existed",
+        }
+        loaded = WeightedFragmentClassification.model_validate(pre_fix)
+        assert loaded.confidences == ()
+        assert loaded.frequencies == (
+            WeightedDimension(value=Frequency.F3, weight=0.8),
+        )
+
+    def test_pre_fix_fragment_frontmatter_round_trips(self) -> None:
+        """A whole Fragment carrying a pre-fix ``weighted`` block round-trips."""
+        fragment = _make_fragment(
+            weighted=WeightedFragmentClassification(
+                frequencies=(WeightedDimension(value=Frequency.F3, weight=0.8),),
+            ),
+        )
+        dumped = fragment.model_dump(mode="json")
+        assert "confidences" in dumped["weighted"]
+        reloaded = Fragment.model_validate(dumped)
+        assert reloaded.weighted is not None
+        assert reloaded.weighted.confidences == ()
+
+    def test_response_without_confidences_parses_to_empty(self) -> None:
+        """A model that omits the new section collapses to ``()``, not an error."""
+        parsed = parse_weighted_yaml(
+            "frequencies:\n  - value: F3\n    weight: 0.8\noverall_confidence: 0.7",
+        )
+        assert parsed.confidences == ()
+
+    def test_malformed_confidences_collapse_to_empty(self) -> None:
+        """A bogus stance value is dropped rather than raising."""
+        parsed = parse_weighted_yaml(
+            "confidences:\n  - value: not-a-stance\n    weight: 0.9\n"
+            "overall_confidence: 0.7",
+        )
+        assert parsed.confidences == ()
+
+
+class TestWeightedDownstreamConsumers:
+    """Restoring confidence unbreaks the readers the nulling silently broke."""
+
+    def test_fully_classified_weighted_fragment_is_not_flagged_for_review(
+        self,
+        llm_config: LLMConfig,
+        fake_invoke: list[str],
+    ) -> None:
+        """``ReviewQueueGenerator.needs_review`` stops flagging every fragment.
+
+        At HEAD every weighted-classified fragment tripped the
+        ``voice.confidence is None`` branch, so the review queue filled with
+        fragments whose only defect was the classifier erasing its own
+        evidence. ``conviction`` is used deliberately: ``musing`` and
+        ``exploring`` are in ``_LOW_CONFIDENCE_LEVELS`` and legitimately
+        still flag.
+        """
+        from creek.classify.review import ReviewQueueGenerator
+
+        fake_invoke[0] = _weighted_yaml_payload(
+            frequencies="  - value: F6\n    weight: 0.8",
+            voice_registers="  - value: analytical\n    weight: 0.9",
+            confidences="  - value: conviction\n    weight: 0.9",
+        )
+        updated = _run_weighted(_essay_fragment(), llm_config)
+        assert updated.voice.confidence == Confidence.CONVICTION
+        assert ReviewQueueGenerator().needs_review(updated) is False
+
+    def test_weighted_fragment_counts_as_fully_classified_for_voice_corpus(
+        self,
+        llm_config: LLMConfig,
+        fake_invoke: list[str],
+    ) -> None:
+        """``generate.voice._is_fully_classified`` returns True (#1309).
+
+        This test passes only because the merge fixed the WAVELENGTH half as
+        well as the voice half: ``_is_fully_classified`` also requires
+        ``wavelength.mode != UNCLASSIFIED``. Silently returning False here is
+        how a fully-classified fragment was dropped from the voice-exemplar
+        corpus without any error surfacing.
+        """
+        from creek.generate.voice import _is_fully_classified
+
+        fake_invoke[0] = _weighted_yaml_payload(
+            frequencies="  - value: F6\n    weight: 0.8",
+            phases="  - value: rising\n    weight: 0.7",
+            modes="  - value: express\n    weight: 0.6",
+            voice_registers="  - value: analytical\n    weight: 0.9",
+            confidences="  - value: conviction\n    weight: 0.9",
+        )
+        updated = _run_weighted(_essay_fragment(), llm_config)
+        assert _is_fully_classified(updated) is True


### PR DESCRIPTION
## Summary

`PrivacyClassifier.classify_tier`'s third INTIMATE trigger is `voice_register == CONFESSIONAL and confidence == CONVICTION`. On the weighted classification path it could never fire, and the run destroyed the evidence a later run would have needed.

**This is a missed escalation — fail-open — not a lowered tier.** I traced every writer of `privacy_tier`: `escalate` takes the max, `apply_tier` assigns outright only when `needs_tier`, `reassess` double-guards, and `vault/writer.py` mirrors it. Nothing lowers a stored tier, even under `--force`. Fragments that should have been INTIMATE simply stayed OPEN — and because the nulling recurred, they routed to the cloud on **every** run rather than being protected after the first. That falsifies the "Known residual" note in `classify_engine.py` promising the escalation "still prevents every *future* egress"; the note is corrected here.

The practical consequence for testing: **an assertion that the tier "did not go down" passes at HEAD and proves nothing.** Every test below asserts the tier goes **UP**, at parity with the single-pick path.

### Three independent causes, all closed

1. **No axis.** The weighted prompt never asked for an author stance, and `_ALLOWED_TOP_LEVEL_KEYS` would have rejected one had the model volunteered it.
2. **`to_legacy()` hard-coded `confidence=None`**, documented as a benign limitation. It was not benign — it was the trigger's second operand.
3. **`_classify_one_weighted` assigned the derived fields wholesale**, overwriting a persisted `conviction` with `None`, `wavelength.descriptor` with `""`, and `mode` with `unclassified`, on every successful run.

The issue body proposes only cause 2's fix (preserve an incoming confidence). That cannot satisfy its own AC #1: a fragment never single-pick-classified has no confidence to preserve, so the weighted path still yields `None` and still misses the escalation. Both halves are required — the real axis for fresh fragments, the merge for persisted ones.

### `merge_onto`

`to_legacy` stays a pure collapse; a new `merge_onto` does the overlay. It rests on one invariant, stated in the code: **every legacy classification field's default IS its "not determined" sentinel** (`UNCLASSIFIED` / `""` / `None`), so `model_dump(exclude_defaults=True)` is exactly the subset the model spoke to. A test pins the delta dict so a future field with a non-sentinel default breaks the build loudly rather than silently resuming the overwrite.

Post-#1358 every profile reaching `merge_onto` is a genuine verdict — all four soft-failure modes return upstream — so a silent dimension means "detected nothing", never "the call died". That is what licenses the rule, and it is recorded as a precondition on the method.

## The privacy judgement, stated plainly for review

Emitting `conviction` from the weighted prompt hands the model a trigger under a ratchet where nothing ever lowers a stored tier, so a manufactured escalation is **permanent**. That deserves scrutiny rather than a silent merge. The reasoning:

- This reaches **parity** with the single-pick path, which has shipped the identical trigger from the same model for its whole life. It removes an inconsistency; it does not create a new class of burial.
- **`overall_confidence` is never mapped to `Confidence`.** They are different quantities — the model's self-rating of its own work versus ontology axis 9, the author's stance. Conflating them would manufacture escalations at scale. The prompt now says so explicitly, and a test pins that `overall_confidence: 0.99` with no `confidences:` section never yields `conviction`.
- **No weight floor, deliberately.** The single-pick path has none, so a floor would make the weighted path *less* likely to surface confessional+conviction than the legacy one — the forbidden direction for a privacy control, and it would break the parity criterion.
- **Guard tests** pin that `musing` and `exploring` do not reach INTIMATE, in memory and on disk. Under a one-way ratchet, over-burying is as much a defect as under-burying.

## Test plan

### RED, proven before the fix

Both reds are wrong values on real objects, not import errors.

**Parity (primary).** Same model verdict, two code paths:

```
assert single_tier == PrivacyTier.INTIMATE      # PASSED at HEAD
>   assert weighted_tier == PrivacyTier.INTIMATE
E   AssertionError: assert <PrivacyTier.UNCLASSIFIED: 'unclassified'> == <PrivacyTier.INTIMATE: 'intimate'>
```

The single-pick arm passes at HEAD while the weighted arm does not — one verdict, two tiers. At HEAD this goes red for **two** independent reasons, and the log shows the first: `Weighted fragment classification failed (unexpected top-level keys ... ['confidences']); returning empty result`. The schema rejects the axis; and even a profile carrying it would be flattened by the hard-coded `confidence=None`.

**Isolating red (merge half alone, HEAD-valid payload, no schema change involved):**

```
assert updated.voice.confidence == Confidence.CONVICTION   # HEAD: None
assert updated.wavelength.descriptor == "Social Anxiety"   # HEAD: ""
assert updated.wavelength.mode == Mode.EXPRESS             # HEAD: 'unclassified'
```

**On disk**, reverting the three source guards turns 5 of 6 tests in the new file red, including `assert None == 'conviction'` (proving `confidence: null` really lands in frontmatter — the write is `model_dump(mode="json")` with no `exclude_none`) and `assert 'open' == 'intimate'` (the escalation genuinely absent).

### Mutation testing

Each guard reverted alone, confirming exactly the intended tests go red:

| Mutation | Result |
|---|---|
| `to_legacy` re-hardcodes `confidence=None` | 7 red |
| `merge_onto` replaces voice wholesale | 4 red |
| `merge_onto` replaces wavelength wholesale | 3 red |
| allow-list drops `confidences` (SEC-004) | 11 red |
| frequency asymmetry guard removed | 2 red |
| holonic JSD drops the dimension | 1 red |

The last one is why it is in the table: **on the first pass it turned nothing red.** `combine` and `decompose_prior` still threaded the axis, so every other test stayed green while children disagreeing maximally on author stance contributed zero divergence, silently overstating the parent's `overall_confidence`. `test_opposed_confidences_dampen_parent_confidence` was added to bind it.

### Wavelength — not in the issue body

The issue names only `voice` as destroyed. The same `model_copy` also blanked `wavelength.descriptor` and overwrote phase/mode; verified empirically. Fixing only voice would have left an identical defect one line above. It also matters downstream: `generate/voice.py::_is_fully_classified` requires `wavelength.mode != UNCLASSIFIED`, so the voice-exemplar corpus test passes only because the wavelength half was fixed too.

### One existing test inverted, deliberately

`test_widen_drops_voice_confidence` asserted `voice_out.confidence is None` — it pinned the defect in place. It is **inverted and renamed** to `test_widen_round_trips_voice_confidence`, not deleted and not left passing. **The issue's "no existing tests break" criterion is therefore unachievable as literally written**, and that is the correct outcome: a test was holding a fail-open privacy hole open. `test_empty_collapses_to_unclassified`, `test_widen_drops_descriptor` and `test_widen_drops_pre_existing_color` all still pass **verbatim**, because `to_legacy` remains a pure collapse.

### SEC-004 and a new hazard #1358 created

The allow-list is an injection boundary. Exactly one key added, pinned by equality (not membership) at 8 keys; the singular `confidence:` is still rejected, and so is `privacy_tier` riding alongside a legal `confidences:` section.

Beyond that, a **structural** drift guard: `test_every_key_the_prompt_requests_is_on_the_allow_list` extracts the top-level keys from the built prompt's YAML skeleton and asserts they are a subset of the allow-list. This exists because #1358 changed the consequence of prompt/validator drift from loud to silent — before it, a mismatch blanked every field on every fragment (catastrophic but obvious); after it, the call fails soft, the rule verdict is preserved, an honest `rules` stamp is written, and the run reports zero errors while the weighted feature is dead on every fragment. A hand-maintained key list cannot catch that, because whoever adds the key updates the list they can see.

### Gate 2

`./scripts/check-all.sh` exit code **0**, 12/12 checks. 9196 passed, 5 skipped, 94.46% branch coverage, per-file TEST-002 gate green, mypy strict clean, ruff verified with `--no-cache` (#1119). The 5 skips are all pre-existing environment skips (Ollama unreachable, live API keys absent) — **zero skipped** across every privacy-related suite (`test_weighted`, `test_holonic`, `test_privacy`, `test_privacy_pass`, `test_prompt_ontology`, the bubble-up pair, and #1358's provenance suite): 281 passed, 0 skipped.

No `# noqa`, `# type: ignore`, `# pylint: disable`, `@pytest.mark.skip` or `--no-verify` introduced; `pyproject.toml` and `scripts/` untouched. #1358's `tests/test_classify_failed_weighted_provenance.py` is untouched, and the only two assertions removed anywhere are the deliberate inversion above and a `_widen_voice_register` → `_widen_optional` rename that gained coverage.

## Residual — please read before merging

**The on-disk acceptance criterion holds for rule-inert bodies only.** `RuleClassifier._build_updates` rebuilds `VoiceClassification` from scratch under an `OR` guard, so for any body its voice matcher fires on, a persisted `confidence` is destroyed *before* the weighted classifier runs and no downstream merge can recover it. Verified: a fragment carrying `{analytical, conviction}` plus "I confess I was afraid" comes back from `RuleClassifier.classify` alone as `{confessional, None}`.

This PR closes the weighted-path defect completely for the fragments the rule pass leaves alone, and makes the boundary **visible rather than implied** — every affected test asserts the precondition explicitly. That guard earned its place during development: an earlier draft titled a fixture "Evidence bearing fragment", the word "evidence" tripped the rules voice matcher, and the precondition assertion caught it rather than letting the test fail for an unrelated reason.

Filed rather than folded in:
- **#1400** (P1) — the rules-layer twin above.
- **#1401** (P2) — `detect_ontology` fails soft with no `succeeded` signal, the same defect #1358 fixed on the fragment path, so a dead provider silently yields an empty draft ontology.

Closes #1309
