### PR TITLE
fix(classify): merge classifier verdicts instead of rebuilding the block

### DIFF
--- a/creek-tools/creek/author/agents.py
+++ b/creek-tools/creek/author/agents.py
@@ -527,6 +527,12 @@ class _FragmentSignal:
         and confidence from ``title + body`` keyword signal; the rule
         classifier does not detect dosage, so dosage is read from the
         fragment's existing frontmatter (``wavelength.dosage``) instead.
+        Reading the *original* fragment for that used to be load-bearing:
+        the rule pass rebuilt the whole wavelength block and blanked the
+        dosage on its way past, so ``classified.wavelength.dosage`` was a
+        sentinel. Since #1331 the pass merges instead, and the two agree —
+        the explicit read is kept because it still states the intent, not
+        because it is the only thing that works.
         ``voice_register`` and ``confidence`` are ``None`` when no keyword
         fired (neither enum has an ``UNCLASSIFIED`` member).
 

--- a/creek-tools/creek/classify/classify_engine.py
+++ b/creek-tools/creek/classify/classify_engine.py
@@ -1506,6 +1506,10 @@ def _classify_one(
             the rules path or on ``--method llm`` runs where the rule
             classifier already cleared the confidence floor; for those
             fragments :attr:`Fragment.weighted` stays ``None``.
+            The *merge* itself is no longer particular to this flag:
+            since #1331 the rule pass and the single-pick LLM parse
+            layer their verdicts the same way, through the one shared
+            rule in :mod:`creek.classify.evidence`.
 
     Returns:
         ``(updated_fragment, skipped, reasoning)``. ``skipped`` is
@@ -1557,7 +1561,11 @@ def _classify_one_weighted(
     classification rather than replacing it wholesale — a dimension
     the profile is silent about leaves the prior value standing. The
     merge rule, and why the wholesale form was a privacy defect, live
-    on :meth:`WeightedFragmentClassification.merge_onto` (#1309).
+    on :func:`creek.classify.evidence.layer_determined_over`, which
+    :meth:`WeightedFragmentClassification.merge_onto` calls (#1309) and
+    which the rule pass upstream of it now calls too (#1331) — so by
+    the time a fragment reaches here its rule-derived evidence is
+    intact rather than already half destroyed.
 
     When the underlying call fails soft to an empty
     profile (whitespace-only body, provider unavailable, transport

--- a/creek-tools/creek/classify/evidence.py
+++ b/creek-tools/creek/classify/evidence.py
@@ -1,0 +1,116 @@
+"""Sparse-verdict layering for the legacy classification blocks.
+
+A classifier pass produces a *sparse verdict*: it speaks to the axes its
+evidence actually covers and stays silent about the rest. Assigning such
+a verdict onto a fragment wholesale erases every axis it was silent
+about, which is how one defect earned two issue numbers — once against
+the weighted path (#1309) and once against the rules path (#1331).
+:func:`layer_determined_over` is the single implementation of the merge
+rule both paths share, so neither can drift back into the bug alone.
+
+**THE** ``exclude_defaults`` **INVARIANT this rests on.** Every legacy
+classification field's default *is* its "not determined" sentinel
+(``UNCLASSIFIED`` / ``[]`` / ``""`` / ``None``). Dumping a verdict with
+``exclude_defaults=True`` therefore yields exactly the subset of axes the
+classifier actually spoke to, and anything it was silent about is simply
+absent from the update — leaving the fragment's prior evidence standing.
+**A future field whose default is not a "not determined" sentinel breaks
+this silently**: such a field would be dumped whenever a pass left it at
+some *other* value and omitted whenever the pass agreed with the
+non-sentinel default, so a classifier that never considered the axis at
+all would start stamping that default over prior evidence again, with no
+test failing on the way past. Give any new classification field a
+sentinel default, or teach this function about it explicitly.
+
+**Why this module imports nothing from** :mod:`creek`. Every caller sits
+inside a delicate import cycle: :mod:`creek.models` defers its import of
+:mod:`creek.classify.weighted` all the way to the bottom of the file
+(``creek/models.py:1149``, carrying a ``noqa: E402`` and explained at
+``creek/models.py:29`` and ``creek/models.py:813``). Importing only
+:mod:`typing` and :mod:`pydantic` — never a :mod:`creek` module — takes
+this helper out of that reasoning entirely.
+
+To be accurate about how load-bearing that is: it is not the *only*
+workable placement. All three callers already import names straight from
+:mod:`creek.models` at module-load time, so defining this above line 1149
+there would have worked too. The standalone module is chosen because it
+is independently better — single-purpose, trivially unit-testable, and
+no new edge into a 1200-line module — with cycle-immunity as a bonus
+rather than a necessity.
+
+:class:`~pydantic.BaseModel` is imported at runtime rather than behind
+:data:`typing.TYPE_CHECKING` deliberately: third-party imports are not
+what the cycle is about, and a guarded import here would be an
+unexecutable line in a module small enough that one of those drops it
+under the per-file coverage floor.
+
+Callers:
+
+- :meth:`creek.classify.rules.RuleClassifier.classify`, through its
+  ``_layer_over_fragment`` step (#1331).
+- :meth:`creek.classify.weighted.WeightedFragmentClassification.merge_onto`
+  (#1309).
+- ``creek.classify.llm.parsing._apply_voice``, the single-pick LLM
+  path's voice block (#1331).
+
+One writer of a legacy block is deliberately **not** a caller:
+``creek.classify.llm.calibration._apply_wavelength`` still rebuilds its
+block wholesale. Routing it through here is entangled with the FEAT-017
+``_biased_enum`` downgrade, which resets mode/orientation/dosage on a low
+self-reported confidence *on purpose*, so whether that should come to
+mean "do not adopt the noisy pick" or keep meaning "erase what we knew"
+is a design call tracked on its own issue. No wavelength axis feeds a
+privacy control, so unlike the voice block that one is metadata loss
+rather than a fail-open.
+"""
+
+from __future__ import annotations
+
+from typing import TypeVar
+
+from pydantic import BaseModel
+
+_ModelT = TypeVar("_ModelT", bound=BaseModel)
+
+
+def layer_determined_over(
+    *,
+    prior: _ModelT,
+    determined: _ModelT,
+) -> _ModelT:
+    """Overlay only the axes *determined* actually decided onto *prior*.
+
+    The merge rule described in this module's docstring: fields of
+    *determined* left at their "not determined" sentinel default are
+    absent from the update, so the corresponding evidence already on
+    *prior* survives. Fields the pass did decide win outright.
+
+    **The arguments are keyword-only on purpose, and it is a safety
+    property rather than a style choice.** Both operands have the same
+    type, so swapping them typechecks perfectly while inverting the
+    merge — the fresh verdict would become the base and the stale
+    evidence would overwrite it. On the voice block that silently
+    inverts a privacy control, and no gate in this repo would catch it.
+    Naming the roles at every call site is the only thing that can.
+
+    Deliberately generic over :class:`~pydantic.BaseModel` rather than
+    typed to the three classification models, because it states
+    something about merging sparse verdicts, not something about those
+    models. That generality is also its one sharp edge: it is only
+    *sound* for a model whose every default is a "not determined"
+    sentinel. :class:`~creek.models.Fragment` itself does not qualify —
+    ``voice_weight`` defaults to ``1.0``, a real value and not an
+    absence — so do not reach for this to merge whole fragments.
+
+    Args:
+        prior: The block already on record — whatever a previous run,
+            the rule pass, or the operator established. Never mutated.
+        determined: This pass's verdict for the same block, carrying a
+            sentinel default on every axis it did not decide.
+
+    Returns:
+        A copy of *prior* with the non-default fields of *determined*
+        applied. An entirely default *determined* yields an unchanged
+        copy of *prior*.
+    """
+    return prior.model_copy(update=determined.model_dump(exclude_defaults=True))

--- a/creek-tools/creek/classify/llm/orchestrator.py
+++ b/creek-tools/creek/classify/llm/orchestrator.py
@@ -284,7 +284,11 @@ class LLMClassifier:
             updates,
             unclassified_threshold=self.config.unclassified_threshold,
         )
-        _apply_voice(data, updates)
+        # Issue #1331: the voice block merges axis-by-axis, so it needs the
+        # one the fragment already carries — a response that names only
+        # ``voice_register`` must not null a persisted ``confidence``, which
+        # is half the INTIMATE privacy trigger.
+        _apply_voice(data, updates, fragment.voice)
         # Issue #877: ``praxis_potential`` is monotone, so the merge needs
         # the verdict the fragment already carries — a model answering
         # ``latent`` for an ``explicit`` fragment must lose. ``_apply_praxis``

--- a/creek-tools/creek/classify/llm/parsing.py
+++ b/creek-tools/creek/classify/llm/parsing.py
@@ -18,6 +18,7 @@ from typing import TypeVar
 
 import yaml
 
+from creek.classify.evidence import layer_determined_over
 from creek.classify.praxis_pass import PRAXIS_POTENTIAL_KEY, escalate
 from creek.models import (
     Confidence,
@@ -597,23 +598,53 @@ def _apply_texture(
 def _apply_voice(
     data: dict[str, object],
     updates: dict[str, object],
+    current: VoiceClassification,
 ) -> None:
-    """Extract voice classification from parsed data.
+    """Layer the response's voice verdict over the recorded one (#1331).
+
+    Takes the fragment's prior value for the same reason
+    :func:`_apply_praxis` (#877) and :func:`_apply_texture` (#878) do.
+    Rebuilding the whole block from the response nulls whichever axis
+    the model was silent about: a response carrying ``voice:
+    {voice_register: confessional}`` and no ``confidence`` used to erase
+    a persisted ``conviction`` — half of the INTIMATE trigger read by
+    :meth:`~creek.classify.privacy.PrivacyClassifier._is_high_confidence_confessional`
+    — so the escalation that evidence should unlock never fired. That is
+    a fail-open, and it is the single-pick LLM path's copy of the defect
+    fixed one layer earlier in
+    :meth:`~creek.classify.rules.RuleClassifier.classify`.
+
+    Unlike the wavelength axes there is no FEAT-017 gating question
+    here: ``voice_register`` and ``confidence`` are not in
+    :data:`~creek.classify.llm.calibration._BIASED_DIMENSIONS`, so no
+    self-reported confidence score is entitled to downgrade them to a
+    sentinel. A model silent about an axis has said nothing, and silence
+    must not erase evidence.
+
+    A response with no ``voice`` block at all stays a **no-op** — no key
+    is written, rather than a wholly-default verdict being merged — so
+    :meth:`~creek.classify.llm.orchestrator.LLMClassifier._apply_classification`
+    can still recognise a run that marked nothing.
 
     Args:
         data: Parsed LLM response.
-        updates: Dict to populate with voice updates.
+        updates: Dict to populate with the merged voice block.
+        current: The voice classification already on the fragment. Only
+            the axes this response actually decided are overlaid on it.
     """
     voice_data = data.get("voice")
     if not isinstance(voice_data, dict):
         return
-    updates["voice"] = VoiceClassification(
-        voice_register=_parse_optional_enum(
-            voice_data.get("voice_register"),
-            VoiceRegister,
-        ),
-        confidence=_parse_optional_enum(
-            voice_data.get("confidence"),
-            Confidence,
+    updates["voice"] = layer_determined_over(
+        prior=current,
+        determined=VoiceClassification(
+            voice_register=_parse_optional_enum(
+                voice_data.get("voice_register"),
+                VoiceRegister,
+            ),
+            confidence=_parse_optional_enum(
+                voice_data.get("confidence"),
+                Confidence,
+            ),
         ),
     )

--- a/creek-tools/creek/classify/rules.py
+++ b/creek-tools/creek/classify/rules.py
@@ -16,6 +16,7 @@ import re
 from enum import Enum
 from typing import TypeVar
 
+from creek.classify.evidence import layer_determined_over
 from creek.models import (
     Confidence,
     Fragment,
@@ -518,6 +519,22 @@ class RuleClassifier:
         with each frequency, phase, mode, voice register, and confidence
         level.  Uses scoring with positional weighting.
 
+        The verdict is **merged, not assigned**: a dimension the
+        matchers said nothing about keeps whatever the fragment already
+        carried, because keyword silence is an absence of evidence and
+        not evidence of absence. See :meth:`_layer_over_fragment` for
+        the rule, including why frequency alone is replaced wholesale.
+
+        This matters beyond bookkeeping. The ``voice.confidence`` the
+        old wholesale assignment destroyed is half of the
+        ``confessional + conviction`` INTIMATE trigger that
+        :class:`~creek.classify.privacy.PrivacyClassifier` reads in
+        ``_is_high_confidence_confessional``
+        (``creek/classify/privacy.py:205-214``), so on a confessional
+        body this pass used to supply one half of the trigger and erase
+        the other in the same breath — a missed escalation (fail-open),
+        not merely a lossy one (#1331).
+
         Args:
             fragment: The fragment to classify.
             content: The markdown body text to scan for keywords.
@@ -571,7 +588,9 @@ class RuleClassifier:
         )
 
         if updates:
-            return fragment.model_copy(update=updates)
+            return fragment.model_copy(
+                update=self._layer_over_fragment(fragment, updates),
+            )
 
         return fragment.model_copy()
 
@@ -757,10 +776,30 @@ class RuleClassifier:
         voice_register: VoiceRegister | None,
         confidence: Confidence | None,
     ) -> dict[str, object]:
-        """Build a dict of model fields to update on the fragment.
+        """Build the sparse verdict for what the matchers determined.
 
-        Only includes fields whose classification produced a result
-        above the configured thresholds.
+        A **pure function of the match results**: it never sees the
+        fragment, and it only names blocks whose classification produced
+        a result above the configured thresholds. Within a named block,
+        every axis the matchers were silent about is left at that
+        field's "not determined" default sentinel — the wavelength block
+        carries no orientation, dosage, colour or descriptor, and the
+        voice block carries ``None`` for whichever of its two axes did
+        not match.
+
+        That makes the result **unsafe to assign wholesale**. Passing it
+        straight to ``fragment.model_copy(update=...)`` replaces each
+        whole block, so those untouched axes overwrite the fragment's
+        prior evidence with sentinels — including the
+        ``voice.confidence`` the INTIMATE privacy escalation reads
+        (#1331). Callers must route it through
+        :meth:`_layer_over_fragment` first.
+
+        The split mirrors the weighted path, where
+        :meth:`~creek.classify.weighted.WeightedFragmentClassification.to_legacy`
+        is a documented pure collapse and
+        :meth:`~creek.classify.weighted.WeightedFragmentClassification.merge_onto`
+        is the separate layering step (#1309).
 
         Args:
             primary: Primary frequency.
@@ -771,8 +810,8 @@ class RuleClassifier:
             confidence: Matched confidence level (or None).
 
         Returns:
-            Dictionary of field names to new values, suitable for
-            ``fragment.model_copy(update=...)``.
+            Dictionary of field names to the values the matchers
+            determined, ready for :meth:`_layer_over_fragment`.
         """
         updates: dict[str, object] = {}
 
@@ -795,6 +834,61 @@ class RuleClassifier:
             )
 
         return updates
+
+    @staticmethod
+    def _layer_over_fragment(
+        fragment: Fragment,
+        updates: dict[str, object],
+    ) -> dict[str, object]:
+        """Layer a sparse verdict over the evidence *fragment* already holds.
+
+        Turns the unsafe-to-assign output of :meth:`_build_updates` into
+        an update dict that is safe to hand to
+        ``fragment.model_copy(update=...)``: the ``wavelength`` and
+        ``voice`` entries are replaced by the fragment's own blocks with
+        only the determined axes overlaid, via
+        :func:`~creek.classify.evidence.layer_determined_over`. An axis
+        the matchers said nothing about keeps whatever was on record.
+
+        THE FREQUENCY ASYMMETRY: ``frequency`` is deliberately **not**
+        layered. :attr:`~creek.models.FrequencyClassification.secondary`
+        is a list, and a list cannot be merged field-wise the way the
+        scalar wavelength and voice axes can — so a freshly picked
+        primary replaces the block wholesale, clearing stale secondaries
+        from an earlier verdict rather than accumulating them. When no
+        primary clears the threshold the block is absent from *updates*
+        entirely and is left completely alone. This matches
+        :meth:`~creek.classify.weighted.WeightedFragmentClassification.merge_onto`
+        on purpose: two divergent merge semantics for one problem is how
+        this defect came to be filed twice (#1331 and #1400).
+
+        Args:
+            fragment: The fragment being classified, carrying whatever
+                evidence a previous run or the operator established.
+            updates: The sparse verdict from :meth:`_build_updates`. Not
+                mutated.
+
+        Returns:
+            A copy of *updates* whose classification blocks are merged
+            onto the fragment's rather than replacing them.
+        """
+        layered = updates.copy()
+
+        wavelength = layered.get("wavelength")
+        if isinstance(wavelength, WavelengthClassification):
+            layered["wavelength"] = layer_determined_over(
+                prior=fragment.wavelength,
+                determined=wavelength,
+            )
+
+        voice = layered.get("voice")
+        if isinstance(voice, VoiceClassification):
+            layered["voice"] = layer_determined_over(
+                prior=fragment.voice,
+                determined=voice,
+            )
+
+        return layered
 
     def _match_voice_register(
         self,

--- a/creek-tools/creek/classify/weighted.py
+++ b/creek-tools/creek/classify/weighted.py
@@ -36,6 +36,8 @@ from typing import TYPE_CHECKING, Generic, TypeVar
 import yaml
 from pydantic import BaseModel, ConfigDict
 
+from creek.classify.evidence import layer_determined_over
+
 # Import :func:`_strip_code_fences` from its defining submodule rather
 # than the :mod:`creek.classify.llm` package surface. The package's
 # ``__init__.py`` re-exports happen *after* every submodule loads, but
@@ -495,6 +497,11 @@ class WeightedFragmentClassification(BaseModel):
         here", never "the call died", so deferring to the fragment's
         prior evidence is always the right reading.
 
+        The rule itself is no longer local to this method:
+        :func:`~creek.classify.evidence.layer_determined_over` holds the
+        single implementation, now shared with the rule classifier's own
+        layering step (#1331), so the two paths cannot drift apart.
+
         Args:
             fragment: The fragment being classified, carrying whatever
                 classification a previous run or the rule classifier
@@ -505,21 +512,19 @@ class WeightedFragmentClassification(BaseModel):
             profile and its legacy classification merged, not replaced.
         """
         freq, wave, voice = self.to_legacy()
-        # THE ``exclude_defaults`` INVARIANT that makes this a merge:
-        # every legacy classification field's default *is* its "not
-        # determined" sentinel (``UNCLASSIFIED`` / ``""`` / ``None``).
-        # So dumping the collapse with ``exclude_defaults=True`` yields
-        # exactly the subset of fields the model actually spoke to, and
-        # anything it was silent about is simply absent from the update
-        # — leaving the fragment's prior evidence standing.
+        # What makes this a merge rather than a replacement is THE
+        # ``exclude_defaults`` INVARIANT, documented in full on
+        # :func:`~creek.classify.evidence.layer_determined_over` — which
+        # is now the one implementation this path and the rules path
+        # (#1331) both call. Read it there before "simplifying" either
+        # call site back into the defect.
         update: dict[str, object] = {
             "weighted": self,
-            "wavelength": fragment.wavelength.model_copy(
-                update=wave.model_dump(exclude_defaults=True),
+            "wavelength": layer_determined_over(
+                prior=fragment.wavelength,
+                determined=wave,
             ),
-            "voice": fragment.voice.model_copy(
-                update=voice.model_dump(exclude_defaults=True),
-            ),
+            "voice": layer_determined_over(prior=fragment.voice, determined=voice),
         }
         # THE FREQUENCY ASYMMETRY: frequency is replaced wholesale when
         # the profile has any frequencies (so stale secondaries from an

--- a/creek-tools/tests/test_classify_weighted_evidence_on_disk.py
+++ b/creek-tools/tests/test_classify_weighted_evidence_on_disk.py
@@ -11,16 +11,23 @@ Why the written file and not the returned ``Fragment``: the write path is
 ``exclude_none``, so a nulled confidence really does land on disk as
 ``confidence: null``. An in-memory assertion cannot see that.
 
-A deliberate limitation is encoded in every test here, and it is the reason
-for the ``_RULE_INERT_BODY`` constant and the explicit precondition
-assertions. ``RuleClassifier._build_updates`` rebuilds ``VoiceClassification``
-from scratch under an ``OR`` guard, so for any body its voice matcher fires
-on, a persisted ``confidence`` is destroyed *before* the weighted classifier
-is ever called and no downstream merge can recover it. That is a separate
-defect at the rules layer, filed as issue #1400 and out of scope here. These
-tests therefore prove the weighted path closes completely **for the fragments
-the rule pass leaves alone**, and they assert that precondition rather than
-quietly depending on it.
+``_RULE_INERT_BODY`` and the explicit precondition assertions were written
+here as the visible boundary of a defect that is now closed. When #1309
+landed, ``RuleClassifier._build_updates`` still rebuilt ``VoiceClassification``
+from scratch under an ``OR`` guard, so for any body its voice matcher fired
+on, a persisted ``confidence`` was destroyed *before* the weighted classifier
+was ever called and no downstream merge could recover it — which meant these
+tests could only prove the weighted path closed **for the fragments the rule
+pass left alone**. Issue #1331 fixed that rules-layer twin, so the rule pass
+now merges its verdict like this one does and the caveat is retired.
+
+The inert fixture stays, and so do the assertions, for a different and better
+reason: these tests are about the *weighted* merge, and a body that fires the
+rule matchers would let the rules layer explain a passing result. Keeping the
+fixture inert keeps the subject of the measurement unambiguous, and
+:func:`_assert_rule_pass_preserves_evidence` now pins a guarantee rather than
+hedging a known gap. The general proof that the rules layer preserves evidence
+for *any* body lives in ``tests/test_rules_preserves_evidence.py``.
 """
 
 from __future__ import annotations
@@ -81,11 +88,13 @@ _RULE_INERT_TITLE: Final[str] = "A quiet note"
 
 The rule matchers read the title as well as the body, and that bites. An
 earlier draft titled this fragment "Evidence bearing fragment"; the word
-"evidence" trips ``_match_voice_register`` into an ``analytical`` verdict,
-which fires the ``OR`` guard at ``rules.py:791`` and destroys the persisted
-``confidence`` before the weighted classifier is reached (#1400) — turning
-these tests red for a reason that has nothing to do with what they measure.
-The precondition assertions caught it.
+"evidence" trips ``_match_voice_register`` into an ``analytical`` verdict.
+Before #1331 that fired the ``OR`` guard at ``rules.py:791`` and destroyed the
+persisted ``confidence`` before the weighted classifier was reached, turning
+these tests red for a reason that had nothing to do with what they measure;
+the precondition assertions caught it. The destruction is fixed, but the inert
+title is kept so a rule-matcher verdict can never be the thing that explains a
+pass here — see the module docstring.
 """
 
 _CONFESSIONAL_CONVICTION_RESPONSE: Final[str] = """\
@@ -192,9 +201,13 @@ def _seed_with_evidence(vault: Path) -> Path:
 def _assert_rule_pass_preserves_evidence(fragment: Fragment) -> None:
     """Assert the rules layer leaves this fragment's evidence intact.
 
-    The visible boundary of this PR. If this ever fails, the rules-layer
-    twin (#1400) has started firing on the test body and the assertions
-    downstream would be measuring the wrong defect.
+    Since #1331 this is a *guarantee* the rule pass makes for any body — it
+    merges its verdict instead of rebuilding the sub-models — rather than the
+    fixture-dependent precondition it was when #1309 wrote it. It is kept
+    because these tests measure the weighted merge specifically: if it ever
+    fails, the rules layer has started moving the very axes the assertions
+    downstream attribute to ``merge_onto``, and those assertions would be
+    measuring the wrong component.
 
     Args:
         fragment: The seeded fragment, before classification.

--- a/creek-tools/tests/test_rules_preserves_evidence.py
+++ b/creek-tools/tests/test_rules_preserves_evidence.py
@@ -1,0 +1,817 @@
+"""The rule pass must merge its verdict, not replace the fragment (#1331).
+
+``RuleClassifier._build_updates`` rebuilds ``WavelengthClassification`` and
+``VoiceClassification`` **from scratch** whenever any one of their axes
+matched, so every axis the matchers were silent about is reset to its
+default. A phase-only body therefore blanks mode, orientation, dosage,
+colour and descriptor; a register-only body blanks a persisted
+``confidence``.
+
+This is the rules-layer twin of the weighted-path defect closed by #1309 /
+PR #1402, and it mirrors that fix's shape: a dimension the classifier said
+nothing about keeps whatever the fragment already carried, while frequency
+keeps its deliberate asymmetry (replaced wholesale when a primary is picked,
+because ``secondary`` is a list and cannot be merged field-wise; left alone
+entirely when no primary is picked). See
+:meth:`creek.classify.weighted.WeightedFragmentClassification.merge_onto`.
+
+**Why this is a privacy defect and not merely lossy bookkeeping.**
+:meth:`~creek.classify.privacy.PrivacyClassifier._is_high_confidence_confessional`
+escalates to ``INTIMATE`` only when ``voice_register`` is ``confessional``
+**and** ``confidence`` is ``conviction``. On a confessional body the rule
+pass supplies the missing half and destroys the half already on disk in the
+same operation, so the escalation that should fire never does. Every writer
+of ``privacy_tier`` is escalate-only, which makes this a **missed
+escalation** — a fail-open — not a lowered tier. Accordingly every privacy
+assertion below asserts the tier goes **UP** to ``INTIMATE``; an assertion
+that "the tier did not go down" passes against the bug and proves nothing.
+
+The bodies used here are characterised empirically, one matcher each. That
+characterisation is load-bearing: if a body silently starts firing a second
+matcher these tests quietly begin measuring something else, so each constant
+records both what it fires and what it deliberately does not.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final
+from unittest.mock import patch
+
+import frontmatter
+import pytest
+
+from creek.classify.classify_engine import run_classify
+from creek.classify.evidence import layer_determined_over
+from creek.classify.llm import LLMClassifier
+from creek.classify.privacy import PrivacyClassifier
+from creek.classify.reatomize import _is_accepted
+from creek.classify.rules import RuleClassifier
+from creek.config import CreekConfig, LLMConfig
+from creek.models import (
+    Authorship,
+    Color,
+    Confidence,
+    Dosage,
+    Fragment,
+    FragmentSource,
+    Frequency,
+    FrequencyClassification,
+    Mode,
+    Orientation,
+    Phase,
+    PrivacyTier,
+    SourcePlatform,
+    VoiceClassification,
+    VoiceRegister,
+    WavelengthClassification,
+)
+from tests.helpers import write_fragment_file
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_FRAGMENT_ID: Final[str] = "frag-1331-rules-merge"
+"""Stable id so the on-disk tests can find the file they seeded."""
+
+_TITLE: Final[str] = "A quiet note"
+"""A title every rule matcher is silent about.
+
+Load-bearing. The matchers score the *title* alongside the body, so a
+descriptive title poisons the fixture: an earlier lane's "Evidence bearing
+fragment" tripped ``_match_voice_register`` on the word "evidence", firing
+the voice guard in a test whose body was meant to be inert.
+"""
+
+_DESCRIPTOR: Final[str] = "Social Anxiety"
+"""The persisted wavelength descriptor — a free-text axis no matcher writes."""
+
+_PHASE_ONLY_BODY: Final[str] = (
+    "The peak arrived. At its peak the whole thing reached a peak of stillness."
+)
+"""Fires the phase matcher (``peaking``) and nothing else.
+
+Deliberately silent for mode, frequency, voice register and confidence, so
+whatever the fragment already carries on those five axes is the only thing
+that can explain their value after the pass.
+"""
+
+_MODE_ONLY_BODY: Final[str] = (
+    "Expressing it, creating it, articulating it: expressing again and creating again."
+)
+"""Fires the mode matcher (``express``) and nothing else.
+
+Deliberately silent for phase — which is the point: phase and mode share one
+``OR`` guard, so a mode-only match is what exposes the cross-axis
+destruction inside :class:`~creek.models.WavelengthClassification`.
+"""
+
+_REGISTER_ONLY_BODY: Final[str] = (
+    "I have to admit something. I confess I was afraid, and honestly I still am."
+)
+"""Fires the voice-register matcher (``confessional``) and nothing else.
+
+Deliberately silent for confidence — the exact shape that makes this a
+privacy defect: the pass supplies half the INTIMATE trigger and destroys the
+other half in the same breath. Also silent for phase, mode and frequency,
+and carries no recovery keyword, so ``INTIMATE`` here can only ever come
+from the confessional+conviction rule.
+"""
+
+_CONFIDENCE_ONLY_BODY: Final[str] = (
+    "I believe this. I know this. It is definitely and certainly the case."
+)
+"""Fires the confidence matcher (``settled``) and nothing else.
+
+Deliberately silent for voice register — the mirror image of
+``_REGISTER_ONLY_BODY``, covering the other half of the voice ``OR`` guard.
+"""
+
+_FREQ_ONLY_BODY: Final[str] = (
+    "Power and dominance and control, power over power, dominance again, control again."
+)
+"""Fires the frequency matcher (primary ``F3``) and nothing else.
+
+Deliberately silent for phase, mode, register and confidence, so it isolates
+the one axis whose replacement is *correct* from the axes whose replacement
+is the bug.
+"""
+
+_RULE_INERT_BODY: Final[str] = (
+    "A plain paragraph about gardening tools and afternoon light."
+)
+"""Fires no matcher at all — the whole-pass no-op control."""
+
+
+def _seeded_fragment(
+    *,
+    voice: VoiceClassification | None = None,
+    frequency: FrequencyClassification | None = None,
+) -> Fragment:
+    """Build a fragment already carrying a full classification.
+
+    The wavelength block is populated on all six axes and the voice block on
+    both, so any axis that comes back at its default after a rule pass was
+    destroyed by that pass rather than never set.
+
+    Args:
+        voice: Voice block to persist; defaults to ``analytical`` +
+            ``conviction`` — an ``ESSAY``/``SELF`` fragment that is *not*
+            INTIMATE, but that holds the ``conviction`` half of the trigger.
+        frequency: Frequency block to persist; defaults to an empty one.
+
+    Returns:
+        The seeded :class:`~creek.models.Fragment`.
+    """
+    if voice is None:
+        voice = VoiceClassification(
+            voice_register=VoiceRegister.ANALYTICAL,
+            confidence=Confidence.CONVICTION,
+        )
+    if frequency is None:
+        frequency = FrequencyClassification()
+    return Fragment(
+        id=_FRAGMENT_ID,
+        title=_TITLE,
+        source=FragmentSource(platform=SourcePlatform.ESSAY, author=Authorship.SELF),
+        frequency=frequency,
+        wavelength=WavelengthClassification(
+            phase=Phase.RISING,
+            mode=Mode.EXPRESS,
+            orientation=Orientation.FEEL,
+            dosage=Dosage.MEDICINE,
+            color=Color.GREEN,
+            descriptor=_DESCRIPTOR,
+        ),
+        voice=voice,
+    )
+
+
+def _assert_wavelength(
+    fragment: Fragment,
+    *,
+    phase: Phase,
+    mode: Mode,
+) -> None:
+    """Assert all six wavelength axes of a seeded fragment at once.
+
+    Every axis is named explicitly rather than spot-checking the two the
+    issue emphasises: the recurring failure mode on this defect is a fix that
+    restores ``mode`` and ``descriptor`` and silently keeps resetting
+    ``orientation``, ``dosage`` or ``color``.
+
+    Args:
+        fragment: The fragment to inspect.
+        phase: The expected phase (the only axis a phase match may change).
+        mode: The expected mode (the only axis a mode match may change).
+    """
+    assert fragment.wavelength.phase == phase
+    assert fragment.wavelength.mode == mode
+    assert fragment.wavelength.orientation == Orientation.FEEL
+    assert fragment.wavelength.dosage == Dosage.MEDICINE
+    assert fragment.wavelength.color == Color.GREEN
+    assert fragment.wavelength.descriptor == _DESCRIPTOR
+
+
+def _assert_voice(
+    fragment: Fragment,
+    *,
+    register: VoiceRegister,
+    confidence: Confidence,
+) -> None:
+    """Assert both voice axes of a seeded fragment.
+
+    Args:
+        fragment: The fragment to inspect.
+        register: The expected voice register.
+        confidence: The expected confidence stance.
+    """
+    assert fragment.voice.voice_register == register
+    assert fragment.voice.confidence == confidence
+
+
+class TestWavelengthMerge:
+    """A wavelength match overlays one axis; it does not rebuild the block."""
+
+    def test_a_phase_match_leaves_the_other_five_axes_standing(self) -> None:
+        """Phase advances to ``peaking`` and nothing else moves.
+
+        At HEAD the ``OR`` guard at ``rules.py:785`` constructs a fresh
+        ``WavelengthClassification(phase=..., mode=...)``, so five of six axes
+        come back at their defaults — ``mode``, ``orientation``, ``dosage``
+        and ``color`` at ``unclassified`` and ``descriptor`` at ``""``.
+        """
+        result = RuleClassifier().classify(
+            _seeded_fragment(),
+            content=_PHASE_ONLY_BODY,
+        )
+        # What the rules DID determine is adopted...
+        assert result.wavelength.phase == Phase.PEAKING
+        # ...and everything they were silent about survives.
+        _assert_wavelength(result, phase=Phase.PEAKING, mode=Mode.EXPRESS)
+
+    def test_a_mode_match_does_not_blank_the_persisted_phase(self) -> None:
+        """Mode is set from the body while the on-record phase survives.
+
+        The cross-destruction case. Phase and mode share a single ``OR``
+        guard, so at HEAD a body that speaks only to mode still rebuilds the
+        whole block and resets a perfectly good ``rising`` to the model
+        default ``unclassified``.
+        """
+        result = RuleClassifier().classify(
+            _seeded_fragment(),
+            content=_MODE_ONLY_BODY,
+        )
+        assert result.wavelength.mode == Mode.EXPRESS
+        _assert_wavelength(result, phase=Phase.RISING, mode=Mode.EXPRESS)
+
+    def test_the_voice_block_is_untouched_by_a_wavelength_match(self) -> None:
+        """A phase-only body has no standing to rewrite the voice axes."""
+        result = RuleClassifier().classify(
+            _seeded_fragment(),
+            content=_PHASE_ONLY_BODY,
+        )
+        _assert_voice(
+            result,
+            register=VoiceRegister.ANALYTICAL,
+            confidence=Confidence.CONVICTION,
+        )
+
+
+class TestVoiceMerge:
+    """A voice match overlays one axis; it does not rebuild the block."""
+
+    def test_a_register_match_keeps_the_persisted_confidence(self) -> None:
+        """Register becomes ``confessional`` and ``conviction`` stays put.
+
+        At HEAD ``rules.py:791`` builds
+        ``VoiceClassification(voice_register=confessional, confidence=None)``
+        — the destruction that costs the fragment its INTIMATE escalation.
+        """
+        result = RuleClassifier().classify(
+            _seeded_fragment(),
+            content=_REGISTER_ONLY_BODY,
+        )
+        _assert_voice(
+            result,
+            register=VoiceRegister.CONFESSIONAL,
+            confidence=Confidence.CONVICTION,
+        )
+
+    def test_a_confidence_match_keeps_the_persisted_register(self) -> None:
+        """Confidence becomes ``settled`` and ``analytical`` stays put.
+
+        The other half of the same ``OR`` guard: at HEAD a body that speaks
+        only to confidence nulls the register.
+        """
+        result = RuleClassifier().classify(
+            _seeded_fragment(),
+            content=_CONFIDENCE_ONLY_BODY,
+        )
+        _assert_voice(
+            result,
+            register=VoiceRegister.ANALYTICAL,
+            confidence=Confidence.SETTLED,
+        )
+
+    def test_the_wavelength_block_is_untouched_by_a_voice_match(self) -> None:
+        """A register-only body has no standing to rewrite the wavelength."""
+        result = RuleClassifier().classify(
+            _seeded_fragment(),
+            content=_REGISTER_ONLY_BODY,
+        )
+        _assert_wavelength(result, phase=Phase.RISING, mode=Mode.EXPRESS)
+
+
+class TestFrequencyAsymmetry:
+    """Frequency is replaced wholesale, and only when a primary is picked."""
+
+    def test_a_frequency_match_replaces_frequency_and_touches_nothing_else(
+        self,
+    ) -> None:
+        """``F3`` lands, stale secondaries clear, voice and wavelength hold.
+
+        The asymmetry is deliberate and mirrors
+        :meth:`~creek.classify.weighted.WeightedFragmentClassification.merge_onto`:
+        ``secondary`` is a list, which cannot be merged field-wise the way
+        the scalar axes can, so a fresh primary clears it rather than
+        accumulating verdicts. Pinned here so nobody later "completes" the
+        merge by making frequency behave like the other two blocks.
+        """
+        result = RuleClassifier().classify(
+            _seeded_fragment(
+                frequency=FrequencyClassification(
+                    primary=Frequency.F1,
+                    secondary=[Frequency.F5],
+                ),
+            ),
+            content=_FREQ_ONLY_BODY,
+        )
+        assert result.frequency.primary == Frequency.F3
+        assert result.frequency.secondary == []
+        _assert_wavelength(result, phase=Phase.RISING, mode=Mode.EXPRESS)
+        _assert_voice(
+            result,
+            register=VoiceRegister.ANALYTICAL,
+            confidence=Confidence.CONVICTION,
+        )
+
+
+class TestMergeIsNotInaction:
+    """The merge preserves prior evidence without disabling the classifier."""
+
+    def test_an_inert_body_changes_nothing(self) -> None:
+        """No matcher fires, so the whole classification comes back as-is."""
+        seeded = _seeded_fragment(
+            frequency=FrequencyClassification(
+                primary=Frequency.F3,
+                secondary=[Frequency.F5],
+            ),
+        )
+        result = RuleClassifier().classify(seeded, content=_RULE_INERT_BODY)
+        assert result.frequency.primary == Frequency.F3
+        assert result.frequency.secondary == [Frequency.F5]
+        _assert_wavelength(result, phase=Phase.RISING, mode=Mode.EXPRESS)
+        _assert_voice(
+            result,
+            register=VoiceRegister.ANALYTICAL,
+            confidence=Confidence.CONVICTION,
+        )
+
+    def test_a_fragment_with_no_prior_classification_still_gets_classified(
+        self,
+    ) -> None:
+        """A fresh fragment is classified normally by the merged pass.
+
+        The guard against the degenerate "fix": a pass that preserved
+        everything by determining nothing would satisfy every other test in
+        this module. The rules must still write what they actually found.
+        """
+        fresh = Fragment(
+            id="frag-1331-fresh",
+            title=_TITLE,
+            source=FragmentSource(
+                platform=SourcePlatform.ESSAY,
+                author=Authorship.SELF,
+            ),
+        )
+        # Precondition: nothing on record to preserve.
+        assert fresh.wavelength.phase == Phase.UNCLASSIFIED
+
+        result = RuleClassifier().classify(fresh, content=_PHASE_ONLY_BODY)
+        assert result.wavelength.phase == Phase.PEAKING
+        # The axes the body is silent about stay at their defaults rather
+        # than being invented.
+        assert result.wavelength.mode == Mode.UNCLASSIFIED
+        assert result.wavelength.descriptor == ""
+
+
+class TestPrivacyEscalation:
+    """The destroyed evidence is half of the INTIMATE trigger."""
+
+    def test_the_rule_pass_escalates_a_confessional_fragment_to_intimate(
+        self,
+    ) -> None:
+        """Supplying ``confessional`` over a persisted ``conviction`` buries it.
+
+        This asserts an escalation **UP** — ``OPEN`` before the pass,
+        ``INTIMATE`` after — and that direction is the whole point. Every
+        writer of ``privacy_tier`` is escalate-only, so "the tier did not go
+        down" is true at HEAD and true after the fix and distinguishes
+        nothing; the defect is a **missed** escalation, a fail-open. The
+        baseline is asserted first so the test proves its own premise rather
+        than assuming it.
+
+        At HEAD the rule pass returns ``{confessional, None}`` and
+        ``_is_high_confidence_confessional`` short-circuits on the ``None``,
+        so the fragment stays ``OPEN`` and is eligible for cloud egress.
+        """
+        fragment = _seeded_fragment()
+        privacy = PrivacyClassifier()
+
+        # Premise: as persisted (analytical + conviction) this ESSAY is OPEN,
+        # so INTIMATE below is a genuine escalation and not the status quo.
+        assert (
+            privacy.classify_tier(fragment, content=_REGISTER_ONLY_BODY)
+            == PrivacyTier.OPEN
+        )
+
+        result = RuleClassifier().classify(fragment, content=_REGISTER_ONLY_BODY)
+        assert (
+            privacy.classify_tier(result, content=_REGISTER_ONLY_BODY)
+            == PrivacyTier.INTIMATE
+        )
+
+    def test_supplied_and_persisted_evidence_reach_the_same_tier(self) -> None:
+        """Same evidence, same tier, however the two halves arrived.
+
+        Arm A already holds both halves on disk and needs no verdict from
+        the rules. Arm B holds ``conviction`` on disk and has the rules
+        supply ``confessional``. The privacy heuristic reads a fragment, not
+        a provenance, so the two must land on the same tier — at HEAD they
+        diverge, because arm B's rule pass eats the half it did not supply.
+        """
+        rules = RuleClassifier()
+        privacy = PrivacyClassifier()
+
+        already_confessional = _seeded_fragment(
+            voice=VoiceClassification(
+                voice_register=VoiceRegister.CONFESSIONAL,
+                confidence=Confidence.CONVICTION,
+            ),
+        )
+        tier_persisted = privacy.classify_tier(
+            rules.classify(already_confessional, content=_RULE_INERT_BODY),
+            content=_RULE_INERT_BODY,
+        )
+        tier_supplied = privacy.classify_tier(
+            rules.classify(_seeded_fragment(), content=_REGISTER_ONLY_BODY),
+            content=_REGISTER_ONLY_BODY,
+        )
+
+        assert tier_persisted == PrivacyTier.INTIMATE
+        assert tier_supplied == PrivacyTier.INTIMATE
+        assert tier_persisted == tier_supplied
+
+    @pytest.mark.parametrize(
+        "stance",
+        [Confidence.MUSING, Confidence.EXPLORING],
+    )
+    def test_a_tentative_stance_is_not_manufactured_into_intimate(
+        self,
+        stance: Confidence,
+    ) -> None:
+        """A confessional register over a tentative stance stays out of INTIMATE.
+
+        Under the escalate-only ratchet a manufactured escalation is
+        permanent burial, so over-protection is as much a defect as
+        under-protection. The stance is asserted to have *survived* as well:
+        without that assertion the test would pass at HEAD for the wrong
+        reason — the field having been destroyed rather than respected.
+
+        Args:
+            stance: The tentative confidence already on the fragment.
+        """
+        result = RuleClassifier().classify(
+            _seeded_fragment(
+                voice=VoiceClassification(
+                    voice_register=VoiceRegister.ANALYTICAL,
+                    confidence=stance,
+                ),
+            ),
+            content=_REGISTER_ONLY_BODY,
+        )
+
+        # The register really was supplied, and the stance really survived,
+        # so the tier below is a judgement and not an accident of erasure.
+        assert result.voice.voice_register == VoiceRegister.CONFESSIONAL
+        assert result.voice.confidence == stance
+        assert (
+            PrivacyClassifier().classify_tier(result, content=_REGISTER_ONLY_BODY)
+            != PrivacyTier.INTIMATE
+        )
+
+
+class TestTheMergePrimitive:
+    """``layer_determined_over`` and the invariant that makes it sound."""
+
+    @pytest.mark.parametrize(
+        ("model", "label"),
+        [
+            (FrequencyClassification, "frequency"),
+            (WavelengthClassification, "wavelength"),
+            (VoiceClassification, "voice"),
+        ],
+    )
+    def test_every_default_is_a_not_determined_sentinel(
+        self,
+        model: type[FrequencyClassification]
+        | type[WavelengthClassification]
+        | type[VoiceClassification],
+        label: str,
+    ) -> None:
+        """A default-constructed block dumps to ``{}`` under ``exclude_defaults``.
+
+        The executable form of the precondition the whole merge rests on. If a
+        future field lands with a default that is a real value rather than an
+        absence — the way ``Fragment.voice_weight`` defaults to ``1.0`` — this
+        goes red here instead of silently teaching every classifier pass to
+        stamp that default over prior evidence again.
+
+        Args:
+            model: The classification block under test.
+            label: Human-readable name, so a failure names the block.
+        """
+        assert model().model_dump(exclude_defaults=True) == {}, label
+
+    def test_a_wholly_undetermined_verdict_changes_nothing(self) -> None:
+        """A pass that decided nothing leaves every axis on record intact."""
+        prior = WavelengthClassification(
+            phase=Phase.RISING,
+            mode=Mode.EXPRESS,
+            orientation=Orientation.FEEL,
+            dosage=Dosage.MEDICINE,
+            color=Color.GREEN,
+            descriptor=_DESCRIPTOR,
+        )
+        merged = layer_determined_over(
+            prior=prior,
+            determined=WavelengthClassification(),
+        )
+        assert merged.model_dump() == prior.model_dump()
+
+    def test_determined_axes_win_and_silent_axes_defer(self) -> None:
+        """The two halves of the rule, on one call."""
+        merged = layer_determined_over(
+            prior=VoiceClassification(
+                voice_register=VoiceRegister.ANALYTICAL,
+                confidence=Confidence.CONVICTION,
+            ),
+            determined=VoiceClassification(
+                voice_register=VoiceRegister.CONFESSIONAL,
+            ),
+        )
+        assert merged.voice_register == VoiceRegister.CONFESSIONAL
+        assert merged.confidence == Confidence.CONVICTION
+
+    def test_neither_operand_is_mutated(self) -> None:
+        """The merge is pure — callers may reuse both inputs afterwards."""
+        prior = VoiceClassification(
+            voice_register=VoiceRegister.ANALYTICAL,
+            confidence=Confidence.CONVICTION,
+        )
+        determined = VoiceClassification(voice_register=VoiceRegister.CONFESSIONAL)
+
+        layer_determined_over(prior=prior, determined=determined)
+
+        assert prior.voice_register == VoiceRegister.ANALYTICAL
+        assert prior.confidence == Confidence.CONVICTION
+        assert determined.voice_register == VoiceRegister.CONFESSIONAL
+        assert determined.confidence is None
+
+    def test_it_is_correct_over_a_mixed_str_and_enum_prior(self) -> None:
+        """``use_enum_values=True`` leaves a prior part ``str``, part enum.
+
+        The classification models set ``use_enum_values=True``, so a field
+        passed to the constructor is stored as its plain ``str`` while a
+        defaulted field keeps the enum member. A prior is therefore a mix of
+        the two depending on how it was built, and any merge that compared
+        values by hand would have to be right on both. This one performs no
+        comparison at all — pinned here so that stays true.
+        """
+        prior = WavelengthClassification(phase=Phase.RISING, descriptor=_DESCRIPTOR)
+        assert isinstance(prior.phase, str)
+        assert isinstance(prior.orientation, Orientation)
+
+        merged = layer_determined_over(
+            prior=prior,
+            determined=WavelengthClassification(mode=Mode.EXPRESS),
+        )
+        assert merged.phase == Phase.RISING
+        assert merged.mode == Mode.EXPRESS
+        assert merged.descriptor == _DESCRIPTOR
+        assert merged.orientation == Orientation.UNCLASSIFIED
+
+
+class TestSinglePickLLMVoiceMerge:
+    """The same fail-open, one layer on: ``_apply_voice`` (#1331)."""
+
+    @staticmethod
+    def _classify(response: str, fragment: Fragment) -> Fragment:
+        """Drive ``LLMClassifier.classify`` over a canned response.
+
+        Args:
+            response: The YAML the provider is made to return.
+            fragment: The fragment to classify.
+
+        Returns:
+            The classified fragment.
+        """
+        classifier = LLMClassifier(config=LLMConfig())
+        classifier._available = True
+        with patch.object(LLMClassifier, "_invoke_llm", return_value=response):
+            return classifier.classify(fragment)
+
+    def test_a_response_silent_on_confidence_keeps_the_persisted_one(self) -> None:
+        """A partial ``voice:`` block must not null the other axis.
+
+        The rules-layer fix alone does not close the fail-open on
+        ``--method llm``: the rule pass preserves ``conviction`` and the
+        single-pick parse then destroyed it a moment later. At HEAD this
+        returned ``confidence=None`` and the fragment silently failed to
+        escalate.
+        """
+        result = self._classify(
+            "voice:\n  voice_register: confessional\n",
+            _seeded_fragment(),
+        )
+        _assert_voice(
+            result,
+            register=VoiceRegister.CONFESSIONAL,
+            confidence=Confidence.CONVICTION,
+        )
+        assert (
+            PrivacyClassifier().classify_tier(result, content=_RULE_INERT_BODY)
+            == PrivacyTier.INTIMATE
+        )
+
+    def test_a_response_with_no_voice_block_is_still_a_no_op(self) -> None:
+        """No ``voice:`` key means no verdict — not a wholly-default merge.
+
+        The early return matters to the caller: ``_apply_classification``
+        reads an empty ``updates`` dict as "this run marked nothing", so
+        writing a merged-but-unchanged block would be a lie about provenance.
+        """
+        result = self._classify(
+            "frequency:\n  primary: F6\n",
+            _seeded_fragment(),
+        )
+        _assert_voice(
+            result,
+            register=VoiceRegister.ANALYTICAL,
+            confidence=Confidence.CONVICTION,
+        )
+        assert result.frequency.primary == Frequency.F6
+
+    def test_what_the_model_did_say_still_wins(self) -> None:
+        """The merge must not stop the model from changing its mind."""
+        result = self._classify(
+            "voice:\n  voice_register: playful\n  confidence: musing\n",
+            _seeded_fragment(),
+        )
+        _assert_voice(
+            result,
+            register=VoiceRegister.PLAYFUL,
+            confidence=Confidence.MUSING,
+        )
+
+
+class TestReatomizeAcceptance:
+    """Characterises the one downstream behaviour this fix moves (#1331)."""
+
+    def test_an_inherited_phase_now_survives_a_mode_only_child(self) -> None:
+        """A re-atomized child keeps the phase it inherited, so it is accepted.
+
+        ``_is_accepted`` rejects any fragment whose ``wavelength.phase`` is
+        ``unclassified``, and a split child inherits its parent's whole
+        wavelength block. At HEAD a child whose keyword pass fired *mode but
+        not phase* had that inherited phase wiped and was rejected, driving
+        the recursion a level deeper; a child with **no** keyword hits at all
+        kept its phase and was accepted. The two cases now agree, which is
+        the point of recording this: the change is a consistency fix, not a
+        loosening. ``classification.reatomize`` is opt-in and off by default,
+        so the blast radius is bounded.
+        """
+        child = RuleClassifier().classify(
+            _seeded_fragment(),
+            content=_MODE_ONLY_BODY,
+        )
+        assert child.wavelength.phase == Phase.RISING
+        assert _is_accepted(child, 1.0, 0.5) is False, (
+            "frequency is still unclassified, so acceptance must not turn on "
+            "phase alone"
+        )
+
+        with_frequency = child.model_copy(
+            update={"frequency": FrequencyClassification(primary=Frequency.F3)},
+        )
+        assert _is_accepted(with_frequency, 1.0, 0.5) is True
+
+
+def _seed_vault(vault: Path) -> Path:
+    """Write one fragment carrying full evidence into *vault*.
+
+    Args:
+        vault: Vault root (created on demand).
+
+    Returns:
+        Path to the freshly-written fragment file.
+    """
+    return write_fragment_file(
+        vault=vault,
+        fragment=_seeded_fragment(),
+        body=_REGISTER_ONLY_BODY,
+    )
+
+
+def _run_rules(vault: Path) -> int:
+    """Run a forced rules classify over *vault*.
+
+    Args:
+        vault: Vault root holding the seeded fragment.
+
+    Returns:
+        The number of fragments the run classified.
+    """
+    return run_classify(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="rules",
+        force=True,
+    ).classified
+
+
+class TestEvidenceOnDisk:
+    """What the written frontmatter says after a real ``run_classify``."""
+
+    def test_a_rules_run_writes_the_merged_evidence_and_the_tier(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The file on disk keeps ``conviction`` and gains ``intimate``.
+
+        Asserted against the written file rather than the returned
+        :class:`~creek.models.Fragment` because the write path is
+        ``new_metadata.update(fragment.model_dump(mode="json"))`` with **no**
+        ``exclude_none``: a nulled confidence really does land in the
+        frontmatter as ``confidence: null``, and an in-memory assertion
+        cannot see that.
+
+        Args:
+            tmp_path: Pytest-provided scratch directory.
+        """
+        vault = tmp_path / "vault"
+        md = _seed_vault(vault)
+
+        assert _run_rules(vault) == 1
+
+        meta = frontmatter.load(md).metadata
+        # The half the rules supplied.
+        assert meta["voice"]["voice_register"] == "confessional"
+        # The half they had no business touching.
+        assert meta["voice"]["confidence"] == "conviction"
+        # The body says nothing about wavelength, so all six axes stand.
+        assert meta["wavelength"]["phase"] == "rising"
+        assert meta["wavelength"]["mode"] == "express"
+        assert meta["wavelength"]["orientation"] == "feel"
+        assert meta["wavelength"]["dosage"] == "medicine"
+        assert meta["wavelength"]["color"] == "green"
+        assert meta["wavelength"]["descriptor"] == _DESCRIPTOR
+        # And the escalation the restored evidence unlocks actually fires.
+        assert meta["privacy_tier"] == "intimate"
+
+    def test_a_second_rules_run_keeps_the_tier_and_its_evidence(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Re-running does not undo the burial or erase what justifies it.
+
+        The engine's stated invariant is that an escalation prevents every
+        *future* egress for a fragment. At HEAD it prevents none: each run
+        nulls the confidence again, so the tier never rises and the fragment
+        routes to the cloud every single time. A tier whose evidence is gone
+        is also one re-ingest away from being unexplainable.
+
+        Args:
+            tmp_path: Pytest-provided scratch directory.
+        """
+        vault = tmp_path / "vault"
+        md = _seed_vault(vault)
+
+        _run_rules(vault)
+        _run_rules(vault)
+
+        meta = frontmatter.load(md).metadata
+        assert meta["privacy_tier"] == "intimate"
+        assert meta["voice"]["voice_register"] == "confessional"
+        assert meta["voice"]["confidence"] == "conviction"
+        assert meta["wavelength"]["descriptor"] == _DESCRIPTOR


### PR DESCRIPTION
## Summary

**In one line:** a classifier pass that was silent about an axis used to erase
that axis, which on the voice block meant erasing half of the `INTIMATE`
privacy trigger — a fail-open. Passes now merge instead of replacing, through
one shared rule.

**Which paths this closes**, because the issue title names only one function
and the real reach is wider:

- `creek classify --method rules` — `_build_updates`, the named defect.
- `creek process` — same rule pass (`pipeline.py:938`), and the sharpest
  consequence: the tier is assigned *before* the provider is chosen, so a
  fragment that should have been `INTIMATE` was seen as `PERSONAL` and routed
  to a **cloud** provider.
- `creek classify --method llm`, single-pick — `_apply_voice`, the identical
  fail-open one layer on. This is the default LLM method, and it is a
  deliberate extension beyond the issue title; the reasoning is in
  [Scope](#scope-one-extension-beyond-the-issue-title-disclosed) below.
- `creek classify --method llm`, weighted — already fixed by #1309; this PR
  re-points it at the shared rule so the two cannot drift apart.

Not closed, deliberately: `_apply_wavelength` on the single-pick LLM path
(metadata loss, not privacy — filed as #1421).

---

`RuleClassifier._build_updates` built a whole fresh `WavelengthClassification`
and a whole fresh `VoiceClassification` from the keyword matchers' verdict, and
`classify` assigned them onto the fragment. Every axis the matchers were silent
about was therefore reset to its default — including axes no matcher can ever
write.

Reproduced at HEAD (`4efc66c`), title `"A quiet note"`, verified rule-inert:

**Wavelength**, body `"The peak arrived. At its peak the whole thing reached a peak of stillness."` (fires `Phase.PEAKING`, nothing else):

```
BEFORE {'phase':'rising','mode':'express','orientation':'feel',
        'dosage':'medicine','color':'green','descriptor':'Social Anxiety'}
AFTER  {'phase':'peaking','mode':'unclassified','orientation':'unclassified',
        'dosage':'unclassified','color':'unclassified','descriptor':''}
```

Five of six axes destroyed — the four the issue names, plus `mode`, because
`phase` and `mode` share one `OR` guard so a match on either rebuilds both.

**Voice**, body `"I have to admit something. I confess I was afraid, and honestly I still am."` (fires `confessional`, no confidence keyword):

```
BEFORE {'voice_register':'analytical','confidence':'conviction'}
AFTER  {'voice_register':'confessional','confidence':None}
```

### Why this is a fail-open and not lossy bookkeeping

Every writer of `privacy_tier` is escalate-only, so nothing here is being
*lowered*. `PrivacyClassifier._is_high_confidence_confessional`
(`creek/classify/privacy.py:205-214`) escalates to `INTIMATE` only on
`voice_register == confessional` **and** `confidence == conviction`, and
short-circuits to `False` if either is `None`.

On a confessional body the rule pass supplies the missing half of that trigger
and destroys the half already on disk **in the same operation**. Verified
end to end with `PrivacyClassifier().classify_tier`:

| | tier |
|---|---|
| the fragment as persisted (`analytical` + `conviction`) | `OPEN` |
| after the rule pass at HEAD (`confessional` + `None`) | `OPEN` |
| with the evidence merged (`confessional` + `conviction`) | **`INTIMATE`** |

So this is a **missed escalation**, not a lowered tier. Every privacy assertion
in this PR therefore asserts the tier goes **UP** to `INTIMATE`. An assertion
that "the tier did not go down" is true at HEAD, true after the fix, and proves
nothing.

### The fix: one merge rule, shared

PR #1402 already merged the right shape for the weighted path
(`WeightedFragmentClassification.merge_onto`). Rather than write a second one,
this PR **extracts** it into `creek.classify.evidence.layer_determined_over` and
routes every classifier pass that writes a legacy block through it:

```python
def layer_determined_over(*, prior: _ModelT, determined: _ModelT) -> _ModelT:
    return prior.model_copy(update=determined.model_dump(exclude_defaults=True))
```

It rests on one invariant, now documented in one place: **every legacy
classification field's default *is* its "not determined" sentinel**
(`UNCLASSIFIED` / `[]` / `""` / `None`), so `exclude_defaults=True` yields
exactly the axes the pass actually spoke to. A test pins that invariant
executably for all three models, so a future field with a non-sentinel default
goes red here instead of silently reintroducing the bug.

Arguments are **keyword-only**, and that is a safety property rather than a
style choice: both operands share a type, so a positional swap typechecks
perfectly while inverting the merge — on the voice block that silently inverts a
privacy control and no gate in this repo would catch it.

`_build_updates` stays a **pure** producer of "what the matchers determined",
mirroring `to_legacy`; the new `_layer_over_fragment` does the layering,
mirroring `merge_onto`. Its docstring now says outright that assigning its
output wholesale is the defect.

**The frequency asymmetry is preserved deliberately.** `frequency` is replaced
wholesale when the matchers pick a primary (clearing stale secondaries, because
`secondary` is a list and cannot be merged field-wise) and left entirely alone
when they do not. This matches `merge_onto` on purpose, and a test pins it so
nobody later "completes" the merge by making frequency behave like the scalar
blocks.

### Scope: one extension beyond the issue title, disclosed

The issue names `_build_updates` only. This PR also fixes `_apply_voice`
(`creek/classify/llm/parsing.py`), the identical wholesale rebuild on the
single-pick LLM path, where a response carrying `voice: {voice_register: ...}`
and no `confidence` nulled a persisted `conviction`.

The chief-architect recommended deferring that to a follow-up; I overrode it,
and the reasoning should be visible rather than buried:

- Fixing only the rules layer would leave the identical fail-open open on
  `--method llm`, the default LLM method — the rule pass would preserve
  `conviction` and the parse would destroy it a moment later. The PR would then
  claim to close a fail-open that stays open.
- That same function already takes the fragment's prior value to merge `praxis`
  (#877) and `emotional_texture` (#878), for exactly this reason. This is the
  third instance of an established local pattern, not a new one.
- Measured: zero existing tests change behaviour as a result.

The cut is at the **privacy boundary**. `_apply_wavelength`
(`creek/classify/llm/calibration.py`) has the same wholesale-rebuild shape and
is **deliberately untouched**: it is entangled with the FEAT-017 `_biased_enum`
downgrade, which resets mode/orientation/dosage on a low self-reported
confidence *on purpose*, so whether that should come to mean "do not adopt the
noisy pick" or keep meaning "erase what we knew" is a design call that deserves
its own issue. No wavelength axis feeds any privacy control, so that one is
metadata loss rather than a fail-open. Filed as #1421.

### Direction: this can only cause more escalations, never fewer

`classify_tier` reads authorship, platform, recovery keywords, and the two voice
axes — no wavelength or frequency field at all. Its only voice branch is a
conjunction of two equality tests against non-default values that short-circuits
to `False` on a `None`. The merge only ever replaces a "not determined" sentinel
with prior evidence; a non-default fresh verdict always wins outright. So the
predicate can only move `False -> True`, and `escalate` / `apply_tier` /
`reassess` are all monotone in the candidate. No path is made less restrictive.

Honest boundary: the rules path is not made *globally* monotone. A prior
`{confessional, conviction}` with a body firing `analytical` still lands
`{analytical, conviction}` and drops out of the INTIMATE trigger. That is
correct — the matchers genuinely determined `analytical`, which is a verdict,
not silence. Only silence now defers.

### Scope also reaches further than the issue says

The issue and the consolidated #1400 comment both describe this as firing on
`creek classify --method llm`. It also fires on `creek classify --method rules`
(`classify_engine.py:1518` returns `rules.classify(...)` directly) and on
`creek process` (`pipeline.py:938`). On `creek process` the consequence is
sharper still, because `apply_tier` runs *after* the rule pass and the provider
is then chosen by `tier_classifiers.for_tier(...)`: a fragment that should have
been `INTIMATE` was seen as `PERSONAL` and routed to a cloud provider. This PR
closes that as a side effect.

## Test plan

New module `tests/test_rules_preserves_evidence.py` — 26 tests, 0 skipped.
Proven RED at HEAD before the fix: **10 failed, 5 passed**, every failure a
wrong value on a real object (no `ImportError`/`AttributeError`). The 5 that
passed at HEAD are declared regression guards, not padding.

- Per-axis wavelength survival, all six axes asserted explicitly on every case —
  the recurring failure on this backlog is a fix that restores the two axes the
  body emphasises and keeps resetting a third.
- Cross-destruction both ways: a phase-only body keeps `mode`, a mode-only body
  keeps `phase`.
- Both halves of the voice `OR` guard.
- **The headline test** asserts the baseline `OPEN` first — so it proves its own
  premise — then asserts `INTIMATE` after the pass.
- **Parity**: a fragment already holding both halves, and a fragment whose rule
  pass supplies one of them, must reach the same tier. At HEAD they diverge.
- **No manufactured escalation**: a `musing`/`exploring` stance under a
  confessional verdict must not reach `INTIMATE` — *and* the test asserts the
  stance survived, without which it would pass at HEAD for the wrong reason
  (the field having been destroyed rather than respected).
- **On disk**, through `run_classify(method="rules")`: the write is
  `model_dump(mode="json")` with no `exclude_none`, so a nulled confidence
  really lands as `confidence: null`; an in-memory assertion cannot see that.
  Asserted on the reloaded frontmatter, including `privacy_tier: intimate`.
- **Idempotence**: run twice; tier and evidence both still stand.
- The merge primitive's own units, including correctness over a prior that is a
  mix of `str` and enum (which `use_enum_values=True` produces), and
  non-mutation of both operands.
- The executable invariant guard: all three classification models dump to `{}`
  under `exclude_defaults`.
- A characterization test for the one downstream behaviour this moves —
  `reatomize._is_accepted`. Filed as #1422; the change makes two previously
  inconsistent cases agree, and `classification.reatomize` is off by default.

**Mutation-tested**, five guards reverted one at a time. Each killed exactly its
intended tests and nothing else:

| reverted guard | tests killed |
|---|---|
| rules wavelength layering | 3 |
| rules voice layering | 8 |
| frequency asymmetry (merged it instead) | 1 |
| single-pick LLM voice merge | 1 |
| `merge_onto` layering | 5, all pre-existing #1309 tests |

That last row is the check that the extraction is behaviour-preserving: the
weighted path's own tests still fail if the shared primitive stops merging.

**Gate 2**: `./scripts/check-all.sh` exit code **0**, 12/12 checks. 9325 passed,
5 skipped — all five are pre-existing environment gates (Ollama unreachable, API
keys unset) in files this diff does not touch. Ruff runs `--no-cache`
throughout.

### Existing tests changed

No test assertion anywhere was changed, weakened, or deleted; zero test lines
were deleted. The only test-file edit is to
`tests/test_classify_weighted_evidence_on_disk.py`, and it is **docstrings
only**.

That module's `_assert_rule_pass_preserves_evidence`, its `_RULE_INERT_BODY` /
`_RULE_INERT_TITLE` constants, and its module docstring were written by the
#1309 lane as the visible boundary of this defect while it was still open. The
helper and every one of its assertions are **kept and still called**; what
changed is what they mean. They were a fixture-dependent precondition hedging a
known gap; they are now a tripwire on a guarantee the rule pass makes
unconditionally. The inert fixture stays for a better reason than the original
one: those tests measure the *weighted* merge, and a rule-firing body would let
the rules layer explain a passing result.

Notably, no existing test needed updating for the behaviour change itself.
That is not luck and it is worth stating: every fixture that reaches a rule pass
starts at model defaults, so the two conditions this fix changes — matchers fire
**and** the fragment already carries non-default evidence — never co-occurred
anywhere in the suite. 260 tests in `test_classify.py` and not one could see
this bug.

### Not fixed here, noted

The rule matchers gate on `primary >= PRIMARY_THRESHOLD`, so a body producing
secondary frequencies but no primary writes nothing and the secondaries are
discarded. Pre-existing, unrelated to evidence destruction, and I have not
verified it beyond reading the threshold logic — recorded here rather than filed
as an issue I did not confirm.

This PR stops the bleeding; it does not resurrect evidence already destroyed on
disk by earlier runs. A repair pass would be a separate change.

Closes #1331
Refs #1309, #1400, #1421, #1422
