### PR TITLE
perf(generate): parse the Unnamed tree once per digest, not once per fragment (20,500 -> 200 at N=200)

### DIFF
--- a/creek-tools/creek/generate/unnamed.py
+++ b/creek-tools/creek/generate/unnamed.py
@@ -43,6 +43,7 @@ from creek.models import Fragment
 from creek.time import effective_authored_at, effective_authored_date
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
 
     from creek.link.embeddings import EmbeddingLinker
@@ -183,16 +184,16 @@ class UnnamedDigestGenerator:
         Returns:
             Path to the generated digest markdown file.
         """
-        all_unnamed = self.load_unnamed_fragments(vault_path)
+        all_unnamed, excerpts = _load_unnamed_with_excerpts(vault_path)
         this_week = self.filter_fragments_in_week(all_unnamed, week_start)
         clusters = self.detect_unnamed_clusters(this_week)
         previous = self._load_history(vault_path, week_start)
         body = self._render_body(
-            vault_path,
             this_week,
             clusters,
             week_start,
             previous=previous,
+            excerpts=excerpts,
         )
         digest_path = self._write_digest(vault_path, week_start, body)
         self._append_history(
@@ -223,18 +224,10 @@ class UnnamedDigestGenerator:
         Returns:
             List of Fragment objects parsed from the vault.
         """
