### PR TITLE
fix(generate): create 00-Creek-Meta/ on demand for the Tag Garden

### DIFF
--- a/creek-tools/creek/generate/tags.py
+++ b/creek-tools/creek/generate/tags.py
@@ -338,6 +338,15 @@ class TagGardenGenerator:
         and suggestion generation, then writes the output to
         ``00-Creek-Meta/Tag-Garden.md`` and persists history.
 
+        ``00-Creek-Meta/`` is created on demand (#1318). This was the one
+        report write site that assumed its folder already existed, so on a
+        vault that had never been scaffolded ``creek report --type tags``
+        died with a raw ``FileNotFoundError`` while every sibling generator
+        succeeded — the #1231 convention, "every write target is created on
+        demand", had never been applied here. The folder name is a literal,
+        not operator input, so nothing beyond one known subdirectory of the
+        already-resolved vault is ever conjured.
+
         Returns:
             Path to the generated Tag-Garden.md file.
         """
@@ -359,6 +368,7 @@ class TagGardenGenerator:
         }
 
         output_path = self.vault_path / "00-Creek-Meta" / "Tag-Garden.md"
+        output_path.parent.mkdir(parents=True, exist_ok=True)
         output_path.write_text(_build_note(front, body), encoding="utf-8")
 
         self._save_history(scan)

--- a/creek-tools/tests/test_tag_garden.py
+++ b/creek-tools/tests/test_tag_garden.py
@@ -50,6 +50,23 @@ def generator(vault: Path) -> TagGardenGenerator:
     return TagGardenGenerator(vault)
 
 
+@pytest.fixture()
+def bare_vault(tmp_path: Path) -> Path:
+    """Create a vault holding ``01-Fragments/`` and nothing else.
+
+    This fixture deliberately omits ``00-Creek-Meta/`` — and with it
+    ``00-Creek-Meta/Processing-Log/``. That omission is the whole point: the
+    ``vault`` fixture above pre-creates both, so it cannot express the state a
+    real vault is in before anything has scaffolded the meta folder, which is
+    exactly the state in which ``generate_garden`` used to die on a missing
+    parent directory (issue #1318). ``01-Fragments/`` is present because
+    ``_write_fragment`` writes into it, and because a vault with no content at
+    all would make the assertions about the seeded tag vacuous.
+    """
+    (tmp_path / "01-Fragments").mkdir()
+    return tmp_path
+
+
 def _write_fragment(vault: Path, name: str, tags: list[str]) -> Path:
     """Write a mock fragment markdown file with frontmatter tags.
 
@@ -683,3 +700,139 @@ class TestTagGardenIsReachableOnceFragmentsCarryTags:
         assert "writing" in content
         assert "| Tag A | Tag B | Co-occurrences |" in content
         assert "| recovery | 2 | 4 | +100% |" in content
+
+
+# ---- The garden scaffolds its own parent directory (#1318) ----
+
+
+class TestGenerateGardenOnAnUnscaffoldedVault:
+    """``generate_garden`` must create ``00-Creek-Meta/`` instead of crashing.
+
+    Every sibling report generator makes its output directory on demand (the
+    #1231 convention); this one wrote straight to
+    ``00-Creek-Meta/Tag-Garden.md``, so on a vault where that folder does not
+    exist the very first write raised ``FileNotFoundError`` and nothing after
+    it ran — history persistence included, even though ``_save_history`` does
+    create its own parent, because it never got the chance.
+
+    These tests use ``bare_vault`` rather than the module's ``vault`` fixture:
+    ``vault`` pre-creates ``00-Creek-Meta`` and its ``Processing-Log``, so it
+    cannot express the defect at all.
+    """
+
+    def test_writes_the_garden_when_00_creek_meta_is_absent(
+        self,
+        bare_vault: Path,
+    ) -> None:
+        """The garden is written even though its parent folder is missing.
+
+        The absence of ``00-Creek-Meta`` is asserted *before* the call, so the
+        test proves it exercised the intended precondition and cannot quietly
+        rot into a duplicate of the happy-path cases above if a future fixture
+        change starts scaffolding the folder. Before the fix, the call raises
+        ``FileNotFoundError`` from ``write_text``.
+        """
+        _write_fragment(bare_vault, "note1", ["recovery"])
+        assert not (bare_vault / "00-Creek-Meta").exists()
+
+        path = TagGardenGenerator(bare_vault).generate_garden()
+
+        assert path == bare_vault / "00-Creek-Meta" / "Tag-Garden.md"
+        assert path.exists()
+        content = path.read_text(encoding="utf-8")
+        assert "recovery" in content
+        assert "type: tag-garden" in content
+
+    def test_history_is_persisted_when_00_creek_meta_is_absent(
+        self,
+        bare_vault: Path,
+    ) -> None:
+        """The scan history is saved too, so the whole call completed.
+
+        ``_save_history`` runs *after* the line that used to crash, which makes
+        this the assertion that distinguishes "the first write was repaired"
+        from "the method now runs end to end". The counts are compared by value
+        rather than checked for mere presence, so a history file written with
+        an empty or placeholder entry cannot pass.
+        """
+        _write_fragment(bare_vault, "note1", ["recovery"])
+
+        TagGardenGenerator(bare_vault).generate_garden()
+
+        history_path = (
+            bare_vault / "00-Creek-Meta" / "Processing-Log" / "tag-history.json"
+        )
+        assert history_path.exists()
+        history = json.loads(history_path.read_text(encoding="utf-8"))
+        assert len(history) == 1
+        assert history[0]["tag_counts"] == {"recovery": 1}
+
+    def test_an_existing_creek_meta_folder_and_its_contents_survive(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Creating the folder is idempotent and clobbers nothing already there.
+
+        Built from ``tmp_path`` rather than ``bare_vault`` because this case
+        needs the opposite precondition: ``00-Creek-Meta`` already exists and
+        already holds an unrelated file. A guard that forgets ``exist_ok`` —
+        or that removes and recreates the directory — still passes every test
+        above but fails here, on ``FileExistsError`` or on the sentinel's
+        exact bytes. The generator is run twice for the same reason: the
+        second pass exercises the path where the folder exists because *this*
+        code made it, not because the vault was scaffolded.
+        """
+        (tmp_path / "01-Fragments").mkdir()
+        (tmp_path / "00-Creek-Meta").mkdir()
+        sentinel = tmp_path / "00-Creek-Meta" / "creek_config.yaml"
+        sentinel_bytes = b"vault_path: /somewhere\n"
+        sentinel.write_bytes(sentinel_bytes)
+        _write_fragment(tmp_path, "note1", ["recovery"])
+
+        generator = TagGardenGenerator(tmp_path)
+        generator.generate_garden()
+        path = generator.generate_garden()
+
+        assert sentinel.read_bytes() == sentinel_bytes
+        assert path.exists()
+        assert path.parent == tmp_path / "00-Creek-Meta"
+
+    def test_the_only_directory_created_is_under_the_vault_root(
+        self,
+        bare_vault: Path,
+    ) -> None:
+        """Scaffolding stays inside the vault, and covers only what is written.
+
+        "Nothing was created outside the vault" cannot be asserted against the
+        whole filesystem without a brittle walk, so it is expressed two ways
+        that are both cheap and deterministic: the output path is relative to
+        the vault root and the new ``00-Creek-Meta`` is a *direct child* of it
+        rather than a sibling or an absolute path elsewhere; and the vault's
+        own parent directory gains no entry, which is the blast radius a
+        ``mkdir(parents=True)`` against a mistyped root would show up in.
+
+        The directory inventory inside the vault is then pinned exactly. A
+        report generator may create the folder it writes into, plus
+        ``Processing-Log`` for its history — it is not a vault scaffolder, and
+        must not materialise the other top-level folders on the way past.
+        """
+        _write_fragment(bare_vault, "note1", ["recovery"])
+        siblings_before = set(bare_vault.parent.iterdir())
+
+        path = TagGardenGenerator(bare_vault).generate_garden()
+
+        meta_dir = bare_vault / "00-Creek-Meta"
+        assert meta_dir.is_dir()
+        assert meta_dir.parent == bare_vault
+        assert path.is_relative_to(bare_vault)
+        assert set(bare_vault.parent.iterdir()) == siblings_before
+        created = {
+            child.relative_to(bare_vault).as_posix()
+            for child in bare_vault.rglob("*")
+            if child.is_dir()
+        }
+        assert created == {
+            "01-Fragments",
+            "00-Creek-Meta",
+            "00-Creek-Meta/Processing-Log",
+        }


### PR DESCRIPTION
## Summary

`TagGardenGenerator.generate_garden` wrote `<vault>/00-Creek-Meta/Tag-Garden.md` without creating its parent directory, so on a vault that had never been scaffolded both `creek report --type tags` and the MCP `creek.report` tool (`creek_mcp/tools/report.py:175`) died with a raw `FileNotFoundError` traceback. This adds the one missing `mkdir`.

**Reproduced before fixing.** Vault containing only `01-Fragments/` with one tagged fragment:

```
TagGardenGenerator(vault_path=v).generate_garden()
  File "creek/generate/tags.py", line 362, in generate_garden
    output_path.write_text(_build_note(front, body), encoding="utf-8")
FileNotFoundError: [Errno 2] No such file or directory: '.../00-Creek-Meta/Tag-Garden.md'

IndexGenerator(vault_path=v).generate_temporal_index()
  -> OK; created 00-Creek-Meta/ on demand
```

The sibling writing into *the same folder* succeeds, which is the whole shape of the bug.

**The census was re-derived at HEAD rather than taken from the issue.** All 32 `.write_text(` sites in `creek/generate/*.py` were enumerated and each checked for a guard. Exactly one is unguarded: `tags.py:362`. Four sites look unguarded on a naive scan and are not — `indexes.py:559` is guarded by `_ensure_frequency_subdir` at `:756`, `voice.py:1004`/`:1061` by `register_dir.mkdir` at `:888`, `wavelength.py:1493` at `:1461` — and the rest (`decisions.py:266`/`:676`, `drafts.py:2266`/`:2327`, `state.py:1708`) rewrite files that already exist. An empirical sweep running all eleven `REPORT_TYPES` against bare vaults confirms `tags` is the only one that crashes. So this is a genuine single-site oversight, not a fix that closes one of several.

The issue's own line numbers were ~15-20 lines stale (it cites `:361-362`; the write is at `:362` at this HEAD and ends up at `:372` after the docstring change, with the new guard on `:371`), and its "16 of 17" enumeration lists 17 `mkdir` lines rather than 17 write sites. The count is directionally right and the conclusion holds.

### Two design calls, made deliberately

**The guard goes at the call site, not in a shared write helper.** This looks like a case for pushing the guard down to a primitive so an eighteenth site inherits it, and the repo has such a primitive — but `creek/_fsio.py:166-170` already records the opposite decision in writing, for `atomic_write_text` (#1312):

> Deliberately does not `mkdir`: … the parent directory must already exist. … conjuring a directory tree here would silently absorb a caller's wrong path.

`creek/generate/*` does not route through that helper at all, and ten sibling modules inline this exact two-line idiom. A private helper inside `tags.py` alone would remove the asymmetry within one module by creating a new one against its ten siblings. The durable guard against a future eighteenth site is the behavioural test below, not an abstraction nothing forces callers through.

**No vault-shape validation is added here.** `mkdir(parents=True)` on a mistyped `--vault` will happily build a tree, and nothing upstream checks: `_resolve_vault` (`creek/cli.py:5922`) returns the path unchanged. Adding a refusal to *this* generator alone would replace one sibling inconsistency with its mirror image — an operator whose `report --type wavelength` succeeded on a path would then be refused by `--type tags` on the same path. The folder name is a hard-coded literal, not operator input, so the blast radius of any one generator is one known subdirectory of an already-resolved root; the risk lives in which root got resolved. Filed as #1414 (P3) against `_resolve_vault`, where one check serves all ~30 commands.

## Test plan

`tests/test_tag_garden.py` gains a `bare_vault` fixture (only `01-Fragments/` — the existing `vault` fixture pre-creates `00-Creek-Meta/` *and* `Processing-Log/`, which is precisely why twenty-odd `generate_garden` tests passed over a live bug) and `TestGenerateGardenOnAnUnscaffoldedVault`:

- `test_writes_the_garden_when_00_creek_meta_is_absent` — asserts the folder's absence *before* the call so the test cannot rot into a duplicate of the happy path, then asserts the note is written.
- `test_history_is_persisted_when_00_creek_meta_is_absent` — `_save_history` runs *after* the crash site and creates its own parent, so it never got the chance. This pins the whole method completing, not just the patched line.
- `test_an_existing_creek_meta_folder_and_its_contents_survive` — runs the generator twice against a pre-existing `00-Creek-Meta/` holding a sentinel file, asserting exact bytes. Forbids a guard that omits `exist_ok` or that recreates the directory.
- `test_the_only_directory_created_is_under_the_vault_root` — pins the blast radius: the vault's parent gains no entry, and the vault's directory inventory is exactly `01-Fragments`, `00-Creek-Meta`, `00-Creek-Meta/Processing-Log`. A "fix" that called a full vault-scaffolder would fail this.

**Mutation-tested, both directions.**

- Reverting the `mkdir` line alone: exactly the 3 new bare-vault tests go red with the real `FileNotFoundError` from `pathlib.write_text`; the other 268 tests in `test_tag_garden.py` + `test_cli.py` + `test_mcp_report_tier_ceiling.py` stay green.
- Dropping `exist_ok=True`: 16 tests go red on `FileExistsError`, including the dedicated no-clobber test.

**Gate 2:** `./scripts/check-all.sh` exit code `0` — 12/12 checks, 9265 passed, 5 skipped, 94.56% coverage (ruff runs `--no-cache`).

**Anti-bypass sweep** over the full diff including tests: no `noqa`, `type: ignore`, `pylint: disable`, `mark.skip`, `xfail`, or `--no-verify`; no threshold touched in `pyproject.toml` or `scripts/`; no test or code deleted (`git diff --numstat` = `+10/-0` and `+153/-0`).

### Process note

The `chief-architect` pass was independent and is what settled the call-site-versus-helper question. Two agents ended up writing `tests/test_tag_garden.py` concurrently after the first appeared to hang; the collision was caught, the duplicate class removed, and the surviving block is a merge of both. Verified afterwards that zero pre-existing lines were deleted or reworded and that all 37 original tests are still present and passing.

Closes #1318
