### PR TITLE
fix(compost): screen withheld fragments at the detection boundary, once (#1311)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -6675,8 +6675,11 @@ def _build_scan_verifier(config: CreekConfig) -> SupportsVerifyCompost:
     ``skip_intimate=True`` — not read from config, so no config edit or flag can
     turn it off — which means an ``Intimate`` fragment is dropped before the
     embedding gate, let alone the verifier. ``Personal`` is therefore the most
-    sensitive tier that can physically reach this provider. Should that forced
-    flag ever become configurable, this resolve call must be re-derived
+    sensitive tier that can physically reach this provider. Issue #1311 moved
+    that drop from inside the fragment detector to the detection *boundary*
+    and made an undeclared ``privacy_tier`` fail closed to ``Intimate``, so
+    the derivation is strictly stronger than when it was written. Should that
+    forced flag ever become configurable, this resolve call must be re-derived
     per-fragment instead of hoisted here.
 
     Unlike :func:`_build_compost_verifier`, an unavailable provider is fatal —

--- a/creek-tools/creek/generate/compost.py
+++ b/creek-tools/creek/generate/compost.py
@@ -36,7 +36,7 @@ from creek.models import (
 from creek.time import effective_authored_at, ensure_aware, now_la
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
+    from collections.abc import Callable, Mapping, Sequence
     from pathlib import Path
 
     from creek.generate.compost_verifier import SupportsVerifyCompost
@@ -145,6 +145,32 @@ def _is_intimate(fragment: Fragment) -> bool:
     return fragment.privacy_tier == PrivacyTier.INTIMATE
 
 
+@dataclass(frozen=True)
+class _AdmittedFragments:
+    """The fragment sequence after withheld fragments have been screened out.
+
+    A distinct type rather than a bare list, so that a detector which has
+    not been screened is a mypy ``arg-type`` error rather than a privacy
+    leak found in production. Every private ``_detect_*`` method on
+    :class:`CompostTracker` takes one of these; nothing else may.
+
+    Attributes:
+        fragments: The admitted fragments, in input order. These are the
+            only fragments any detector may read — their IDs, titles and
+            timestamps are the only ones that may reach a compost note.
+        withheld_thread_titles: Titles of every thread linked by a
+            *withheld* fragment. Deliberately titles and not the
+            ``Fragment`` objects: the thread detector is the one that
+            copies ``frag.title`` and ``frag.id`` into a note, so handing
+            it withheld fragments would keep the leak one edit away. It is
+            also what makes suppression O(1) per thread instead of
+            re-parsing every withheld fragment's wikilinks per thread.
+    """
+
+    fragments: tuple[Fragment, ...]
+    withheld_thread_titles: frozenset[str]
+
+
 def _sanitize_filename(title: str) -> str:
     """Sanitise a title for use as part of a filename."""
     cleaned = re.sub(r"[^\w\s-]", "", title).strip()
@@ -248,8 +274,40 @@ class CompostTracker:
         3. Tagged projects that appear in early fragments but have not
            been mentioned for more than :attr:`project_gap_days`.
 
-        Paradox-tagged and intimate-tier fragments are skipped per
-        ``skip_paradox`` / ``skip_intimate`` on the constructor.
+        **Withheld fragments are screened out once, here, before any
+        detector runs.** Paradox-tagged fragments (``skip_paradox``) and
+        intimate-tier fragments (``skip_intimate``) are removed by
+        :meth:`_screen`, which is the single chokepoint: a withheld
+        fragment contributes no ID, no title, no excerpt, no count and no
+        date to any candidate, and — because the screen happens before
+        :meth:`_group_fragments_by_tag` — cannot bring a project identity
+        into existence. Screening at the boundary rather than inside each
+        detector is load-bearing, not tidiness: a project candidate's
+        ``source_id`` and ``title`` *are* the tag, which reaches the note's
+        filename and ``_Compost-Report.md``, so filtering the emitted
+        ``fragment_ids`` lists would leave a tag carried only by intimate
+        fragments naming a file in the vault (issue #1311).
+
+        Three consequences are deliberate:
+
+        * **Silent omission.** A thread named only by withheld fragments
+          yields no candidate at all. Emitting one with
+          ``_No related fragments were recorded._`` in place of its
+          fragment list would announce that the thread's only fragments are
+          protected — which is the fact being protected. Suppression is
+          conditioned on withheld-ness, never on emptiness: a thread whose
+          fragments simply have not been ingested still composts.
+        * **A project alive only in withheld fragments falls silent.**
+          Silence is measured over the admitted set, so such a project now
+          produces a compost note it would not have produced before. This
+          is accepted: no withheld fragment becomes admitted, and the note
+          is derived entirely from admitted fragments.
+        * **The thread reason is an accepted residual channel.**
+          :meth:`_thread_reason` reads ``Thread.last_seen`` from the
+          thread's own frontmatter, not from fragments, so a dormancy
+          window stamped by a withheld fragment survives screening.
+          ``02-Threads/<id>.md`` is an ordinary vault note, so this
+          discloses nothing a reader could not already see.
 
         Args:
             threads: Threads to scan.
@@ -263,47 +321,129 @@ class CompostTracker:
             A list of :class:`CompostCandidate` models, ordered
             thread-candidates → fragment-candidates → project-candidates.
         """
-        thread_candidates = self._detect_threads(threads, fragments)
+        admitted = self._screen(fragments)
+        thread_candidates = self._detect_threads(threads, admitted)
         fragment_candidates = self._detect_abandonment_fragments(
-            fragments,
+            admitted,
             fragment_bodies or {},
         )
-        project_candidates = self._detect_disappeared_projects(fragments)
+        project_candidates = self._detect_disappeared_projects(admitted)
         return [*thread_candidates, *fragment_candidates, *project_candidates]
+
+    def _is_withheld(self, fragment: Fragment) -> bool:
+        """Return whether *fragment* is excluded from compost detection.
+
+        The single predicate behind both skip policies. Keeping the
+        ``paradox`` and ``intimate`` tests in one place means a change to
+        either — issue #1210 moves paradox detection from ``tags`` to
+        ``emotional_texture`` — is a change to one expression rather than
+        to every detector.
+        """
+        if self._skip_paradox and _is_paradox(fragment):
+            return True
+        return self._skip_intimate and _is_intimate(fragment)
+
+    def _screen(self, fragments: list[Fragment]) -> _AdmittedFragments:
+        """Partition *fragments* into what detection may see and what it may not.
+
+        The one chokepoint enforcing ``skip_paradox`` / ``skip_intimate``.
+        Runs before every detector, so nothing downstream needs to know the
+        policies exist — and a detector added later is guarded by
+        construction. Withheld fragments are reduced immediately to the set
+        of thread titles they mention; no withheld :class:`Fragment` object
+        travels any further.
+
+        Args:
+            fragments: Every fragment loaded for this detection pass.
+
+        Returns:
+            The admitted fragments, plus every thread title any withheld
+            fragment names. That set is deliberately not "titles *only*
+            withheld fragments name": a thread also named by an admitted
+            fragment appears in it too, and :meth:`_thread_candidate`
+            draws the distinction by checking the set only when no
+            admitted fragment turned out to be related.
+        """
+        admitted: list[Fragment] = []
+        withheld_thread_titles: set[str] = set()
+        for fragment in fragments:
+            if self._is_withheld(fragment):
+                withheld_thread_titles.update(_fragment_thread_titles(fragment))
+            else:
+                admitted.append(fragment)
+        return _AdmittedFragments(
+            fragments=tuple(admitted),
+            withheld_thread_titles=frozenset(withheld_thread_titles),
+        )
 
     def _detect_threads(
         self,
         threads: list[Thread],
-        fragments: list[Fragment],
+        admitted: _AdmittedFragments,
     ) -> list[CompostCandidate]:
-        """Detect compost candidates whose source is a thread."""
+        """Detect compost candidates whose source is a thread.
+
+        Mirrors :meth:`_detect_disappeared_projects`: the per-source
+        decision lives in :meth:`_thread_candidate`, and this method only
+        collects what that returns.
+        """
         today = self._now.date()
         candidates: list[CompostCandidate] = []
         for thread in threads:
-            reason = self._thread_reason(thread, today)
-            if reason is None:
-                continue
-            related = [
-                frag
-                for frag in fragments
-                if thread.title in _fragment_thread_titles(frag)
-            ]
-            candidates.append(
-                CompostCandidate(
-                    source_type="thread",
-                    source_id=thread.id,
-                    title=thread.title,
-                    reason=reason,
-                    fragment_ids=[frag.id for frag in related],
-                    energy_fragment_ids=[
-                        frag.id for frag in related if _fragment_is_energetic(frag)
-                    ],
-                    energy_excerpts=[
-                        frag.title for frag in related if _fragment_is_energetic(frag)
-                    ],
-                ),
-            )
+            candidate = self._thread_candidate(thread, admitted, today)
+            if candidate is not None:
+                candidates.append(candidate)
         return candidates
+
+    def _thread_candidate(
+        self,
+        thread: Thread,
+        admitted: _AdmittedFragments,
+        today: date,
+    ) -> CompostCandidate | None:
+        """Return a candidate for *thread*, or ``None`` if it is not compost.
+
+        Two ways to return ``None``. The thread may simply not be dormant
+        or resolved. Or every fragment naming it may have been withheld, in
+        which case the candidate is omitted rather than written with an
+        empty fragment list — see the silent-omission paragraph on
+        :meth:`detect_compost_candidates`. That second condition tests
+        withheld-ness, never emptiness: a thread whose fragments have not
+        been ingested yet has no withheld fragments either, and must still
+        compost.
+        """
+        reason = self._thread_reason(thread, today)
+        if reason is None:
+            return None
+        related = self._related_fragments(thread, admitted)
+        if not related and thread.title in admitted.withheld_thread_titles:
+            return None
+        energetic = [frag for frag in related if _fragment_is_energetic(frag)]
+        return CompostCandidate(
+            source_type="thread",
+            source_id=thread.id,
+            title=thread.title,
+            reason=reason,
+            fragment_ids=[frag.id for frag in related],
+            energy_fragment_ids=[frag.id for frag in energetic],
+            energy_excerpts=[frag.title for frag in energetic],
+        )
+
+    @staticmethod
+    def _related_fragments(
+        thread: Thread,
+        admitted: _AdmittedFragments,
+    ) -> list[Fragment]:
+        """Return the admitted fragments that wiki-link *thread* by title.
+
+        Reads ``admitted.fragments`` and nothing else, so a withheld
+        fragment cannot be "related" to anything.
+        """
+        return [
+            frag
+            for frag in admitted.fragments
+            if thread.title in _fragment_thread_titles(frag)
+        ]
 
     def _thread_reason(self, thread: Thread, today: date) -> str | None:
         """Return a compost reason for *thread*, or ``None`` if not a candidate."""
@@ -316,25 +456,23 @@ class CompostTracker:
 
     def _detect_abandonment_fragments(
         self,
-        fragments: list[Fragment],
+        admitted: _AdmittedFragments,
         bodies: Mapping[str, str],
     ) -> list[CompostCandidate]:
         """Detect fragments that semantically describe abandonment (FEAT-018).
 
         Two-stage pipeline: embedding-similarity gate → optional LLM
-        verifier. Paradox-tagged and intimate-tier fragments are
-        skipped here so neither the embedding nor the verifier sees
-        them — important because the verifier may call out to a cloud
-        LLM and intimate content must never leave the device.
+        verifier. Neither the embedding gate nor the verifier can see a
+        paradox-tagged or intimate-tier fragment, because :meth:`_screen`
+        removed it upstream in :meth:`detect_compost_candidates` — the
+        guarantee is now structural rather than a check inside this loop.
+        That matters because the verifier may call out to a cloud LLM and
+        intimate content must never leave the device.
         """
         if self._similarity_fn is None:
             return []
         candidates: list[CompostCandidate] = []
-        for fragment in fragments:
-            if self._skip_paradox and _is_paradox(fragment):
-                continue
-            if self._skip_intimate and _is_intimate(fragment):
-                continue
+        for fragment in admitted.fragments:
             body = bodies.get(fragment.id, "")
             text = f"{fragment.title}\n{body}".strip() if body else fragment.title
             similarity = self._similarity_fn(text)
@@ -392,11 +530,19 @@ class CompostTracker:
 
     def _detect_disappeared_projects(
         self,
-        fragments: list[Fragment],
+        admitted: _AdmittedFragments,
     ) -> list[CompostCandidate]:
-        """Detect tagged projects that have fallen silent."""
+        """Detect tagged projects that have fallen silent.
+
+        Grouping runs over the admitted fragments only, so a tag carried
+        exclusively by withheld fragments never becomes a project identity
+        — which is the leak channel that filtering a candidate's
+        ``fragment_ids`` cannot close, since the identity *is* the tag.
+        Both the ``project_min_fragments`` count and the silence date are
+        therefore computed from admitted fragments alone.
+        """
         cutoff = self._now - timedelta(days=self.project_gap_days)
-        tag_fragments = self._group_fragments_by_tag(fragments)
+        tag_fragments = self._group_fragments_by_tag(admitted.fragments)
         candidates: list[CompostCandidate] = []
         for tag, frags in tag_fragments.items():
             candidate = self._project_candidate(tag, frags, cutoff)
@@ -406,7 +552,7 @@ class CompostTracker:
 
     @staticmethod
     def _group_fragments_by_tag(
-        fragments: list[Fragment],
+        fragments: Sequence[Fragment],
     ) -> dict[str, list[Fragment]]:
         """Group fragments by each tag they carry."""
         grouped: dict[str, list[Fragment]] = defaultdict(list)

--- a/creek-tools/creek/generate/compost_scan.py
+++ b/creek-tools/creek/generate/compost_scan.py
@@ -16,12 +16,19 @@ but wrong for a command that writes to the vault. Here a fragment that clears
 the gate but was not verified routes to the operator review queue, never to
 canonical compost. An embedding hit is a suspicion, not a finding.
 
-**Intimate content never reaches the verifier.** ``skip_intimate`` is forced
-on rather than plumbed through :class:`~creek.config.CompostConfig`, so no
-config edit or flag can send intimate fragment bodies to a cloud provider.
-``creek/cli.py``'s ``_build_compost_verifier`` carries a durable caveat about
-exactly this call site; ``creek.cli._build_scan_verifier`` is the tier-aware
-builder that caveat asks for.
+**Intimate content never reaches the verifier — or the vault.**
+``skip_intimate`` is forced on rather than plumbed through
+:class:`~creek.config.CompostConfig`, so no config edit or flag can send
+intimate fragment bodies to a cloud provider. ``creek/cli.py``'s
+``_build_compost_verifier`` carries a durable caveat about exactly this call
+site; ``creek.cli._build_scan_verifier`` is the tier-aware builder that caveat
+asks for. Two things widen that guarantee past egress (issue #1311):
+:meth:`~creek.generate.compost.CompostTracker._screen` removes withheld
+fragments at the detection boundary, so they reach the *note writer* no more
+than they reach the verifier; and :func:`_load_fragments` re-derives each
+tier from raw frontmatter, so a note that declares no tier at all fails
+closed to ``intimate`` instead of inheriting the model's ``unclassified``
+default.
 
 **Costs are quoted before they are incurred.** Detection runs gate-only
 first, so the candidate count — and therefore the LLM call count — is known
@@ -40,6 +47,7 @@ import frontmatter
 import yaml
 from pydantic import ValidationError
 
+from creek.classify.privacy_filter import raw_privacy_tier
 from creek.generate.compost import CANONICAL_RELDIR, CompostTracker
 from creek.generate.compost_verifier import CompostVerdict
 from creek.models import Thread
@@ -188,14 +196,37 @@ def _load_fragments(vault_path: Path) -> tuple[list[Fragment], dict[str, str]]:
     verifier is shown both. :func:`creek.vault.reader.iter_vault_fragments`
     is the only loader that returns them alongside the validated model.
 
+    Each fragment's ``privacy_tier`` is re-derived from its **raw**
+    frontmatter through :func:`creek.classify.privacy_filter.raw_privacy_tier`
+    before it leaves this function, following the precedent
+    ``creek.generate.mining`` sets for liminal fragments. Reading the tier
+    off the validated model instead would fail *open* on the one case that
+    matters: ``Fragment.privacy_tier`` defaults to ``unclassified`` when the
+    key is absent, so a hand-written or legacy note that never declared a
+    tier at all would be admitted, while ``raw_privacy_tier`` — and
+    therefore every other reader in the codebase — resolves the same file to
+    ``intimate``. Two tools that disagree about one file is a bug class, not
+    a style question (issue #1311).
+
+    The narrowing is scoped to the missing key: an explicit ``unclassified``
+    ranks with ``personal`` (#876/#961) and stays admitted. An
+    *unrecognised* tier string never reaches here — it fails
+    ``Fragment.model_validate`` and
+    :func:`creek.vault.reader.try_load_fragment` drops the note — which
+    ``tests/test_compost_scan.py`` pins so that behaviour stays a contract
+    rather than an accident.
+
     Args:
         vault_path: Root of the Obsidian vault.
 
     Returns:
-        ``(fragments, {fragment_id: body})``.
+        ``(fragments, {fragment_id: body})``, with tiers already narrowed.
     """
     records = iter_vault_fragments(vault_path / _FRAGMENTS_RELDIR)
-    fragments = [fragment for _path, fragment, _body, _raw in records]
+    fragments = [
+        fragment.model_copy(update={"privacy_tier": raw_privacy_tier(raw)})
+        for _path, fragment, _body, raw in records
+    ]
     bodies = {fragment.id: body for _path, fragment, body, _raw in records}
     return fragments, bodies
 

--- a/creek-tools/tests/test_compost.py
+++ b/creek-tools/tests/test_compost.py
@@ -7,6 +7,7 @@ utilities. All behaviour maps to the acceptance criteria on Issue #40.
 
 from __future__ import annotations
 
+import inspect
 from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING
 from zoneinfo import ZoneInfo
@@ -15,12 +16,13 @@ import frontmatter
 import pytest
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Mapping
     from pathlib import Path
 
 from creek.generate.compost import (
     CompostCandidate,
     CompostTracker,
+    _AdmittedFragments,
 )
 from creek.generate.compost_verifier import (
     CompostVerdict,
@@ -1160,3 +1162,303 @@ class TestTimezoneAwareClock:
             f"{before.isoformat()}-{_TZ_PROJECT_TAG}.md",
             f"{after.isoformat()}-{_TZ_PROJECT_TAG}.md",
         }
+
+
+# ---- Issue #1311: the screened-fragment boundary ---------------------------
+#
+# ``skip_intimate`` / ``skip_paradox`` used to be enforced inside a single
+# detector, so the thread and project detectors copied withheld fragments'
+# titles and IDs into vault notes — and, on the project path, the withheld
+# fragment's *tag* became the note's identity: its title, its
+# ``original_project``, its filename, and a line in ``_Compost-Report.md``.
+# Filtering the emitted lists cannot reach that, because the candidate *is*
+# the tag. The screen therefore runs once, on the fragment sequence, before
+# any detector sees it.
+
+
+_GRIEF_THREAD_TITLE = "Grief Work"
+"""Thread title shared by the residual-channel test's fixtures."""
+
+
+class _RecordingTracker(CompostTracker):
+    """Tracker that records the fragment IDs each private detector was handed.
+
+    The inheritance property under test is structural: a future fourth
+    detector added to ``detect_compost_candidates`` is guarded by
+    construction only if the screen happens at the boundary rather than
+    inside each detector.
+    """
+
+    def __init__(self, *, now: datetime) -> None:
+        """Initialise the tracker and the per-detector recording map."""
+        super().__init__(now=now, similarity_fn=_high_similarity)
+        self.seen: dict[str, tuple[str, ...]] = {}
+
+    def _detect_threads(
+        self,
+        threads: list[Thread],
+        admitted: _AdmittedFragments,
+    ) -> list[CompostCandidate]:
+        """Record the admitted IDs, then delegate."""
+        self.seen["threads"] = tuple(frag.id for frag in admitted.fragments)
+        return super()._detect_threads(threads, admitted)
+
+    def _detect_abandonment_fragments(
+        self,
+        admitted: _AdmittedFragments,
+        bodies: Mapping[str, str],
+    ) -> list[CompostCandidate]:
+        """Record the admitted IDs, then delegate."""
+        self.seen["fragments"] = tuple(frag.id for frag in admitted.fragments)
+        return super()._detect_abandonment_fragments(admitted, bodies)
+
+    def _detect_disappeared_projects(
+        self,
+        admitted: _AdmittedFragments,
+    ) -> list[CompostCandidate]:
+        """Record the admitted IDs, then delegate."""
+        self.seen["projects"] = tuple(frag.id for frag in admitted.fragments)
+        return super()._detect_disappeared_projects(admitted)
+
+
+def _fingerprint(candidate: CompostCandidate) -> tuple[object, ...]:
+    """Return every field of *candidate* that a compost note renders."""
+    return (
+        candidate.source_type,
+        candidate.source_id,
+        candidate.title,
+        candidate.reason,
+        tuple(candidate.fragment_ids),
+        tuple(candidate.energy_fragment_ids),
+        tuple(candidate.energy_excerpts),
+    )
+
+
+def _dormant(thread_id: str, title: str, last_seen: date) -> Thread:
+    """Build a dormant thread with a caller-chosen ``last_seen``."""
+    return Thread(
+        id=thread_id,
+        title=title,
+        status=ThreadStatus.DORMANT,
+        first_seen=date(2023, 1, 1),
+        last_seen=last_seen,
+        fragment_count=3,
+        frequency_affinity=[Frequency.F5],
+        description="Ran hot for a season and then went quiet.",
+    )
+
+
+class TestScreenedFragmentBoundary:
+    """The single screen at the top of ``detect_compost_candidates``."""
+
+    def test_every_detector_receives_only_admitted_fragments(
+        self,
+        reference_now: datetime,
+    ) -> None:
+        """All three detectors are handed the same screened tuple."""
+        corpus = [
+            _fragment(
+                frag_id="f-open",
+                title="Kept going",
+                created=datetime(2024, 5, 1, 9, 0, 0),
+            ),
+            _fragment(
+                frag_id="f-intimate",
+                title="Therapy: the affair and the shame",
+                created=datetime(2024, 5, 2, 9, 0, 0),
+                privacy_tier=PrivacyTier.INTIMATE,
+            ),
+            _fragment(
+                frag_id="f-paradox",
+                title="Both true at once",
+                created=datetime(2024, 5, 3, 9, 0, 0),
+                tags=["paradox"],
+            ),
+        ]
+        tracker = _RecordingTracker(now=reference_now)
+
+        tracker.detect_compost_candidates([], corpus)
+
+        assert tracker.seen == {
+            "threads": ("f-open",),
+            "fragments": ("f-open",),
+            "projects": ("f-open",),
+        }
+
+    def test_every_detector_declares_the_screened_fragment_type(self) -> None:
+        """A fourth detector taking a raw ``list[Fragment]`` must not compile.
+
+        MyPy already rejects *passing* an unscreened list to a screened
+        detector, but it cannot object to a new detector that declares
+        ``list[Fragment]`` and is called with the raw sequence — which is
+        exactly how this defect was introduced. Annotations are compared as
+        strings: ``compost.py`` uses ``from __future__ import annotations``
+        and imports ``Mapping`` only under ``TYPE_CHECKING``, so
+        ``typing.get_type_hints`` raises ``NameError`` on
+        ``_detect_abandonment_fragments`` — the one method this most needs
+        to police.
+        """
+        detectors = {
+            name: fn
+            for name, fn in inspect.getmembers(CompostTracker, inspect.isfunction)
+            if name.startswith("_detect_")
+        }
+
+        assert set(detectors) == {
+            "_detect_threads",
+            "_detect_abandonment_fragments",
+            "_detect_disappeared_projects",
+        }
+        for name, fn in detectors.items():
+            annotations = [
+                param.annotation for param in inspect.signature(fn).parameters.values()
+            ]
+            assert "_AdmittedFragments" in annotations, name
+
+    def test_screening_equals_removing_the_withheld_fragments_up_front(
+        self,
+        reference_now: datetime,
+    ) -> None:
+        """FORBIDDEN DIRECTION: nothing admitted at HEAD stops being emitted.
+
+        Screening is proved to be exactly subtraction — every candidate the
+        unguarded tracker derives from the admitted fragments alone is still
+        produced, field for field. Because the withheld fragment is the
+        *most recent* member of the ``zine`` group, equality of ``reason``
+        also pins that counts and dates come from the admitted set only.
+        """
+        thread = _dormant("thr-deep", "Deep Work", date(2025, 1, 1))
+        admitted = [
+            _fragment(
+                frag_id="f-open-a",
+                title="Kept going",
+                created=datetime(2024, 5, 1, 9, 0, 0),
+                tags=["zine"],
+                threads=["[[Deep Work]]"],
+            ),
+            _fragment(
+                frag_id="f-open-b",
+                title="Also kept",
+                created=datetime(2024, 5, 2, 9, 0, 0),
+                tags=["zine"],
+            ),
+        ]
+        withheld = _fragment(
+            frag_id="f-hidden",
+            title="Therapy: the affair and the shame",
+            created=datetime(2024, 5, 3, 9, 0, 0),
+            tags=["zine"],
+            threads=["[[Deep Work]]"],
+            privacy_tier=PrivacyTier.INTIMATE,
+        )
+
+        screened = CompostTracker(now=reference_now).detect_compost_candidates(
+            [thread],
+            [*admitted, withheld],
+        )
+        baseline = CompostTracker(
+            now=reference_now,
+            skip_intimate=False,
+            skip_paradox=False,
+        ).detect_compost_candidates([thread], admitted)
+
+        assert [_fingerprint(c) for c in screened] == [
+            _fingerprint(c) for c in baseline
+        ]
+        assert screened
+        assert all("f-hidden" not in c.fragment_ids for c in screened)
+
+    def test_a_project_alive_only_in_withheld_fragments_becomes_silent(
+        self,
+        reference_now: datetime,
+    ) -> None:
+        """ACCEPTED BEHAVIOUR CHANGE — decided here, not discovered in review.
+
+        Screening the fragment sequence changes the *silence* arithmetic: a
+        project whose only recent activity is withheld now looks dormant and
+        gets a compost note it would not have got before. The semantics are
+        deliberate — "a project alive only in intimate content is silent in
+        the non-intimate view" — and the direction is the safe one: no
+        withheld fragment becomes admitted, and the new note is derived
+        entirely from admitted fragments, disclosing nothing about the
+        protected content. Operators will see new files appear.
+        """
+        corpus = [
+            _fragment(
+                frag_id="f-zine-1",
+                title="Laying out the zine",
+                created=datetime(2024, 5, 1, 9, 0, 0),
+                tags=["zine"],
+            ),
+            _fragment(
+                frag_id="f-zine-2",
+                title="Zine paper stock",
+                created=datetime(2024, 5, 1, 9, 0, 0),
+                tags=["zine"],
+            ),
+            _fragment(
+                frag_id="f-zine-private",
+                title="Therapy: the affair and the shame",
+                created=datetime(2026, 3, 25, 9, 0, 0),
+                tags=["zine"],
+                privacy_tier=PrivacyTier.INTIMATE,
+            ),
+        ]
+
+        unguarded = CompostTracker(
+            now=reference_now,
+            skip_intimate=False,
+        ).detect_compost_candidates([], corpus)
+        guarded = CompostTracker(now=reference_now).detect_compost_candidates(
+            [],
+            corpus,
+        )
+
+        assert [c for c in unguarded if c.source_type == "project"] == []
+        projects = [c for c in guarded if c.source_type == "project"]
+        assert len(projects) == 1
+        assert projects[0].source_id == "zine"
+        assert projects[0].fragment_ids == ["f-zine-1", "f-zine-2"]
+        assert projects[0].reason == "Project silent for 700 days"
+
+    def test_a_thread_reason_is_thread_derived_not_fragment_derived(
+        self,
+        reference_now: datetime,
+    ) -> None:
+        """ACCEPTED RESIDUAL CHANNEL — pinned rather than recomputed.
+
+        ``_thread_reason`` reads ``Thread.last_seen`` off the thread's own
+        frontmatter, so screening the fragment sequence cannot change it: a
+        thread whose ``last_seen`` was stamped by a withheld fragment still
+        reports the dormancy measured from that date. This is accepted, not
+        overlooked. ``02-Threads/<id>.md`` is an ordinary vault note any
+        reader already sees, so the compost note discloses nothing new — and
+        recomputing the reason from fragments would break the guarantee that
+        a thread with no ingested fragments still composts at all.
+        """
+        thread = _dormant("thr-grief", _GRIEF_THREAD_TITLE, date(2025, 1, 1))
+        corpus = [
+            _fragment(
+                frag_id="f-open",
+                title="A note anyone may read",
+                created=datetime(2023, 6, 1, 9, 0, 0),
+                threads=[f"[[{_GRIEF_THREAD_TITLE}]]"],
+            ),
+            _fragment(
+                frag_id="f-hidden",
+                title="Therapy: the affair and the shame",
+                created=datetime(2025, 1, 1, 9, 0, 0),
+                threads=[f"[[{_GRIEF_THREAD_TITLE}]]"],
+                privacy_tier=PrivacyTier.INTIMATE,
+            ),
+        ]
+
+        candidates = CompostTracker(now=reference_now).detect_compost_candidates(
+            [thread],
+            corpus,
+        )
+
+        threads = [c for c in candidates if c.source_type == "thread"]
+        assert len(threads) == 1
+        assert threads[0].fragment_ids == ["f-open"]
+        assert threads[0].reason == "Dormant for 455 days"

--- a/creek-tools/tests/test_compost_scan.py
+++ b/creek-tools/tests/test_compost_scan.py
@@ -27,6 +27,7 @@ import frontmatter
 import pytest
 
 from creek.config import CompostConfig
+from creek.generate.compost import CompostTracker
 from creek.generate.compost_scan import (
     load_composted_source_ids,
     run_compost_scan,
@@ -37,6 +38,7 @@ from creek.models import (
     FragmentSource,
     Frequency,
     FrequencyClassification,
+    PraxisPotential,
     PrivacyTier,
     SourcePlatform,
     Thread,
@@ -104,6 +106,20 @@ def vault(tmp_path: Path) -> Path:
     return tmp_path
 
 
+_RECENT = datetime(2026, 3, 1, 9, 0, 0)
+"""Default fragment authoring date — 31 days before :data:`_NOW`."""
+
+_BACK_DATED = datetime(2024, 5, 1, 9, 0, 0)
+"""Authoring date old enough to trip the 180-day project-silence gap.
+
+Load-bearing for every project-path test in this module. With the
+:data:`_RECENT` default the silence detector never fires, so a test that
+asserts "no note names this tag" passes on a vault where no note was
+written for any reason at all — vacuously green, which is precisely the
+failure mode the privacy tests below exist to rule out.
+"""
+
+
 def _write_fragment(
     vault_path: Path,
     *,
@@ -112,27 +128,63 @@ def _write_fragment(
     body: str = "I have let this one go.",
     tags: list[str] | None = None,
     privacy_tier: PrivacyTier = PrivacyTier.UNCLASSIFIED,
+    created: datetime = _RECENT,
+    threads: list[str] | None = None,
+    praxis_potential: PraxisPotential = PraxisPotential.NONE,
+    drop_privacy_tier: bool = False,
 ) -> Fragment:
     """Write a fragment note into ``01-Fragments`` and return the model.
 
-    ``created``/``ingested`` are pinned near :data:`_NOW` so the FEAT-031
-    project-silence detector never fires incidentally — these tests are
-    about the fragment path, and a stray project candidate would make the
-    plan counts ambiguous.
+    ``created``/``ingested`` default to :data:`_RECENT` so the FEAT-031
+    project-silence detector never fires incidentally — most tests here
+    are about the fragment path, and a stray project candidate would make
+    the plan counts ambiguous. Pass ``created=_BACK_DATED`` to exercise
+    the project path deliberately.
+
+    Args:
+        vault_path: Root of the vault to write into.
+        frag_id: Fragment ID, also the filename stem.
+        title: Fragment title.
+        body: Note body text.
+        tags: Tags carried by the fragment; each one is a project identity
+            to :meth:`CompostTracker._group_fragments_by_tag`.
+        privacy_tier: Declared tier written into the frontmatter.
+        created: Authoring timestamp, mirrored into ``ingested``.
+        threads: ``[[Wikilink]]`` thread references.
+        praxis_potential: ``EXPLICIT`` marks the fragment as carrying
+            surviving energy, which is what puts its **title** into a
+            candidate's ``energy_excerpts`` — the only path by which a
+            fragment title, rather than its ID, reaches a compost note.
+        drop_privacy_tier: When ``True`` the ``privacy_tier`` key is
+            removed from the written frontmatter entirely, modelling a
+            hand-written or legacy note. Distinct from an explicit
+            ``unclassified``: the model default silently supplies
+            ``unclassified`` for a *missing* key, which is why
+            :func:`creek.classify.privacy_filter.raw_privacy_tier` reads
+            the raw mapping instead.
+
+    Returns:
+        The :class:`~creek.models.Fragment` as written (before any
+        fail-closed tier narrowing the loader applies).
     """
     fragment = Fragment(
         id=frag_id,
         title=title,
         source=FragmentSource(platform=SourcePlatform.JOURNAL),
-        created=datetime(2026, 3, 1, 9, 0, 0),
-        ingested=datetime(2026, 3, 1, 9, 0, 0),
+        created=created,
+        ingested=created,
         frequency=FrequencyClassification(primary=Frequency.F5),
         voice=VoiceClassification(),
+        praxis_potential=praxis_potential,
+        threads=threads or [],
         tags=tags or [],
         privacy_tier=privacy_tier,
     )
+    metadata = fragment.model_dump(mode="json")
+    if drop_privacy_tier:
+        metadata.pop("privacy_tier")
     post = frontmatter.Post(content=body)
-    post.metadata.update(fragment.model_dump(mode="json"))
+    post.metadata.update(metadata)
     path = vault_path / "01-Fragments" / f"{frag_id}.md"
     path.write_text(frontmatter.dumps(post), encoding="utf-8")
     return fragment
@@ -163,6 +215,32 @@ def _notes_in(vault_path: Path, relpath: str) -> list[Path]:
     if not folder.exists():
         return []
     return [p for p in sorted(folder.glob("*.md")) if not p.name.startswith("_")]
+
+
+def _compost_tree(vault_path: Path) -> list[Path]:
+    """Return every markdown file under the whole ``10-Liminal/Compost`` subtree.
+
+    ``rglob``, not ``glob``: :data:`CompostConfig.review_queue_relpath`
+    defaults to ``10-Liminal/Compost/Review``, and :func:`_notes_in` — like
+    :meth:`CompostTracker._load_existing_compost_notes` — only walks the top
+    level. A privacy assertion that misses the review subtree misses half
+    the surface.
+    """
+    folder = vault_path / _CANONICAL_RELDIR
+    if not folder.exists():
+        return []
+    return sorted(folder.rglob("*.md"))
+
+
+def _compost_tree_text(vault_path: Path) -> str:
+    """Return the concatenated bytes of every note in the compost subtree.
+
+    Assertions run against written vault content rather than against
+    :class:`CompostCandidate` models, because the leak this guards is in
+    what lands on disk — including in filenames, which no model-level
+    assertion can see.
+    """
+    return "\n".join(p.read_text(encoding="utf-8") for p in _compost_tree(vault_path))
 
 
 # ---- Routing: confirmed / ambiguous / rejected ----
@@ -373,6 +451,353 @@ def test_paradox_fragment_is_skipped_when_configured(vault: Path) -> None:
 
     assert verifier.calls == []
     assert result.composted == []
+
+
+# ---- Privacy: withheld fragments reach no note, no filename, no report ----
+#
+# Issue #1311. ``skip_intimate`` used to guard only the *fragment* detection
+# path, so a withheld fragment's title and ``[[id]]`` still landed in thread
+# and project notes — and, for projects, the intimate-derived *tag* became the
+# note's ``title``, its ``original_project``, its FILENAME, and a line in
+# ``_Compost-Report.md``. Filtering the emitted ``fragment_ids`` /
+# ``energy_excerpts`` lists — the fix the issue body proposed — does not close
+# that last channel, because the project candidate's identity *is* the tag.
+# These tests therefore assert on written vault bytes and on note names.
+
+
+_WITHHELD_KINDS: tuple[str, ...] = ("intimate", "paradox")
+"""The two skip policies that must behave identically at the boundary.
+
+Every leak test below is parametrised over this tuple. An emptied
+parametrize list makes privacy tests vanish behind a green gate, so
+:func:`test_the_withheld_kind_matrix_covers_both_skip_policies` pins its
+contents and the suite is run with ``-rs`` to confirm nothing is skipped.
+"""
+
+
+def _never_similar(_text: str) -> float:
+    """Similarity stub below every floor — isolates the thread/project paths."""
+    return 0.0
+
+
+def _write_withheld(
+    vault_path: Path,
+    *,
+    kind: str,
+    frag_id: str,
+    title: str,
+    tags: list[str] | None = None,
+    threads: list[str] | None = None,
+    created: datetime = _RECENT,
+    praxis_potential: PraxisPotential = PraxisPotential.NONE,
+) -> Fragment:
+    """Write a fragment that compost detection must withhold.
+
+    Args:
+        vault_path: Root of the vault to write into.
+        kind: ``"intimate"`` (declares ``privacy_tier: intimate``) or
+            ``"paradox"`` (adds the ``paradox`` tag).
+        frag_id: Fragment ID, also the filename stem.
+        title: Fragment title — the string that must not escape.
+        tags: Additional tags; each is a project identity to the detector.
+        threads: ``[[Wikilink]]`` thread references.
+        created: Authoring timestamp, mirrored into ``ingested``.
+        praxis_potential: ``EXPLICIT`` routes the title into
+            ``energy_excerpts``, putting it on the leak surface.
+
+    Returns:
+        The written :class:`~creek.models.Fragment`.
+    """
+    extra_tags = list(tags or [])
+    privacy_tier = PrivacyTier.UNCLASSIFIED
+    if kind == "intimate":
+        privacy_tier = PrivacyTier.INTIMATE
+    else:
+        extra_tags.append("paradox")
+    return _write_fragment(
+        vault_path,
+        frag_id=frag_id,
+        title=title,
+        tags=extra_tags,
+        privacy_tier=privacy_tier,
+        created=created,
+        threads=threads,
+        praxis_potential=praxis_potential,
+    )
+
+
+def test_the_withheld_kind_matrix_covers_both_skip_policies() -> None:
+    """Guard the parametrize list itself against silently emptying out."""
+    assert set(_WITHHELD_KINDS) == {"intimate", "paradox"}
+
+
+@pytest.mark.parametrize("kind", _WITHHELD_KINDS)
+def test_a_tag_carried_only_by_withheld_fragments_produces_no_compost_note(
+    vault: Path,
+    kind: str,
+) -> None:
+    """The criterion the issue body omits: the *tag itself* is the leak.
+
+    A project candidate's ``source_id`` and ``title`` are the tag, so a tag
+    carried only by withheld fragments must yield no candidate at all —
+    otherwise the tag reaches the filename, the frontmatter, the body, and
+    the rollup report even after every fragment ID has been filtered out.
+    """
+    for idx in (1, 2):
+        _write_withheld(
+            vault,
+            kind=kind,
+            frag_id=f"f-hidden-{idx}",
+            title=f"Therapy: the affair and the shame ({idx})",
+            tags=["affair-recovery"],
+            created=_BACK_DATED,
+        )
+    config = CompostConfig()
+
+    result = run_compost_scan(
+        vault,
+        similarity_fn=_never_similar,
+        verifier=None,
+        config=config,
+        now=_NOW,
+    )
+    CompostTracker(now=_NOW).generate_compost_report(vault)
+
+    assert result.composted == []
+    assert result.review_queued == []
+    assert _notes_in(vault, _CANONICAL_RELDIR) == []
+    assert not any("affair-recovery" in p.name for p in _compost_tree(vault))
+    text = _compost_tree_text(vault)
+    for secret in ("affair-recovery", "f-hidden-1", "f-hidden-2", "the affair"):
+        assert secret not in text
+    assert (
+        load_composted_source_ids(
+            vault,
+            review_queue_relpath=config.review_queue_relpath,
+        )
+        == set()
+    )
+
+
+@pytest.mark.parametrize("kind", _WITHHELD_KINDS)
+def test_a_withheld_fragment_never_reaches_a_thread_compost_note(
+    vault: Path,
+    kind: str,
+) -> None:
+    """A dormant thread's note names its open fragments and only those.
+
+    Both fragments are marked ``EXPLICIT`` so both titles are on the
+    ``energy_excerpts`` surface: the assertion is that the guard subtracts
+    the withheld one rather than that titles never appear.
+    """
+    _write_thread(vault, thread_id="thr-deep", title="Deep Work")
+    _write_withheld(
+        vault,
+        kind=kind,
+        frag_id="f-hidden-1",
+        title="Therapy: the affair and the shame",
+        threads=["[[Deep Work]]"],
+        praxis_potential=PraxisPotential.EXPLICIT,
+    )
+    _write_fragment(
+        vault,
+        frag_id="f-open-1",
+        title="Timeboxing experiment",
+        threads=["[[Deep Work]]"],
+        praxis_potential=PraxisPotential.EXPLICIT,
+    )
+
+    result = run_compost_scan(
+        vault,
+        similarity_fn=_never_similar,
+        verifier=None,
+        config=CompostConfig(),
+        now=_NOW,
+    )
+    CompostTracker(now=_NOW).generate_compost_report(vault)
+
+    assert len(result.composted) == 1
+    text = _compost_tree_text(vault)
+    # Negative branch: withholding must subtract, not suppress wholesale.
+    assert "f-open-1" in text
+    assert "Timeboxing experiment" in text
+    assert "f-hidden-1" not in text
+    assert "the affair" not in text
+    assert not any("affair" in p.name for p in _compost_tree(vault))
+
+
+@pytest.mark.parametrize("kind", _WITHHELD_KINDS)
+def test_a_dormant_thread_whose_only_fragments_are_withheld_writes_no_note(
+    vault: Path,
+    kind: str,
+) -> None:
+    """SILENT OMISSION is the contract — an empty note is itself a disclosure.
+
+    Writing the note with ``_No related fragments were recorded._`` in place
+    of the fragment list announces "this thread's only fragments are
+    protected", which is the fact being protected. The candidate is dropped.
+    """
+    _write_thread(vault, thread_id="thr-deep", title="Deep Work")
+    _write_withheld(
+        vault,
+        kind=kind,
+        frag_id="f-hidden-1",
+        title="Therapy: the affair and the shame",
+        threads=["[[Deep Work]]"],
+    )
+
+    result = run_compost_scan(
+        vault,
+        similarity_fn=_never_similar,
+        verifier=None,
+        config=CompostConfig(),
+        now=_NOW,
+    )
+    CompostTracker(now=_NOW).generate_compost_report(vault)
+
+    assert result.composted == []
+    assert _notes_in(vault, _CANONICAL_RELDIR) == []
+    text = _compost_tree_text(vault)
+    assert "_No related fragments were recorded._" not in text
+    assert "Deep Work" not in text
+    assert "f-hidden-1" not in text
+
+
+def test_a_dormant_thread_with_no_fragments_at_all_still_composts(
+    vault: Path,
+) -> None:
+    """REGRESSION FENCE, not a mutation test — expected green before and after.
+
+    Suppression is conditioned on *withheld-ness*, never on emptiness.
+    ``tests/test_compost.py::TestDetectCompostCandidates::
+    test_dormant_thread_detected`` passes ``fragments=[]`` and requires a
+    candidate, so simplifying the branch to ``if not related: continue``
+    would silently stop composting every thread whose fragments have not
+    been ingested yet. This test exists to make that simplification fail.
+    """
+    _write_thread(vault, thread_id="thr-lonely", title="Sourdough experiments")
+
+    result = run_compost_scan(
+        vault,
+        similarity_fn=_never_similar,
+        verifier=None,
+        config=CompostConfig(),
+        now=_NOW,
+    )
+
+    assert len(result.composted) == 1
+    assert frontmatter.load(str(result.composted[0])).get("original_thread") == (
+        "[[thr-lonely]]"
+    )
+
+
+# ---- Privacy: failing closed on tiers the model would default open ----
+
+
+def test_a_fragment_with_no_privacy_tier_key_is_withheld(vault: Path) -> None:
+    """A missing ``privacy_tier`` key must read INTIMATE, not ``unclassified``.
+
+    ``Fragment.privacy_tier`` defaults to ``unclassified`` when the key is
+    absent, so reading the tier off the validated model admits a note that
+    never declared a tier at all.
+    :func:`creek.classify.privacy_filter.raw_privacy_tier` — the house
+    fail-closed reader, mirrored onto liminal fragments by
+    ``creek.generate.mining`` — resolves the same file to ``intimate``. Two
+    readers must not disagree about one file, so the scan's loader
+    materialises the raw-derived tier before the tracker ever sees it.
+    """
+    for idx in (1, 2):
+        _write_fragment(
+            vault,
+            frag_id=f"f-untiered-{idx}",
+            title=f"Notes from the untiered project ({idx})",
+            tags=["untiered-project"],
+            created=_BACK_DATED,
+            drop_privacy_tier=True,
+        )
+
+    result = run_compost_scan(
+        vault,
+        similarity_fn=_never_similar,
+        verifier=None,
+        config=CompostConfig(),
+        now=_NOW,
+    )
+    CompostTracker(now=_NOW).generate_compost_report(vault)
+
+    assert result.composted == []
+    assert _notes_in(vault, _CANONICAL_RELDIR) == []
+    assert not any("untiered-project" in p.name for p in _compost_tree(vault))
+    assert "untiered-project" not in _compost_tree_text(vault)
+
+
+def test_an_explicitly_unclassified_fragment_is_still_admitted(vault: Path) -> None:
+    """The narrowing is scoped to the *missing* key, not to every open note.
+
+    An explicit ``unclassified`` ranks with ``personal`` (#876/#961) and is
+    admitted; only the absent key fails closed. Without this negative branch
+    "withhold everything" would satisfy every other privacy test here.
+    """
+    for idx in (1, 2):
+        _write_fragment(
+            vault,
+            frag_id=f"f-open-{idx}",
+            title=f"Notes from the open project ({idx})",
+            tags=["open-project"],
+            created=_BACK_DATED,
+            privacy_tier=PrivacyTier.UNCLASSIFIED,
+        )
+
+    result = run_compost_scan(
+        vault,
+        similarity_fn=_never_similar,
+        verifier=None,
+        config=CompostConfig(),
+        now=_NOW,
+    )
+
+    assert len(result.composted) == 1
+    assert any("open-project" in p.name for p in _compost_tree(vault))
+
+
+def test_a_fragment_with_an_unrecognised_privacy_tier_never_contributes(
+    vault: Path,
+) -> None:
+    """PIN, not a mutation-tested assertion — this is already green today.
+
+    An unrecognised tier string fails ``Fragment.model_validate``, so
+    ``creek.vault.reader.try_load_fragment`` drops the note before the
+    tracker sees it. That is fail-closed *by accident*: a future
+    ``mode="before"`` coercer on ``Fragment.privacy_tier``, of the kind
+    ``AuthorProfile.default_privacy_tier`` already carries, would make the
+    note load with a defaulted tier and silently admit it. This test is what
+    turns that accident into a contract.
+    """
+    for idx in (1, 2):
+        _write_fragment(
+            vault,
+            frag_id=f"f-bad-{idx}",
+            title=f"Notes from the secret project ({idx})",
+            tags=["secret-project"],
+            created=_BACK_DATED,
+        )
+        path = vault / "01-Fragments" / f"f-bad-{idx}.md"
+        post = frontmatter.load(str(path))
+        post.metadata["privacy_tier"] = "super-secret"
+        path.write_text(frontmatter.dumps(post), encoding="utf-8")
+
+    result = run_compost_scan(
+        vault,
+        similarity_fn=_never_similar,
+        verifier=None,
+        config=CompostConfig(),
+        now=_NOW,
+    )
+    CompostTracker(now=_NOW).generate_compost_report(vault)
+
+    assert result.composted == []
+    assert not any("secret-project" in p.name for p in _compost_tree(vault))
+    assert "secret-project" not in _compost_tree_text(vault)
 
 
 # ---- Idempotency ----


### PR DESCRIPTION
## Summary

`skip_intimate` / `skip_paradox` guarded only one of `CompostTracker`'s three
detection paths, so dormant-thread and disappeared-project compost notes copied
intimate fragments' titles and `[[ids]]` straight into the operator's vault.

**The fix the issue body proposes does not close the leak, and the body's own
acceptance criterion passes under it.** I implemented Tasks 2 and 3 exactly as
written — filter `fragment_ids` and `energy_excerpts` in `_detect_threads` and
`_project_candidate` — on a scratch copy of HEAD and ran the real
`run_compost_scan` over a vault whose only two fragments are
`privacy_tier: intimate` and both tagged `affair-recovery`. Output:

```
FILES WRITTEN: ['2026-04-01-affair-recovery.md', '_Compost-Report.md']
title: affair-recovery
original_project: affair-recovery
reason: Project silent for 700 days
## What it was
A project titled **affair-recovery** that has since composted back into the vault.
## Related Fragments
_No related fragments were recorded._
--- _Compost-Report.md ---
- [[2026-04-01-affair-recovery|affair-recovery]]

body's own AC -- no intimate fragment id or title appears: True
but the intimate-only tag names a file in the vault: True
```

A project candidate's `source_id` and `title` **are the tag**, and that tag
reaches the filename (`compost.py` builds it from `candidate.title`), the
frontmatter, the body, and the rollup report. Filtering the emitted *lists*
cannot suppress an identity that only intimate fragments brought into
existence. That project exists solely because two intimate fragments carry
that tag.

So the guard goes at the boundary instead, once:

- **`_AdmittedFragments`** — a frozen dataclass holding the screened fragment
  tuple plus `withheld_thread_titles: frozenset[str]`. `CompostTracker._screen()`
  runs at the top of `detect_compost_candidates`, and all three detectors are
  retyped to take it, so an unscreened detector is a mypy `arg-type` error
  rather than a privacy leak. The now-redundant per-path guard is deleted.
  Titles rather than `Fragment` objects deliberately: the thread detector is the
  one proven to copy `frag.title`/`frag.id` into a note, and precomputing the
  set once is O(withheld) instead of O(threads x withheld) regex re-parses on a
  35k-fragment vault.
- **Silent omission.** A thread named only by withheld fragments yields no
  candidate. A note reading `_No related fragments were recorded._` announces
  that the thread's only fragments are protected — which is the fact being
  protected. Suppression is conditioned on withheld-ness, never emptiness: a
  thread whose fragments have not been ingested yet must still compost, and
  `test_a_dormant_thread_with_no_fragments_at_all_still_composts` is the fence
  that stops a later "simplification" to `if not related`.
- **Fail-closed tiers.** `_is_intimate` read `fragment.privacy_tier` off the
  *validated model*, so a note whose frontmatter has **no `privacy_tier` key**
  got the model default `unclassified` and was admitted — while
  `raw_privacy_tier({})` and `fragment_tier(f, {})` both return `INTIMATE`, and
  `mining.py` already materialises the raw tier onto liminal fragments so two
  readers cannot disagree about one file. `compost_scan._load_fragments` was
  discarding the raw frontmatter; it now plumbs it through and narrows each
  tier via `raw_privacy_tier`. In the repro an untiered fragment produced a
  whole extra note. The narrowing is scoped to the *missing* key — an explicit
  `unclassified` stays admitted (#876/#961), pinned by its own test.
- **Docstrings.** `detect_compost_candidates` claimed the guard already covered
  all paths; it was false for two of three. Rewritten to state the guarantee
  the code now provides, plus both accepted behaviour changes below. The
  `compost_scan` module claim and `cli.py`'s `Personal`-ceiling derivation were
  re-read: both stay true and get strictly stronger, and say so.

### Two accepted behaviour changes — decided here, not left for review

1. **A project alive only in intimate content now falls silent.** Screening
   changes the silence arithmetic, so such a project gets a note it would not
   have got before (verified: HEAD `[]` → fixed `['2026-04-01-zine.md']`). No
   fragment that was excluded becomes included, and the new note is derived
   entirely from admitted fragments, so it discloses nothing about the
   protected content. "A project alive only in intimate content is silent in
   the non-intimate view" is the right semantics. Named test:
   `test_a_project_alive_only_in_withheld_fragments_becomes_silent`. Operators
   will see new files appear.
2. **The thread `reason` is an accepted residual channel.** `_thread_reason`
   reads `Thread.last_seen` off the thread's own frontmatter, not from
   fragments, so no fragment screen can reach it: a thread whose `last_seen`
   was stamped by an intimate fragment still reports `Dormant for 455 days`.
   Not recomputed, because `02-Threads/<id>.md` is an ordinary vault note any
   reader already sees, and recomputing would break the guarantee that a thread
   with no ingested fragments composts at all. Pinned by
   `test_a_thread_reason_is_thread_derived_not_fragment_derived`. The scope's
   "dates from the admitted set only" criterion is therefore real on the
   project path and satisfied there.

### Remediation gap (not paid here)

Notes already written into an operator's `10-Liminal/Compost/` are **not**
retroactively cleaned, and `load_composted_source_ids` treats their leaked
source IDs as already-composted, so no future scan revisits them — the exposure
is self-perpetuating. `creek lint`'s compost check reads titles back out of
those notes and prints them, so it is fixed transitively for *new* scans only.
Filed as #1403 (`creek compost scan --rewrite`).

### Deliberately not folded in

#1210 (`_is_paradox` reads `tags`, not `emotional_texture`), #1334 (compost
filename collision), #1177. The paradox predicate now lives in one place
(`_is_withheld` → `_is_paradox`), so #1210 stays a one-line change.
**#1334 must not disambiguate the filename by folding in `source_id`** — for a
project candidate that is the tag, i.e. exactly the intimate-derived string
this PR keeps out of the filesystem.

## Test plan

Behavioural, through the real `run_compost_scan`, asserting on **file contents
and filenames on disk** — the filename is a leak surface model-level assertions
miss entirely. 16 new tests; 109 pass across the four compost suites (93
before), **zero skipped**.

`tests/test_compost_scan.py` — leak surface, parametrised over
`("intimate", "paradox")`:

- `test_a_tag_carried_only_by_withheld_fragments_produces_no_compost_note` —
  the criterion the body omits. No note, no filename containing the tag, the
  tag/ids/titles in no file under the `rglob`'d compost subtree (which covers
  the `Review/` queue that `_notes_in`'s `glob` misses), `_Compost-Report.md`
  regenerated inside the test and asserted clean, and
  `load_composted_source_ids` empty.
- `test_a_withheld_fragment_never_reaches_a_thread_compost_note` — both
  fragments marked `EXPLICIT` so both titles are on the `energy_excerpts`
  surface; asserts the open fragment's id **is** still present. Negative
  branch: withholding must subtract, not suppress wholesale.
- `test_a_dormant_thread_whose_only_fragments_are_withheld_writes_no_note` —
  silent omission, including that the disclosure placeholder never appears.
- `test_a_dormant_thread_with_no_fragments_at_all_still_composts` — the fence.
- `test_a_fragment_with_no_privacy_tier_key_is_withheld` /
  `test_an_explicitly_unclassified_fragment_is_still_admitted` — fail-closed,
  and its scope.
- `test_a_fragment_with_an_unrecognised_privacy_tier_never_contributes` —
  a **pin, not a mutation-tested assertion**; green today because pydantic
  rejects the value and `try_load_fragment` drops the note. Its docstring names
  the hazard: a future `mode="before"` coercer on `Fragment.privacy_tier`, of
  the kind `AuthorProfile.default_privacy_tier` already carries, would silently
  admit it.
- `test_the_withheld_kind_matrix_covers_both_skip_policies` — guards the
  parametrize list itself; an emptied list makes privacy tests vanish behind a
  green gate.

`tests/test_compost.py::TestScreenedFragmentBoundary` — structural:

- `test_every_detector_receives_only_admitted_fragments` — recorder subclass;
  all three detectors get the same screened tuple, so a fourth path is guarded
  by construction.
- `test_every_detector_declares_the_screened_fragment_type` — mypy rejects
  *passing* a raw list to a screened detector but cannot object to a new
  detector declared as `list[Fragment]`, which is exactly how this defect was
  introduced. Compares `inspect.signature` annotations **as strings**: bare
  `typing.get_type_hints` raises `NameError: name 'Mapping' is not defined` on
  `_detect_abandonment_fragments` (`from __future__ import annotations` plus a
  `TYPE_CHECKING`-only import) — the one method it most needs to police.
- `test_screening_equals_removing_the_withheld_fragments_up_front` — forbidden
  direction. Screened-mixed and unguarded-admitted-only corpora produce
  identical candidates field for field; because the withheld fragment is the
  *most recent* of its tag group, equality of `reason` also pins that counts
  and dates come from the admitted set only.

**Mutation results** — each source hunk reverted in turn on a scratch copy
(never `git stash`; it is shared across worktrees):

| mutation | tests that go red |
|---|---|
| `_screen` admits everything | 16, incl. both pre-existing intimate/paradox tests |
| silent-omission branch removed | 2 (only the omission tests) |
| fail-closed tier read removed | 1 (only the untiered test) |
| suppression keyed on emptiness not withheld-ness | 4, incl. two pre-existing thread tests |
| a detector re-declared with a widened type | 1 (the reflection fence) |
| **the issue body's own Tasks 2/3 fix, on HEAD** | **the headline test still fails** |

That last row is the point: the body's fix is green against the body's AC and
red against this one.

**Gate 2** — `./scripts/check-all.sh` **exit 0**, 12/12 checks. 9212 passed / 5
skipped (all five pre-existing and environment-gated: Ollama unreachable, no
live API keys). `ruff check --no-cache` and `ruff format --no-cache --check`
clean, mypy strict clean, xenon clean, bandit/pip-audit clean. Coverage 94.48%
aggregate; `compost.py` 97.83%, `compost_scan.py` 86.05%; per-file gate holds.
`_detect_threads` went rank C under the added branch, so the per-thread
decision was extracted into `_thread_candidate`, mirroring the existing
`_project_candidate` shape.

No `# noqa`, `# type: ignore`, `pytest.mark.skip`, `--no-verify`, threshold
edits, or deleted tests anywhere in the diff, tests included.

Closes #1311
