### PR TITLE
fix(cli): stop creek sync --help calling --dry-run "the current default"

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -1152,6 +1152,127 @@ def _sync_validate_source(
         raise typer.Exit(code=2)
 
 
+def _sync_tier_b_fragment_count(vault_path: Path) -> int:
+    """Count the fragments a Tier-B pass could bill an LLM call for (#1335).
+
+    An upper bound, not an invoice: the pass skips fragments that are already
+    classified (``force=False``), so the announcement says "up to".
+
+    Args:
+        vault_path: Vault root whose ``01-Fragments`` tree is measured.
+
+    Returns:
+        The number of fragment notes under ``01-Fragments``, or ``0`` when
+        that directory does not exist yet.
+    """
+    root = vault_path / "01-Fragments"
+    if not root.exists():
+        return 0
+    return sum(1 for _ in root.rglob("*.md"))
+
+
+def _sync_gate_tier_b(
+    tier_norm: str,
+    vault_path: Path,
+    *,
+    dry_run: bool,
+    assume_yes: bool,
+) -> None:
+    """Announce Tier B's cost and, at a TTY, confirm it before spending (#1335).
+
+    Only a real Tier-B pass is gated: Tier A is the cheap per-source chain and
+    a dry run spends nothing. The announcement is unconditional because a
+    scheduler log is the only place a nightly Tier-B pass is otherwise opaque;
+    the *confirmation* is TTY-gated because every unit
+    :mod:`creek.sync.schedule` installs invokes a bare
+    ``creek sync --tier B --vault <path>`` with no ``--yes`` and no stdin, and
+    a prompt there would block forever on a question nobody can answer. The
+    skipped confirmation is stated out loud rather than left as an invisible
+    fork in behaviour.
+
+    All of this command's added branching lives here so ``sync`` itself gains
+    none, mirroring the :func:`_gate_consent` pair above.
+
+    Args:
+        tier_norm: The normalised tier, ``"A"`` or ``"B"``.
+        vault_path: Vault root the pass would classify.
+        dry_run: Whether this invocation only echoes the plan.
+        assume_yes: Whether ``--yes`` waived the confirmation.
+
+    Raises:
+        typer.Exit: With code ``1`` when the operator declines, before any
+            step (and before ``last-run.json``) is touched.
+    """
+    if tier_norm != "B" or dry_run:
+        return
+    count = _sync_tier_b_fragment_count(vault_path)
+    console.print(
+        f"[bold][sync] Tier B will classify up to {count} fragments "
+        f"(one LLM call each), then link and rebuild the index.[/bold]",
+    )
+    if not _is_interactive():
+        console.print("[sync] non-interactive; proceeding without confirmation.")
+        return
+    if not _confirm("Continue?", assume_yes=assume_yes):
+        console.print("[yellow]Aborted.[/yellow]")
+        raise typer.Exit(code=1)
+
+
+def _sync_dispatch_guarded(
+    tier_norm: str,
+    *,
+    dry_run: bool,
+    config: CreekConfig,
+    vault_path: Path,
+    source: str | None,
+) -> dict[str, int] | None:
+    """Dispatch the tier, turning a provider refusal into a legible exit (#1335).
+
+    ``creek classify --method llm`` already catches this refusal; the sync path
+    did not, so a Tier-B tick with an unreachable provider (or no cloud
+    consent) died with an unhandled traceback into a scheduler log. The
+    exception carries its own provider-specific remediation, so this prints
+    that text rather than restating it, and lets the exit propagate before
+    ``last-run.json`` can record a pass that never ran.
+
+    The handler wraps the whole dispatch rather than only the Tier-B branch,
+    which is wider than the risk it covers but cannot misfire: Tier A always
+    classifies with ``method="rules"``, and
+    :func:`~creek.classify.classify_engine.run_classify` only builds the
+    provider-backed tier classifiers — the sole thing that raises this — when
+    the method is ``"llm"``. Keeping one handler here rather than two keeps
+    ``sync`` itself free of a ``try`` block.
+
+    Args:
+        tier_norm: The normalised tier, ``"A"`` or ``"B"``.
+        dry_run: Whether to echo the plan instead of executing it.
+        config: The resolved vault config.
+        vault_path: Vault root to operate on.
+        source: Optional single Tier-A source override.
+
+    Returns:
+        Per-source ingested counts for a real Tier-A run, else ``None``.
+
+    Raises:
+        typer.Exit: With code ``1`` when the configured LLM provider refuses.
+    """
+    from creek.classify.classify_engine import LLMProviderUnavailableError
+
+    try:
+        counts = _sync_dispatch(
+            tier_norm,
+            dry_run=dry_run,
+            config=config,
+            vault_path=vault_path,
+            source=source,
+        )
+    except LLMProviderUnavailableError as exc:
+        console.print(f"[red][sync] tier {tier_norm} aborted: {exc}[/red]")
+        raise typer.Exit(code=1) from exc
+    else:
+        return counts
+
+
 @app.command()
 def sync(
     tier: str = typer.Option(
@@ -1163,7 +1284,16 @@ def sync(
         help="Limit a Tier-A run to one source (explicitly overrides its toggle)",
     ),
     dry_run: bool = typer.Option(
-        False, "--dry-run", help="Echo the plan without executing (current default)"
+        False,
+        "--dry-run",
+        help=(
+            "Echo the ordered plan and run nothing. Opt-in: a bare invocation "
+            "executes the tier, and Tier B spends one LLM call per "
+            "unclassified fragment before linking and rebuilding the index."
+        ),
+    ),
+    yes: bool = typer.Option(
+        False, "--yes", "-y", help="Skip the interactive Tier-B confirmation."
     ),
     install_schedule: str | None = typer.Option(
         None,
@@ -1187,8 +1317,15 @@ def sync(
     ``--tier A`` is the cheap per-source pass (pull -> incremental ingest ->
     rules classify) for each enabled source; ``--tier B`` is the nightly global
     pass (LLM classify -> link -> index). Linking and indexing run only in Tier
-    B (R6). ``--dry-run`` echoes the ordered plan without executing. Every run
-    records ``00-Creek-Meta/State/sync/last-run.json``; because every step is
+    B (R6). A bare invocation executes the chosen tier; ``--dry-run`` is the
+    opt-in that echoes the ordered plan and runs nothing.
+
+    Tier B spends one LLM call per unclassified fragment, so it announces that
+    cost on every run and asks for confirmation **only at an interactive
+    terminal**: ``--yes`` skips the question, and a scheduled or otherwise
+    non-interactive run (every unit ``--install-schedule`` writes) proceeds
+    unprompted. Every run records
+    ``00-Creek-Meta/State/sync/last-run.json``; because every step is
     idempotent, a missed tick self-heals on the next run (no catch-up queue).
 
     ``--install-schedule launchd|systemd`` emits the host's schedule units and
@@ -1212,8 +1349,11 @@ def sync(
     config = _load_config_for_vault(vault)
     vault_path = vault or config.vault_path
     _sync_validate_source(tier_norm, source, config)
+    # After validation on purpose: announcing a cost for an invocation that is
+    # about to be rejected as a usage error would be misleading.
+    _sync_gate_tier_b(tier_norm, vault_path, dry_run=dry_run, assume_yes=yes)
 
-    source_counts = _sync_dispatch(
+    source_counts = _sync_dispatch_guarded(
         tier_norm,
         dry_run=dry_run,
         config=config,
@@ -5692,7 +5832,10 @@ def author(
     dry_run: bool = typer.Option(
         False,
         "--dry-run",
-        help="Print the pipeline plan and stub evidence summary without authoring.",
+        help=(
+            "Print the pipeline plan and the gathered evidence summary, "
+            "without voicing or reflection."
+        ),
     ),
     max_rounds: int | None = typer.Option(
         None,

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -1650,9 +1650,11 @@ class SyncConfig(BaseModel):
     """Scheduling configuration for ``creek sync`` (#676 / SPEC R3).
 
     Holds the per-source enable toggles and the two-tier cadence. The cadence
-    values are config-tunable (decision #5) even though the skeleton command
-    does not schedule anything yet — a later issue emits the launchd/systemd
-    units that read them.
+    values are config-tunable (decision #5) and are read by
+    :func:`~creek.sync.schedule.render_launchd_plists`,
+    :func:`~creek.sync.schedule.render_systemd_units` and
+    :func:`~creek.sync.schedule.render_crontab`, which
+    ``creek sync --install-schedule launchd|systemd`` writes to disk.
     """
 
     tier_a_interval_minutes: int = Field(default=30, ge=1)

--- a/creek-tools/creek/pipeline.py
+++ b/creek-tools/creek/pipeline.py
@@ -123,8 +123,12 @@ def resolve_tier_a_plan(source: str) -> list[str]:
 
     Tier A is the cheap, per-source pass: pull the source, incrementally
     ingest it, then run the offline rules classifier. This is a *plan* (an
-    ordered list of human-readable step strings) — the skeleton command echoes
-    it; real execution lands in a later issue.
+    ordered list of human-readable step strings), which is all
+    ``creek sync --tier A --dry-run`` prints. A bare ``creek sync --tier A``
+    does not use this function at all: #678 shipped real execution, and the
+    equivalent steps are run for real by
+    :func:`~creek.cli._sync_run_tier_a`. Keep the two in step — this list is
+    what the operator is shown when they ask what the tier *would* do.
     """
     ingest_type = sync_ingest_type(source)
     return [

--- a/creek-tools/docs/sync-workflow.md
+++ b/creek-tools/docs/sync-workflow.md
@@ -24,6 +24,31 @@ creek sync --tier B --vault /path/to/vault    # nightly global pass
 creek sync --tier A --dry-run --vault ...      # echo the plan without running
 ```
 
+## A bare invocation executes — `--dry-run` is opt-in
+
+There is no preview mode by default. `creek sync --tier B` really runs: **one
+LLM call per unclassified fragment** across the whole vault, then the link pass,
+then a full index rebuild. On a cloud `classification` provider that is real
+token spend and real data egress. Pass `--dry-run` to see the ordered plan
+without any of it.
+
+Before a real Tier-B pass, `creek sync` prints what it is about to do —
+including how many fragments it may bill for — and then:
+
+| where it runs | what happens |
+|---|---|
+| Interactive terminal (stdin is a TTY) | asks `Continue?`; answering no aborts before any step runs and records nothing |
+| Scheduled or piped (launchd, systemd, cron, CI, any non-TTY) | **proceeds unprompted**, and says so in the output |
+
+The scheduled case is deliberate: the units written by `--install-schedule` are
+bare `creek sync --tier B` invocations with no stdin, so a prompt there would
+block a timer nobody is watching. It does mean the confirmation protects the
+operator at a keyboard and **not** the nightly run — the cost line is printed
+either way precisely so the scheduler log records what the pass cost. Use
+`--yes` to skip the prompt in an interactive shell.
+
+Tier A is not gated: it is the cheap, offline pass.
+
 ## Enabling sources
 
 Each source has an on/off toggle under `sync.sources` in your config. The

--- a/creek-tools/tests/test_cli_author.py
+++ b/creek-tools/tests/test_cli_author.py
@@ -151,6 +151,27 @@ def test_author_command_surface_is_not_stale_stub_text() -> None:
     assert "real, deterministic" in author_cmd.__doc__.lower()
 
 
+def test_author_help_does_not_call_the_evidence_summary_a_stub() -> None:
+    """``--dry-run``'s help must not call the evidence summary a stub (#1335).
+
+    The sibling of the ``creek sync`` help fix. ``author --dry-run`` calls the
+    conductor's real ``gather_evidence`` and prints the real claim and
+    source-fragment counts (asserted by
+    :func:`test_author_dry_run_prints_plan_and_evidence`), but the option's
+    help string still advertised a "stub evidence summary" — telling the
+    operator the numbers are fake when they are not, which is exactly the
+    class of drift #1335 is about. The docstring at ``cli.py`` already says
+    the desk does real work; the option help has to agree.
+    """
+    result = runner.invoke(app, ["author", "--help"])
+
+    assert result.exit_code == 0, result.output
+    flat = _flatten_panel(result.output)
+    # Guards the negative assertion below against a vacuous pass on empty help.
+    assert "--dry-run" in flat, flat
+    assert "stub evidence" not in flat.lower(), flat
+
+
 def test_author_run_prints_verdict(tmp_path: Path) -> None:
     """A full author run prints the verdict and a body."""
     result = runner.invoke(

--- a/creek-tools/tests/test_sync.py
+++ b/creek-tools/tests/test_sync.py
@@ -1,9 +1,11 @@
-"""Skeleton ``creek sync`` command — dry-run plan + state round-trip (#676).
+"""``creek sync`` plan echoing + state round-trip (#676).
 
 Tier A is the cheap per-source pass (pull → incremental ingest → rules
 classify); Tier B is the nightly global pass (LLM classify → link → index).
-This skeleton only echoes the ordered plan and round-trips
-``00-Creek-Meta/State/sync/last-run.json`` — no real execution.
+This module covers the ``--dry-run`` surface — echoing the ordered plan and
+round-tripping ``00-Creek-Meta/State/sync/last-run.json``. Real tier execution
+shipped in #678 and is covered by ``test_sync_exec.py``; a bare invocation
+(no ``--dry-run``) executes the tier for real.
 """
 
 from __future__ import annotations

--- a/creek-tools/tests/test_sync_exec.py
+++ b/creek-tools/tests/test_sync_exec.py
@@ -8,6 +8,7 @@ idempotent, a re-run produces no duplicates.
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 
 from typer.testing import CliRunner
@@ -19,9 +20,11 @@ from creek.cli import (
     _sync_link,
     _sync_pull,
     _sync_source_input,
+    _sync_state_path,
     app,
 )
 from creek.config import CreekConfig, SyncConfig
+from tests.helpers import write_raw_fragment_file
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -29,6 +32,66 @@ if TYPE_CHECKING:
     import pytest
 
 runner = CliRunner()
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+# The Unicode Box Drawing block — the glyphs Rich uses to frame the options
+# panel in ``--help`` output. Matched as a range so a Rich border-set change
+# cannot quietly reintroduce the wrapping brittleness below.
+_BOX_DRAWING_RE = re.compile("[─-╿]")
+
+# "3 ... fragment" (or "fragment ... 3") with no other digit in between, so a
+# count that lands nowhere near the noun cannot satisfy the assertion.
+_COUNT_THEN_NOUN_RE = re.compile(r"\b3\b\D{0,60}?fragments?\b", re.IGNORECASE)
+_NOUN_THEN_COUNT_RE = re.compile(r"fragments?\b\D{0,60}?\b3\b", re.IGNORECASE)
+
+
+def _flatten(text: str) -> str:
+    """Return *text* with ANSI codes, Rich panel borders and wrapping removed.
+
+    Rich frames ``--help`` in a box and soft-wraps long cells, so a literal
+    phrase under test can arrive split across lines with ``│`` borders and
+    padding in between. Dropping the box-drawing range and collapsing runs of
+    whitespace rejoins the sentence, which matters most for the *negative*
+    assertions here: an un-flattened haystack would let "current default"
+    survive in the help simply by wrapping, and the test would pass anyway.
+
+    Args:
+        text: Raw captured CLI output.
+
+    Returns:
+        The single-spaced, escape-free, border-free form of *text*.
+    """
+    return " ".join(_BOX_DRAWING_RE.sub(" ", _ANSI_RE.sub("", text)).split())
+
+
+def _sync_help_option_cell(option: str) -> str:
+    """Return the flattened ``creek sync --help`` help cell for *option*.
+
+    Isolates one row of Rich's options panel — the option name plus any
+    wrapped continuation lines, stopping at the next row (which always carries
+    a ``--`` flag) — so an assertion about *this* option's wording cannot be
+    satisfied or defeated by a neighbouring option's text.
+
+    Args:
+        option: The long flag whose help cell to extract (e.g. ``--dry-run``).
+
+    Returns:
+        The single-spaced help row, or ``""`` when the option is absent.
+    """
+    result = runner.invoke(app, ["sync", "--help"])
+    assert result.exit_code == 0, result.output
+    cleaned = _BOX_DRAWING_RE.sub(" ", _ANSI_RE.sub("", result.output))
+    row: list[str] = []
+    for line in cleaned.splitlines():
+        stripped = line.strip()
+        if row:
+            if not stripped or "--" in stripped:
+                break
+            row.append(stripped)
+        elif stripped.startswith(option):
+            row.append(stripped)
+    return " ".join(" ".join(row).split())
 
 
 def _fake_config(
@@ -268,3 +331,350 @@ class TestTierAIdempotent:
         assert r2.exit_code == 0, r2.output
         after = len(list((vault / "01-Fragments").rglob("*.md")))
         assert after == before  # idempotent self-heal, no duplicates
+
+
+# ---- The advertised default must match the real one (#1335) -------------
+
+
+class TestSyncDefaultTruthfulness:
+    """``creek sync --help`` must describe the default the CLI actually has."""
+
+    def test_sync_help_and_default_cannot_drift_apart(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The runtime default and the ``--dry-run`` help text move together (#1335).
+
+        Two halves, deliberately in one test so neither can be "fixed" alone:
+
+        * **Behaviour.** A bare ``sync --tier B`` reaches the LLM classifier —
+          the same chain ``TestTierOrchestration::test_tier_b_runs_global_chain``
+          pins in full; asserted here only as the anchor the help text is
+          measured against, not as a second copy of that assertion.
+        * **Wording.** The help must not call ``--dry-run`` the default (the
+          shipped string said ``(current default)`` while the option defaulted
+          to ``False``), and must say the bare run executes.
+
+        A help-string-only assertion would be vacuous: it would still pass if
+        someone made ``--dry-run`` default to ``True``, at which point the
+        rewritten help would be the lie instead. The behavioural half is what
+        catches that inversion, and pairing them means a future edit to either
+        the string or the default fails until the other agrees.
+        """
+        calls = _spy_steps(monkeypatch)
+        cfg = _fake_config(tmp_path / "v", tmp_path / "src", {"fakesrc": True})
+        monkeypatch.setattr("creek.cli._load_config_for_vault", lambda _v: cfg)
+
+        run = runner.invoke(
+            app, ["sync", "--tier", "B", "--vault", str(tmp_path / "v")]
+        )
+        assert run.exit_code == 0, run.output
+        assert "classify:llm" in calls, "the bare default must really execute"
+
+        help_result = runner.invoke(app, ["sync", "--help"])
+        assert help_result.exit_code == 0, help_result.output
+        flat = _flatten(help_result.output)
+        low = flat.lower()
+        assert "(current default)" not in low, flat
+        assert "current default" not in low, flat
+        assert "executes" in low, flat
+
+        cell = _sync_help_option_cell("--dry-run")
+        assert "--dry-run" in cell, "the --dry-run help row was not found"
+        assert "default" not in cell.lower(), cell
+
+
+# ---- Tier-B confirmation gate (#1335) -----------------------------------
+
+
+class TestTierBConfirmationGate:
+    """A real Tier-B pass is confirmed interactively and never in a schedule."""
+
+    def test_interactive_tier_b_declined_executes_nothing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Answering ``n`` at the Tier-B prompt aborts before any step runs.
+
+        Catches a gate that prompts but ignores the answer, or one placed after
+        ``_sync_dispatch`` — either way the LLM classifier would already have
+        billed the operator by the time they said no.
+        """
+        calls = _spy_steps(monkeypatch)
+        cfg = _fake_config(tmp_path / "v", tmp_path / "src", {"fakesrc": True})
+        monkeypatch.setattr("creek.cli._load_config_for_vault", lambda _v: cfg)
+        monkeypatch.setattr("creek.cli._is_interactive", lambda: True)
+
+        result = runner.invoke(
+            app,
+            ["sync", "--tier", "B", "--vault", str(tmp_path / "v")],
+            input="n\n",
+        )
+
+        assert calls == [], result.output
+        assert result.exit_code != 0, result.output
+        assert "aborted" in _flatten(result.output).lower(), result.output
+
+    def test_interactive_tier_b_confirmed_executes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Answering ``y`` runs the full Tier-B chain, after a cost warning.
+
+        Catches a gate that refuses to proceed on a yes, and a gate that runs
+        the chain without ever telling the operator what it costs: the output
+        must name the LLM before the chain runs.
+        """
+        calls = _spy_steps(monkeypatch)
+        cfg = _fake_config(tmp_path / "v", tmp_path / "src", {"fakesrc": True})
+        monkeypatch.setattr("creek.cli._load_config_for_vault", lambda _v: cfg)
+        monkeypatch.setattr("creek.cli._is_interactive", lambda: True)
+
+        result = runner.invoke(
+            app,
+            ["sync", "--tier", "B", "--vault", str(tmp_path / "v")],
+            input="y\n",
+        )
+
+        assert result.exit_code == 0, result.output
+        assert calls == ["classify:llm", "link", "index"]
+        assert "llm" in _flatten(result.output).lower(), result.output
+
+    def test_non_interactive_tier_b_runs_without_prompting(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A non-TTY Tier-B run executes unprompted — the schedules depend on it.
+
+        ``creek/sync/schedule.py`` renders every launchd plist, systemd unit and
+        crontab line as a bare ``creek sync --tier B --vault "<path>"`` with no
+        ``--yes`` and no stdin. If the confirmation is not TTY-gated, every one
+        of those units blocks on a prompt nobody can answer (here: EOF, a
+        non-zero exit and an empty call log), and the product silently stops
+        syncing. This test is that contract; it is the one that must keep
+        passing when the gate lands.
+
+        The non-TTY premise is asserted by monkeypatching ``_is_interactive``
+        rather than inherited from ``CliRunner``: relying on the runner's stdin
+        happening not to be a terminal would make the test's whole subject an
+        accident of the harness, and a future runner change would turn this
+        from a schedule guard into a second copy of the plain execution test.
+
+        The cost line must still appear. A confirmation only reaches an
+        operator at a keyboard, but the launchd/systemd log is the one place a
+        nightly Tier-B pass is otherwise completely opaque, so the announcement
+        is unconditional and the *skipped* confirmation is stated out loud.
+        Without that, the TTY fork would be an invisible behavioural
+        difference — the same species of undisclosed default this issue exists
+        to remove.
+        """
+        calls = _spy_steps(monkeypatch)
+        cfg = _fake_config(tmp_path / "v", tmp_path / "src", {"fakesrc": True})
+        monkeypatch.setattr("creek.cli._load_config_for_vault", lambda _v: cfg)
+        monkeypatch.setattr("creek.cli._is_interactive", lambda: False)
+
+        result = runner.invoke(
+            app, ["sync", "--tier", "B", "--vault", str(tmp_path / "v")]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert calls == ["classify:llm", "link", "index"]
+        flat = _flatten(result.output)
+        assert "continue?" not in flat.lower(), result.output
+        assert "llm" in flat.lower(), result.output
+        assert "non-interactive" in flat.lower(), result.output
+
+    def test_yes_flag_skips_the_prompt_when_interactive(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``--yes`` runs Tier B at a TTY with no stdin to answer the prompt.
+
+        No input is supplied, so a gate that ignores ``--yes`` hits EOF and
+        exits non-zero with an empty call log.
+        """
+        calls = _spy_steps(monkeypatch)
+        cfg = _fake_config(tmp_path / "v", tmp_path / "src", {"fakesrc": True})
+        monkeypatch.setattr("creek.cli._load_config_for_vault", lambda _v: cfg)
+        monkeypatch.setattr("creek.cli._is_interactive", lambda: True)
+
+        result = runner.invoke(
+            app, ["sync", "--tier", "B", "--yes", "--vault", str(tmp_path / "v")]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert calls == ["classify:llm", "link", "index"]
+
+    def test_tier_a_is_not_gated_when_interactive(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Tier A is cheap, so it runs at a TTY with no confirmation.
+
+        Catches a gate keyed on ``not dry_run`` alone rather than on the tier:
+        with no input supplied, a gated Tier A would EOF instead of running its
+        pull -> ingest -> rules chain.
+        """
+        calls = _spy_steps(monkeypatch)
+        cfg = _fake_config(tmp_path / "v", tmp_path / "src", {"fakesrc": True})
+        monkeypatch.setattr("creek.cli._load_config_for_vault", lambda _v: cfg)
+        monkeypatch.setattr("creek.cli._is_interactive", lambda: True)
+
+        result = runner.invoke(
+            app, ["sync", "--tier", "A", "--vault", str(tmp_path / "v")]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert calls == ["pull:fakesrc", "ingest:fakesrc", "classify:rules"]
+        assert "continue?" not in _flatten(result.output).lower(), result.output
+
+    def test_dry_run_tier_b_is_not_gated_when_interactive(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A Tier-B plan costs nothing, so ``--dry-run`` is never confirmed.
+
+        Catches a gate keyed on the tier alone rather than on ``not dry_run``:
+        with no input supplied, a gated dry run would EOF and exit non-zero
+        instead of echoing the plan.
+        """
+        calls = _spy_steps(monkeypatch)
+        cfg = _fake_config(tmp_path / "v", tmp_path / "src", {"fakesrc": True})
+        monkeypatch.setattr("creek.cli._load_config_for_vault", lambda _v: cfg)
+        monkeypatch.setattr("creek.cli._is_interactive", lambda: True)
+
+        result = runner.invoke(
+            app, ["sync", "--tier", "B", "--dry-run", "--vault", str(tmp_path / "v")]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert calls == []
+        assert "continue?" not in _flatten(result.output).lower(), result.output
+
+    def test_tier_b_prompt_states_the_measured_cost(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The prompt names how many fragments the run is about to bill for.
+
+        Three fragments are seeded, so a gate that prints a generic warning —
+        or that counts something other than the vault's fragments — fails. The
+        measured cost is one LLM call per unclassified fragment, so the number
+        the operator is shown has to come from the vault they are about to run
+        against.
+        """
+        vault = tmp_path / "v"
+        for frag_id in ("frag-a", "frag-b", "frag-c"):
+            write_raw_fragment_file(vault, "01-Fragments/Journal", frag_id, frag_id)
+        calls = _spy_steps(monkeypatch)
+        cfg = _fake_config(vault, tmp_path / "src", {"fakesrc": True})
+        monkeypatch.setattr("creek.cli._load_config_for_vault", lambda _v: cfg)
+        monkeypatch.setattr("creek.cli._is_interactive", lambda: True)
+
+        result = runner.invoke(
+            app, ["sync", "--tier", "B", "--vault", str(vault)], input="n\n"
+        )
+
+        assert calls == [], result.output
+        assert result.exit_code != 0, result.output
+        flat = _flatten(result.output)
+        names_the_count = bool(
+            _COUNT_THEN_NOUN_RE.search(flat) or _NOUN_THEN_COUNT_RE.search(flat)
+        )
+        assert names_the_count, flat
+        assert "llm" in flat.lower(), flat
+
+    def test_declined_tier_b_records_no_run(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A declined Tier B leaves ``last-run.json`` unwritten (#1335).
+
+        ``_write_sync_state`` runs *after* the dispatch, so aborting at the
+        gate skips it. That is currently an accident of statement order rather
+        than a decision, and it is worth pinning: ``creek sync --status`` reads
+        this file, and a run that was refused before it started must not be
+        able to report itself as the vault's most recent sync. A future
+        refactor that hoists the state write above the dispatch — a reasonable-
+        looking change, since the file also records dry runs — would make the
+        status table lie about work that never happened.
+        """
+        vault = tmp_path / "v"
+        calls = _spy_steps(monkeypatch)
+        cfg = _fake_config(vault, tmp_path / "src", {"fakesrc": True})
+        monkeypatch.setattr("creek.cli._load_config_for_vault", lambda _v: cfg)
+        monkeypatch.setattr("creek.cli._is_interactive", lambda: True)
+
+        result = runner.invoke(
+            app, ["sync", "--tier", "B", "--vault", str(vault)], input="n\n"
+        )
+
+        assert calls == [], result.output
+        assert not _sync_state_path(vault).exists(), "a refused run recorded itself"
+
+    def test_the_emitted_schedule_command_runs_unprompted(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The argv this product writes into timers still executes Tier B (#1335).
+
+        Every other test here hand-writes its argv, which means they all agree
+        with each other and none of them agrees with
+        :func:`~creek.sync.schedule._tier_args` — the function whose output is
+        baked into the launchd plists, systemd units and crontab lines that
+        ``creek sync --install-schedule`` installs on the operator's machine.
+        Feeding that exact argv back through the CLI binds the two together, so
+        a future change to either the emitted command or the CLI's default
+        cannot silently desynchronise them.
+
+        This is the concrete form of why the fix for this issue corrects the
+        help text instead of inverting the default: the argv asserted below
+        carries no ``--dry-run``, so making dry-run the default would turn
+        every installed timer into a no-op that exits 0.
+        """
+        from creek.sync.schedule import _tier_args
+
+        vault = tmp_path / "v"
+        calls = _spy_steps(monkeypatch)
+        cfg = _fake_config(vault, tmp_path / "src", {"fakesrc": True})
+        monkeypatch.setattr("creek.cli._load_config_for_vault", lambda _v: cfg)
+        monkeypatch.setattr("creek.cli._is_interactive", lambda: False)
+
+        argv = _tier_args(vault, "B")
+        assert argv[0] == "creek", argv
+        assert "--dry-run" not in argv, argv
+
+        result = runner.invoke(app, argv[1:])
+
+        assert result.exit_code == 0, result.output
+        assert calls == ["classify:llm", "link", "index"]
+
+    def test_provider_refusal_aborts_legibly(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A refused LLM provider exits 1 with a message, not a traceback (#1335).
+
+        ``creek classify --method llm`` catches
+        :class:`~creek.classify.classify_engine.LLMProviderUnavailableError`
+        and prints the provider's own remediation hint; the sync path did not,
+        so a Tier-B tick with no cloud consent died with an unhandled traceback
+        into a scheduler log. The exception carries the remediation text
+        already, so this asserts the detail reaches the operator rather than
+        re-checking consent here — restating the hint would be a second copy
+        that could drift from the engine's.
+
+        ``last-run.json`` must also stay unwritten: an aborted pass that
+        recorded itself would make the next ``--status`` claim Tier B ran.
+        """
+        from creek.classify.classify_engine import LLMProviderUnavailableError
+
+        vault = tmp_path / "v"
+        _spy_steps(monkeypatch)
+        cfg = _fake_config(vault, tmp_path / "src", {"fakesrc": True})
+        monkeypatch.setattr("creek.cli._load_config_for_vault", lambda _v: cfg)
+        monkeypatch.setattr("creek.cli._is_interactive", lambda: False)
+
+        def _refuse(_v: Path, _c: CreekConfig, _m: str) -> None:
+            raise LLMProviderUnavailableError(
+                provider="anthropic", detail="set CREEK_CLOUD_CONSENT=1"
+            )
+
+        monkeypatch.setattr("creek.cli._sync_classify", _refuse)
+
+        result = runner.invoke(app, ["sync", "--tier", "B", "--vault", str(vault)])
+
+        assert result.exit_code == 1, result.output
+        flat = _flatten(result.output)
+        assert "set CREEK_CLOUD_CONSENT=1" in flat, flat
+        assert "Traceback" not in result.output, result.output
+        assert not _sync_state_path(vault).exists(), "an aborted run recorded itself"


### PR DESCRIPTION
## Summary

`creek sync --help` advertised `--dry-run` as **"the current default"** while the option defaulted to `False`. `--help` is the only thing standing between an operator and an unattended full-vault LLM pass, so someone reading it and running `creek sync --tier B` "to see what it would do" instead ran it.

**The premise checks out, but every line cite in the issue was stale.** `cli.py:912-914` is now `:1165-1167`; the `# ---- creek sync: real tier execution (#678)` banner is at `:914`, not `:661`; the two "sibling stale docstrings" are at `pipeline.py:126-127` and `config.py:1653-1655`, not `:84` and `:1639-1641`. The provenance claim **holds**: `git log -S "current default" -- creek/cli.py` returns exactly one commit, `dbd6c39` (#676's dry-run skeleton), and #678 made the tiers execute without touching the string.

### Measured cost, not an adjective

Instrumented on a fixture vault, stubbing only `LLMClassifier._invoke_llm` so the CLI, `_sync_dispatch`, `_sync_run_tier_b` and `run_classify` all run for real:

| fragments | LLM calls | exit |
|---|---|---|
| 12 | 12 | 0 |
| 50 | 50 | 0 |
| 100 | 100 | 0 |

Exactly **one LLM call per unclassified fragment**, up to **3x on retry** (`MAX_RETRIES = 3`), then the embeddings link pass and a full index rebuild — reporting success the whole way. On the repo's own 35k-fragment vault that is ~35,000 calls.

### The decision: fix the text, don't invert the default

`creek/sync/schedule.py:34-40` renders **every** launchd plist, systemd unit and crontab line as a bare `creek sync --tier B --vault "<path>"` — no `--dry-run`, and `tests/test_sync_schedule.py:93-127` pins that. Making dry-run the default would silently neuter every timer the product itself installs: the nightly pass would echo a plan into a log nobody reads and exit 0 while the vault quietly stopped being classified, linked and indexed. That is a worse failure than the one filed, because it looks like success.

So the string is corrected and a rail is added in the shape that **breaks nobody**:

| who | before | after |
|---|---|---|
| Operator at a terminal | bare run silently spends the vault | sees the cost, must confirm (`--yes` skips) |
| launchd / systemd / cron | bare run spends the vault, silently | **unchanged** — proceeds unprompted, and the cost now lands in the log |
| Scripts, CI, pipes (any non-TTY) | — | **unchanged** |
| Anyone reading `--help` | told it was a preview | told a bare invocation executes |

Nobody's existing invocation changes behaviour. The confirmation is gated on `_is_interactive()` (`cli.py:381`), which is `False` for every scheduled and piped caller; the cost line prints **unconditionally**, and the non-TTY path prints `non-interactive; proceeding without confirmation` so the fork is disclosed rather than hidden — replacing "dry-run is the default" with an undisclosed "it asks first (except when it doesn't)" would be the same defect class. `docs/sync-workflow.md` states the fork in a table.

### The sibling census (a fix for `sync` alone would have left another lying `--help`)

All 12 `--dry-run` options in `cli.py` audited, stated default vs. actual, plus every `help=` that claims a default:

- **`sync --dry-run`** — lying. Fixed here.
- **`author --dry-run`** (`cli.py:5692`) — said "stub evidence summary"; the branch really calls `gather_evidence` (embedding retrieval + graph walk) and the command docstring says so. Fixed here.
- **`save --tier`** (`cli.py:5345`) — claims it "defaults to the source fragments' max tier"; `_resolve_save_tier` hardcodes `PrivacyTier.OPEN`. Privacy-relevant and the fix is a design call (correct the help vs. implement inheritance), so filed as **#1434** rather than patched blind.
- The other nine (`discord`, `ingest`, `redact`, `fill`, five `purge` subcommands, `compost scan`) are accurate and genuinely wired.

### Consent and privacy

Audited, because a full-vault LLM pass on a cloud provider is data egress. **No leak.** The consent gate covers this path and fails closed: `has_cloud_consent()` is enforced at provider construction, and `run_classify` raises at `classify_engine.py:532` *before* it reads a single fragment. `ModelRouter._enforce_local_for_intimate` keeps Intimate content local and the tier is stamped before routing reads it. Embeddings are local-only (ADR-0004).

One real asymmetry found and **fixed here**: `classify --method llm` catches `LLMProviderUnavailableError`; the sync path did not, so a consent-less Tier-B tick died with an unhandled traceback into a scheduler log. It now exits 1 with the provider's own remediation, `last-run.json` unwritten. (`_preflight_cloud_consent` was deliberately **not** reused — it fires on *any* cloud stage, so a vault with a cloud `author` stage and a local `classification` stage would have started failing nightly, and its message hardcodes the wrong command.)

What remains is a product decision, not a bug: consent is an ambient env var, and "non-Intimate" includes `PERSONAL` (DMs, chatbot logs, unmapped sources), with **no tier ceiling anywhere on the classify path**. Filed as **#1435**.

### Docs

Swept `docs/`, `creek-tools/docs/`, all READMEs, `creek/templates/`, `.claude/`. **Zero** repetitions of the false claim — `"current default"` appeared exactly once in the whole tree, in the code. `docs/sync-workflow.md` gains the cost/confirmation/`--yes`/TTY semantics.

### Also retired

Three "the skeleton command …, real execution lands in a later issue" claims whose features all shipped: `pipeline.py:126-127` (`_sync_run_tier_a`), `config.py:1653-1655` (`creek/sync/schedule.py`), and `tests/test_sync.py`'s module docstring.

## Test plan

Gate 2 `./scripts/check-all.sh` → **exit 0**, 12/12 checks, 9420 passed / 5 skipped (all pre-existing environmental: Ollama, API keys). Ruff clean under `--no-cache`.

**The regression test pins the true default behaviourally, not the string.** `test_sync_help_and_default_cannot_drift_apart` asserts both halves in one test: a bare `sync --tier B` reaches `classify:llm`, **and** the help no longer says `current default`. A help-string-only assertion would be vacuous — it would still pass if someone made `--dry-run` default to `True`, at which point the rewritten help would be the new lie. Pairing them means an edit to either the string or the default fails until the other agrees.

`test_the_emitted_schedule_command_runs_unprompted` feeds `creek.sync.schedule._tier_args(vault, "B")[1:]` straight into the CLI, binding the argv baked into installed timers to the CLI's real behaviour so the two cannot desynchronise.

**Mutation battery: 11/11 killed** (bytes snapshotted and restored — verified byte-identical by SHA afterwards, never `git checkout`):

| mutant | caught by |
|---|---|
| `--dry-run` default inverted to `True` | `test_sync_help_and_default_cannot_drift_apart` |
| `(current default)` wording restored | same |
| TTY guard deleted (prompt always) | `test_non_interactive_tier_b_runs_without_prompting` |
| cost line moved behind the TTY check | same |
| provider-refusal handler removed | `test_provider_refusal_aborts_legibly` |
| `dry_run` no longer exempt from the gate | `test_dry_run_tier_b_is_not_gated_when_interactive` |
| Tier A gated too | `test_tier_a_is_not_gated_when_interactive` |
| `--yes` ignored | `test_yes_flag_skips_the_prompt_when_interactive` |
| fragment count faked | `test_tier_b_prompt_states_the_measured_cost` |
| decline answer ignored | `test_interactive_tier_b_declined_executes_nothing` |
| `author` "stub evidence" restored | `test_author_help_does_not_call_the_evidence_summary_a_stub` |

End-to-end after the fix: a bare non-TTY `sync --tier B` over 25 fragments still makes 25 LLM calls and exits 0 — behaviour preserved, cost now announced.

Gate 2.5 `code-review-orchestrator`: **CLEAN**, no blockers.

**Known trade-off:** `_sync_tier_b_fragment_count` counts all `01-Fragments/**/*.md` rather than only unclassified ones — one cheap `rglob` instead of parsing every frontmatter — so the line says "up to N". On a large mature vault that number will read high relative to what is actually billed.

Closes #1335
Refs #1434, #1435
