### PR TITLE
fix(ingest): merge split chat turns, and stop dropping the operator's own words

### DIFF
--- a/creek-tools/creek/ingest/chatgpt.py
+++ b/creek-tools/creek/ingest/chatgpt.py
@@ -28,6 +28,7 @@ from creek.ingest.base import (
     RawDocument,
     normalize_encoding,
 )
+from creek.ingest.turns import group_turn_runs, merge_turn_texts
 from creek.models import Authorship
 
 if TYPE_CHECKING:
@@ -540,12 +541,24 @@ def _pair_messages_to_fragments(
     conversation_id: str | None = None,
     conversation_create_time: float | None = None,
 ) -> list[ParsedFragment]:
-    """Pair consecutive user+assistant messages into fragments.
+    """Pair user+assistant turns into fragments.
 
-    Iterates through the ordered message list, pairing each user
-    message with the following assistant message. System messages
-    and unpaired user messages at the end are skipped. Each fragment
-    title includes a turn index to prevent collisions.
+    Segments the ordered message list into ``(user_run, assistant_run)``
+    turns via :func:`creek.ingest.turns.group_turn_runs`, merging each
+    run's text. System and tool messages are skipped; an unanswered user
+    turn at the end is discarded. Each fragment title includes a turn
+    index to prevent collisions.
+
+    Until #1333 this was an index walk that paired a user message only
+    with a *strictly adjacent* assistant message, which lost content
+    three ways, all silently: the first of two consecutive user messages
+    was skipped entirely, the second of two consecutive assistant
+    messages was swept up by the "any other role" arm, and a system node
+    sitting between a question and its answer suppressed the whole
+    exchange — despite this docstring already claiming system messages
+    were skipped. The user-side loss is the costly one: those fragments
+    are ``source.author=self`` and are what the voice fingerprint trains
+    on.
 
     FEAT-031: each pair carries ``authored_at`` derived from the
     user message's ``create_time``. When the per-message field is
