### PR TITLE
fix(vault): descend into nested platform subfolders, and stop recording tombs that did not happen

### DIFF
--- a/creek-tools/creek/ingest/pipeline.py
+++ b/creek-tools/creek/ingest/pipeline.py
@@ -398,7 +398,16 @@ def tomb_missing_units(
 
     A tomb that fails on I/O is collected into *errors* and the unit is left
     live in the ledger so the next full-source pass retries it, rather than
-    crashing the whole run. Returns the number of units actually tombed.
+    crashing the whole run. A tomb that finds nothing to move is treated the
+    same way (#1332) — see :func:`_tomb_one_unit`.
+
+    Returns:
+        The number of fragments this call actually relocated into
+        ``10-Liminal/Orphaned/``. Not the number of units considered, and
+        not the number of ledger records written: a unit whose fragment was
+        already tombed has its record reconciled but moved nothing, so it
+        does not count. The figure is printed to the operator verbatim, so
+        it may only ever name work that happened.
     """
     if ledger is None or not input_path.is_dir():
         return 0
@@ -409,22 +418,80 @@ def tomb_missing_units(
         record = ledger.get(source_key)
         if record is None:
             continue
-        try:
-            writer.tomb_fragment(record.fragment_id)
-        except (OSError, KeyError) as exc:
-            errors.append(
-                f"[{source_type}] failed to tomb {record.fragment_id}: {exc}",
-            )
-            continue
-        ledger.record(
-            source_key,
-            record.fragment_id,
-            record.content_hash,
-            last_seen=record.last_seen,
-            tombed=True,
-        )
-        tombed += 1
+        tombed += _tomb_one_unit(ledger, writer, record, errors, source_type)
     return tombed
+
+
+def _tomb_one_unit(
+    ledger: SourceLedger,
+    writer: VaultWriter,
+    record: LedgerRecord,
+    errors: list[str],
+    source_type: str,
+) -> int:
+    """Soft-tomb one vanished unit; return 1 only if this call moved it.
+
+    The three outcomes are kept distinct because conflating them is the
+    #1332 defect. Before it, the caller discarded
+    :meth:`~creek.vault.writer.VaultWriter.tomb_fragment`'s return value and
+    recorded ``tombed=True`` unconditionally, so a lookup that found nothing
+    wrote a permanent lie into the ledger — ``live_keys`` never revisits a
+    tombed record — and reported a tomb the operator could disprove by
+    opening the vault.
+
+    - **Relocated.** The fragment moved. Record it and count it.
+    - **Already tombed.** ``tomb_fragment`` returns ``None`` both when it
+      found nothing and when the fragment is already in the orphan
+      directory, so the two are separated by asking
+      :meth:`~creek.vault.writer.VaultWriter.find_tombed_fragment`. This is
+      the state a crash between the file move and the ledger append leaves
+      behind — the tomb-then-record ordering is deliberate, because the
+      reverse leaves ``tombed=True`` on a live fragment, which
+      ``live_keys`` guarantees is permanent. Recording it here is not a
+      guess: the vault is showing the tombstone. Nothing moved, so nothing
+      is counted.
+    - **Not found.** No live fragment and no tombstone. The record stays
+      live so the next full-source pass retries, and the miss is reported.
+      Recording success here is the behaviour this function exists to
+      remove; recording a third ledger state instead would need every
+      reader of ``tombed`` to learn a new case to answer the same question.
+
+    Args:
+        ledger: The ledger to reconcile; written only on a proven tomb.
+        writer: Vault writer performing the relocation and the lookups.
+        record: The ledgered unit that this pass no longer saw.
+        errors: Collector for ``[<source_type>] …`` operator messages.
+        source_type: Registry key, used to prefix those messages.
+
+    Returns:
+        ``1`` when this call relocated the fragment, else ``0``.
+    """
+    try:
+        moved = writer.tomb_fragment(record.fragment_id)
+        # ``or`` short-circuits, so the orphan directory is consulted only
+        # when nothing was relocated. A ``Path`` is always truthy, so this
+        # falls back exactly when *moved* is ``None``.
+        tombstone = moved or writer.find_tombed_fragment(record.fragment_id)
+    except (OSError, KeyError) as exc:
+        errors.append(
+            f"[{source_type}] failed to tomb {record.fragment_id}: {exc}",
+        )
+        return 0
+    if tombstone is None:
+        errors.append(
+            f"[{source_type}] no fragment found to tomb for "
+            f"{record.fragment_id} (source {record.source_key}); left live "
+            f"in the ledger for the next full-source pass",
+        )
+        return 0
+    ledger.record(
+        record.source_key,
+        record.fragment_id,
+        record.content_hash,
+        last_seen=record.last_seen,
+        tombed=True,
+    )
+    return 1 if moved is not None else 0
 
 
 def should_skip_unit(

--- a/creek-tools/creek/vault/writer.py
+++ b/creek-tools/creek/vault/writer.py
@@ -868,17 +868,78 @@ class VaultWriter:
             self._log_provenance_locked(fragment.id, fragment.type, existing)
         return existing
 
+    @staticmethod
+    def _fragment_search_dirs(fragments_root: Path) -> list[Path]:
+        """Return every directory under *fragments_root* a fragment may sit in.
+
+        The union of two sets, and both halves earn their place:
+
+        - **Declared** — every distinct value of :data:`_PLATFORM_SUBFOLDER`,
+          joined a segment at a time. This is what makes a *nested* value
+          reachable. ``substack -> "Writing/Substack"`` is the only two-level
+          entry today, and enumerating immediate children alone probed the
+          empty ``Writing`` index and never descended (#1332). Deriving the
+          set from the routing map means a future third level is covered the
+          day it is added rather than the day someone remembers the scan.
+        - **On disk** — the immediate child directories, which is what this
+          method used to return outright. Kept, because narrowing to the
+          declared set would newly *lose* fragments in any directory the map
+          no longer names — a hand-made folder, or one an older release
+          routed to. Shipping that inside a fix for "the lookup misses
+          things" would be the same defect wearing a tidier map.
+
+        Derived per call rather than memoised at import: the routing map is
+        monkeypatched by tests and read at call time by
+        :meth:`_fragment_target_dir`, so a frozen copy would answer for a map
+        that is no longer in force. The cost is a dozen path joins against an
+        ``iterdir`` syscall this method already pays.
+
+        Args:
+            fragments_root: The ``01-Fragments`` directory, which must exist.
+
+        Returns:
+            Deduplicated, sorted directories. Declared entries that do not
+            exist on disk are included and create nothing: the index load
+            returns an empty mapping for a non-directory. It does *cache*
+            that emptiness against the path, which is new — before #1332
+            only directories that already existed were ever visited — and
+            within one :class:`VaultWriter` it is harmless, because
+            :meth:`_write_model` mutates the same cached dict in place. It
+            does widen, by the width of one lookup, the cross-process index
+            staleness already declared out of scope for BUG-006 in the
+            ``self._lock`` docstring: another process could create and
+            populate a declared directory between this process caching it
+            empty and a later write in the same run.
+        """
+        declared = (
+            fragments_root.joinpath(*subfolder.split("/"))
+            for subfolder in dict.fromkeys(_PLATFORM_SUBFOLDER.values())
+        )
+        on_disk = (p for p in fragments_root.iterdir() if p.is_dir())
+        # Deduplicate on the resolved Path, not the string: ``Writing`` is
+        # both a declared value (ESSAY) and an on-disk child, and visiting it
+        # twice would let one lookup fire ``_repair_index_locked``'s append
+        # twice.
+        return sorted({*declared, *on_disk})
+
     def _find_in_fragments_locked(self, fragment_id: str) -> Path | None:
         """Return the live fragment file for *fragment_id* under 01-Fragments.
 
         Caller must hold ``self._lock``. Scans each platform subfolder's id
         index so a tomb does not need to know which subfolder a fragment
-        landed in.
+        landed in — including the nested ones, which is what
+        :meth:`_fragment_search_dirs` is for.
+
+        This searches ``01-Fragments`` only. A *borrowed* fragment lives
+        under ``11-Other-Authors/<slug>/`` (see :meth:`_fragment_target_dir`)
+        and is deliberately out of reach here; that gap is tracked in #1424,
+        and since #1332 a caller that cannot find a fragment is told so
+        rather than assuming the fragment was dealt with.
         """
         fragments_root = self.vault_path / _FRAGMENTS_RELPART
         if not fragments_root.is_dir():
             return None
-        for subdir in sorted(p for p in fragments_root.iterdir() if p.is_dir()):
+        for subdir in self._fragment_search_dirs(fragments_root):
             found = self._find_existing_locked(fragment_id, subdir)
             if found is not None:
                 return found
@@ -893,18 +954,54 @@ class VaultWriter:
         answer "does this vault still hold the id the old derivation would
         have minted?" without walking and parsing every fragment file.
 
-        Read-only and index-backed, so asking is cheap and asking cannot
-        change anything.
+        Read-only and index-backed, so asking is cheap. Asking also no
+        longer *writes*: until #1332 a lookup over a directory with nothing
+        to index persisted a zero-byte ``.id-index.jsonl`` into the
+        operator's vault, which made this paragraph's promise false in
+        exactly the directories the nested-subfolder fix now visits. See
+        :meth:`_load_index_locked`.
 
         Args:
             fragment_id: The id to look for.
 
         Returns:
-            The fragment's path, or ``None`` when the vault does not hold
-            it (including when ``01-Fragments/`` does not exist).
+            The fragment's path, or ``None`` when ``01-Fragments/`` does not
+            hold it (including when that directory does not exist). Scoped
+            deliberately: a *borrowed* fragment lives under
+            ``11-Other-Authors/<slug>/`` and is never reported here, so
+            ``None`` means "not live under ``01-Fragments``", not "absent
+            from the vault". That gap is tracked in #1424 — its fix needs a
+            search set bounded by something other than the author count,
+            which is a different shape from #1332's.
         """
         with self._lock:
             return self._find_in_fragments_locked(fragment_id)
+
+    def find_tombed_fragment(self, fragment_id: str) -> Path | None:
+        """Return the *tombed* file for *fragment_id*, or ``None`` (#1332).
+
+        The orphan-directory counterpart to :meth:`find_fragment`, wrapping
+        the same lookup :meth:`restore_fragment` already trusts to locate a
+        tombstone.
+
+        It exists so a caller can tell a tomb that *failed* apart from one
+        that had already happened. :meth:`tomb_fragment` returns ``None`` for
+        both, and
+        :func:`creek.ingest.pipeline.tomb_missing_units` must not treat them
+        alike: the first is a miss that has to be reported and retried, while
+        the second is the state a crash between the file move and the ledger
+        append leaves behind, and it converges only if it can be recognised.
+
+        Args:
+            fragment_id: The id to look for in ``10-Liminal/Orphaned/``.
+
+        Returns:
+            The tombstone's path, or ``None`` when no tombed file declares
+            this id.
+        """
+        orphan_dir = self.vault_path.joinpath(*_ORPHANED_RELPARTS)
+        with self._lock:
+            return self._find_existing_locked(fragment_id, orphan_dir)
 
     def _relocate_fragment_locked(
         self,
@@ -1483,7 +1580,17 @@ class VaultWriter:
         the JSONL file (later entries overwrite earlier ones, so the
         last successful write wins). If the JSONL file is missing the
         index is rebuilt by scanning the directory's ``.md`` files and
-        the result is persisted so subsequent processes skip the scan.
+        the result is persisted so subsequent processes skip the scan —
+        **unless the rebuild found nothing**, in which case nothing is
+        written (#1332). A memo of "no ids here" saves a glob over an
+        empty directory and costs a file created in the operator's vault
+        by a *lookup*; the sole caller that reached this path with an
+        empty directory was the tomb scan, which left a trail of zero-byte
+        ``.id-index.jsonl`` files behind every miss. Re-globbing an empty
+        directory once per :class:`VaultWriter` is the cheaper side of that
+        trade, and it keeps :meth:`find_fragment` genuinely read-only.
+        Pre-existing zero-byte index files stay valid: they parse to the
+        same empty mapping a rescan produces.
 
         When the JSONL file is *present but damaged* — an unparseable
         line, or a file that cannot be read at all — the mappings it
@@ -1526,7 +1633,8 @@ class VaultWriter:
                 index = self._recover_damaged_index(index_path, target_dir, load)
         elif target_dir.is_dir():
             index = self._rebuild_index(target_dir)
-            self._persist_full_index(target_dir, index)
+            if index:
+                self._persist_full_index(target_dir, index)
         else:
             index = {}
         self._dir_indexes[target_dir] = index
@@ -1655,7 +1763,9 @@ class VaultWriter:
         """Atomically write a fresh JSONL index file from *index*.
 
         Used only on first-time index construction (scanning a vault
-        that predates the index file). Steady-state updates use
+        that predates the index file), and only when that scan found at
+        least one id — see :meth:`_load_index_locked` for why an empty
+        rebuild must not be memoised (#1332). Steady-state updates use
         :meth:`_append_index_entry`, which is O(1) per write.
         """
         target_dir.mkdir(parents=True, exist_ok=True)

--- a/creek-tools/tests/test_ingest_orphan_tomb.py
+++ b/creek-tools/tests/test_ingest_orphan_tomb.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 import frontmatter
 import pytest
@@ -19,11 +19,10 @@ import pytest
 from creek.cli import _run_ingest
 from creek.ingest import INGESTOR_REGISTRY
 from creek.ingest.ledger import SourceLedger
+from creek.ingest.markdown import _infer_platform
+from creek.ingest.pipeline import TOMBING_SOURCES, tomb_missing_units
 from creek.models import Fragment, FragmentSource, SourcePlatform
-from creek.vault.writer import VaultWriter
-
-if TYPE_CHECKING:
-    from pathlib import Path
+from creek.vault.writer import _PLATFORM_SUBFOLDER, VaultWriter
 
 
 def _make_vault(tmp_path: Path) -> Path:
@@ -596,3 +595,408 @@ class TestOrphanLifecycle:
         rec = ledger.get("personal/journal/2026-06-26.md")
         assert rec is not None
         assert rec.tombed is False
+
+
+# ---- Nested platform subfolders (#1332) --------------------------------
+
+
+def _fragment_for(platform: str) -> Fragment:
+    """Build a fragment for *platform* with an id unique to that platform."""
+    return Fragment(
+        id=f"frag-{platform}-01",
+        title="Piece",
+        source=FragmentSource(platform=SourcePlatform(platform)),
+    )
+
+
+def _ledger_lines(vault: Path, source: str = "markdown") -> list[dict[str, object]]:
+    """Parse the ledger JSONL off disk, by hand, with no reload machinery.
+
+    ``SourceLedger.load`` collapses the append-only log to one record per
+    key, so it cannot answer "was a ``tombed: true`` line ever written?".
+    Reading the raw bytes can, which is the assertion #1332 needs: the bug
+    was a *record* that lied, not a lookup that returned the wrong thing.
+    """
+    path = SourceLedger.path_for(vault, source)
+    if not path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+class TestNestedPlatformTombLookup:
+    """Every platform in the routing map must be tombable (#1332).
+
+    ``_PLATFORM_SUBFOLDER`` holds exactly one two-level value
+    (``substack -> "Writing/Substack"``), and the tomb lookup used to
+    enumerate only the immediate children of ``01-Fragments`` — so it
+    probed the empty ``Writing`` index and never descended into
+    ``Substack``. ``restore_fragment`` routes through
+    ``_fragment_target_dir`` and resolved the nested path correctly, so
+    the two halves of #674 disagreed with each other.
+    """
+
+    def test_the_routing_map_is_total_and_holds_a_nested_value(self) -> None:
+        """The parametrised sweep below is known to cover the nested case.
+
+        Guards two ways the sweep could go vacuous: a map that stopped
+        covering every ``SourcePlatform``, and a map with no multi-level
+        value left in it (which would make the whole nesting question
+        untested while every test still passed).
+        """
+        assert set(_PLATFORM_SUBFOLDER) == {str(p) for p in SourcePlatform}
+        assert len(_PLATFORM_SUBFOLDER) == 14
+        nested = {k: v for k, v in _PLATFORM_SUBFOLDER.items() if "/" in v}
+        assert nested, "no multi-level subfolder left; the nesting sweep is vacuous"
+
+    @pytest.mark.parametrize("platform", sorted(_PLATFORM_SUBFOLDER))
+    def test_every_platform_round_trips_through_a_tomb(
+        self, tmp_path: Path, platform: str
+    ) -> None:
+        """A written fragment is found and relocated for every platform."""
+        assert _PLATFORM_SUBFOLDER, "empty routing map would skip every case"
+        vault = _make_vault(tmp_path)
+        writer = VaultWriter(vault_path=vault)
+        fragment = _fragment_for(platform)
+        written = writer.write_fragment(fragment, body="body")
+        assert written.parent == vault / "01-Fragments" / _PLATFORM_SUBFOLDER[platform]
+
+        tombed = writer.tomb_fragment(fragment.id)
+
+        assert tombed is not None, f"tomb_fragment returned None for {platform}"
+        assert tombed.parent == vault / "10-Liminal" / "Orphaned"
+        assert not written.exists(), f"{platform} fragment still live at {written}"
+        post = frontmatter.load(str(tombed))
+        assert post["id"] == fragment.id
+        assert post["lifecycle"] == "orphaned"
+
+    def test_find_fragment_resolves_a_nested_subfolder_before_any_tomb(
+        self, tmp_path: Path
+    ) -> None:
+        """The public read-only lookup descends into ``Writing/Substack`` too."""
+        vault = _make_vault(tmp_path)
+        writer = VaultWriter(vault_path=vault)
+        fragment = _fragment_for(str(SourcePlatform.SUBSTACK))
+        written = writer.write_fragment(fragment, body="body")
+
+        assert written.parent == vault / "01-Fragments" / "Writing" / "Substack"
+        assert writer.find_fragment(fragment.id) == written
+
+    def test_a_three_level_subfolder_resolves_without_a_code_change(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Adding a deeper routing value must not need the scan updated.
+
+        The acceptance criterion for #1332: the search set is derived from
+        the routing map, so a hypothetical third level is covered the day
+        someone adds it rather than the day someone remembers to.
+        """
+        monkeypatch.setitem(
+            _PLATFORM_SUBFOLDER, str(SourcePlatform.OTHER), "Writing/Substack/Deep"
+        )
+        vault = _make_vault(tmp_path)
+        writer = VaultWriter(vault_path=vault)
+        fragment = _fragment_for(str(SourcePlatform.OTHER))
+        written = writer.write_fragment(fragment, body="body")
+
+        assert written.parent == vault / "01-Fragments/Writing/Substack/Deep"
+        assert writer.find_fragment(fragment.id) == written
+
+    def test_a_directory_the_map_does_not_name_is_still_searched(
+        self, tmp_path: Path
+    ) -> None:
+        """Back-compat: a hand-made ``01-Fragments`` subfolder still resolves.
+
+        The scan is the union of the map's values and what is actually on
+        disk. Narrowing it to the declared set alone would stop finding
+        fragments in any directory an older release, or the operator,
+        created — a silent regression this test refuses.
+        """
+        vault = _make_vault(tmp_path)
+        legacy = vault / "01-Fragments" / "LegacyCustom"
+        legacy.mkdir(parents=True)
+        (legacy / "note.md").write_text(
+            "---\nid: frag-legacy01\ntitle: Legacy\n---\nBody.\n", encoding="utf-8"
+        )
+
+        found = VaultWriter(vault_path=vault).find_fragment("frag-legacy01")
+
+        assert found == legacy / "note.md"
+
+    def test_substack_tomb_and_restore_agree_on_the_nested_path(
+        self, tmp_path: Path
+    ) -> None:
+        """The tomb/restore asymmetry #1332 names is closed in both directions.
+
+        ``restore_fragment`` routes through ``_fragment_target_dir`` and
+        always resolved ``Writing/Substack``; the tomb side did not. An
+        uncontended round trip must land back on the original filename.
+        """
+        vault = _make_vault(tmp_path)
+        writer = VaultWriter(vault_path=vault)
+        fragment = _fragment_for(str(SourcePlatform.SUBSTACK))
+        written = writer.write_fragment(fragment, body="body")
+
+        assert writer.tomb_fragment(fragment.id) is not None
+        assert not written.exists()
+
+        restored = writer.restore_fragment(fragment)
+
+        assert restored == written
+        assert _orphan_files(vault) == []
+        assert "lifecycle" not in frontmatter.load(str(restored)).metadata
+
+
+class TestLookupChangesNothing:
+    """Asking where a fragment is must not write to the vault (#1332).
+
+    ``find_fragment``'s docstring promised that "asking cannot change
+    anything". It could: a lookup over a directory holding nothing to
+    index persisted a zero-byte ``.id-index.jsonl`` there, and #1332
+    widens the set of directories a lookup visits — so the claim has to
+    become executable before the reach grows.
+    """
+
+    def test_a_missing_id_leaves_the_vault_byte_identical(self, tmp_path: Path) -> None:
+        """A lookup that finds nothing creates, removes and edits nothing."""
+        vault = _make_vault(tmp_path)
+        writer = VaultWriter(vault_path=vault)
+        writer.write_fragment(_journal_fragment(), body="body")
+        before = {
+            p.relative_to(vault): (p.read_bytes() if p.is_file() else None)
+            for p in vault.rglob("*")
+        }
+
+        assert writer.find_fragment("frag-absent") is None
+
+        after = {
+            p.relative_to(vault): (p.read_bytes() if p.is_file() else None)
+            for p in vault.rglob("*")
+        }
+        assert after == before
+
+    def test_a_miss_leaves_no_empty_index_behind(self, tmp_path: Path) -> None:
+        """Scanning an empty subfolder must not persist a zero-byte index.
+
+        The narrow companion to the snapshot above, naming the exact
+        artefact the issue reported: the failed Substack scan wrote
+        ``01-Fragments/Writing/.id-index.jsonl`` at zero bytes.
+        """
+        vault = _make_vault(tmp_path)
+        (vault / "01-Fragments" / "Writing").mkdir(parents=True, exist_ok=True)
+
+        assert VaultWriter(vault_path=vault).find_fragment("frag-absent") is None
+
+        stray = vault / "01-Fragments" / "Writing" / ".id-index.jsonl"
+        assert not stray.exists(), f"zero-byte index left at {stray}"
+
+    def test_find_tombed_fragment_reports_the_orphan_dir(self, tmp_path: Path) -> None:
+        """The new orphan-dir lookup answers what the tomb sweep asks it.
+
+        Mirrors ``test_public_find_existing_uses_lock``: the public shim
+        resolves a known id through the lock and reports ``None`` for an
+        unknown one. This is the evidence the sweep uses to tell "already
+        tombed" apart from "not found", so it may not guess either way.
+        """
+        vault = _make_vault(tmp_path)
+        writer = VaultWriter(vault_path=vault)
+        fragment = _journal_fragment()
+        live = writer.write_fragment(fragment, body="body")
+
+        assert writer.find_tombed_fragment(fragment.id) is None  # live, not tombed
+
+        tombed = writer.tomb_fragment(fragment.id)
+
+        assert not live.exists()
+        assert writer.find_tombed_fragment(fragment.id) == tombed
+        assert writer.find_tombed_fragment("frag-absent") is None
+
+
+# ---- The tomb record must not outrun the tomb (#1332) ------------------
+
+
+class TestTombOutcomeIsRecordedHonestly:
+    """``tomb_missing_units`` may only record what actually happened.
+
+    It used to discard ``tomb_fragment``'s return value and record
+    ``tombed=True`` unconditionally, so a lookup miss wrote a permanent
+    lie into the ledger and reported a tomb to the operator while the
+    fragment stayed live with no ``lifecycle`` marker.
+
+    These call ``tomb_missing_units`` directly rather than through
+    ``_ingest``: markdown ingest can only mint journal/essay/code/markdown
+    platforms, so the failure has to be staged at the unit boundary.
+    """
+
+    @staticmethod
+    def _stage(tmp_path: Path) -> tuple[Path, VaultWriter, SourceLedger]:
+        """Return a scaffolded vault with a writer and an empty ledger."""
+        vault = _make_vault(tmp_path)
+        return (
+            vault,
+            VaultWriter(vault_path=vault),
+            SourceLedger.load(vault, source="markdown"),
+        )
+
+    @staticmethod
+    def _sweep(
+        vault: Path, writer: VaultWriter, ledger: SourceLedger
+    ) -> tuple[int, list[str]]:
+        """Run a full-source tomb sweep that sees no live source units."""
+        errors: list[str] = []
+        count = tomb_missing_units(
+            ledger, writer, vault / "01-Fragments", set(), errors, "markdown"
+        )
+        return count, errors
+
+    def test_a_tomb_that_found_nothing_is_not_recorded_tombed(
+        self, tmp_path: Path
+    ) -> None:
+        """A miss reports an error and leaves the ledger record live."""
+        vault, writer, ledger = self._stage(tmp_path)
+        fragment = _journal_fragment()
+        written = writer.write_fragment(fragment, body="body")
+        moved = vault / "09-Reference" / written.name
+        moved.parent.mkdir(parents=True, exist_ok=True)
+        written.rename(moved)  # out of 01-Fragments: the lookup genuinely misses
+        ledger.record("personal/journal/gone.md", fragment.id, "hash-1")
+
+        count, errors = self._sweep(vault, writer, ledger)
+
+        assert count == 0
+        assert any("no fragment found to tomb" in e for e in errors)
+        assert moved.exists()
+        assert "lifecycle" not in frontmatter.load(str(moved)).metadata
+        assert _orphan_files(vault) == []
+        assert not any(
+            line["source_key"] == "personal/journal/gone.md" and line["tombed"]
+            for line in _ledger_lines(vault)
+        ), "a tombed=True line was written for a tomb that did not happen"
+        reloaded = SourceLedger.load(vault, source="markdown")
+        assert "personal/journal/gone.md" in reloaded.live_keys()
+
+    def test_an_already_tombed_fragment_converges_without_inflating_the_count(
+        self, tmp_path: Path
+    ) -> None:
+        """The ledger catches up to a tomb the vault can prove already happened.
+
+        A crash between ``tomb_fragment`` moving the file and
+        ``ledger.record`` appending the line leaves exactly this state.
+        Treating it as a hard failure would make it recur on every future
+        pass and never converge.
+        """
+        vault, writer, ledger = self._stage(tmp_path)
+        fragment = _journal_fragment()
+        writer.write_fragment(fragment, body="body")
+        already = writer.tomb_fragment(fragment.id)
+        assert already is not None
+        ledger.record("personal/journal/gone.md", fragment.id, "hash-1")
+
+        count, errors = self._sweep(vault, writer, ledger)
+
+        assert count == 0, "nothing was relocated by this call"
+        assert errors == []
+        assert _orphan_files(vault) == [already]
+        assert frontmatter.load(str(already))["lifecycle"] == "orphaned"
+        rec = SourceLedger.load(vault, source="markdown").get(
+            "personal/journal/gone.md"
+        )
+        assert rec is not None
+        assert rec.tombed is True
+
+    def test_a_successful_tomb_still_counts_and_records(self, tmp_path: Path) -> None:
+        """The guard must not be satisfiable by refusing to tomb anything."""
+        vault, writer, ledger = self._stage(tmp_path)
+        fragment = _journal_fragment()
+        written = writer.write_fragment(fragment, body="body")
+        ledger.record("personal/journal/gone.md", fragment.id, "hash-1")
+
+        count, errors = self._sweep(vault, writer, ledger)
+
+        assert count == 1
+        assert errors == []
+        assert not written.exists()
+        orphans = _orphan_files(vault)
+        assert len(orphans) == 1
+        assert frontmatter.load(str(orphans[0]))["lifecycle"] == "orphaned"
+        rec = SourceLedger.load(vault, source="markdown").get(
+            "personal/journal/gone.md"
+        )
+        assert rec is not None
+        assert rec.tombed is True
+
+    def test_the_reported_count_equals_the_number_relocated(
+        self, tmp_path: Path
+    ) -> None:
+        """A mixed batch reports the tombs it performed, not the units it saw."""
+        vault, writer, ledger = self._stage(tmp_path)
+        source = FragmentSource(platform=SourcePlatform.JOURNAL)
+        tombable = Fragment(id="frag-live001", title="Live", source=source)
+        writer.write_fragment(tombable, body="body")
+        ledger.record("personal/journal/a.md", tombable.id, "hash-a")
+
+        lost = Fragment(id="frag-lost001", title="Lost", source=source)
+        lost_path = writer.write_fragment(lost, body="body")
+        moved = vault / "09-Reference" / lost_path.name
+        moved.parent.mkdir(parents=True, exist_ok=True)
+        lost_path.rename(moved)
+        ledger.record("personal/journal/b.md", lost.id, "hash-b")
+
+        prior = Fragment(id="frag-prior01", title="Prior", source=source)
+        writer.write_fragment(prior, body="body")
+        writer.tomb_fragment(prior.id)
+        ledger.record("personal/journal/c.md", prior.id, "hash-c")
+        before = len(_orphan_files(vault))
+
+        count, errors = self._sweep(vault, writer, ledger)
+
+        assert count == 1
+        assert len(_orphan_files(vault)) == before + 1
+        assert len(errors) == 1
+        assert "frag-lost001" in errors[0]
+
+
+# ---- Why no shipped vault needs migrating (#1332) ----------------------
+
+
+class TestLedgeredTombingCannotMintANestedPlatform:
+    """The lookup half of #1332 is latent, so there is nothing to migrate.
+
+    A vault could only hold a ``tombed=True`` record for a fragment still
+    live under ``01-Fragments`` if the ledgered tomb sweep had missed a
+    *nested* fragment — and it cannot reach one. Tombing arms only for
+    the source types in ``TOMBING_SOURCES``, and the markdown ingestor,
+    the sole member, cannot mint a platform whose routing value has a
+    second level.
+
+    This is asserted rather than argued because it is the whole basis for
+    shipping no migration. The day someone arms tombing for a source type
+    that *can* mint ``substack``, this goes red and the migration
+    question becomes real again.
+    """
+
+    def test_only_markdown_tombs_and_markdown_routes_one_level_deep(self) -> None:
+        """No platform the tombing ingestor can produce is nested."""
+        assert frozenset({"markdown"}) == TOMBING_SOURCES
+        # `_detect_document_type` is documented and implemented to return
+        # exactly these four, so crossing them with the path heuristics
+        # enumerates every platform a markdown ingest can reach.
+        document_types = ("journal", "essay", "technical", "notes")
+        paths = (
+            Path("personal/journal/2026-01-01.md"),
+            Path("writing/essays/piece.md"),
+            Path("inbox/loose-note.md"),
+        )
+        reachable = {
+            _infer_platform(doc_type, path)
+            for doc_type in document_types
+            for path in paths
+        }
+
+        assert reachable, "empty reachable set would make this vacuous"
+        assert SourcePlatform.SUBSTACK not in reachable
+        nested = {p for p in reachable if "/" in _PLATFORM_SUBFOLDER[str(p)]}
+        assert nested == set(), f"a tombing ingest can now mint {nested}"


### PR DESCRIPTION
## Summary

Two defects, and the second is the serious one.

**The lookup miss.** `_PLATFORM_SUBFOLDER[SUBSTACK] = "Writing/Substack"` is the
only two-level value in the routing map, and `_find_in_fragments_locked`
enumerated only `01-Fragments`'s immediate children — so it probed the empty
`Writing` index and never descended into `Substack`. `tomb_fragment` and the
public `find_fragment` returned `None` for every Substack fragment, while
`restore_fragment` (routing through `_fragment_target_dir`) resolved the nested
path correctly. The two halves of #674 disagreed with each other.

**The lie.** `tomb_missing_units` discarded `tomb_fragment`'s return value and
did `ledger.record(..., tombed=True)` and `tombed += 1` unconditionally. A tomb
that found nothing therefore reported a tomb to the operator and wrote a
permanent falsehood into the ledger — permanent because `live_keys()` never
revisits a tombed record. Reproduced against `origin/main` before any code was
written:

```
reported tombed count        = 1
errors                       = []
fragment still live on disk  = True (01-Fragments/Writing/Substack/2026-08-11-T.md)
lifecycle key in frontmatter = False
orphan dir contents          = []
ledger raw bytes:
  {"source_key": "posts/gone.md", ..., "tombed": false}
  {"source_key": "posts/gone.md", ..., "tombed": true}
reloaded live_keys()         = set()
```

A fix that only makes the lookup descend leaves the unconditional-success path
intact, and it would lie again the next time any lookup failed for any reason.
Both are fixed.

### What changed

- **`VaultWriter._fragment_search_dirs`** (new) returns the **union** of every
  distinct `_PLATFORM_SUBFOLDER` value joined a segment at a time, and the
  immediate on-disk child directories. The declared half makes nested values
  reachable and makes a future *third* level free; the on-disk half is today's
  behaviour, kept because narrowing to the declared set would newly lose
  fragments in any directory the map no longer names — the same defect in a
  tidier map. Deduplicated on the resolved `Path` (`Writing` is both a declared
  value and an on-disk child, and visiting it twice could fire
  `_repair_index_locked`'s append twice) and derived per call, because the
  routing map is read at call time by `_fragment_target_dir` and monkeypatched
  by tests — a frozen copy would answer for a map no longer in force.

  Rejected: flattening `_PLATFORM_SUBFOLDER[SUBSTACK]` to `"Writing"`. It is the
  one-character alternative and it is a silent data migration — every existing
  Substack fragment in every live vault would be orphaned from its routing
  directory.

- **`_tomb_one_unit`** (new) carries the per-record body out of
  `tomb_missing_units` and separates three outcomes:
  - *relocated* — record the tomb, count it;
  - *already tombed* — the new public `VaultWriter.find_tombed_fragment` finds
    the fragment in `10-Liminal/Orphaned/`, so the ledger is reconciled on
    evidence the vault is showing, but nothing moved so nothing is counted;
  - *not found* — append `no fragment found to tomb …` to `errors`, write no
    ledger record, count nothing, and leave the unit live so the next
    full-source pass retries. Same shape as the existing `(OSError, KeyError)`
    branch, which is non-fatal and printed to the operator.

  The already-tombed branch is not politeness. Tomb-then-record is the correct
  crash ordering — the reverse leaves `tombed=True` on a live fragment, which
  `live_keys` makes permanent — and this branch is what lets the surviving
  state (tombstone on disk, ledger record still live) converge instead of
  erroring on every future pass forever.

- **The count is now the number of relocations.** It is printed verbatim as
  `N tombed`, so it may only name work that happened. A reconciliation moved
  nothing and contributes zero.

- **Lookups stopped writing to the vault.** `_load_index_locked` persisted an
  empty rebuild, so scanning a directory with nothing to index left a zero-byte
  `.id-index.jsonl` behind — which made `find_fragment`'s docstring claim that
  "asking cannot change anything" false, in exactly the directories this PR
  teaches it to visit. Guarded by `if index:`, and the claim is now an
  executable test.

### Migration: nothing to migrate, and here is why

The divergent state a migration would repair — `tombed=True` while the fragment
is still live under `01-Fragments` — **has no producer**. Tombing arms only for
`TOMBING_SOURCES == {"markdown"}`; the markdown ingestor's `_infer_platform` can
only yield `journal`/`essay`/`technical`/`markdown`, every one of them a
single-level subfolder. The ledgered sweep therefore cannot reach a nested
fragment, so the lookup defect is **latent, not live**, and no shipped vault is
corrupted by it. The one lie that *is* reachable today (a fragment moved out of
`01-Fragments` by hand) leaves a fragment `find_fragment` cannot see, so it is
undetectable as well as unrepairable.

A detect-and-report advisory was designed and tested, then cut on that
reasoning: its only firing population would have been the operator manually
restoring a fragment from `10-Liminal/Orphaned/` — precisely the case it would
have to take no action on. `TestLedgeredTombingCannotMintANestedPlatform`
asserts the reachability argument instead of leaving it in a commit message; it
goes red the day someone arms tombing for a source type that can mint
`substack`, which is the day the migration question becomes real.

Nothing in this PR deletes, moves, or rewrites operator vault state.

### The zero-byte index files

Not created any more, and existing ones need no cleanup: `_read_index_records`
parses an empty file to `{}` with `torn_lines=0`, identical to a rescan of an
empty directory. They are stale memos, not damage, and this PR does not delete
files from anyone's vault to tidy them.

### Notes

- Filed #1424 for the sibling gap this PR does **not** close: a *borrowed*
  fragment lives in `11-Other-Authors/<slug>/` and no id lookup can see it. Not
  reachable from the tomb sweep (no ingestor sets `author_slug`), and its fix
  needs a search set bounded by something other than the author count. Cited
  from `find_fragment`'s docstring.
- Pre-existing and out of scope: the index-repair path can raise `ValueError`,
  which `tomb_missing_units`'s `except (OSError, KeyError)` does not catch
  (adjacent to #1325's `RuntimeError` note).
- **Process disclosure:** an independent chief-architect pass was run and its
  verdicts are reflected here — in particular it rejected the migration
  advisory, and its argument is the one given above. The test and
  implementation specialists stalled, so those were written by the conductor
  rather than by independent specialist passes; a `code-review-orchestrator`
  pass was run over the finished diff.

## Test plan

- Both defects reproduced against `origin/main` first, asserting on-disk state:
  `tomb_fragment -> None` for substack against a real path for journal, the
  fragment still present with no `lifecycle` key, the orphan directory empty,
  and the ledger's raw JSONL bytes carrying `"tombed": true`.
- 14 new test functions in `tests/test_ingest_orphan_tomb.py` across four
  classes — 27 collected cases with the platform sweep expanded (18 -> 45
  in that file). Every
  assertion is on-disk (file presence, frontmatter keys, raw ledger bytes, a
  before/after byte-map of the whole vault) rather than lookup-shaped — a reader
  that repairs what it reads can make a return-value assertion vacuous.
- The platform sweep is parametrized over `sorted(_PLATFORM_SUBFOLDER)` and
  guarded by a companion test asserting the map still covers all 14
  `SourcePlatform` members and still holds a multi-level value, so an emptied
  parametrize list cannot pass silently. Zero tests skipped.
- **Mutation-tested**, one guard broken at a time; each mutant killed by a
  distinct test: revert the traversal to immediate children (killed by the
  substack sweep case); narrow the union to declared-only (killed by the
  undeclared-directory test); restore the empty-index persist (killed by the
  byte-identical-vault test); disable the not-found guard (killed by the
  raw-ledger-bytes test); make the count always 1 (killed by the
  no-inflation test); remove the already-tombed branch (killed by the
  convergence test); make `find_tombed_fragment` always answer yes (killed by
  its own test).
- `./scripts/check-all.sh` exit **0** — 12/12 checks, 9352 passed, 5 skipped
  (all pre-existing environment skips), coverage 94.60%.
- No `# noqa`, `# type: ignore`, `pytest.mark.skip`, `--no-verify`, threshold
  change, or deleted test in the diff. Every deleted line is a docstring line
  rewritten in place or code moved into `_tomb_one_unit`; no assertion was
  removed.

Closes #1332