-        unnamed_dir = vault_path.joinpath(*_UNNAMED_SUBPATH)
-        if not unnamed_dir.is_dir():
-            return []
-
-        fragments: list[Fragment] = []
-        for md_file in sorted(unnamed_dir.rglob("*.md")):
-            if _DIGESTS_SUBFOLDER in md_file.relative_to(unnamed_dir).parts:
-                continue
-            fragment = _load_fragment(md_file)
-            if fragment is not None:
-                fragments.append(fragment)
-        return fragments
+        # A projection of the shared walk: each body is bound for one loop
+        # iteration and discarded, so this costs no more memory than the
+        # per-file parse it always did.
+        return [fragment for fragment, _body in _iter_unnamed_records(vault_path)]
 
     @staticmethod
     def filter_fragments_in_week(
@@ -333,28 +326,31 @@ class UnnamedDigestGenerator:
 
     def _render_body(
         self,
-        vault_path: Path,
         fragments: list[Fragment],
         clusters: list[list[Fragment]],
         week_start: date,
         *,
         previous: _HistoryEntry | None,
+        excerpts: dict[str, str],
     ) -> str:
         """Render the complete markdown body for the digest.
 
         Args:
-            vault_path: Path to the root of the Obsidian vault.
             fragments: Fragments observed this week.
             clusters: Similarity clusters detected this week.
             week_start: Monday of the target ISO week.
             previous: Previous history entry, or ``None`` when no prior
                 run has been recorded.
+            excerpts: Mapping of fragment ID to a short body excerpt, built
+                by :func:`_load_unnamed_with_excerpts` during the single
+                pass over the Unnamed tree. It covers every unnamed
+                fragment, not just *fragments*; the extra entries are
+                simply never looked up.
 
         Returns:
             The markdown body (without frontmatter).
         """
         week_end = week_start + timedelta(days=_WEEK_LENGTH_DAYS - 1)
-        excerpts = _build_excerpt_map(vault_path, fragments)
         sections = [
             f"# Unnamed Digest — {week_start.isoformat()} to {week_end.isoformat()}\n",
             _render_fragments_section(fragments, excerpts),
@@ -527,15 +523,20 @@ def _upsert_history_entry(
     return merged
 
 
-def _load_fragment(md_file: Path) -> Fragment | None:
-    """Parse a markdown file into a :class:`Fragment`, or ``None`` on failure.
+def _load_fragment(md_file: Path) -> tuple[Fragment, str] | None:
+    """Parse a markdown file into ``(fragment, body)``, or ``None`` on failure.
+
+    Returns the markdown body alongside the validated model so a caller that
+    needs an excerpt already has it and never reopens the file. The shape is
+    the one :func:`creek.generate.skills._load_fragment` already sets for the
+    same job in this package.
 
     Args:
         md_file: Path to the markdown file.
 
     Returns:
-        The parsed Fragment, or ``None`` when the file is not a valid
-        fragment record.
+        ``(fragment, body)`` when the file is a valid fragment record, or
+        ``None`` when it is not.
     """
     try:
         post = frontmatter.load(str(md_file))
@@ -546,7 +547,7 @@ def _load_fragment(md_file: Path) -> Fragment | None:
     if metadata.get("type") != "fragment":
         return None
     try:  # noqa: TRY101  # Separate failure modes: file IO vs schema validation each return None with distinct debug logs.
-        return Fragment.model_validate(metadata)
+        return Fragment.model_validate(metadata), post.content
     except ValidationError:
         logger.debug("Skipping invalid fragment frontmatter: %s", md_file)
         return None
@@ -585,48 +586,100 @@ def _connected_components(
     return [buckets[root] for root in sorted(buckets)]
 
 
-def _excerpt_from_file(fragment_path: Path | None) -> str:
-    """Read a short excerpt from the fragment's markdown body.
+def _excerpt_from_body(body: str) -> str:
+    """Cut a short, single-line excerpt from a fragment's markdown body.
+
+    Newlines collapse to spaces because the excerpt is rendered as a markdown
+    list item, where an embedded newline would break out of the bullet and
+    corrupt the digest's structure.
 
     Args:
-        fragment_path: Path to the fragment file, or ``None`` when
-            unavailable.
+        body: The fragment's markdown body, as already parsed from its file.
 
     Returns:
-        A trimmed excerpt of at most :data:`_EXCERPT_MAX_CHARS`
-        characters; empty string when no body is present.
+        A trimmed excerpt of at most :data:`_EXCERPT_MAX_CHARS` characters —
+        the last of which is an ellipsis when the body was truncated — or the
+        empty string when the body carries no text.
     """
-    if fragment_path is None or not fragment_path.exists():
+    collapsed = body.strip().replace("\n", " ")
+    if not collapsed:
         return ""
-    post = frontmatter.load(str(fragment_path))
-    body = post.content.strip().replace("\n", " ")
-    if not body:
-        return ""
-    if len(body) <= _EXCERPT_MAX_CHARS:
-        return body
-    return body[: _EXCERPT_MAX_CHARS - 1].rstrip() + "…"
+    if len(collapsed) <= _EXCERPT_MAX_CHARS:
+        return collapsed
+    return collapsed[: _EXCERPT_MAX_CHARS - 1].rstrip() + "…"
 
 
-def _find_fragment_file(vault_path: Path, fragment_id: str) -> Path | None:
-    """Locate the markdown file for a fragment by ID, under 10-Liminal/Unnamed/.
+def _iter_unnamed_records(vault_path: Path) -> Iterator[tuple[Fragment, str]]:
+    """Yield ``(fragment, body)`` for each valid fragment under ``Unnamed/``.
+
+    The single definition of the Unnamed walk: the directory guard, the
+    ``sorted`` ``rglob`` order (which is what makes duplicate-ID resolution
+    deterministic rather than filesystem-dependent), and the ``Digests/``
+    skip that keeps generated digests out of the fragment set.
+
+    This is deliberately a **lazy generator** — it ``yield``s, and must never
+    be "cleaned up" into a list comprehension. The laziness *is* the memory
+    property: each body is live only for the consumer's loop iteration, so a
+    vault with tens of thousands of unnamed notes never holds every body at
+    once. Materialising a list would keep every test in the suite green while
+    silently reintroducing unbounded retention.
+
+    Unlike :func:`creek.vault.reader.iter_vault_fragments`, which yields
+    ``(path, fragment, body, raw)``, this yields no path and no raw metadata:
+    nothing downstream consumes them now that excerpts come from the body in
+    hand, and carrying unused data would be dead weight.
 
     Args:
         vault_path: Path to the root of the Obsidian vault.
-        fragment_id: Fragment ID to find.
 
-    Returns:
-        The matching markdown path, or ``None`` if not found.
+    Yields:
+        ``(fragment, body)`` per markdown file that validates as a
+        :class:`Fragment`, in sorted path order.
     """
     unnamed_dir = vault_path.joinpath(*_UNNAMED_SUBPATH)
     if not unnamed_dir.is_dir():
-        return None
-    for md_file in unnamed_dir.rglob("*.md"):
+        return
+    for md_file in sorted(unnamed_dir.rglob("*.md")):
         if _DIGESTS_SUBFOLDER in md_file.relative_to(unnamed_dir).parts:
             continue
-        post = frontmatter.load(str(md_file))
-        if post.get("id") == fragment_id:
-            return md_file
-    return None
+        record = _load_fragment(md_file)
+        if record is not None:
+            yield record
+
+
+def _load_unnamed_with_excerpts(
+    vault_path: Path,
+) -> tuple[list[Fragment], dict[str, str]]:
+    """Load every unnamed fragment and its excerpt in one pass over the tree.
+
+    Exactly one frontmatter parse per unnamed markdown file for a whole digest
+    run (#1321): the excerpt is cut from the body of the file the fragment was
+    parsed from, so the tree is never rescanned to find a fragment's own file.
+    Only the truncated excerpts are retained — the bodies fall out of scope as
+    the generator advances.
+
+    Excerpts are built for *every* unnamed fragment, not just the target
+    week's. ``filter_fragments_in_week`` runs after this load, so restricting
+    the map would mean either duplicating that predicate here or holding all
+    bodies live until the filter runs. An out-of-week entry costs at most
+    :data:`_EXCERPT_MAX_CHARS` characters and is simply never looked up.
+
+    Args:
+        vault_path: Path to the root of the Obsidian vault.
+
+    Returns:
+        ``(fragments, {fragment_id: excerpt})``.
+    """
+    fragments: list[Fragment] = []
+    excerpts: dict[str, str] = {}
+    for fragment, body in _iter_unnamed_records(vault_path):
+        fragments.append(fragment)
+        # ``setdefault`` is first-wins, so a duplicated ID publishes the
+        # sorted-first file's excerpt — the deterministic successor to the old
+        # "first unsorted rglob match wins". Plain assignment would be
+        # last-wins: the same arbitrary pick, pointed the other way.
+        excerpts.setdefault(fragment.id, _excerpt_from_body(body))
+    return fragments, excerpts
 
 
 def _render_fragments_section(
@@ -660,26 +713,6 @@ def _render_fragments_section(
             lines.append(f"- Excerpt: {excerpt}")
         lines.append("")
     return "\n".join(lines) + "\n"
-
-
-def _build_excerpt_map(
-    vault_path: Path,
-    fragments: list[Fragment],
-) -> dict[str, str]:
-    """Build a mapping of fragment ID to a short markdown body excerpt.
-
-    Args:
-        vault_path: Path to the root of the Obsidian vault.
-        fragments: Fragments whose excerpts to resolve.
-
-    Returns:
-        Mapping of fragment ID to excerpt string.
-    """
-    excerpts: dict[str, str] = {}
-    for frag in fragments:
-        path = _find_fragment_file(vault_path, frag.id)
-        excerpts[frag.id] = _excerpt_from_file(path)
-    return excerpts
 
 
 def _render_clusters_section(clusters: list[list[Fragment]]) -> str:

--- a/creek-tools/tests/test_unnamed_digest.py
+++ b/creek-tools/tests/test_unnamed_digest.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, date, datetime, timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import frontmatter
 import pytest
@@ -20,6 +20,7 @@ import pytest
 from creek.config import EmbeddingsConfig
 from creek.generate.unnamed import (
     UnnamedDigestGenerator,
+    _iter_unnamed_records,
     _render_fragments_section,
 )
 from creek.link.embeddings import EmbeddingLinker
@@ -749,3 +750,412 @@ class TestStableDigestGenerated:
         path.write_bytes(b"\xff\xfe not valid utf-8")
         out = _stable_digest_generated(path, "body", "2026-02-09", "2026-02-15")
         assert out.endswith("+00:00")
+
+
+# ---- #1321: one parse per file, and the excerpt behaviour that must survive ----
+
+
+def _spy_on_frontmatter_load(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Record every path handed to ``frontmatter.load``, delegating to the real one.
+
+    :mod:`creek.generate.unnamed` does a module-level ``import frontmatter`` and
+    calls ``frontmatter.load(...)`` from three separate helpers, so the attribute
+    is resolved on the module object at call time and patching it here is picked
+    up by every one of them. The real loader still runs — including raising — so
+    nothing about the behaviour under test changes; this only observes.
+
+    Deliberately a call counter rather than a wall-clock or ``tracemalloc``
+    probe. The cost being pinned is "how many times is the Unnamed tree parsed",
+    which is exact, machine-independent, and cheap enough for the default lane;
+    a timing probe would be none of those and would earn a ``slow`` marker.
+
+    Args:
+        monkeypatch: The builtin pytest fixture; it restores the real
+            ``frontmatter.load`` at teardown.
+
+    Returns:
+        The live record — ``str(path)`` per call, in call order. Read it after
+        the call under test.
+    """
+    real_load = frontmatter.load
+    loaded: list[str] = []
+
+    def _spy(fd: Any, *args: Any, **kwargs: Any) -> Any:
+        """Record *fd*, then delegate to (and raise exactly like) the real load."""
+        loaded.append(str(fd))
+        return real_load(fd, *args, **kwargs)
+
+    monkeypatch.setattr(frontmatter, "load", _spy)
+    return loaded
+
+
+def _write_unnamed_fragment_with_body(
+    vault: Path,
+    name: str,
+    *,
+    body: str,
+    created: datetime,
+    title: str | None = None,
+    frag_id: str | None = None,
+) -> Path:
+    """Write an Unnamed fragment whose markdown *body* the caller controls.
+
+    :func:`_write_unnamed_fragment` hard-codes ``"Body content for <name>."``,
+    which cannot express the three cases the excerpt renderer actually branches
+    on (over-length, empty, multi-line). This is the same writer with the body
+    lifted into a parameter; the frontmatter it emits is identical.
+
+    Args:
+        vault: Root vault path.
+        name: Filename stem (without extension). Also decides ``rglob``
+            sort order, which some callers below depend on.
+        body: Exact markdown body to write beneath the frontmatter.
+        created: Creation timestamp, mirrored into ``ingested`` so the
+            FEAT-031 authored-date fallback buckets the fragment as intended.
+        title: Fragment title; defaults to *name*.
+        frag_id: Fragment ID; defaults to ``frag-<name>``.
+
+    Returns:
+        Path to the written markdown file.
+    """
+    fragment = Fragment(
+        id=frag_id or f"frag-{name}",
+        title=title or name,
+        source=FragmentSource(platform=SourcePlatform.JOURNAL),
+        created=created,
+        ingested=created,
+    )
+    data = fragment.model_dump(mode="json")
+    post = frontmatter.Post(content=body, **data)
+    path = vault / "10-Liminal" / "Unnamed" / f"{name}.md"
+    path.write_text(frontmatter.dumps(post), encoding="utf-8")
+    return path
+
+
+def _excerpt_lines(digest_text: str) -> list[str]:
+    """Return the excerpt text of every ``- Excerpt:`` line in a rendered digest.
+
+    Asserting on this rather than on ``in digest_text`` substrings makes the
+    *absence* of an excerpt assertable (an empty list) and pins the rendered
+    text exactly, so a truncation off-by-one cannot hide inside a substring
+    match.
+
+    Args:
+        digest_text: The full text of a generated digest note.
+
+    Returns:
+        One entry per excerpt line, in document order, with the
+        ``"- Excerpt: "`` prefix stripped.
+    """
+    prefix = "- Excerpt: "
+    return [
+        line.removeprefix(prefix)
+        for line in digest_text.splitlines()
+        if line.startswith(prefix)
+    ]
+
+
+class TestDigestParsesEachUnnamedFileOnce:
+    """#1321: the weekly digest must parse each Unnamed file exactly once."""
+
+    @pytest.mark.parametrize("n_fragments", [2, 8])
+    def test_generate_weekly_digest_parses_each_unnamed_file_exactly_once(
+        self,
+        generator: UnnamedDigestGenerator,
+        vault: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        n_fragments: int,
+    ) -> None:
+        """One ``frontmatter.load`` per Unnamed markdown file, whatever N is (#1321).
+
+        COST MODEL. ``generate_weekly_digest`` currently walks the Unnamed tree
+        three separate times for a week in which all ``N`` fragments fall:
+        ``load_unnamed_fragments`` parses every file (``N``), then
+        ``_build_excerpt_map`` calls ``_find_fragment_file`` per fragment and
+        each of those re-parses the tree until it hits its ID
+        (``N(N+1)/2`` on the reference run), then ``_excerpt_from_file``
+        re-loads the very file the scan just opened (``N``). Measured at HEAD:
+        ``N=2 -> 7`` calls against an expected 2, and ``N=8 -> 52`` against an
+        expected 8 — a 6.5x over-read that grows quadratically
+        (``N=200 -> 20,500``). One pass over the tree is sufficient: the
+        excerpt is in the body of the file ``load_unnamed_fragments`` already
+        opened.
+
+        WHAT THE COUNTER PREVENTS. A future lane reaching for the convenient
+        ``_find_fragment_file(vault_path, frag.id)`` inside a per-fragment loop
+        reintroduces the whole quadratic immediately and silently — every
+        existing test still passes, because the output is byte-identical. Only
+        a call count notices. The uniqueness assertion is the durable half: it
+        survives a feature that legitimately adds a file to the folder, where a
+        bare ``== N`` would not.
+
+        ANTI-VACUITY. ``n_files`` is read off the filesystem, not from the spy,
+        and is anchored to the parametrized ``N`` first — otherwise a fixture
+        that wrote nothing would satisfy ``0 == 0``. The trailing excerpt
+        assertions stop the cheapest possible "fix" (dropping excerpt
+        resolution entirely) from turning this green.
+
+        ``N`` is capped low on purpose: ``detect_unnamed_clusters`` is
+        genuinely ``O(N^2)`` in numpy over the in-week set, and that axis is
+        out of scope here. No ``slow`` marker — this repo reserves it for
+        wall-clock and ``tracemalloc`` benchmarks, and a call count is neither.
+        """
+        week_start = _week_start()
+        for i in range(n_fragments):
+            _write_unnamed_fragment(
+                vault,
+                f"n{i:02d}",
+                created=datetime.combine(
+                    week_start + timedelta(days=i % 7), datetime.min.time(), tzinfo=UTC
+                ),
+            )
+
+        unnamed_dir = vault / "10-Liminal" / "Unnamed"
+        md_files = sorted(unnamed_dir.rglob("*.md"))
+        n_files = len(md_files)
+        # Anchor the expectation to the fixture before trusting it as a bound.
+        assert n_files == n_fragments
+
+        loaded = _spy_on_frontmatter_load(monkeypatch)
+        digest_path = generator.generate_weekly_digest(vault, week_start)
+
+        assert len(loaded) == n_files  # exactly one parse per file
+        assert len(set(loaded)) == len(loaded)  # and no file parsed twice
+
+        # The parse budget is only meaningful if the digest is still complete.
+        content = digest_path.read_text(encoding="utf-8")
+        for md_file in md_files:
+            assert f"- Excerpt: Body content for {md_file.stem}." in content
+
+    def test_iter_unnamed_records_parses_lazily_one_file_at_a_time(
+        self,
+        vault: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``_iter_unnamed_records`` must stay a generator, not materialise a list.
+
+        WHY THIS IS A SEPARATE TEST. Fixing #1321's quadratic *parse* count would
+        be a hollow win if it were bought with an unbounded *memory* cost. The
+        walk yields ``(fragment, body)`` and the whole `10-Liminal/Unnamed/`
+        tree is, by design, the vault's accumulating residue — the digest exists
+        to report that it grows. Holding every body live at once is the scale
+        failure that a naive ``return [record for ...]`` would introduce.
+
+        WHAT THIS CATCHES THAT NOTHING ELSE DOES. Converting the generator to a
+        list comprehension is behaviourally invisible: every other test in this
+        file, the parse *count* test above included, stays green, because the
+        totals and the rendered bytes are identical either way. Only the
+        *timing* of the parses distinguishes them. Drawing a single record and
+        asserting exactly one file has been opened is the observable difference:
+        eager materialisation parses all five here before ``next`` returns.
+        """
+        when = datetime.combine(_week_start(), datetime.min.time(), tzinfo=UTC)
+        for i in range(5):
+            _write_unnamed_fragment(vault, f"lazy{i:02d}", created=when)
+
+        loaded = _spy_on_frontmatter_load(monkeypatch)
+        records = _iter_unnamed_records(vault)
+
+        # Creating the generator must not touch the filesystem at all.
+        assert loaded == []
+
+        next(records)
+        assert len(loaded) == 1  # one record drawn == exactly one file parsed
+
+
+class TestDigestExcerptRendering:
+    """Excerpt behaviour the #1321 refactor must preserve byte-for-byte.
+
+    ``_excerpt_from_file`` is about to lose its file-reading half and become a
+    pure ``_excerpt_from_body(body: str) -> str``. These three pin the
+    formatting contract at the *digest output* level rather than by calling the
+    helper, so they keep holding under whatever the helper ends up being named.
+    All three are expected to PASS at HEAD: they are the equivalence net around
+    the refactor, not the RED test.
+    """
+
+    def test_long_body_excerpt_truncates_to_199_chars_plus_ellipsis(
+        self,
+        generator: UnnamedDigestGenerator,
+        vault: Path,
+    ) -> None:
+        """A body over 200 chars renders 199 characters then U+2026.
+
+        ``_EXCERPT_MAX_CHARS`` is 200 and the truncation spends one of those on
+        the ellipsis, so the rendered excerpt is exactly 200 characters wide.
+        Asserting the exact string (not ``startswith``) is what makes an
+        off-by-one in the slice fatal, and the second assertion pins that the
+        tail was genuinely dropped rather than merely decorated.
+        """
+        week_start = _week_start()
+        long_body = "a" * 250
+        _write_unnamed_fragment_with_body(
+            vault,
+            "long",
+            body=long_body,
+            created=datetime.combine(week_start, datetime.min.time(), tzinfo=UTC),
+            frag_id="frag-long",
+        )
+        path = generator.generate_weekly_digest(vault, week_start)
+        content = path.read_text(encoding="utf-8")
+
+        expected = "a" * 199 + "…"
+        assert len(expected) == 200
+        assert _excerpt_lines(content) == [expected]
+        assert long_body not in content
+
+    def test_empty_body_emits_no_excerpt_line(
+        self,
+        generator: UnnamedDigestGenerator,
+        vault: Path,
+    ) -> None:
+        """A fragment with an empty body gets no ``- Excerpt:`` line at all.
+
+        The renderer suppresses the bullet rather than emitting a dangling
+        ``- Excerpt:`` with nothing after it. Expected GREEN at HEAD; it is
+        here so the refactor cannot quietly start rendering empty bullets.
+        The link assertion keeps the test honest — the fragment really is in
+        the digest, so the missing excerpt line means suppression, not absence.
+        """
+        week_start = _week_start()
+        _write_unnamed_fragment_with_body(
+            vault,
+            "hollow",
+            body="",
+            created=datetime.combine(week_start, datetime.min.time(), tzinfo=UTC),
+            frag_id="frag-hollow",
+        )
+        path = generator.generate_weekly_digest(vault, week_start)
+        content = path.read_text(encoding="utf-8")
+
+        assert "[[frag-hollow]]" in content
+        assert _excerpt_lines(content) == []
+
+    def test_multiline_body_collapses_newlines_to_spaces(
+        self,
+        generator: UnnamedDigestGenerator,
+        vault: Path,
+    ) -> None:
+        """A multi-line body renders as one line with single spaces at the joins.
+
+        An excerpt is a markdown list item, so an embedded newline would break
+        out of the bullet and corrupt the digest's structure. Untested at the
+        digest level until now, which is precisely the kind of gap a refactor
+        of the excerpt helper walks into. Expected GREEN at HEAD.
+        """
+        week_start = _week_start()
+        _write_unnamed_fragment_with_body(
+            vault,
+            "multiline",
+            body="line one\nline two\nline three",
+            created=datetime.combine(week_start, datetime.min.time(), tzinfo=UTC),
+            frag_id="frag-multiline",
+        )
+        path = generator.generate_weekly_digest(vault, week_start)
+        content = path.read_text(encoding="utf-8")
+
+        assert _excerpt_lines(content) == ["line one line two line three"]
+
+
+class TestDigestExcerptResolutionCorrectness:
+    """#1321: which file an excerpt may come from — a deliberate behaviour change.
+
+    Both tests in this class are expected RED at HEAD. They are not regressions
+    the refactor must avoid; they are defects the refactor is required to fix,
+    recorded here so the change of behaviour is deliberate and reviewed rather
+    than incidental.
+    """
+
+    def test_duplicate_ids_resolve_to_the_sorted_first_file(
+        self,
+        generator: UnnamedDigestGenerator,
+        vault: Path,
+    ) -> None:
+        """Two valid fragments sharing an ID resolve deterministically (#1321).
+
+        HEAD's ``_find_fragment_file`` returns the first **unsorted**
+        ``rglob`` match, and ``rglob`` yields ``os.scandir`` order — hash-
+        ordered on APFS, roughly insertion-ordered on ext4, promised by
+        nobody. So today the excerpt published under a duplicated ID is
+        whichever file the filesystem happened to hand over first: this test
+        may pass by accident on one machine and fail on the next, which is
+        itself the bug. ``load_unnamed_fragments`` already iterates
+        ``sorted(...)``, so building the excerpt map from that single pass
+        makes sorted-first-wins the defined answer everywhere.
+
+        The assertion is on body content, not on a path, so it pins the
+        observable outcome rather than the resolution mechanism. Asserting
+        the list is non-empty first stops a "no excerpt for duplicates"
+        implementation from satisfying the set comparison vacuously.
+        """
+        week_start = _week_start()
+        when = datetime.combine(week_start, datetime.min.time(), tzinfo=UTC)
+        _write_unnamed_fragment_with_body(
+            vault,
+            "aaa-dupe",
+            body="AAA BODY.",
+            title="Duplicate A",
+            frag_id="frag-dupe",
+            created=when,
+        )
+        _write_unnamed_fragment_with_body(
+            vault,
+            "zzz-dupe",
+            body="ZZZ BODY.",
+            title="Duplicate Z",
+            frag_id="frag-dupe",
+            created=when,
+        )
+        path = generator.generate_weekly_digest(vault, week_start)
+        content = path.read_text(encoding="utf-8")
+
+        excerpts = _excerpt_lines(content)
+        assert excerpts, "the duplicated ID must still resolve to some excerpt"
+        assert set(excerpts) == {"AAA BODY."}
+        assert "ZZZ BODY." not in content
+
+    def test_non_fragment_file_never_supplies_a_fragment_excerpt(
+        self,
+        generator: UnnamedDigestGenerator,
+        vault: Path,
+    ) -> None:
+        """A stray non-fragment note must not be published under a fragment (#1321).
+
+        HEAD's ``_find_fragment_file`` matches on ``post.get("id")`` alone and
+        never checks ``type``, while ``load_unnamed_fragments`` — the pass that
+        decides what a fragment *is* — skips anything whose ``type`` is not
+        ``fragment``. The two disagree. With ``aab-stray.md`` sorting ahead of
+        the real ``ccc-empty.md`` and carrying the same ``id``, the generated
+        digest at HEAD contains ``- Excerpt: STRAY BODY.`` beneath the real
+        fragment's heading: a non-fragment file's text, attributed to a
+        fragment, in a note the user reads as a summary of their own writing.
+
+        This is a deliberate correction, not a preserved behaviour. Resolving
+        excerpts from the fragments ``load_unnamed_fragments`` already parsed
+        removes the second, laxer definition of "fragment file" entirely; the
+        real fragment's body is empty, so the correct output has no excerpt
+        line. The wiki-link assertion pins that the fragment itself is still
+        listed, so the absent excerpt cannot be an absent fragment.
+        """
+        week_start = _week_start()
+        when = datetime.combine(week_start, datetime.min.time(), tzinfo=UTC)
+        _write_unnamed_fragment_with_body(
+            vault,
+            "ccc-empty",
+            body="",
+            title="The Real Fragment",
+            frag_id="frag-empty",
+            created=when,
+        )
+        stray = vault / "10-Liminal" / "Unnamed" / "aab-stray.md"
+        stray.write_text(
+            "---\ntype: not-a-fragment\nid: frag-empty\n---\nSTRAY BODY.\n",
+            encoding="utf-8",
+        )
+
+        path = generator.generate_weekly_digest(vault, week_start)
+        content = path.read_text(encoding="utf-8")
+
+        assert "[[frag-empty]]" in content
+        assert "STRAY BODY." not in content
+        assert _excerpt_lines(content) == []


### PR DESCRIPTION
## Summary

The Unnamed weekly digest walked and re-parsed the entire `10-Liminal/Unnamed/`
tree three times over, once more per fragment. `load_unnamed_fragments` already
parsed every file and then **discarded `post.content`** — which is exactly what
the next two passes rebuilt quadratically: `_build_excerpt_map` called
`_find_fragment_file` per fragment (a full rescan each time), and
`_excerpt_from_file` then re-loaded the file that scan had just opened, to read a
body pass #1 had already held.

The fix keeps the body from the walk that was happening anyway.

### Measured: before and after

Parse count is the primary evidence because it is exact and machine-independent.
Instrumented `frontmatter.load` around `generate_weekly_digest`, all N fragments
inside the target week:

| N | before | after | wall clock before → after |
|---|--------|-------|---------------------------|
| 25 | 375 | **25** | 0.39s → 0.04s |
| 50 | 1,375 | **50** | 0.18s → 0.01s |
| 100 | 5,250 | **100** | 0.70s → 0.02s |
| 200 | 20,500 | **200** | 2.70s → 0.03s |

The before column reproduces the issue's `N + N(N+1)/2 + N` to the digit
(the issue reported 1,375 / 5,250 / 20,500). After: exactly **N** — one parse per
unnamed markdown file for the whole digest run. Quadratic → linear; ~90x wall
clock at N=200, and the gap widens with N. Extrapolated at 2,000 unnamed
fragments: ~2.0M parses → 2,000.

### Output equivalence

Generated a digest before and after on the same fixture vaults and diffed the
bytes (`generated:` stamp normalised, since it is wall-clock by design).

- Clean vaults at N=25/50/100/200: **byte-identical**, all four.
- One adversarial fixture (nested subdirs, empty body, >200-char body, multi-line
  body, `Digests/` file, duplicate ids, a non-fragment stray): **exactly one line
  differs**, and it is a bug being fixed — see below. Nothing else moved,
  including digest section order and the history JSON.

## Behaviour changes — both deliberate, both tested

**1. A non-fragment file can no longer supply a fragment's excerpt.** This is the
one byte difference. `_find_fragment_file` matched on raw frontmatter `id` across
*every* markdown file, including ones that are not `type: fragment` and ones that
fail `Fragment.model_validate`. On the fixture, a stray:

```
---
type: not-a-fragment
id: frag-empty
---
STRAY BODY.
```

caused the digest to render, under the *real* `frag-empty` fragment's heading:

```
### The Real Fragment
- Link: [[frag-empty]]
- Excerpt: STRAY BODY.
```

An unrelated file's body published under a fragment's title. Excerpts now resolve
only from files that validate as fragments, so that line correctly disappears.
Pinned by `test_non_fragment_file_never_supplies_a_fragment_excerpt`, which is RED
at HEAD.

**2. Duplicate ids resolve deterministically.** `_find_fragment_file` returned the
first **unsorted** `rglob` match, so which of two same-id files supplied the
excerpt depended on filesystem iteration order. The map is now built with
`excerpts.setdefault(...)` during the `sorted()` walk: first-wins, the
deterministic successor to "first match wins". Plain assignment would be
last-wins — the same arbitrary pick aimed the other way. Pinned by
`test_duplicate_ids_resolve_to_the_sorted_first_file`.

## Shape: why not the signature change the issue proposed

The issue proposed returning `(path, fragment, body)` from `load_unnamed_fragments`.
Not done, for two reasons:

- **It moves a declared public API.** `load_unnamed_fragments` sits under this
  module's `# ---- Public API ----` banner. Its signature, name, and contract are
  unchanged here, and its five tests are byte-untouched — which is the cheapest
  available proof that this is a pure performance fix with no API drift.
- **It retains the wrong thing.** That method loads *all* unnamed fragments (the
  history record's `total_unnamed` depends on it), not just the week's, so a list
  of `(path, fragment, body)` holds every unnamed body live at once.
  `10-Liminal/Unnamed/` is by design the vault's accumulating residue — the digest
  exists to report that it grows. Trading a CPU quadratic for an unbounded memory
  retention on the same call path is not a fix.

Instead:

- `_iter_unnamed_records(vault_path) -> Iterator[tuple[Fragment, str]]` — a **lazy
  generator**, the single definition of the Unnamed walk (directory guard,
  `sorted(rglob("*.md"))`, `Digests/` skip). No `path` and no `raw` in the tuple, a
  deliberate deviation from `creek.vault.reader.iter_vault_fragments`: nothing
  downstream consumes them once `_find_fragment_file` is gone.
- `_load_unnamed_with_excerpts` consumes it once, building the fragment list and
  the id→excerpt map in the same loop. Only the ≤200-char excerpts are retained;
  bodies fall out of scope as the generator advances. At 35k fragments that is
  ~7MB of excerpts instead of >100MB of bodies.
- `load_unnamed_fragments` becomes a projection over the same generator.
- `_load_fragment` now returns `tuple[Fragment, str] | None` — the shape
  `creek.generate.skills._load_fragment` already uses for the same job in this
  package.
- `_excerpt_from_file` → pure `_excerpt_from_body(body: str) -> str`;
  `_find_fragment_file` and `_build_excerpt_map` deleted.

One honest cost, stated plainly: excerpts are now built for every unnamed fragment
rather than just the week's, because `filter_fragments_in_week` runs *after* the
load — restricting the map would mean either duplicating that tested predicate or
holding all bodies until it runs. The old `_build_excerpt_map` was week-scoped, so
this is a small new cost the previous code did not pay: bounded at
`_EXCERPT_MAX_CHARS` (200) per out-of-week fragment, no extra parses, and the
entries are simply never looked up. It is dwarfed by what it replaces.

### Other callers

`load_unnamed_fragments`: one production caller (`generate_weekly_digest`) plus
five tests, all unchanged. `_find_fragment_file`, `_build_excerpt_map` and
`_excerpt_from_file` had no callers outside this module. Both entry points —
`creek report --type unnamed` (`creek/cli.py:_report_unnamed`) and MCP
`_generate_unnamed` (`creek_mcp/tools/report.py`) — reach this only through
`generate_weekly_digest`, whose signature is unchanged, so neither file is touched.

## Test plan

`./scripts/check-all.sh` → **exit 0**. 12/12 checks, 9298 passed, coverage 94.60%,
per-file coverage gate passed.

New tests, all in `tests/test_unnamed_digest.py`:

- `test_generate_weekly_digest_parses_each_unnamed_file_exactly_once[2,8]` — the
  durable regression guard. Spies on `frontmatter.load` and asserts one parse per
  file plus no file parsed twice. RED at HEAD: `7 == 2` and `52 == 8`.
- `test_iter_unnamed_records_parses_lazily_one_file_at_a_time` — draws a single
  record and asserts exactly one file was opened. Guards the memory property:
  collapsing the generator into a list is otherwise completely invisible.
- Excerpt-formatting equivalence net (GREEN before and after): 199 chars + `…`
  truncation, empty body emits no excerpt line, newlines collapse to spaces.
- The two behaviour-change tests described above.

**Mutation-tested** — each mutation kills exactly the intended test and nothing
else:

| mutation | result |
|---|---|
| revert to the multi-walk (i.e. HEAD) | parse-count test RED: `7 == 2`, `52 == 8` |
| add back a second walk | parse-count test RED: `4 == 2`, `16 == 8` |
| `setdefault` → plain assignment | duplicate-id test RED: `{'ZZZ BODY.'} == {'AAA BODY.'}` |
| lazy generator → eager list | laziness test RED — **and all 43 others stay green** |

That last row is the point of having the laziness test at all.

## Scope

Out of scope and deliberately untouched: the `yaml.YAMLError` gap in
`_load_fragment` (#924) — its `except (OSError, ValueError)` and its
`# noqa: TRY101` are verbatim from HEAD, and no new exception handling was added.
Note two of #924's three cited call sites (`unnamed.py:601` and `:626`) are deleted
outright by this change; only the guarded load inside `_load_fragment` survives, so
#924 wants rescoping. Commented there.

Also out of scope: the corrupt-history / excerpt-boundary coverage gaps (#871), and
a docs drift found while reading (`docs/generation.md` points the `unnamed` report
at a path the code has never written) — filed as #1419 rather than fixed here.

Closes #1321