@@ -564,84 +577,103 @@ def _pair_messages_to_fragments(
             ``create_time`` for the FEAT-031 ``authored_at`` fallback.
 
     Returns:
-        A list of ``ParsedFragment`` objects, one per pair.
+        A list of ``ParsedFragment`` objects, two per turn.
     """
     conv_authored_at = _epoch_to_authored_at(conversation_create_time)
+    turns = group_turn_runs(
+        messages,
+        role_of=_get_message_role,
+        human_role="user",
+        assistant_role="assistant",
+    )
 
     fragments: list[ParsedFragment] = []
-    turn_idx = 0
-    i = 0
-    while i < len(messages):
-        msg = messages[i]
-        role = _get_message_role(msg)
-
-        if role == "system":
-            i += 1
-            continue
-
-        if role == "user":
-            user_text = _extract_message_text(msg)
-            user_time: float | None = msg.get("create_time")
-            # Look for the next assistant message
-            if i + 1 < len(messages):
-                next_msg = messages[i + 1]
-                next_role = _get_message_role(next_msg)
-                if next_role == "assistant":
-                    assistant_text = _extract_message_text(next_msg)
-                    fragment_ts = (
-                        _epoch_to_la_datetime(user_time)
-                        if user_time
-                        else conversation_timestamp
-                    )
-                    msg_authored_at = _epoch_to_authored_at(user_time)
-                    authored_at = (
-                        msg_authored_at
-                        if msg_authored_at is not None
-                        else conv_authored_at
-                    )
-                    # Emit the human turn and the AI turn as two
-                    # separately-attributed fragments instead of one merged
-                    # fragment, so the AI's prose can never train the voice
-                    # proxy. Both share the conversation id, turn index, and
-                    # timestamp so threading/linking still works.
-                    base_meta: dict[str, Any] = {
-                        "platform": "chatgpt",
-                        "authored_at": authored_at,
-                    }
-                    if conversation_id is not None:
-                        base_meta["conversation_id"] = conversation_id
-                    fragments.extend(
-                        (
-                            ParsedFragment(
-                                content=user_text,
-                                metadata=base_meta
-                                | {
-                                    "title": f"{title} (turn {turn_idx})",
-                                    "author_role": _ROLE_SELF,
-                                },
-                                source_path=source_path,
-                                timestamp=fragment_ts,
-                            ),
-                            ParsedFragment(
-                                content=assistant_text,
-                                metadata=base_meta
-                                | {
-                                    "title": f"{title} (turn {turn_idx}, AI)",
-                                    "author_role": _ROLE_AI,
-                                },
-                                source_path=source_path,
-                                timestamp=fragment_ts,
-                            ),
-                        )
-                    )
-                    turn_idx += 1
-                    i += 2
-                    continue
-            # No assistant follows: skip this user message
-            i += 1
-            continue
-
-        # Skip any other role (e.g., tool)
-        i += 1
-
+    for turn_idx, (user_run, assistant_run) in enumerate(turns):
+        fragments.extend(
+            _build_turn_fragments(
+                user_run=user_run,
+                assistant_run=assistant_run,
+                turn_idx=turn_idx,
+                title=title,
+                conversation_timestamp=conversation_timestamp,
+                source_path=source_path,
+                conversation_id=conversation_id,
+                conv_authored_at=conv_authored_at,
+            )
+        )
     return fragments
+
+
+def _build_turn_fragments(
+    *,
+    user_run: list[dict[str, Any]],
+    assistant_run: list[dict[str, Any]],
+    turn_idx: int,
+    title: str,
+    conversation_timestamp: datetime,
+    source_path: str,
+    conversation_id: str | None,
+    conv_authored_at: datetime | None,
+) -> list[ParsedFragment]:
+    """Build the human and AI fragments for one ChatGPT turn.
+
+    The human turn and the AI turn are emitted as two
+    separately-attributed fragments rather than one merged fragment, so
+    the model's prose can never train the voice proxy. Both share the
+    conversation id, turn index, and timestamp so threading/linking
+    still works.
+
+    Args:
+        user_run: The turn's consecutive user messages, in order.
+        assistant_run: The turn's consecutive assistant messages.
+        turn_idx: Zero-based index of this turn in the conversation.
+        title: The conversation title.
+        conversation_timestamp: Fallback timestamp for the turn.
+        source_path: The source file path.
+        conversation_id: Optional ChatGPT conversation ID for metadata.
+        conv_authored_at: Conversation-level FEAT-031 fallback.
+
+    Returns:
+        ``[human_fragment, ai_fragment]`` for this turn.
+    """
+    user_text = merge_turn_texts([_extract_message_text(m) for m in user_run])
+    assistant_text = merge_turn_texts([_extract_message_text(m) for m in assistant_run])
+    # The run's *last* user message stamps the turn — the one the reply
+    # actually answered, and the one the pre-#1333 adjacency walk already
+    # picked, so no already-correct fragment id churns.
+    user_time: float | None = user_run[-1].get("create_time")
+    fragment_ts = (
+        _epoch_to_la_datetime(user_time) if user_time else conversation_timestamp
+    )
+    msg_authored_at = _epoch_to_authored_at(user_time)
+    authored_at = msg_authored_at if msg_authored_at is not None else conv_authored_at
+
+    base_meta: dict[str, Any] = {
+        "platform": "chatgpt",
+        "authored_at": authored_at,
+    }
+    if conversation_id is not None:
+        base_meta["conversation_id"] = conversation_id
+
+    return [
+        ParsedFragment(
+            content=user_text,
+            metadata=base_meta
+            | {
+                "title": f"{title} (turn {turn_idx})",
+                "author_role": _ROLE_SELF,
+            },
+            source_path=source_path,
+            timestamp=fragment_ts,
+        ),
+        ParsedFragment(
+            content=assistant_text,
+            metadata=base_meta
+            | {
+                "title": f"{title} (turn {turn_idx}, AI)",
+                "author_role": _ROLE_AI,
+            },
+            source_path=source_path,
+            timestamp=fragment_ts,
+        ),
+    ]

--- a/creek-tools/creek/ingest/claude.py
+++ b/creek-tools/creek/ingest/claude.py
@@ -27,6 +27,7 @@ from creek.ingest.base import (
     normalize_timestamp,
     parse_authored_at,
 )
+from creek.ingest.turns import group_turn_runs, merge_turn_texts
 from creek.models import Authorship
 
 if TYPE_CHECKING:
@@ -149,35 +150,94 @@ def _normalize_messages(
 # ---- Turn Pairing ----
 
 
+def _message_role(msg: dict[str, Any]) -> str:
+    """Return a normalized message's role, or ``""`` when it has none.
+
+    Args:
+        msg: A normalized message dict.
+
+    Returns:
+        The ``role`` field as a string.
+    """
+    return str(msg.get("role", ""))
+
+
+def _collapse_run(
+    run: list[dict[str, Any]],
+    carrier: dict[str, Any],
+) -> dict[str, Any]:
+    """Collapse a same-role run into one message dict (#1333).
+
+    Args:
+        run: The consecutive same-role messages of one turn side.
+        carrier: The message of *run* whose non-content fields survive.
+            Which one that is matters: :func:`_resolve_timestamp` and
+            :func:`_resolve_authored_at` read ``created_at`` off the
+            human dict, and both fragments of the turn are stamped from
+            it, so the human carrier is the run's **last** message —
+            what the pre-#1333 code already used. Anything else would
+            re-stamp, and therefore re-mint the id of, the AI fragment
+            whose text has not changed at all.
+
+    Returns:
+        A copy of *carrier* whose ``content`` is the merged run text.
+    """
+    merged = carrier.copy()
+    merged["content"] = merge_turn_texts(
+        [_extract_text(msg.get("content", "")) for msg in run]
+    )
+    return merged
+
+
 def _pair_turns(
     messages: list[dict[str, Any]],
 ) -> list[tuple[dict[str, Any], dict[str, Any]]]:
     """Pair human turns with their corresponding assistant responses.
 
-    Skips system prompts. Consecutive human messages are merged (only the
-    last is kept). A trailing human message without an assistant response
-    is discarded.
+    Skips system prompts. **Consecutive human messages are merged** into
+    one human turn, and consecutive assistant messages into one assistant
+    turn, joined by :data:`~creek.ingest.turns.TURN_TEXT_SEPARATOR`. A
+    trailing human message without an assistant response is discarded.
+
+    Until #1333 this function kept only *one* message per run — the last
+    human, the first assistant — and dropped the others without a word.
+    Sending a thought in two messages before the model replies is
+    ordinary usage, so the first half of the operator's own prose never
+    reached a fragment, and therefore never reached the voice corpus,
+    which is built from ``source.author=self`` fragments. The docstring
+    said "merged (only the last is kept)"; those are two different
+    behaviours and the code did the second.
+
+    Merging the assistant side does not fight
+    :meth:`creek.clean.filters.chatbot.ChatbotFilter._collapse_regenerations`,
+    which reduces an assistant run to its last message on the theory that
+    the earlier ones are regenerations. That filter runs *before* pairing
+    (:meth:`ClaudeIngestor._parse_conversation`), so when it is
+    configured this function only ever sees a single assistant message
+    and returns it byte-identically. When it is not configured, ingest
+    has no evidence about which of two assistant messages the operator
+    meant to keep, and preserving both is the only non-lossy answer.
 
     Args:
         messages: List of normalized message dicts.
 
     Returns:
-        List of (human_message, assistant_message) tuples.
+        List of (human_message, assistant_message) tuples, one per turn,
+        each carrying its run's merged text.
     """
-    pairs: list[tuple[dict[str, Any], dict[str, Any]]] = []
-    pending_human: dict[str, Any] | None = None
-
-    for msg in messages:
-        role = msg.get("role", "")
-        if role == "system":
-            continue
-        if role == "human":
-            pending_human = msg
-        elif role == "assistant" and pending_human is not None:
-            pairs.append((pending_human, msg))
-            pending_human = None
-
-    return pairs
+    runs = group_turn_runs(
+        messages,
+        role_of=_message_role,
+        human_role="human",
+        assistant_role="assistant",
+    )
+    return [
+        (
+            _collapse_run(human_run, human_run[-1]),
+            _collapse_run(assistant_run, assistant_run[0]),
+        )
+        for human_run, assistant_run in runs
+    ]
 
 
 # ---- Timestamp Resolution ----

--- a/creek-tools/creek/ingest/turns.py
+++ b/creek-tools/creek/ingest/turns.py
@@ -1,0 +1,141 @@
+"""Conversation turn grouping shared by the chat ingestors (#1333).
+
+A "turn" in a chat export is not one message. Splitting a thought across
+two sends before the model replies is ordinary usage, and so is a model
+that answers in two. Both the Claude and the ChatGPT export walks
+therefore meet *runs* of consecutive same-role messages, and both used
+to keep exactly one message per run and drop the rest — silently, with
+no error, no counter, and no trace in the vault.
+
+The human half of that loss is the expensive one. Human turns are
+written as ``source.author = self`` fragments, and those are the only
+fragments the voice fingerprint is trained on
+(:meth:`creek.generate.voice.VoiceExemplarCollector._eligible_register`),
+so a dropped first half meant the fingerprint learned from a filtered
+sample of how the operator writes.
+
+This module holds the two primitives that fix it once for both
+ingestors rather than twice, differently:
+
+* :func:`group_turn_runs` — segment a message list into
+  ``(human_run, assistant_run)`` pairs.
+* :func:`merge_turn_texts` — join one run's texts into one turn body.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+_Message = TypeVar("_Message")
+
+TURN_TEXT_SEPARATOR: Final[str] = "\n\n"
+"""Separator joining the messages of one same-role run into one body.
+
+A blank line, not a bare newline. Each sent message is a *block-level*
+unit, and a blank line is the only separator CommonMark treats as a
+block boundary: under a single newline an indented code block or a list
+sent as its own message becomes a lazy continuation of the preceding
+paragraph, and two sentences run together into one. The blank line also
+survives :meth:`creek.ingest.claude.ClaudeIngestor.convert_to_markdown`,
+which prefixes every line of a human turn with ``"> "`` — the separator
+becomes a quoted blank line and keeps two paragraphs inside one
+blockquote, where a soft break would have fused them.
+
+No *visible* delimiter (a ``---`` rule, a ``[continued]`` marker) is
+inserted, because whatever goes here is indistinguishable downstream
+from text the operator actually wrote: it is embedded, classified, and
+weighed by the voice fingerprint as their prose.
+"""
+
+
+def merge_turn_texts(texts: Sequence[str]) -> str:
+    """Join the texts of one same-role run into a single turn body.
+
+    A **one-element run is returned byte-identically** — not stripped,
+    not normalised, not re-wrapped. That is the load-bearing case rather
+    than the degenerate one: fragment ids hash the content
+    (:func:`creek.ingest.base.generate_fragment_id`), so any change to
+    an already-correct single-message turn would re-mint its id and
+    orphan the fragment already sitting in the vault. Every turn the
+    drop never touched must come out of here exactly as it went in.
+
+    A multi-element run drops the parts that are empty once stripped —
+    an empty send contributes no words, only blank lines — and joins the
+    rest with :data:`TURN_TEXT_SEPARATOR`.
+
+    Args:
+        texts: The extracted texts of one run's messages, in order.
+
+    Returns:
+        The merged turn body; ``""`` for an empty run.
+    """
+    if len(texts) == 1:
+        return texts[0]
+    return TURN_TEXT_SEPARATOR.join(text for text in texts if text.strip())
+
+
+def group_turn_runs(
+    messages: Sequence[_Message],
+    *,
+    role_of: Callable[[_Message], str],
+    human_role: str,
+    assistant_role: str,
+) -> list[tuple[list[_Message], list[_Message]]]:
+    """Segment a message list into ``(human_run, assistant_run)`` pairs.
+
+    One pass. Consecutive human messages accumulate into a run; the
+    assistant messages answering them accumulate into the next run; the
+    pair is flushed when a human speaks again or the input ends.
+
+    Three deliberate behaviours, all of which the two callers previously
+    had to state for themselves and one of which they disagreed on:
+
+    * **Any other role is skipped without breaking the pair.** A system
+      prompt or a tool result between a question and its answer is not a
+      turn and must not prevent one. ChatGPT's index walk required
+      strict adjacency, so ``user, system, assistant`` produced *no*
+      fragment at all — contradicting its own docstring, which already
+      said system messages were skipped.
+    * **A leading assistant run is dropped.** With nobody to answer,
+      there is no turn.
+    * **A trailing human run is dropped.** A question the model never
+      answered has no pair. Both ingestors already did this and both
+      docstrings already promised it.
+
+    For every input that previously yielded pairs at all, the number of
+    pairs is unchanged: a run collapses into the same single pair it
+    used to, so ``turn_index`` never renumbers.
+
+    Args:
+        messages: The conversation's messages, in order.
+        role_of: Extracts a message's role. Claude reads a ``role`` key
+            and ChatGPT a nested ``author.role``, so the accessor is a
+            parameter rather than a shared assumption about the shape.
+        human_role: The role naming the owner's own messages
+            (``"human"`` for Claude, ``"user"`` for ChatGPT).
+        assistant_role: The role naming the model's messages.
+
+    Returns:
+        The ``(human_run, assistant_run)`` pairs, in order. Both lists of
+        every returned pair are non-empty.
+    """
+    pairs: list[tuple[list[_Message], list[_Message]]] = []
+    human_run: list[_Message] = []
+    assistant_run: list[_Message] = []
+
+    for message in messages:
+        role = role_of(message)
+        if role == human_role:
+            if assistant_run:
+                pairs.append((human_run, assistant_run))
+                human_run, assistant_run = [], []
+            human_run.append(message)
+        elif role == assistant_role and human_run:
+            assistant_run.append(message)
+
+    if assistant_run:
+        pairs.append((human_run, assistant_run))
+    return pairs

--- a/creek-tools/docs/ingestion.md
+++ b/creek-tools/docs/ingestion.md
@@ -257,6 +257,25 @@ creek ingest --refresh-ai-chat --vault ~/Vault
 
 It walks `01-Fragments/`, re-splits each merged Claude/ChatGPT fragment into a human (`self`) and a quarantined AI (`ai`, `voice_weight=0.0`) fragment, and removes the merged file. Running it twice is a no-op; a vault with no merged chat fragments is unchanged. Afterwards, `creek voice-authenticity` (see [generation](./generation.md#voice-fidelity-feat-040)) should report a near-zero AI-corpus leak.
 
+### Split messages are one turn
+
+A turn is not a message. Sending a thought in two messages before the model replies is ordinary usage, and so is a model that answers in two. Both ingestors now merge each run of consecutive same-role messages into one turn, joined by a **blank line** — a bare newline would let an indented code block or a list sent as its own message be absorbed into the previous paragraph. Anything that is neither a human nor an assistant message (a system prompt, a tool result) is skipped and no longer breaks the turn around it.
+
+Before [#1333](https://github.com/Geoffe-Ga/Creek-Vault/issues/1333) each run kept exactly one message and dropped the rest silently. The costly half was the human side: those fragments are `source.author = self`, so the voice fingerprint was trained on a filtered sample of how the operator actually writes.
+
+**Recovering an affected vault.** Re-ingest the export:
+
+```bash
+creek ingest --type claude --input ~/exports/claude --vault ~/Vault
+```
+
+The Claude and ChatGPT sources are unledgered (only `markdown` is — see [Idempotency](#idempotency) above), so nothing records those turns as already processed and the re-ingest genuinely recovers the missing text. Two things to know before running it:
+
+* Nothing is deleted or rewritten. The recovered turn has different content, so it hashes to a **new** fragment id and is written alongside the truncated fragment already in the vault, which stays exactly where it is. Expect near-duplicates for every affected turn and remove the short ones by hand.
+* Aggregate parents built over those turns (`creek atomize`, FEAT-022) hash their ordered child ids, so a recovered child mints a new parent too and the old parent is left behind the same way.
+
+Turn *numbering* is unaffected: a run collapses into the same single turn it always produced, so `turn_index` and the `(turn N)` titles do not shift. The one exception is a ChatGPT conversation with a system or tool node between a question and its answer, which used to yield no fragments at all and now yields the turn it should always have.
+
 ## Document attribution (the name on the file)
 
 A DOCX carries `core_properties.author` and a PDF carries `/Author` — Word stamps one on every save. That name answers "what name is on the file", which is **not** the question `source.author` answers ("whose views does this stand for?", on the `self|ai|other|collaborative` axis). Ingest keeps the two apart:

--- a/creek-tools/tests/test_chatgpt_ingest.py
+++ b/creek-tools/tests/test_chatgpt_ingest.py
@@ -1461,3 +1461,117 @@ class TestLinearizeTreeParentOnlyMapping:
 
         texts = [m["content"]["parts"][0] for m in ordered]
         assert texts == ["Q", "long", "follow"]
+
+
+def _chain_conversation(
+    turns: list[tuple[str, str]],
+    title: str = "Consecutive Chat",
+    create_time: float = 1700042400.0,
+) -> dict[str, Any]:
+    """Build a ChatGPT conversation whose mapping is one linear chain.
+
+    Mirrors the node shape of :func:`_minimal_conversation` (root -> ... ->
+    leaf, each node carrying an ``author.role`` and text ``parts``) but lets
+    a test state the exact role sequence it needs.
+
+    Args:
+        turns: Ordered ``(role, text)`` pairs, one message node each.
+        title: Conversation title.
+        create_time: Unix epoch for the conversation; each node is stamped
+            ten seconds after its predecessor.
+
+    Returns:
+        A dict representing one ChatGPT conversation.
+    """
+    mapping: dict[str, Any] = {
+        "root": {"id": "root", "message": None, "parent": None, "children": []},
+    }
+    parent = "root"
+    for idx, (role, text) in enumerate(turns):
+        node_id = f"n{idx}"
+        mapping[parent]["children"] = [node_id]
+        mapping[node_id] = {
+            "id": node_id,
+            "message": {
+                "id": node_id,
+                "author": {"role": role},
+                "content": {"content_type": "text", "parts": [text]},
+                "create_time": create_time + 10.0 * (idx + 1),
+            },
+            "parent": parent,
+            "children": [],
+        }
+        parent = node_id
+    return {
+        "title": title,
+        "create_time": create_time,
+        "update_time": create_time + 100.0,
+        "mapping": mapping,
+    }
+
+
+class TestChatGPTConsecutiveMessages:
+    """Runs of same-role messages must all reach a fragment (issue #1333).
+
+    The old index walk paired a user message only with a strictly adjacent
+    assistant message, so the first of two consecutive user messages was
+    skipped, the second of two consecutive assistant messages was dropped,
+    and a system node between the turns broke the pair entirely — even
+    though system messages are documented as skipped.
+    """
+
+    def test_consecutive_user_messages_merge_into_human_fragment(self) -> None:
+        """Both user messages of a run land in the human fragment."""
+        conv = _chain_conversation(
+            [
+                ("user", "Part one"),
+                ("user", "Part two"),
+                ("assistant", "Reply"),
+            ]
+        )
+        ingestor = ChatGPTIngestor()
+        fragments = ingestor.parse(_make_raw_doc([conv]))
+
+        assert len(fragments) == 2
+        assert fragments[0].metadata["author_role"] == "self"
+        # Both halves of the operator's question, separated by a blank line.
+        assert fragments[0].content == "Part one\n\nPart two"
+        assert fragments[1].content == "Reply"
+
+    def test_consecutive_assistant_messages_merge_into_ai_fragment(self) -> None:
+        """Both assistant messages of a run land in the AI fragment."""
+        conv = _chain_conversation(
+            [
+                ("user", "Question"),
+                ("assistant", "A one"),
+                ("assistant", "A two"),
+            ]
+        )
+        ingestor = ChatGPTIngestor()
+        fragments = ingestor.parse(_make_raw_doc([conv]))
+
+        assert len(fragments) == 2
+        assert fragments[0].content == "Question"
+        assert fragments[1].metadata["author_role"] == "ai"
+        assert fragments[1].content == "A one\n\nA two"
+
+    def test_system_message_between_turns_does_not_break_the_pair(self) -> None:
+        """A system node mid-conversation is skipped, not a pair divider."""
+        conv = _chain_conversation(
+            [
+                ("user", "Question"),
+                ("system", "System prompt."),
+                ("assistant", "Reply"),
+            ]
+        )
+        ingestor = ChatGPTIngestor()
+        fragments = ingestor.parse(_make_raw_doc([conv]))
+
+        # Before #1333 this yielded zero fragments: the system node broke
+        # strict adjacency and the whole exchange was dropped.
+        assert len(fragments) == 2
+        assert fragments[0].content == "Question"
+        assert fragments[1].content == "Reply"
+        assert "System prompt." not in fragments[0].content
+        assert "System prompt." not in fragments[1].content
+        assert [f.metadata["author_role"] for f in fragments] == ["self", "ai"]

--- a/creek-tools/tests/test_ingest_claude.py
+++ b/creek-tools/tests/test_ingest_claude.py
@@ -1060,7 +1060,13 @@ class TestEdgeCases:
         assert "\u2728" in fragments[1].content
 
     def test_consecutive_human_messages(self, ingestor: ClaudeIngestor) -> None:
-        """parse() should handle consecutive human messages correctly."""
+        """A run of consecutive human messages merges into one human fragment.
+
+        Both messages must reach the fragment, separated by a blank line.
+        Human turns are ``source.author=self`` and are what the voice
+        fingerprint trains on, so dropping one makes the voice corpus a
+        filtered sample of the operator's own prose (issue #1333).
+        """
         conv = _make_single_conversation(
             messages=[
                 {
@@ -1082,8 +1088,123 @@ class TestEdgeCases:
         )
         raw = _raw_doc_from_export(_make_claude_export([conv]))
         fragments = ingestor.parse(raw)
-        # Should handle gracefully; at least one fragment produced
-        assert len(fragments) >= 1
+        # Until issue #1333 this test ended at ``assert len(fragments) >= 1``,
+        # which no return value could fail: it corroborated the drop rather
+        # than catching it. The run is one turn pair -> one human + one AI
+        # fragment.
+        assert len(fragments) == 2
+        human_content = fragments[0].content
+        assert "First human message" in human_content
+        assert "Second human message" in human_content
+        # Separated by exactly one blank line, so the second message keeps its
+        # own Markdown block instead of running on from the first.
+        assert human_content == "First human message\n\nSecond human message"
+        assert fragments[0].metadata["author_role"] == "self"
+        assert fragments[1].content == "Response to both"
+
+    def test_consecutive_assistant_messages(self, ingestor: ClaudeIngestor) -> None:
+        """A run of consecutive assistant messages merges into one AI fragment.
+
+        The second and later assistant messages of a run were dropped for the
+        same reason the human ones were: the pairing loop only had room for
+        one message per side (issue #1333).
+        """
+        conv = _make_single_conversation(
+            messages=[
+                {
+                    "role": "human",
+                    "content": "One question",
+                    "created_at": "2024-11-15T10:00:00Z",
+                },
+                {
+                    "role": "assistant",
+                    "content": "Reply part one",
+                    "created_at": "2024-11-15T10:00:15Z",
+                },
+                {
+                    "role": "assistant",
+                    "content": "Reply part two",
+                    "created_at": "2024-11-15T10:00:30Z",
+                },
+            ],
+        )
+        raw = _raw_doc_from_export(_make_claude_export([conv]))
+        fragments = ingestor.parse(raw)
+        assert len(fragments) == 2
+        assert fragments[0].content == "One question"
+        assert fragments[1].content == "Reply part one\n\nReply part two"
+        assert fragments[1].metadata["author_role"] == "ai"
+
+    def test_single_message_turn_content_is_unchanged(
+        self, ingestor: ClaudeIngestor
+    ) -> None:
+        """An ordinary one-message turn keeps its content byte-for-byte.
+
+        Fragment ids hash the content, so the merge introduced for issue
+        #1333 must not strip, normalise, or re-wrap a turn that was already
+        a single message — otherwise every existing fragment id churns.
+        """
+        human_text = "A question with deliberate trailing space  \n\n"
+        assistant_text = "An answer that also ends in a newline.\n"
+        conv = _make_single_conversation(
+            messages=[
+                {
+                    "role": "human",
+                    "content": human_text,
+                    "created_at": "2024-11-15T10:00:00Z",
+                },
+                {
+                    "role": "assistant",
+                    "content": assistant_text,
+                    "created_at": "2024-11-15T10:00:15Z",
+                },
+            ],
+        )
+        raw = _raw_doc_from_export(_make_claude_export([conv]))
+        fragments = ingestor.parse(raw)
+        assert len(fragments) == 2
+        # Byte-identical, whitespace included: this is the id-stability
+        # guarantee.
+        assert fragments[0].content == human_text
+        assert fragments[1].content == assistant_text
+
+    def test_consecutive_human_turn_uses_last_message_timestamp(
+        self, ingestor: ClaudeIngestor
+    ) -> None:
+        """A merged human run is stamped from the LAST message of the run.
+
+        The timestamp (and ``authored_at``) are read off the human side of
+        the pair, and the pre-#1333 code kept the last human message. Keeping
+        the last one preserves the timestamp both fragments carry, which is
+        what stops the AI fragment's id from churning.
+        """
+        conv = _make_single_conversation(
+            messages=[
+                {
+                    "role": "human",
+                    "content": "Setting the scene",
+                    "created_at": "2024-11-15T18:00:00Z",
+                },
+                {
+                    "role": "human",
+                    "content": "and here is the actual question",
+                    "created_at": "2024-11-15T18:30:00Z",
+                },
+                {
+                    "role": "assistant",
+                    "content": "The answer",
+                    "created_at": "2024-11-15T18:30:15Z",
+                },
+            ],
+        )
+        raw = _raw_doc_from_export(_make_claude_export([conv]))
+        fragments = ingestor.parse(raw)
+        assert len(fragments) == 2
+        # 18:30 UTC in November = 10:30 PST (UTC-8).
+        expected = datetime(2024, 11, 15, 10, 30, tzinfo=LA_TZ)
+        assert fragments[0].timestamp == expected
+        assert fragments[1].timestamp == expected
+        assert fragments[0].metadata["authored_at"] == expected
 
     def test_conversation_missing_uuid(self, ingestor: ClaudeIngestor) -> None:
         """parse() should handle conversations missing uuid."""

--- a/creek-tools/tests/test_ingest_resplit.py
+++ b/creek-tools/tests/test_ingest_resplit.py
@@ -14,6 +14,8 @@ from typing import TYPE_CHECKING
 
 import frontmatter
 
+from creek.ingest.base import ParsedFragment
+from creek.ingest.claude import ClaudeIngestor
 from creek.ingest.refresh import resplit_merged_ai_chat
 from creek.models import Authorship, Fragment, FragmentSource, SourcePlatform
 from creek.vault.reader import iter_vault_fragments
@@ -176,6 +178,49 @@ def test_already_split_human_fragment_is_skipped(tmp_path: Path) -> None:
 
     assert result.resplit == 0
     assert result.skipped == 1
+
+
+def test_merged_run_human_fragment_is_skipped(tmp_path: Path) -> None:
+    """A human fragment holding a merged message run is not re-split (#1333).
+
+    Consecutive human messages now merge into one turn separated by a blank
+    line, so a human fragment body is no longer a single paragraph — and
+    ``_parse_claude_merged`` reads any *non-blank* line that escapes the
+    blockquote as the assistant's prose. (A blank separator is safe whether
+    or not it carries the ``>``; the parser drops blank lines from that
+    bucket. A non-blank one is not.) So the guarantee this test pins is
+    that ``ClaudeIngestor.convert_to_markdown`` blockquotes **every** line
+    of a multi-paragraph human turn. The body is produced by that method
+    rather than hand-written, so a future change that lets any line through
+    unprefixed fails here instead of silently making the migration
+    destructive: it would otherwise split this fragment and re-attribute
+    the second half of the operator's own words to the AI.
+    """
+    vault = tmp_path / "vault"
+    merged_run_text = "First half of my thought\n\nSecond half of my thought"
+    body = ClaudeIngestor().convert_to_markdown(
+        ParsedFragment(
+            content=merged_run_text,
+            metadata={"turn_text": merged_run_text, "author_role": "self"},
+            source_path="/exports/claude.json",
+            timestamp=datetime(2024, 11, 15, 10, 0, tzinfo=UTC),
+        ),
+    )
+    # Guard the precondition the safety argument rests on.
+    assert all(line.startswith(">") for line in body.split("\n"))
+    target = _write_merged(
+        vault,
+        platform=SourcePlatform.CLAUDE,
+        body=body,
+        name="merged_run",
+    )
+
+    result = resplit_merged_ai_chat(vault)
+
+    assert result.resplit == 0
+    assert result.skipped == 1
+    assert target.exists()
+    assert target.read_text(encoding="utf-8").endswith(body)
 
 
 def test_empty_vault_is_unchanged(tmp_path: Path) -> None:

--- a/creek-tools/tests/test_ingest_turns.py
+++ b/creek-tools/tests/test_ingest_turns.py
@@ -1,0 +1,216 @@
+"""Tests for creek.ingest.turns — shared conversation turn-run grouping.
+
+Issue #1333: both the Claude and the ChatGPT ingestors kept only one
+message from a run of consecutive same-role messages and silently dropped
+the rest. Human turns are ``source.author=self`` and are what the voice
+fingerprint trains on, so a dropped human message makes the voice corpus a
+filtered sample of the operator's prose. This module pins the two shared
+primitives the ingestors are rebuilt on:
+
+- :func:`merge_turn_texts` — join a run's texts without disturbing the
+  single-message case, whose bytes must stay identical so already-correct
+  fragment ids never churn.
+- :func:`group_turn_runs` — one pass over an ordered message list yielding
+  ``(human_run, assistant_run)`` pairs, skipping roles that participate in
+  neither run rather than letting them break a pair.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from creek.ingest.turns import (
+    TURN_TEXT_SEPARATOR,
+    group_turn_runs,
+    merge_turn_texts,
+)
+
+# ---- Helpers ----
+
+Message = dict[str, str]
+Pair = tuple[list[Message], list[Message]]
+
+
+def _msg(role: str, text: str) -> Message:
+    """Build a minimal message dict for the grouping tests.
+
+    Args:
+        role: The message's role (``human``, ``assistant``, ``system``, ...).
+        text: The message body; unique per message so list equality is a
+            meaningful assertion.
+
+    Returns:
+        A plain dict with ``role`` and ``content`` keys.
+    """
+    return {"role": role, "content": text}
+
+
+def _role_of(message: Message) -> str:
+    """Read the role off a test message dict.
+
+    Args:
+        message: A message built by :func:`_msg`.
+
+    Returns:
+        The message's role string.
+    """
+    return message["role"]
+
+
+def _group(messages: list[Message]) -> list[Pair]:
+    """Group messages with the Claude role vocabulary.
+
+    Args:
+        messages: The ordered message list to group.
+
+    Returns:
+        The ``(human_run, assistant_run)`` pairs produced by
+        :func:`group_turn_runs`.
+    """
+    return group_turn_runs(
+        messages,
+        role_of=_role_of,
+        human_role="human",
+        assistant_role="assistant",
+    )
+
+
+# ---- merge_turn_texts() ----
+
+
+class TestMergeTurnTexts:
+    """Tests for :func:`creek.ingest.turns.merge_turn_texts`."""
+
+    def test_single_element_returns_that_element(self) -> None:
+        """A one-message run merges to exactly that message's text."""
+        assert merge_turn_texts(["only"]) == "only"
+
+    def test_single_element_is_byte_identical(self) -> None:
+        """A single unstripped element is returned with its bytes untouched."""
+        # Load-bearing invariant: a single-message turn is byte-identical, so
+        # no already-correct fragment id churns when #1333 lands. Stripping
+        # here would rewrite every ordinary turn in the vault.
+        assert merge_turn_texts(["  padded  \n"]) == "  padded  \n"
+
+    def test_single_whitespace_only_element_is_returned_verbatim(self) -> None:
+        """Even an all-whitespace lone element survives the single-element path.
+
+        The empty-after-strip filter belongs to the multi-element join only;
+        applying it first would turn this into ``""`` and change the content
+        (and therefore the id) of an existing fragment.
+        """
+        assert merge_turn_texts(["   "]) == "   "
+
+    def test_two_elements_join_with_one_blank_line(self) -> None:
+        """Two messages join with exactly one blank line between them."""
+        assert TURN_TEXT_SEPARATOR == "\n\n"
+        assert merge_turn_texts(["a", "b"]) == "a\n\nb"
+
+    def test_whitespace_only_elements_are_dropped(self) -> None:
+        """Elements that are empty after ``.strip()`` drop out of a merge."""
+        assert merge_turn_texts(["a", "   ", "b"]) == "a\n\nb"
+
+    def test_empty_sequence_returns_empty_string(self) -> None:
+        """An empty run merges to the empty string, not to a separator."""
+        assert merge_turn_texts([]) == ""
+
+    def test_indented_block_starts_its_own_markdown_block(self) -> None:
+        """The separator is a blank line so an indented block stays a block."""
+        merged = merge_turn_texts(["Here is the snippet:", "    indented_code_line()"])
+        # A single "\n" would make the indented line a lazy continuation of
+        # the preceding paragraph instead of a code block, so the merge would
+        # change how the fragment renders as well as what it contains.
+        assert "\n\n    indented_code_line()" in merged
+        assert merged == "Here is the snippet:\n\n    indented_code_line()"
+
+
+# ---- group_turn_runs() ----
+
+
+class TestGroupTurnRuns:
+    """Tests for :func:`creek.ingest.turns.group_turn_runs`."""
+
+    def test_consecutive_humans_form_one_pair(self) -> None:
+        """A run of two human messages is one pair holding both of them."""
+        h1 = _msg("human", "part one of my question")
+        h2 = _msg("human", "and part two")
+        a1 = _msg("assistant", "answer")
+
+        pairs = _group([h1, h2, a1])
+
+        assert pairs == [([h1, h2], [a1])]
+
+    def test_consecutive_assistants_form_one_pair(self) -> None:
+        """A run of two assistant messages is one pair holding both of them."""
+        h1 = _msg("human", "q")
+        a1 = _msg("assistant", "reply part one")
+        a2 = _msg("assistant", "reply part two")
+
+        pairs = _group([h1, a1, a2])
+
+        assert pairs == [([h1], [a1, a2])]
+
+    def test_system_message_does_not_break_a_pair(self) -> None:
+        """A system message between the turns is skipped, not a divider."""
+        h1 = _msg("human", "q")
+        sys_msg = _msg("system", "you are a helpful assistant")
+        a1 = _msg("assistant", "a")
+
+        pairs = _group([h1, sys_msg, a1])
+
+        assert pairs == [([h1], [a1])]
+        human_run, assistant_run = pairs[0]
+        assert all(m is not sys_msg for m in (*human_run, *assistant_run))
+
+    @pytest.mark.parametrize("role", ["system", "tool", "unknown"])
+    def test_non_participating_roles_are_skipped(self, role: str) -> None:
+        """Any role that is neither human nor assistant is passed over.
+
+        Args:
+            role: A role that participates in neither run.
+        """
+        h1 = _msg("human", "q")
+        other = _msg(role, "noise")
+        a1 = _msg("assistant", "a")
+
+        assert _group([other, h1, other, a1, other]) == [([h1], [a1])]
+
+    def test_leading_assistant_without_human_is_skipped(self) -> None:
+        """An assistant message with no preceding human starts no pair."""
+        a0 = _msg("assistant", "unprompted preamble")
+        h1 = _msg("human", "q")
+        a1 = _msg("assistant", "a")
+
+        pairs = _group([a0, h1, a1])
+
+        assert pairs == [([h1], [a1])]
+
+    def test_trailing_human_run_is_discarded(self) -> None:
+        """A human run with no assistant response yields no pair."""
+        h1 = _msg("human", "q")
+        a1 = _msg("assistant", "a")
+        h2 = _msg("human", "unanswered follow-up")
+
+        pairs = _group([h1, a1, h2])
+
+        assert pairs == [([h1], [a1])]
+
+    def test_two_runs_pair_in_order(self) -> None:
+        """Two exchanges of merged runs produce two pairs, in source order."""
+        h1 = _msg("human", "q one")
+        h2 = _msg("human", "q one continued")
+        a1 = _msg("assistant", "a one")
+        a2 = _msg("assistant", "a one continued")
+        h3 = _msg("human", "q two")
+        a3 = _msg("assistant", "a two")
+
+        pairs = _group([h1, h2, a1, a2, h3, a3])
+
+        # Pair count is invariant with the pre-#1333 implementation: a run
+        # collapses into the same single pair it used to, so ``turn_index``
+        # never renumbers and no existing fragment id churns.
+        assert pairs == [([h1, h2], [a1, a2]), ([h3], [a3])]
+
+    def test_empty_input_returns_no_pairs(self) -> None:
+        """An empty message list groups to an empty pair list."""
+        assert _group([]) == []


### PR DESCRIPTION
## Summary

A turn in a chat export is not a message. Splitting a thought across two sends before the model replies is ordinary usage — and until now the first half never reached a fragment.

`ClaudeIngestor._pair_turns` kept exactly one message from each run of consecutive same-role messages and dropped the rest, silently: no error, no counter, no trace in the vault. Its docstring said *"Consecutive human messages are merged (only the last is kept)"* — two different behaviours in one sentence, and the code did the second.

**Why this is worse than a lost message.** Human turns are written as `source.author = self` fragments, and self-authored fragments are the entire training sample for the voice fingerprint (`VoiceExemplarCollector._eligible_register`). So the fingerprint was not learning from how the operator writes; it was learning from a *silently filtered* view of how the operator writes — the second half of every split thought, never the first, with no signal that anything was missing.

This merges each run into one turn, in both chat ingestors, and makes the docstrings true.

## Where the issue was wrong, and where it understated the defect

**The reproduction in the issue does not reproduce the bug it describes.** It passes `{"sender": "human", "text": ...}`; the ingestor keys on `role` and `content`. Run verbatim it returns `[]` — but because *no role ever matched*, not because of the overwrite. Re-run against the shape the code actually reads, the defect is real:

```
_pair_turns([{'role':'human','content':'part one of my question'},
             {'role':'human','content':'and part two'},
             {'role':'assistant','content':'answer'}])
-> [({'role': 'human', 'content': 'and part two'}, {'role': 'assistant', 'content': 'answer'})]
```

That mismatch is itself worth a look and is filed as #1428: no code anywhere in the package maps `sender`/`text`, and every Claude fixture uses `role`/`content`, so the tests agree with the ingestor and neither has ever met a real export. Settling it needs one paste of a real `conversations.json`, which is why it is a separate issue rather than a guess made here.

**The defect is symmetric, and the issue scoped it to humans only.** The same function drops the 2nd and later messages of an *assistant* run, because `pending_human` is already cleared:

```
_pair_turns([{'role':'human','content':'q'},
             {'role':'assistant','content':'reply part one'},
             {'role':'assistant','content':'reply part two'}])
-> [({'role':'human','content':'q'}, {'role':'assistant','content':'reply part one'})]
```

Fixed here too.

**ChatGPT is defective the same way**, which the issue listed as "check, but not assumed defective". `_pair_messages_to_fragments` was an index walk with strict adjacency lookahead, and it lost content three ways: `user, user, assistant` skipped the first user; `user, assistant, assistant` swept the second assistant into the "any other role" arm; and `user, system, assistant` produced **zero** fragments, because a system node broke adjacency — contradicting that function's own docstring, which already claimed system messages were skipped.

## The design decision: merge, and join with a blank line

Merging is the right reading — two messages before a reply are one utterance split by the send button — but the separator is a real choice, and `"\n".join` is the wrong one. `TURN_TEXT_SEPARATOR` is `"\n\n"` because:

- A blank line is the only separator CommonMark treats as a **block** boundary. Under a single newline, an indented code block or a list sent as its own message becomes a lazy continuation of the preceding paragraph, and two sentences run together into one.
- `ClaudeIngestor.convert_to_markdown` prefixes every line of a human turn with `"> "`. A blank separator becomes a quoted blank line and keeps two paragraphs inside one blockquote; a soft break would have fused them.
- No *visible* delimiter (`---`, `[continued]`) is inserted. Whatever goes there is indistinguishable downstream from text the operator wrote — it gets embedded, classified, and weighed by the voice fingerprint as their prose.

**Merging the assistant side does not fight `ChatbotFilter._collapse_regenerations`**, which reduces an assistant run to its last message on the theory that the earlier ones are regenerations. That filter runs *before* pairing, so when it is configured the merge only ever sees a single assistant message and returns it byte-identically. When it is not configured, ingest has no evidence about which of two assistant messages the operator meant to keep, and preserving both is the only non-lossy answer. (The filter has its own turn-shaping problems: #1427.)

## No ids shift, by construction

Fragment ids are `SHA-256(identity_key, timestamp, content)`. Neither chat ingestor sets `source_unit`, so `turn_index` is **not** in the id — and pair count is invariant with the old implementation for every input that previously produced pairs, so `turn_index` and the `(turn N)` titles do not renumber either. The single exception is ChatGPT `user, system, assistant`, which went from 0 pairs to 1.

Two deliberate choices keep the blast radius to the text actually being recovered:

- **`merge_turn_texts` returns a one-element run byte-identically** — not stripped, not normalised. That is the load-bearing case, not the degenerate one: any change to an already-correct single-message turn would re-mint its id and orphan the fragment already on disk. Two tests pin it and a stripping mutation reds four.
- **The human carrier of a merged run is its *last* message.** `_resolve_timestamp` / `_resolve_authored_at` read the human dict, and *both* fragments of the turn are stamped from it. The pre-fix code already used the last human, so keeping it means the AI fragment — whose text has not changed at all — keeps its timestamp and therefore its id. Same reasoning for `user_run[-1].get("create_time")` on the ChatGPT side.

## Migration: re-ingest genuinely recovers it, and nothing is deleted

Vaults ingested from Claude/ChatGPT exports are missing that text today. The first thing to check was whether re-ingesting is a no-op — the shape #1393 is open for — and it is not: `ledger_for_source` serves a ledger only for `markdown`, so the chat sources are unledgered and nothing records those turns as already processed. `creek ingest --type claude --input <export dir> --vault <vault>` recovers the text.

It is not free of residue, and the honest version is in `docs/ingestion.md`:

- The recovered turn has different content, so it hashes to a **new** id and is written *alongside* the truncated fragment, which stays exactly where it is. Expect near-duplicates on affected turns.
- Aggregate parents (`creek atomize`, FEAT-022) hash their ordered child ids, so a recovered child mints a new parent and leaves the old one behind the same way.

No vault content is deleted or rewritten on a heuristic, and no new migration command is added. The seventh detect-and-report in a row.

## Downstream check

`--refresh-ai-chat` (`resplit_merged_ai_chat`) decides whether a fragment is a *merged pre-split* turn by looking for non-blockquoted prose in the body. A merged human run is now multi-paragraph, so this needed checking: it is safe, because `convert_to_markdown` blockquotes every line and `_parse_claude_merged` discards blank lines from the "assistant prose" bucket. A regression test now builds its body by calling `convert_to_markdown` rather than hand-writing it, so a future change that lets any line through unprefixed fails the test instead of silently making the migration destructive — it would otherwise re-attribute the second half of the operator's own words to the AI.

## The tautological test

`tests/test_ingest_claude.py::test_consecutive_human_messages` ended at:

```python
# Should handle gracefully; at least one fragment produced
assert len(fragments) >= 1
```

No implementation that returns anything can fail that. It named the exact scenario and asserted nothing about it — which is why the bug survived being tested. It is **inverted in place, not deleted**: same name, same fixture messages, now asserting that both messages' text reaches the human fragment separated by a blank line, with a comment recording that the old assertion corroborated the drop.

## Test plan

- `./scripts/check-all.sh` → **exit 0**. 9377 passed, 5 skipped (all pre-existing environment skips: Ollama, live API keys), 94.60% coverage, per-file gate clean, ruff `--no-cache` clean, refurb clean.
- New `tests/test_ingest_turns.py` (18 tests) pins both primitives directly, including the byte-identity invariant and the indented-code-block separator case.
- Mutation-tested, each half independently:
  - revert `claude.py` alone → exactly 2 tests red (the two Claude drop tests);
  - revert `chatgpt.py` alone → exactly 3 tests red (the three ChatGPT tests);
  - separator `"\n\n"` → `"\n"` → 7 red;
  - remove the single-element short-circuit → 1 red (the whitespace-only case, precisely the one it exists for);
  - strip each part before joining → 4 red, including both id-stability guards.
- Bypass sweep over the whole diff including tests: no `# noqa`, `# type: ignore`, `pylint: disable`, skip/xfail, `--no-verify`, threshold edits, or deleted tests. The only deletions are the two rewritten function bodies and the three lines of the inverted assertion.

## Follow-ups filed

- #1426 (P1) — split chat human turns are silently excluded from the AI-style fingerprint: `extract_user_turns` requires a `**User**:` marker that per-turn-split bodies do not carry, so it drops them. Same class of silent filtering as this bug, one layer up.
- #1427 (P2) — `ChatbotFilter`'s short-human-turn drop manufactures assistant adjacencies that its regeneration collapse then discards.
- #1428 (P2) — verify `ClaudeIngestor` against a real claude.ai export before trusting the `role`/`content` shape.

Closes #1333
