### PR TITLE
fix(generate): key paradox notes on the fragment pair, not the calendar day (#1320)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -455,29 +455,38 @@ def _parse_since_arg(text: str) -> datetime:
     return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
 
 
-def _print_ingest_warning(message: str) -> None:
-    """Show one ingest advisory to the operator, as it is detected (#1329).
+def _print_advisory(message: str) -> None:
+    """Show one operator advisory on the console, as it is detected (#1329).
 
-    Warnings go to the same stdout console as every other ``creek ingest``
-    advisory (``_warn_if_discovered_but_empty``, ``_print_pin_findings``)
-    rather than to stderr: this command's output is human prose, not data on a
-    pipe, and an advisory routed to a stream none of its neighbours use is one
-    an operator can lose.
+    Advisories go to the same stdout console as every other advisory the
+    surrounding command prints, rather than to stderr: these commands' output
+    is human prose, not data on a pipe, and an advisory routed to a stream
+    none of its neighbours use is one an operator can lose.
 
-    The exit code is deliberately left alone. A warning reports vault state
+    The exit code is deliberately left alone. An advisory reports vault state
     that will cause trouble later, not a failure of this run — and
-    ``creek sync`` shares this path, so escalating would turn every scheduled
-    pass over an un-migrated vault into a hard failure.
+    ``creek sync`` shares the ingest path, so escalating would turn every
+    scheduled pass over an un-migrated vault into a hard failure.
 
     ``escape`` and ``soft_wrap=True`` are load-bearing for the same reasons as
-    in :func:`_print_pin_findings`: the text carries a shell command the
-    operator is meant to copy, and rich would otherwise be free to wrap it
-    across lines (or read a bracketed path as markup).
+    in :func:`_print_pin_findings`: the text carries paths and commands the
+    operator is meant to read or copy, and rich would otherwise be free to
+    wrap them across lines (or read a bracketed path as markup — a paradox
+    advisory names ``[[wikilink]]`` literally).
+
+    Args:
+        message: The advisory text from the pipeline that detected it.
+    """
+    console.print(f"[yellow]{escape(message)}[/yellow]", soft_wrap=True)
+
+
+def _print_ingest_warning(message: str) -> None:
+    """Show one ingest advisory to the operator, as it is detected (#1329).
 
     Args:
         message: The advisory text from the ingest pipeline.
     """
-    console.print(f"[yellow]{escape(message)}[/yellow]", soft_wrap=True)
+    _print_advisory(message)
 
 
 def _run_ingest(
@@ -3882,7 +3891,13 @@ def _report_paradox(vault_path: Path, override: PrivacyTierOverride) -> None:
 
     Wires the implemented ``ParadoxDetector`` to a runnable command: scans the
     vault for contradictory pairs and writes one neutral note per paradox into
-    ``10-Liminal/Paradoxes/``. Idempotent; deterministic (no LLM).
+    ``10-Liminal/Paradoxes/``. Deterministic (no LLM), and idempotent because
+    the generator skips pairs an existing note already records (#1320) — so a
+    re-run on a later day writes nothing rather than a second copy.
+
+    Any pre-#1320 duplicate copies already in the vault are reported through
+    ``on_warning`` as they are detected, before the empty/success line, and are
+    never deleted.
 
     Args:
         vault_path: Vault root.
@@ -3898,11 +3913,20 @@ def _report_paradox(vault_path: Path, override: PrivacyTierOverride) -> None:
     from creek.generate.paradox import generate_paradoxes
 
     config = _load_config_for_vault(vault_path)
-    written = generate_paradoxes(vault_path, config.embeddings)
+    written = generate_paradoxes(
+        vault_path,
+        config.embeddings,
+        on_warning=_print_advisory,
+    )
     if not written:
+        # Deliberately covers both empty cases: no contradictory pair exists,
+        # and every pair that exists is already recorded. `generate_paradoxes`
+        # returns `[]` for both and the difference does not change what the
+        # operator should do — the notes they want are in the folder either way.
         console.print(
-            "[yellow]No paradox notes generated: "
-            "no contradictory fragment pairs found.[/yellow]",
+            "[yellow]No paradox notes generated: no contradictory fragment "
+            "pairs beyond those already recorded in "
+            "10-Liminal/Paradoxes/.[/yellow]",
         )
         return
     console.print(

--- a/creek-tools/creek/generate/paradox.py
+++ b/creek-tools/creek/generate/paradox.py
@@ -25,6 +25,7 @@ deliberately neutral: no resolution, prescription, or judgment.
 from __future__ import annotations
 
 import itertools
+import logging
 import math
 import re
 from dataclasses import dataclass, field
@@ -32,16 +33,19 @@ from datetime import date
 from typing import TYPE_CHECKING
 
 import frontmatter
+import yaml
 
 from creek.link.neighbours import cosine_neighbours
 from creek.models import Confidence, Dosage, Frequency, Phase
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Callable, Iterable
     from pathlib import Path
 
     from creek.config import EmbeddingsConfig
     from creek.models import Fragment
+
+logger = logging.getLogger(__name__)
 
 
 CONTRADICTION_KEYWORDS: tuple[str, ...] = (
@@ -131,6 +135,47 @@ _CONTRADICTION_DESCRIPTIONS: dict[str, str] = {
 
 
 _FILENAME_SANITIZER = re.compile(r"[^\w\-]+")
+
+
+_PARADOX_SUBPATH: tuple[str, str] = ("10-Liminal", "Paradoxes")
+"""Vault-relative folder paradox notes are written to and read back from."""
+
+
+_PAIR_SIZE: int = 2
+"""Fragments per paradox — the arity both the filename and the pair key use."""
+
+
+_WIKILINK_BRACKETS = re.compile(r"[\[\]]")
+"""Strips ``[[…]]`` from a frontmatter fragment reference.
+
+:meth:`ParadoxDetector.create_paradox_note` writes bare ids, but the sibling
+Synchronicity notes write wikilinks and an operator may normalise a paradox
+note by hand. Stripping costs nothing and makes the pair key tolerant of both,
+exactly as ``synchronicity._existing_synchronicity_pairs`` is.
+"""
+
+
+_DUPLICATE_SAMPLE: int = 3
+"""How many redundant note paths the pre-#1320 advisory names before stopping."""
+
+
+_DUPLICATE_WARNING_TEMPLATE: str = (
+    "This vault holds {count} paradox notes recording only {pairs} distinct "
+    "fragment pair(s). Before #1320 the note filename embedded the detection "
+    "date, so every re-run on a new calendar day wrote a fresh copy of an "
+    "unchanged paradox. This run wrote no further copy. The redundant notes "
+    "are left exactly where they are: {sample}. Nothing is deleted "
+    "automatically — open them in your vault and keep whichever one carries "
+    "the reflection you wrote. Any [[wikilink]] pointing at one of them keeps "
+    "resolving until you act."
+)
+"""Advisory for a vault still holding pre-#1320 per-calendar-day copies.
+
+Names paths and nothing else. A paradox note's excerpts are fragment prose and
+its tags can be intimate-derived, so neither belongs in a console line (#1404);
+the filename is already on disk and already surfaced by the state report's
+Liminal Watch, so naming it discloses nothing new.
+"""
 
 
 def _cosine_similarity(a: list[float], b: list[float]) -> float:
@@ -250,7 +295,10 @@ class Paradox:
         excerpts: Short excerpts (one per fragment, matching
             :attr:`fragment_ids` order).
         detected_date: The date the paradox was recorded. Defaults to
-            today.
+            today, and :meth:`ParadoxDetector._build_paradox` leaves it at
+            that default, so it advances on every run. It is a record, not
+            an identity: the pair in :attr:`fragment_ids` is what
+            :func:`generate_paradoxes` keys on (#1320).
         similarity: Optional cosine similarity score between the
             fragments when embeddings are available. Stored for
             diagnostics; never surfaced to the human.
@@ -573,9 +621,16 @@ class ParadoxDetector:
         * states the detected tension in neutral, descriptive language;
         * includes the :data:`REFLECTION_PROMPT`.
 
-        The note is idempotent with respect to the paradox: writing the
-        same :class:`Paradox` twice produces the same file path and
-        overwrites the content without creating duplicates.
+        **This method clobbers.** The path it writes to embeds
+        ``paradox.detected_date``, so it is stable for one
+        :class:`Paradox` value — pass the same object twice and the second
+        call overwrites the first note in place. It is *not* stable for one
+        paradox across runs, because :attr:`Paradox.detected_date` defaults
+        to the day the object was built. Idempotency across runs is not this
+        method's job and never was: it belongs to
+        :func:`generate_paradoxes`, which reads the folder back and does not
+        call this method for a pair already recorded (#1320). Callers that
+        write notes themselves inherit the clobber.
 
         Args:
             paradox: The paradox to record.
@@ -584,7 +639,7 @@ class ParadoxDetector:
         Returns:
             The path to the written markdown note.
         """
-        target_dir = vault_path / "10-Liminal" / "Paradoxes"
+        target_dir = vault_path.joinpath(*_PARADOX_SUBPATH)
         target_dir.mkdir(parents=True, exist_ok=True)
 
         tags = ["paradox"]
@@ -797,33 +852,180 @@ class ParadoxDetector:
 
     @staticmethod
     def _filename(paradox: Paradox) -> str:
-        """Build a stable filename for a paradox note."""
+        """Build the filename for a paradox note.
+
+        Deterministic per :class:`Paradox` *value*, not per paradox: the
+        ``detected_date`` prefix means the same contradiction detected on two
+        days yields two names. That prefix is deliberately kept — it is the
+        operator-facing label the state report's Liminal Watch renders
+        verbatim (``creek/generate/state.py``), and paradox notes carry no
+        ``title:`` or ``aliases:``, so the stem is the only handle a
+        hand-written ``[[wikilink]]`` can use. :func:`generate_paradoxes`
+        supplies the cross-run identity instead (#1320).
+        """
         iso = paradox.detected_date.isoformat()
-        stem = "-".join(paradox.fragment_ids[:2]) or "paradox"
+        stem = "-".join(paradox.fragment_ids[:_PAIR_SIZE]) or "paradox"
         sanitized = _FILENAME_SANITIZER.sub("-", stem).strip("-")
         return f"{iso}-{sanitized}.md"
+
+
+def _recorded_pair(note: Path) -> frozenset[str] | None:
+    """Return the fragment pair a paradox note records, or ``None``.
+
+    ``None`` covers three cases that must all be non-fatal, because
+    ``10-Liminal/Paradoxes/`` is an operator-editable folder with a second
+    producer: the file is unreadable, its YAML is malformed, or it carries no
+    two-element ``fragments:`` list. That last case is the common one — a
+    ``creek save --target paradox`` note records its provenance under
+    ``saved_from.contributing_fragments``, so it must never be mistaken for a
+    detector-recorded pair and suppress a real paradox.
+
+    Args:
+        note: Path to a candidate markdown note.
+
+    Returns:
+        The recorded fragment pair, or ``None`` when the note records none.
+    """
+    try:
+        post = frontmatter.loads(note.read_text(encoding="utf-8"))
+    except (OSError, ValueError, yaml.YAMLError):
+        return None
+    raw = post.get("fragments")
+    if not isinstance(raw, list) or len(raw) < _PAIR_SIZE:
+        return None
+    return frozenset(
+        _WIKILINK_BRACKETS.sub("", str(item)).strip() for item in raw[:_PAIR_SIZE]
+    )
+
+
+def _paradox_notes_by_pair(vault_path: Path) -> dict[frozenset[str], list[Path]]:
+    """Map every already-recorded fragment pair to the notes recording it.
+
+    One pass over ``10-Liminal/Paradoxes/``, serving both jobs that need it:
+    the idempotency key for this run, and the census of pre-#1320 duplicates.
+    The pair — not the filename — is the identity, which is what makes the
+    scan see a note written on any earlier date.
+
+    Args:
+        vault_path: Root of the Obsidian vault.
+
+    Returns:
+        Recorded pair to the notes recording it, in sorted filename order.
+        Empty when the folder does not exist.
+    """
+    by_pair: dict[frozenset[str], list[Path]] = {}
+    folder = vault_path.joinpath(*_PARADOX_SUBPATH)
+    if not folder.is_dir():
+        return by_pair
+    for note in sorted(folder.glob("*.md")):
+        pair = _recorded_pair(note)
+        if pair is not None:
+            by_pair.setdefault(pair, []).append(note)
+    return by_pair
+
+
+def _advisory_for(
+    vault_path: Path,
+    by_pair: dict[frozenset[str], list[Path]],
+) -> str | None:
+    """Render the pre-#1320 duplicate advisory from an already-read census.
+
+    Args:
+        vault_path: Root of the Obsidian vault, used to relativise paths.
+        by_pair: Output of :func:`_paradox_notes_by_pair`.
+
+    Returns:
+        The advisory text, or ``None`` when no pair is recorded twice.
+    """
+    duplicated = {pair: notes for pair, notes in by_pair.items() if len(notes) > 1}
+    if not duplicated:
+        return None
+    notes = sorted(itertools.chain.from_iterable(duplicated.values()))
+    sample = ", ".join(
+        str(note.relative_to(vault_path)) for note in notes[:_DUPLICATE_SAMPLE]
+    )
+    if len(notes) > _DUPLICATE_SAMPLE:
+        sample = f"{sample}, …"
+    return _DUPLICATE_WARNING_TEMPLATE.format(
+        count=len(notes),
+        pairs=len(duplicated),
+        sample=sample,
+    )
+
+
+def duplicate_paradox_warning(vault_path: Path) -> str | None:
+    """Return the pre-#1320 duplicate-note advisory, or ``None`` (#1320).
+
+    Before #1320 a paradox note's identity lived only in its date-stamped
+    filename, so every run on a new calendar day wrote another copy of an
+    unchanged paradox. Fixing the generator stops the growth; it cannot undo
+    what is already on disk, and an operator who ran weekly for a year has ~52
+    copies of every paradox — one of which may carry the reflection they wrote
+    under :data:`REFLECTION_PROMPT`.
+
+    **Detected, reported, and left alone**, the answer #1304, #1305 and #1329
+    each gave the same shape of problem. Which copy to keep is a judgement
+    about the operator's own writing, and a generator does not get to make it
+    on a heuristic. The advisory is self-clearing: once the strays are gone,
+    the scan finds one note per pair and the run goes quiet. It is silent on a
+    fresh vault and on a vault that has only ever been generated once.
+
+    This is the read-only entry point — ask a vault whether it is affected
+    without writing to it. :func:`generate_paradoxes` renders the same advisory
+    from the folder scan it has already done, rather than calling this and
+    reading the folder a second time; both go through one formatter, so the
+    two can not drift.
+
+    Args:
+        vault_path: Root of the Obsidian vault.
+
+    Returns:
+        The advisory text, or ``None`` when every pair is recorded once.
+    """
+    return _advisory_for(vault_path, _paradox_notes_by_pair(vault_path))
 
 
 def generate_paradoxes(
     vault_path: Path,
     embeddings_config: EmbeddingsConfig,
+    *,
+    on_warning: Callable[[str], None] | None = None,
 ) -> list[Path]:
     """Detect contradictory fragment pairs and write paradox notes (#711).
 
     The runnable wiring for ``creek report --type paradox``: loads the vault's
     fragments and their cached embeddings, runs :class:`ParadoxDetector`, and
-    writes one note per paradox into ``10-Liminal/Paradoxes/``. Idempotent — each
-    note's path is stable per paradox, so re-running overwrites in place rather
-    than duplicating. Embeddings sharpen the topic-sharing rules; when the cache
-    is empty only the thread/frequency rules can match (still useful, no crash).
+    writes one note per paradox into ``10-Liminal/Paradoxes/``. Embeddings
+    sharpen the topic-sharing rules; when the cache is empty only the
+    thread/frequency rules can match (still useful, no crash).
+
+    **Idempotent**: a fragment pair already captured by an existing note is
+    skipped, so re-running never duplicates and never rewrites — necessary
+    because the note's filename embeds the detection date, which advances on
+    its own, so the filename alone is not stable across runs (#1320). The key
+    is the note's ``fragments:`` frontmatter, read back from the folder, which
+    is how a note written on any earlier day is still recognised. Skipping
+    rather than overwriting is also what preserves a reflection the operator
+    wrote into an existing note. This mirrors
+    :func:`~creek.generate.synchronicity.generate_synchronicities` and
+    :func:`~creek.generate.decisions.generate_decisions`, which key their own
+    read-back scans on the pair set and the source fragment id respectively.
 
     Args:
         vault_path: Root of the Obsidian vault.
         embeddings_config: Embeddings config (model + cache) used to load the
             per-vault vector cache for the topic-similarity rules.
+        on_warning: Called with each operator advisory at the moment it is
+            detected — today only :func:`duplicate_paradox_warning`'s. Optional
+            so callers that predate the channel (the MCP report tool) are
+            unchanged; the advisory still reaches the log either way.
 
     Returns:
-        Paths of the paradox notes written this run (empty when none are found).
+        Paths of the paradox notes written this run. Empty when no
+        contradictory pair was found *or* when every pair found is already
+        recorded — the caller cannot tell those apart from the return value
+        alone, which is why ``creek report`` phrases its empty-result line to
+        cover both.
     """
     from creek.link.embeddings import EmbeddingLinker, embeddings_cache_path
     from creek.vault.reader import iter_vault_fragments
@@ -839,7 +1041,35 @@ def generate_paradoxes(
     )
     embeddings = {fid: cached.vector for fid, cached in cache.items()}
     detector = ParadoxDetector()
-    return [
-        detector.create_paradox_note(paradox, vault_path)
-        for paradox in detector.detect_paradoxes(fragments, embeddings=embeddings)
-    ]
+    already = _paradox_notes_by_pair(vault_path)
+    _warn(_advisory_for(vault_path, already), on_warning)
+    written: list[Path] = []
+    for paradox in detector.detect_paradoxes(fragments, embeddings=embeddings):
+        pair = frozenset(paradox.fragment_ids[:_PAIR_SIZE])
+        if pair in already:
+            continue
+        note = detector.create_paradox_note(paradox, vault_path)
+        written.append(note)
+        # Recording it here also stops a pair the detector emits twice in one
+        # run from being written twice, exactly as the sibling loops do.
+        already[pair] = [note]
+    return written
+
+
+def _warn(advisory: str | None, on_warning: Callable[[str], None] | None) -> None:
+    """Log an advisory and hand it to the caller in the same breath.
+
+    The single way an advisory leaves this module. Logging without notifying
+    *on_warning* is how it becomes invisible to an operator at a terminal, so
+    the two are not separable here — the funnel is lifted verbatim from
+    ``creek.ingest.pipeline.run_ingest``'s (#1329).
+
+    Args:
+        advisory: The advisory text, or ``None`` for nothing to report.
+        on_warning: Optional consumer, typically the CLI's console printer.
+    """
+    if advisory is None:
+        return
+    logger.warning("%s", advisory)
+    if on_warning is not None:
+        on_warning(advisory)

--- a/creek-tools/docs/emergence.md
+++ b/creek-tools/docs/emergence.md
@@ -46,6 +46,8 @@ Four detection rules; a fragment pair matching any one becomes a paradox:
 
 Output: a note in `10-Liminal/Paradoxes/` linking both fragments, a neutral description of the tension, and the `#paradox` tag plus relevant frequency tags. CLI: `creek report --type paradox`.
 
+Re-running is idempotent (#1320) — a fragment pair already captured by an existing note is skipped, never rewritten, so a note you have annotated survives every later run. The key is the note's `fragments:` frontmatter, not its filename: the filename embeds the detection date, so before #1320 a weekly run left one copy of every paradox per calendar day. Vaults that already hold those copies are told so, by count and by path, on the next run — and nothing is deleted for you, because which copy carries your reflection is not a judgement the generator gets to make.
+
 ---
 
 ## §10.3 — Synchronicity Detection

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -1573,6 +1573,85 @@ def test_report_paradox_writes_notes(tmp_path: Path) -> None:
     assert sorted((vault / "10-Liminal" / "Paradoxes").glob("*.md"))
 
 
+def _seed_paradox_pair(vault: Path) -> None:
+    """Write two fragments whose opposite confidence on one thread is a paradox."""
+    from creek.models import (
+        Confidence,
+        Fragment,
+        FragmentSource,
+        SourcePlatform,
+        VoiceClassification,
+    )
+    from tests.helpers import write_fragment_file
+
+    for fid, conf in (
+        ("frag-cli-dupe-aa", Confidence.MUSING),
+        ("frag-cli-dupe-bb", Confidence.SETTLED),
+    ):
+        write_fragment_file(
+            vault=vault,
+            fragment=Fragment(
+                id=fid,
+                title="career ambitions",
+                source=FragmentSource(platform=SourcePlatform.JOURNAL),
+                voice=VoiceClassification(confidence=conf),
+                threads=["thread-career"],
+            ),
+            body="a contradiction worth holding",
+        )
+
+
+def test_report_paradox_rerun_writes_no_second_copy(tmp_path: Path) -> None:
+    """A second `report --type paradox` run records nothing new (#1320).
+
+    The CLI-level pin on the fix: the empty-result line must not claim no
+    contradictory pair was found when one was found and already recorded.
+    """
+    vault = _report_vault(tmp_path)
+    _seed_paradox_pair(vault)
+    runner.invoke(app, ["report", "--type", "paradox", "--vault", str(vault)])
+
+    result = runner.invoke(app, ["report", "--type", "paradox", "--vault", str(vault)])
+
+    assert result.exit_code == 0, result.output
+    assert "already recorded" in result.output
+    assert len(list((vault / "10-Liminal" / "Paradoxes").glob("*.md"))) == 1
+
+
+def test_report_paradox_reports_pre_existing_duplicates(tmp_path: Path) -> None:
+    """Pre-#1320 duplicate copies are named on the console and left on disk."""
+    import frontmatter
+
+    vault = _report_vault(tmp_path)
+    _seed_paradox_pair(vault)
+    runner.invoke(app, ["report", "--type", "paradox", "--vault", str(vault)])
+    (original,) = (vault / "10-Liminal" / "Paradoxes").glob("*.md")
+    stray = original.with_name("2020-01-01-frag-cli-dupe-aa-frag-cli-dupe-bb.md")
+    post = frontmatter.loads(original.read_text(encoding="utf-8"))
+    post["detected_date"] = "2020-01-01"
+    stray.write_text(frontmatter.dumps(post), encoding="utf-8")
+
+    result = runner.invoke(app, ["report", "--type", "paradox", "--vault", str(vault)])
+
+    assert result.exit_code == 0, result.output
+    assert "#1320" in result.output
+    assert "Nothing is deleted automatically" in result.output
+    assert stray.exists()
+    assert original.exists()
+
+
+def test_report_paradox_is_quiet_when_no_duplicates(tmp_path: Path) -> None:
+    """An operator must not be accused of duplicates on every clean run."""
+    vault = _report_vault(tmp_path)
+    _seed_paradox_pair(vault)
+    runner.invoke(app, ["report", "--type", "paradox", "--vault", str(vault)])
+
+    result = runner.invoke(app, ["report", "--type", "paradox", "--vault", str(vault)])
+
+    assert result.exit_code == 0, result.output
+    assert "#1320" not in result.output
+
+
 def test_report_synchronicity_writes_notes(tmp_path: Path) -> None:
     """`report --type synchronicity` writes notes + reports success (#711, #726).
 

--- a/creek-tools/tests/test_liminal_report_generators.py
+++ b/creek-tools/tests/test_liminal_report_generators.py
@@ -81,7 +81,13 @@ class TestGenerateParadoxes:
         assert len(_paradox_notes(vault)) == 1
 
     def test_idempotent(self, tmp_path: Path) -> None:
-        """Re-running writes the same note in place (no duplicate)."""
+        """Re-running records nothing new (#1320).
+
+        This assertion used to read "writes the same note in place", which was
+        only ever true within a single calendar day — the note path embeds
+        ``detected_date``. The cross-day case, and the read-back scan that now
+        supplies the identity, live in ``tests/test_paradox_idempotency.py``.
+        """
         vault = _vault(tmp_path)
         for fid, conf in (
             ("frag-parax-cccc", Confidence.MUSING),
@@ -98,9 +104,11 @@ class TestGenerateParadoxes:
                 ),
                 body="body",
             )
-        generate_paradoxes(vault, EmbeddingsConfig())
-        generate_paradoxes(vault, EmbeddingsConfig())
-        assert len(_paradox_notes(vault)) == 1  # stable path → overwrite
+        first = generate_paradoxes(vault, EmbeddingsConfig())
+        second = generate_paradoxes(vault, EmbeddingsConfig())
+        assert len(first) == 1
+        assert second == []  # the pair is already recorded → skipped, not rewritten
+        assert len(_paradox_notes(vault)) == 1
 
     def test_empty_vault_no_notes(self, tmp_path: Path) -> None:
         """A vault with fewer than two fragments yields no paradoxes."""

--- a/creek-tools/tests/test_paradox_idempotency.py
+++ b/creek-tools/tests/test_paradox_idempotency.py
@@ -1,0 +1,466 @@
+"""Paradox notes must not duplicate on a new calendar day (#1320).
+
+``Paradox.detected_date`` is ``field(default_factory=date.today)`` and
+``ParadoxDetector._build_paradox`` never passes it, so every run stamps today.
+``_filename`` embeds that date, so the note path is stable per paradox *per
+day* — running ``creek report --type paradox`` weekly for a year leaves 52
+copies of every paradox in ``10-Liminal/Paradoxes/``.
+
+Reproduced on ``main`` for one unchanged fragment pair::
+
+    day 1: wrote 2026-08-10-frag-1-frag-2.md
+    day 2: wrote 2026-08-11-frag-1-frag-2.md
+    ON DISK: ['2026-08-10-frag-1-frag-2.md', '2026-08-11-frag-1-frag-2.md']
+
+**Clock injection.** There is no freezegun/time_machine in this repo, and —
+unlike ``tests/test_ingest_generic_idempotent.py``, which monkeypatches
+``creek.ingest.generic.datetime`` — patching ``creek.generate.paradox.date``
+does **nothing** here: ``default_factory=date.today`` captured the bound
+``date.today`` at class-definition time, so the module attribute is never
+consulted. Verified: with that attribute patched to a 1999 fake,
+``Paradox().detected_date`` still returned the real today.
+
+So "yesterday's run" is staged the only honest way available — by writing its
+note through the same public path (``create_paradox_note``) with an explicit
+past ``detected_date``. Those are byte-for-byte the bytes a run on that date
+left behind; nothing else in the note derives from the clock.
+:data:`_PRIOR_RUN_DATE` is a fixed date in the past rather than
+``today - 1 day`` so the test cannot straddle a midnight rollover.
+
+:class:`TestSecondRunSameDay` needs no clock manipulation at all: it pins that
+a re-run reports nothing new, which the date-stamped filename cannot express.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import date
+from typing import TYPE_CHECKING
+
+import frontmatter
+import pytest
+
+from creek.config import EmbeddingsConfig
+from creek.generate.paradox import (
+    REFLECTION_PROMPT,
+    ParadoxDetector,
+    duplicate_paradox_warning,
+    generate_paradoxes,
+)
+from creek.models import (
+    Confidence,
+    Fragment,
+    FragmentSource,
+    SourcePlatform,
+    VoiceClassification,
+)
+from creek.vault.reader import iter_vault_fragments
+from tests.helpers import write_fragment_file
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_PRIOR_RUN_DATE = date(2020, 1, 1)
+"""Stands in for "the day the previous run happened".
+
+Fixed rather than relative so no assertion here can straddle midnight.
+"""
+
+_PAIR = (("frag-parax-1", Confidence.MUSING), ("frag-parax-2", Confidence.SETTLED))
+"""Two fragments on one thread with opposite confidence — fires Rule 2."""
+
+
+# ---- Fixtures / helpers ----------------------------------------------------
+
+
+def _vault(tmp_path: Path) -> Path:
+    """Scaffold a vault holding exactly one contradictory fragment pair."""
+    vault = tmp_path / "vault"
+    for sub in ("00-Creek-Meta", "01-Fragments", "10-Liminal/Paradoxes"):
+        (vault / sub).mkdir(parents=True, exist_ok=True)
+    for fid, confidence in _PAIR:
+        write_fragment_file(
+            vault=vault,
+            fragment=Fragment(
+                id=fid,
+                title="career ambitions",
+                source=FragmentSource(platform=SourcePlatform.JOURNAL),
+                voice=VoiceClassification(confidence=confidence),
+                threads=["thread-career"],
+            ),
+            body="the same thread, settled differently",
+        )
+    return vault
+
+
+def _notes(vault: Path) -> list[str]:
+    """Every paradox note filename currently on disk, sorted."""
+    return sorted(p.name for p in (vault / "10-Liminal" / "Paradoxes").glob("*.md"))
+
+
+def _seed_prior_run(vault: Path, *, on: date) -> list[Path]:
+    """Write the notes a ``generate_paradoxes`` run on *on* would have left.
+
+    Uses the production detector and the production write path, so the result
+    is byte-identical to that run's output — only ``detected_date`` is pinned.
+    """
+    fragments = [
+        fragment
+        for _path, fragment, _body, _raw in iter_vault_fragments(
+            vault / "01-Fragments",
+        )
+    ]
+    detector = ParadoxDetector()
+    written: list[Path] = []
+    for paradox in detector.detect_paradoxes(fragments):
+        paradox.detected_date = on
+        written.append(detector.create_paradox_note(paradox, vault))
+    return written
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> Path:
+    """A vault with one contradictory fragment pair and no paradox notes yet."""
+    return _vault(tmp_path)
+
+
+# ---- The headline regression ----------------------------------------------
+
+
+class TestNewCalendarDay:
+    """A later run must not re-record a pair a previous run already recorded."""
+
+    def test_prior_days_note_is_not_duplicated(self, vault: Path) -> None:
+        """The #1320 repro: two runs, two dates, one unchanged pair, one note."""
+        prior = _seed_prior_run(vault, on=_PRIOR_RUN_DATE)
+        assert len(prior) == 1, "fixture must produce exactly one paradox"
+        assert _notes(vault) == ["2020-01-01-frag-parax-1-frag-parax-2.md"]
+
+        written = generate_paradoxes(vault, EmbeddingsConfig())
+
+        assert written == []
+        assert _notes(vault) == ["2020-01-01-frag-parax-1-frag-parax-2.md"]
+
+    def test_the_operators_reflection_survives_the_next_run(
+        self,
+        vault: Path,
+    ) -> None:
+        """Skipping, not overwriting — the note exists to be written in.
+
+        This is the assertion that encodes why the issue's remedy (a) — drop
+        the date from the filename — was rejected. Under (a) the path becomes
+        stable across runs and ``create_paradox_note``'s unconditional
+        ``write_text`` clobbers the note every week, destroying whatever the
+        operator wrote under :data:`REFLECTION_PROMPT`. Trading 52 harmless
+        copies for silent loss of the operator's own prose is the worse bug.
+        """
+        (prior_note,) = _seed_prior_run(vault, on=_PRIOR_RUN_DATE)
+        reflection = "\n## My reflection\n\nBoth were true in different rooms.\n"
+        prior_note.write_text(
+            prior_note.read_text(encoding="utf-8") + reflection,
+            encoding="utf-8",
+        )
+        before = prior_note.read_bytes()
+
+        generate_paradoxes(vault, EmbeddingsConfig())
+
+        assert prior_note.read_bytes() == before
+        assert reflection in prior_note.read_text(encoding="utf-8")
+
+    def test_pair_key_ignores_fragment_order(self, vault: Path) -> None:
+        """``[b, a]`` on disk suppresses ``[a, b]`` — the key is the pair set."""
+        (prior_note,) = _seed_prior_run(vault, on=_PRIOR_RUN_DATE)
+        post = frontmatter.loads(prior_note.read_text(encoding="utf-8"))
+        assert post["fragments"] == ["frag-parax-1", "frag-parax-2"]
+        post["fragments"] = ["frag-parax-2", "frag-parax-1"]
+        prior_note.write_text(frontmatter.dumps(post), encoding="utf-8")
+
+        assert generate_paradoxes(vault, EmbeddingsConfig()) == []
+        assert len(_notes(vault)) == 1
+
+    def test_a_genuinely_new_pair_is_still_written(self, vault: Path) -> None:
+        """The guard skips recorded pairs only — it must not freeze the folder."""
+        _seed_prior_run(vault, on=_PRIOR_RUN_DATE)
+        for fid, confidence in (
+            ("frag-parax-3", Confidence.MUSING),
+            ("frag-parax-4", Confidence.SETTLED),
+        ):
+            write_fragment_file(
+                vault=vault,
+                fragment=Fragment(
+                    id=fid,
+                    title="a second tension",
+                    source=FragmentSource(platform=SourcePlatform.JOURNAL),
+                    voice=VoiceClassification(confidence=confidence),
+                    threads=["thread-other"],
+                ),
+                body="another thread, settled differently",
+            )
+
+        written = generate_paradoxes(vault, EmbeddingsConfig())
+
+        assert len(written) == 1
+        assert "frag-parax-3-frag-parax-4" in written[0].name
+        assert len(_notes(vault)) == 2
+
+
+class TestSecondRunSameDay:
+    """No clock manipulation: a re-run must report nothing new."""
+
+    def test_second_run_writes_nothing(self, vault: Path) -> None:
+        """Run 2 returns ``[]`` rather than re-reporting a recorded paradox."""
+        first = generate_paradoxes(vault, EmbeddingsConfig())
+        second = generate_paradoxes(vault, EmbeddingsConfig())
+
+        assert len(first) == 1
+        assert second == []
+        assert len(_notes(vault)) == 1
+
+
+# ---- The scan must survive whatever else lives in that folder --------------
+
+
+class TestReadBackScanRobustness:
+    """``10-Liminal/Paradoxes/`` is operator-editable and multi-producer."""
+
+    def test_malformed_yaml_note_does_not_crash_the_scan(self, vault: Path) -> None:
+        """A hand-broken note is skipped, not fatal.
+
+        ``frontmatter.loads`` raises ``yaml.ParserError`` here, which is **not**
+        a ``ValueError`` — the sibling scan at
+        ``synchronicity._existing_synchronicity_pairs`` catches only
+        ``(OSError, ValueError)`` and does crash on this input (tracked
+        separately). This scan must not.
+        """
+        broken = vault / "10-Liminal" / "Paradoxes" / "2019-05-05-broken.md"
+        broken.write_text(
+            "---\nfragments: [a, b\ntype: paradox\n---\nbody\n",
+            encoding="utf-8",
+        )
+
+        written = generate_paradoxes(vault, EmbeddingsConfig())
+
+        assert len(written) == 1
+
+    def test_unreadable_entry_is_skipped(self, vault: Path) -> None:
+        """A directory matching ``*.md`` raises ``OSError`` and is skipped."""
+        (vault / "10-Liminal" / "Paradoxes" / "not-a-file.md").mkdir()
+
+        written = generate_paradoxes(vault, EmbeddingsConfig())
+
+        assert len(written) == 1
+
+    def test_hand_saved_paradox_note_does_not_suppress_generation(
+        self,
+        vault: Path,
+    ) -> None:
+        """``creek save --target paradox`` notes carry no ``fragments:`` key.
+
+        They land in the same folder (``creek/save/router.py:51``) with a
+        ``saved_from.contributing_fragments`` provenance block instead, so they
+        must never be mistaken for a recorded detector pair.
+        """
+        saved = vault / "10-Liminal" / "Paradoxes" / "2019-05-05-a-contradiction.md"
+        post = frontmatter.Post(
+            content="A reflection naming a tension.\n",
+            title="A contradiction",
+            type="paradox",
+            tags=["paradox"],
+            privacy_tier="open",
+            saved_from={
+                "source_kind": "conversation",
+                "source_id": "",
+                "contributing_fragments": ["frag-parax-1", "frag-parax-2"],
+            },
+        )
+        saved.write_text(frontmatter.dumps(post), encoding="utf-8")
+
+        written = generate_paradoxes(vault, EmbeddingsConfig())
+
+        assert len(written) == 1
+
+    def test_short_fragments_list_is_skipped(self, vault: Path) -> None:
+        """A one-element ``fragments:`` list records no pair."""
+        partial = vault / "10-Liminal" / "Paradoxes" / "2019-05-05-partial.md"
+        post = frontmatter.Post(
+            content="half a record\n",
+            type="paradox",
+            fragments=["frag-parax-1"],
+        )
+        partial.write_text(frontmatter.dumps(post), encoding="utf-8")
+
+        written = generate_paradoxes(vault, EmbeddingsConfig())
+
+        assert len(written) == 1
+
+    def test_missing_folder_is_not_an_error(self, tmp_path: Path) -> None:
+        """A vault that has never held a paradox note still generates one."""
+        bare = _vault(tmp_path)
+        (bare / "10-Liminal" / "Paradoxes").rmdir()
+
+        written = generate_paradoxes(bare, EmbeddingsConfig())
+
+        assert len(written) == 1
+
+
+# ---- Migration: vaults that already hold duplicates ------------------------
+
+
+class TestExistingDuplicatesAreReportedNotDeleted:
+    """Every pre-#1320 vault already holds duplicates. Name them; touch none."""
+
+    @staticmethod
+    def _seed_duplicates(vault: Path, *, days: tuple[int, ...]) -> list[Path]:
+        """Stage one note per calendar day for the same unchanged pair."""
+        return [
+            note
+            for day in days
+            for note in _seed_prior_run(vault, on=date(2020, 1, day))
+        ]
+
+    def test_duplicates_are_reported_and_left_on_disk(self, vault: Path) -> None:
+        """The advisory names the count; every file survives the run."""
+        seeded = self._seed_duplicates(vault, days=(1, 2, 3))
+        assert len(seeded) == 3
+        advisories: list[str] = []
+
+        written = generate_paradoxes(
+            vault,
+            EmbeddingsConfig(),
+            on_warning=advisories.append,
+        )
+
+        assert written == []
+        assert len(_notes(vault)) == 3
+        assert all(note.exists() for note in seeded)
+        assert len(advisories) == 1
+        assert "#1320" in advisories[0]
+        # Pin the rendered phrase, not the bare digit: "#1320" already supplies
+        # a "3", so `"3" in advisory` would pass for any count at all.
+        assert (
+            "3 paradox notes recording only 1 distinct fragment pair(s)"
+            in (advisories[0])
+        )
+
+    def test_advisory_names_the_duplicate_files(self, vault: Path) -> None:
+        """An operator cannot act on a count alone — the paths are named."""
+        self._seed_duplicates(vault, days=(1, 2))
+        advisories: list[str] = []
+
+        generate_paradoxes(vault, EmbeddingsConfig(), on_warning=advisories.append)
+
+        assert "2020-01-01-frag-parax-1-frag-parax-2.md" in advisories[0]
+        assert "2020-01-02-frag-parax-1-frag-parax-2.md" in advisories[0]
+
+    def test_advisory_never_proposes_deletion(self, vault: Path) -> None:
+        """Vault content is the operator's. The advisory says so, in words."""
+        self._seed_duplicates(vault, days=(1, 2))
+        advisories: list[str] = []
+
+        generate_paradoxes(vault, EmbeddingsConfig(), on_warning=advisories.append)
+
+        assert "Nothing is deleted automatically" in advisories[0]
+        for verb in ("deleting", "removed", "pruned"):
+            assert verb not in advisories[0].lower()
+
+    def test_no_advisory_when_the_vault_is_clean(self, vault: Path) -> None:
+        """One note per pair is the healthy state — stay quiet."""
+        _seed_prior_run(vault, on=_PRIOR_RUN_DATE)
+        advisories: list[str] = []
+
+        generate_paradoxes(vault, EmbeddingsConfig(), on_warning=advisories.append)
+
+        assert advisories == []
+
+    def test_the_advisory_is_self_clearing(self, vault: Path) -> None:
+        """Once the operator removes the strays, the run goes quiet."""
+        seeded = self._seed_duplicates(vault, days=(1, 2, 3))
+        for stray in seeded[1:]:
+            stray.unlink()
+        advisories: list[str] = []
+
+        generate_paradoxes(vault, EmbeddingsConfig(), on_warning=advisories.append)
+
+        assert advisories == []
+
+    def test_advisory_sample_is_capped(self, vault: Path) -> None:
+        """A year of weekly runs must not print 52 paths."""
+        self._seed_duplicates(vault, days=tuple(range(1, 11)))
+        advisories: list[str] = []
+
+        generate_paradoxes(vault, EmbeddingsConfig(), on_warning=advisories.append)
+
+        named = re.findall(r"2020-01-\d\d-frag-parax-1-frag-parax-2\.md", advisories[0])
+        assert len(named) < 10
+        # The count is still the true total, even though the sample is capped.
+        assert (
+            "10 paradox notes recording only 1 distinct fragment pair(s)"
+            in (advisories[0])
+        )
+
+    def test_on_warning_is_optional(self, vault: Path) -> None:
+        """Callers that predate the channel (MCP) still run unchanged."""
+        self._seed_duplicates(vault, days=(1, 2))
+
+        assert generate_paradoxes(vault, EmbeddingsConfig()) == []
+        assert len(_notes(vault)) == 2
+
+
+class TestDuplicateParadoxWarning:
+    """The public pure detector backing the advisory (the #1305 shape)."""
+
+    def test_reports_only_pairs_recorded_more_than_once(self, vault: Path) -> None:
+        """A pair recorded once is not a duplicate."""
+        _seed_prior_run(vault, on=date(2020, 1, 1))
+        _seed_prior_run(vault, on=date(2020, 1, 2))
+
+        advisory = duplicate_paradox_warning(vault)
+
+        assert advisory is not None
+        assert "2 paradox notes recording only 1 distinct fragment pair(s)" in advisory
+
+    def test_each_duplicated_pair_is_counted_once(self, vault: Path) -> None:
+        """Two duplicated pairs read as two, not four (#1394's M23)."""
+        for fid, confidence in (
+            ("frag-parax-3", Confidence.MUSING),
+            ("frag-parax-4", Confidence.SETTLED),
+        ):
+            write_fragment_file(
+                vault=vault,
+                fragment=Fragment(
+                    id=fid,
+                    title="a second tension",
+                    source=FragmentSource(platform=SourcePlatform.JOURNAL),
+                    voice=VoiceClassification(confidence=confidence),
+                    threads=["thread-other"],
+                ),
+                body="another thread, settled differently",
+            )
+        _seed_prior_run(vault, on=date(2020, 1, 1))
+        _seed_prior_run(vault, on=date(2020, 1, 2))
+
+        advisory = duplicate_paradox_warning(vault)
+
+        assert advisory is not None
+        assert "4 paradox notes recording only 2 distinct fragment pair(s)" in advisory
+
+    def test_clean_vault_reports_nothing(self, vault: Path) -> None:
+        """One note per pair is silence (#1394's M24)."""
+        _seed_prior_run(vault, on=_PRIOR_RUN_DATE)
+
+        assert duplicate_paradox_warning(vault) is None
+
+    def test_missing_folder_reports_nothing(self, tmp_path: Path) -> None:
+        """A vault with no Paradoxes folder is not a crash."""
+        assert duplicate_paradox_warning(tmp_path / "nowhere") is None
+
+    def test_advisory_names_no_fragment_prose(self, vault: Path) -> None:
+        """Paths only — excerpts and tags can be intimate-derived (#1404)."""
+        _seed_prior_run(vault, on=date(2020, 1, 1))
+        _seed_prior_run(vault, on=date(2020, 1, 2))
+
+        advisory = duplicate_paradox_warning(vault)
+
+        assert advisory is not None
+        assert "career ambitions" not in advisory
+        assert REFLECTION_PROMPT not in advisory


### PR DESCRIPTION
## Summary

Paradox notes are named `<YYYY-MM-DD>-<fragA>-<fragB>.md`. `Paradox.detected_date` is `field(default_factory=date.today)` and `_build_paradox` never overrides it, so every run stamps today and the path is stable per paradox *per day*. Running `creek report --type paradox` weekly for a year left 52 copies of every paradox in `10-Liminal/Paradoxes/`.

Reproduced at `ca1b9c3`, one unchanged fragment pair, real listing:

```
day 1 (2026-08-10): wrote 2026-08-10-frag-1-frag-2.md
day 2 (2026-08-11): wrote 2026-08-11-frag-1-frag-2.md
ON DISK for ONE unchanged fragment pair:
  ['2026-08-10-frag-1-frag-2.md', '2026-08-11-frag-1-frag-2.md']
```

All four line cites in the issue are exact at `ca1b9c3`. One half of the issue's claim is overstated, though: `generate_paradoxes:815-817` ("re-running overwrites in place rather than duplicating") is flatly false, but `create_paradox_note:576-578` ("writing the same `Paradox` twice produces the same file path") is *literally true* — same object, same date — just badly misleading beside the first. Both are rewritten; only one was a lie.

`generate_paradoxes` now reads `10-Liminal/Paradoxes/` back, keys each note on `frozenset(fragments[:2])` from its frontmatter, and **skips** a pair already recorded. That is the shape both siblings already use — `synchronicity._existing_synchronicity_pairs` and `decisions._existing_decision_fragment_ids` — so this closes a divergent-sibling-contract gap, not just a bug.

### Why the read-back scan and not the issue's preferred remedy

The issue rated remedy (a) — drop the date from the filename — "simpler". It is a silent-data-loss regression, and three independent facts say so:

1. **It clobbers the operator's writing.** `create_paradox_note` ends in an unconditional `write_text`. Make the path stable and every weekly run overwrites the note in place — destroying whatever reflection the operator wrote under `REFLECTION_PROMPT`. That prompt *is* the product; the note exists to be annotated. Trading 52 harmless copies for silent loss of the operator's own prose is the worse trade, and it is exactly the class this repo has declined three times. This is pinned by `test_the_operators_reflection_survives_the_next_run`, which goes red under a mutation implementing (a) with the byte diff showing the prose gone.
2. **It breaks `[[wikilinks]]` with no fallback.** Nothing in production writes a link *at* a paradox note, but `vault/links.py:174` registers every note's stem in the link index, and paradox notes emit no `title:` and no `aliases:` — the stem is the only handle a hand-written `[[2026-04-12-frag-a-frag-b]]` can use. Every other date-prefixed generator (threads, eddies) puts the human-readable name in `aliases:`; paradox is the outlier that never got it. Renaming without an alias breaks the link silently.
3. **It does not converge an existing vault.** With identity living only in the filename, an existing `2026-04-12-a-b.md` is unrecognisable to a new scheme, so the next run writes *one more* file before stabilising.

Two further options were considered and rejected: recovering the recorded `detected_date` and rewriting at the original path (re-introduces the clobber), and deriving `detected_date` from fragment timestamps (makes a field named `detected_date` lie, and still adds a file to every existing vault).

The filename is therefore unchanged. That also protects the state report's Liminal Watch (`generate/state.py:942`), which renders the paradox file stem verbatim as operator-facing text and uses `p.name` as its sort tiebreak.

### Migration — every existing vault already holds duplicates

Fixing the generator stops the growth; it cannot undo what is on disk. New public `duplicate_paradox_warning(vault_path) -> str | None` **detects and reports**: the count, the number of distinct pairs, and a sample-capped list of paths. It is delivered through a new keyword-only `on_warning` callback on `generate_paradoxes` plus `logger.warning`, and `creek report --type paradox` prints it.

**Nothing is deleted.** Which copy to keep is a judgement about the operator's own writing — one of them may carry their reflection — and a generator does not get to make it on a heuristic. This is the fourth instance of the shape #1304, #1305 and #1329 each established; the funnel is lifted from `creek/ingest/pipeline.py`'s. The advisory is self-clearing (remove the strays and the run goes quiet), silent on a clean vault, and names **paths only** — no fragment title, excerpt, or tag, per #1404.

`creek report --type paradox`'s empty-result line said "no contradictory fragment pairs found", which this change would newly turn into a lie (pairs exist; they are already recorded). It now covers both cases honestly. `_report_synchronicity` has the same pre-existing imprecision and is deliberately left alone.

### Relationship to #1334 — declined, with reasons (commented on the issue)

#1334 asks that its fix be "shaped so #1320 can adopt it". Same smell, opposite failure mode: #1320 over-produces harmlessly; #1334 *destroys* (the second same-titled candidate overwrites the first and the index oscillates `b -> a -> b` forever). #1320's identity key was already unique and already on disk, so a read-back scan sufficed; #1334's key is a title, which is not unique and needs a filename **disambiguator**. Proof they are disjoint: `decisions.py` already has a read-back scan and it does not help.

Flagged loudly on #1334: its Task 1's `source_id` option is already ruled out (for a compost project candidate the `source_id` *is* the tag, which can be intimate-derived — the string #1404 just stopped leaking into the filesystem), and its surviving option, `VaultWriter._atomic_create`'s counter-suffix retry, **never overwrites** — so a paradox generator "adopting" it would mint `a-b-2.md`, `a-b-3.md`, … every run, institutionalising this bug rather than fixing it. The only shareable abstraction across these generators is the read-back scan, never the filename builder. Filed as #1417 with that constraint written into its scope.

### Follow-ups filed

- **#1416** (P1, bug) — `_existing_synchronicity_pairs` catches `(OSError, ValueError)`, but `frontmatter.loads` raises `yaml.ParserError` on malformed YAML, which is neither. Reproduced: one hand-broken note takes down `creek report --type synchronicity`. `decisions.py:1026` gets it right and this PR's `_recorded_pair` follows `decisions.py`.
- **#1417** (P2, refactor) — extract the now-three near-identical read-back scans; read-back only, never a shared filename builder.

## Test plan

New `tests/test_paradox_idempotency.py` (22 tests, zero skipped) plus a strengthened `test_liminal_report_generators.py::TestGenerateParadoxes::test_idempotent` and three new CLI tests.

**Clock injection.** There is no freezegun/time_machine here, and patching `creek.generate.paradox.date` does **nothing** — `default_factory=date.today` captured the bound method at class-definition time. Verified empirically: with the module attribute patched to a 1999 fake, `Paradox().detected_date` still returned the real today. "Yesterday's run" is therefore staged by writing its note through the same public path with an explicit past `detected_date` — byte-for-byte the bytes that run left. A fixed 2020 date is used so no assertion can straddle midnight. `TestSecondRunSameDay` needs no clock manipulation at all.

**RED proven at `ca1b9c3`** before implementing — 4 behavioural failures, including the headline `assert 2 == 1` on files-on-disk.

**Mutation tested**, three mutants, each restored:

| Mutation | Result |
|---|---|
| Delete the `if pair in already: continue` guard | 8 red — 6 new, 1 strengthened, 1 new CLI. No pre-existing test noticed, which is why the bug survived. |
| Force the advisory to `None` | 8 red — exactly the advisory tests |
| The issue's remedy (a): dateless filename, no guard | 14 red, including the reflection test, whose byte diff shows the operator's prose replaced by the regenerated body |

Also covered: pair key is order-insensitive; a genuinely new pair is still written alongside an old one (blocks a lazy "folder non-empty → do nothing"); malformed YAML, a short `fragments:` list, an unreadable `*.md` directory entry, and a `creek save --target paradox` note (which records provenance under `saved_from.contributing_fragments`, not a top-level `fragments:`) are each skipped **while a legitimate paradox is still written in the same run** — so an over-broad `except` cannot pass; a missing `10-Liminal/Paradoxes/` folder; advisory counted once per pair, silent when clean, self-clearing, sample-capped, and carrying no fragment prose.

**Gate 2:** `./scripts/check-all.sh` exit code **0** — 9286 unit tests, ruff (`--no-cache`), mypy strict, pylint 9.71, bandit, pip-audit, refurb, tryceratops, interrogate, complexity, 90% aggregate + per-file coverage.

**Bypass sweep** over the whole diff including tests: no `# noqa`, `# type: ignore`, `# pylint: disable`, `@pytest.mark.skip/xfail`, or `--no-verify` added; `pyproject.toml` and `scripts/` untouched. The one refurb finding this change produced (`FURB179`) was fixed at the root with `itertools.chain.from_iterable`, not suppressed.

Closes #1320
