### PR TITLE
fix(link): make the embeddings summary true of the parquet, and stop building 43GB of edges to count them

### DIFF
--- a/creek-tools/CHANGELOG.md
+++ b/creek-tools/CHANGELOG.md
@@ -83,3 +83,21 @@ to locate the originating commit for any reference below.
   operator's edits: it now preserves the local version alongside as
   `<name>.bak` (e.g. `mediums/essay.MEDIUM.md.bak`) before
   overwriting.
+- **`creek link --method embeddings` now reports what actually happened on
+  disk, not an assumption about it** (#1337). The summary line used to claim
+  a single "N fragment(s) embedded" count regardless of cache state; it now
+  reports three independent numbers — `scanned` (fragments loaded from the
+  vault), `computed` (vectors the model actually produced this run, i.e.
+  cache misses only — legitimately zero on a warm cache), and `cached`
+  (rows in `00-Creek-Meta/embeddings.parquet` after the run). When nothing
+  reached disk — an empty vault, or a cache write that failed — the line
+  now says `no vectors written` instead of silently repeating a stale count;
+  a failed cache write was previously swallowed into a log line only, with
+  the CLI still exiting 0. Separately, counting resonance edges no longer
+  materializes a `Resonance` object per pair
+  (`EmbeddingLinker.count_resonances` walks the same traversal as
+  `find_resonances` without allocating them), making peak memory
+  independent of edge count. Resonance edges are still not persisted, and
+  the `embeddings.parquet` schema is unchanged (`fragment_id`,
+  `content_hash`, `model_name`, `embedding`, `computed_at`) — no on-disk
+  format changed, and no migration is needed.

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -2665,6 +2665,14 @@ def _format_link_summary(summary: LinkSummary) -> str:
     to disk (eddies). Per-method strings name the actual side effect so
     operators can correlate the number with what they see on disk.
 
+    The embeddings sentence carries three separate numbers because they
+    are three separate facts and every pairing of them can differ:
+    *scanned* is the corpus size, *computed* is the local-model work this
+    run paid for (zero on a warm cache), and *cached* is what the parquet
+    holds after the write (the whole corpus on that same warm run, or zero
+    if the write failed). The similarity edges sit outside all three —
+    nothing persists them at all (#1337).
+
     Args:
         summary: The link summary returned by
             :func:`creek.link.link_engine.run_link`.
@@ -2681,11 +2689,18 @@ def _format_link_summary(summary: LinkSummary) -> str:
         # the parquet. Only the vectors are — the similarity edges are
         # computed in memory and dropped, because there is no Resonance
         # writer and Fragment has no ``resonances`` field.
+        # #1337: the remaining three claims are now measured rather than
+        # assumed. "embedded" conflated the corpus with the vectors this
+        # run computed (a warm cache computes none), and the cache clause
+        # was a hardcoded assertion that survived an empty vault and a
+        # swallowed OSError alike. Only the *edges* clause says "not
+        # persisted", so that phrase unambiguously pins the edge claim.
         body = (
-            f"Embeddings linker: {fragments} fragment(s) embedded, "
+            f"Embeddings linker: {fragments} fragment(s) scanned, "
+            f"{summary.fragments_embedded} vector(s) computed, "
             f"{summary.similarity_edges} similarity edge(s) computed in memory "
-            f"(not persisted — no resonance writer exists); vectors cached in "
-            f"00-Creek-Meta/embeddings.parquet."
+            f"(not persisted — no resonance writer exists); "
+            f"{_format_embeddings_cache_clause(summary)}."
         )
     elif summary.method == "eddies":
         body = (
@@ -2717,6 +2732,41 @@ def _format_link_summary(summary: LinkSummary) -> str:
         msg = f"Unknown link method: {summary.method!r}"
         raise ValueError(msg)
     return f"[bold green]{body}[/bold green]"
+
+
+def _format_embeddings_cache_clause(summary: LinkSummary) -> str:
+    """Render the parquet clause for the embeddings sentence.
+
+    Issue #1337: the clause used to be a constant asserting that vectors
+    had been cached, which stayed true-looking on the two paths where
+    nothing reached disk — a fragmentless vault (the cache write never
+    runs) and a swallowed ``OSError`` from a full or read-only volume.
+    Both now say so out loud, which is the only operator-visible trace of
+    that deliberately-swallowed error.
+
+    Extracted rather than inlined for the same reason as
+    :func:`_format_cluster_stats`: xenon's ``--max-modules B`` bites on
+    this module's aggregate, so branches live in their own small function.
+
+    Args:
+        summary: The link summary being rendered.
+
+    Returns:
+        The clause naming the row count the run persisted, or the explicit
+        admission that it persisted none.
+    """
+    # Named from the canonical constants rather than a literal, so a
+    # rename of the cache file cannot leave the sentence pointing at a
+    # path that no longer exists.
+    from creek.link.embeddings import (
+        EMBEDDINGS_CACHE_DIR,
+        EMBEDDINGS_CACHE_FILENAME,
+    )
+
+    cache_label = f"{EMBEDDINGS_CACHE_DIR}/{EMBEDDINGS_CACHE_FILENAME}"
+    if summary.vectors_persisted > 0:
+        return f"{summary.vectors_persisted} vector(s) cached in {cache_label}"
+    return f"no vectors written to {cache_label}"
 
 
 def _format_cluster_stats(summary: LinkSummary) -> str:

--- a/creek-tools/creek/link/embeddings.py
+++ b/creek-tools/creek/link/embeddings.py
@@ -25,7 +25,7 @@ from creek.models import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping
+    from collections.abc import Iterable, Iterator, Mapping
     from pathlib import Path
 
     import numpy as np
@@ -441,6 +441,187 @@ def _is_hierarchy_suppressed(
     return abs(index_a - index_b) <= sibling_skip_window
 
 
+@dataclass(frozen=True, eq=False)
+class _ResonanceScan:
+    """Everything the pair traversal needs, derived once from the raw inputs.
+
+    Built by :meth:`EmbeddingLinker._prepare_scan` and shared verbatim by
+    :meth:`~EmbeddingLinker.find_resonances` and
+    :meth:`~EmbeddingLinker.count_resonances` so the two entry points
+    cannot diverge on their inputs — including on how they *fail*. The
+    ragged-input ``ValueError`` numpy raises while stacking ``vectors``
+    happens inside the shared preparation step, so both surfaces raise it
+    identically (#1337).
+
+    ``eq=False`` because ``normalized`` is a numpy array: the generated
+    ``__eq__`` would raise ``ValueError`` ("truth value of an array … is
+    ambiguous") and the generated ``__hash__`` a ``TypeError``, so a frozen
+    dataclass would otherwise advertise equality and hashability it cannot
+    honour. Identity comparison is the honest contract — a scan is a
+    one-shot bundle of derived inputs, never a key or a value to compare.
+
+    Attributes:
+        ids: Fragment IDs in the row order of ``normalized``.
+        normalized: L2-normalised embedding matrix, so a dot product of
+            two rows is their cosine similarity.
+        threshold: Minimum cosine similarity for a pair to be emitted.
+        ancestors: Precomputed ancestor sets (see :func:`_hierarchy_index`).
+        sibling_positions: Precomputed sibling positions (idem).
+        levels: Fragment ID to declared structural level, used only when
+            materialising :class:`Resonance` records.
+        sibling_skip_window: Adjacent-sibling suppression radius.
+    """
+
+    ids: list[str]
+    normalized: NDArray[np.float32]
+    threshold: float
+    ancestors: dict[str, frozenset[str]]
+    sibling_positions: dict[str, tuple[str, int]]
+    levels: dict[str, FragmentLevel]
+    sibling_skip_window: int
+
+
+@dataclass
+class _ScanStats:
+    """Mutable tally the lazy pair scan writes back to its caller.
+
+    A generator cannot return a value alongside what it yields, so the
+    hierarchy-suppression count — which the exact and top-k paths both
+    accumulate mid-traversal — travels in this holder instead. The caller
+    owns it and reads it only after fully consuming the generator; a
+    partial consumer would see a partial tally.
+
+    Attributes:
+        suppressed: Above-threshold pairs dropped as hierarchy-trivial
+            (ancestor/descendant, or siblings inside the skip window).
+    """
+
+    suppressed: int = 0
+
+
+def _resonances_exact(
+    scan: _ResonanceScan,
+    stats: _ScanStats,
+) -> Iterator[tuple[int, int, float]]:
+    """Lazily yield every above-threshold pair ``(i, j, similarity)``, ``i < j``.
+
+    Computes the upper triangle one row-block at a time so peak memory is
+    ``block_rows x N`` rather than the full matrix. The laziness is the
+    point: :meth:`EmbeddingLinker.count_resonances` consumes this without
+    ever holding an edge, which is what keeps counting allocation-free at
+    35k fragments (#1337).
+
+    Args:
+        scan: Prepared inputs shared with the other entry point.
+        stats: Mutable tally; ``suppressed`` is incremented in place.
+
+    Yields:
+        ``(i, j, similarity)`` triples in ascending ``(i, j)`` index order,
+        where ``i`` and ``j`` index :attr:`_ResonanceScan.ids`.
+    """
+    import numpy as np  # lazy: numpy lives in the [embeddings] extra
+
+    ids = scan.ids
+    n = len(ids)
+    for start in range(0, n, _RESONANCE_BLOCK_ROWS):
+        stop = min(start + _RESONANCE_BLOCK_ROWS, n)
+        block_sims = scan.normalized[start:stop] @ scan.normalized.T
+        for local_index, i in enumerate(range(start, stop)):
+            row = block_sims[local_index]
+            # Upper triangle only: fragment i against each j > i.
+            above = np.nonzero(row[i + 1 :] >= scan.threshold)[0]
+            for offset in above:
+                j = i + 1 + int(offset)
+                if _is_hierarchy_suppressed(
+                    ids[i],
+                    ids[j],
+                    ancestors=scan.ancestors,
+                    sibling_positions=scan.sibling_positions,
+                    sibling_skip_window=scan.sibling_skip_window,
+                ):
+                    stats.suppressed += 1
+                    continue
+                yield i, j, float(row[j])
+        del block_sims
+
+
+def _resonances_topk(
+    scan: _ResonanceScan,
+    stats: _ScanStats,
+    *,
+    top_k: int,
+) -> Iterator[tuple[int, int, float]]:
+    """Yield each fragment's *top_k* best above-threshold neighbours.
+
+    Bounds the edge set to O(n·k). Each directed (i -> neighbour) pick is
+    folded to its undirected ``(i < j)`` form and de-duplicated, so the
+    output is always a subset of the exact path's edges; the picks are then
+    sorted into the same ascending ``(i, j)`` order the exact path emits.
+
+    Unlike :func:`_resonances_exact` this is a generator for signature
+    parity only — dedup-then-sort is inherently eager, so the full O(n·k)
+    pick list is materialised before the first triple is yielded. That
+    bound is small enough not to be the #1337 heap problem; pretending to
+    stream here would only hide the allocation.
+
+    Args:
+        scan: Prepared inputs shared with the other entry point.
+        stats: Mutable tally; ``suppressed`` is incremented in place.
+        top_k: Maximum neighbours to keep per fragment.
+
+    Yields:
+        ``(i, j, similarity)`` triples in ascending ``(i, j)`` index order.
+    """
+    ids = scan.ids
+    n = len(ids)
+    seen: set[tuple[int, int]] = set()
+    picked: list[tuple[int, int, float]] = []
+    for start in range(0, n, _RESONANCE_BLOCK_ROWS):
+        stop = min(start + _RESONANCE_BLOCK_ROWS, n)
+        block_sims = scan.normalized[start:stop] @ scan.normalized.T
+        for local_index, i in enumerate(range(start, stop)):
+            row = block_sims[local_index]
+            for j in _top_k_neighbours(row, i, scan.threshold, top_k):
+                lo, hi = (i, j) if i < j else (j, i)
+                if (lo, hi) in seen:
+                    continue
+                seen.add((lo, hi))
+                if _is_hierarchy_suppressed(
+                    ids[lo],
+                    ids[hi],
+                    ancestors=scan.ancestors,
+                    sibling_positions=scan.sibling_positions,
+                    sibling_skip_window=scan.sibling_skip_window,
+                ):
+                    stats.suppressed += 1
+                    continue
+                picked.append((lo, hi, float(row[j])))
+        del block_sims
+    # Tuples sort lexicographically; (lo, hi) keys are unique (deduped via
+    # ``seen``), so this yields ascending (i, j) order without a key.
+    picked.sort()
+    yield from picked
+
+
+def _log_scan_result(scan: _ResonanceScan, stats: _ScanStats, count: int) -> None:
+    """Log the outcome of a fully-consumed pair scan.
+
+    Args:
+        scan: The prepared scan that was traversed.
+        stats: The tally the traversal wrote to. Only meaningful once the
+            generator has been drained.
+        count: Number of resonances the traversal produced.
+    """
+    if stats.suppressed:
+        logger.info(
+            "Suppressed %d hierarchy-trivial resonance(s) "
+            "(ancestor/descendant or adjacent siblings within %d)",
+            stats.suppressed,
+            scan.sibling_skip_window,
+        )
+    logger.info("Found %d resonance(s)", count)
+
+
 class EmbeddingLinker:
     """Generate embeddings and find semantic resonances between fragments.
 
@@ -722,6 +903,10 @@ class EmbeddingLinker:
         With no *fragments* mapping (the flat-fragment contract) the
         suppression is inert and behaviour is identical to pre-FEAT-024.
 
+        Callers that only need the edge total should use
+        :meth:`count_resonances`, which walks the same traversal without
+        building a :class:`Resonance` per pair.
+
         Args:
             embeddings: Mapping of fragment IDs to their embedding vectors.
             fragments: Optional mapping of fragment ID to :class:`Fragment`
@@ -734,9 +919,96 @@ class EmbeddingLinker:
             A list of :class:`Resonance` records, one per qualifying pair,
             in ascending ``(i, j)`` fragment-index order.
         """
+        scan = self._prepare_scan(embeddings, fragments, sibling_skip_window)
+        if scan is None:
+            return []
+
+        stats = _ScanStats()
+        # The comprehension drains the generator, so ``stats.suppressed`` is
+        # complete by the time it is logged. A future *partial* consumer of
+        # :meth:`_scan_pairs` would see only a partial tally.
+        resonances = [
+            Resonance(
+                fragment_a_id=scan.ids[i],
+                fragment_b_id=scan.ids[j],
+                similarity=similarity,
+                from_level=scan.levels[scan.ids[i]],
+                to_level=scan.levels[scan.ids[j]],
+            )
+            for i, j, similarity in self._scan_pairs(scan, stats)
+        ]
+        _log_scan_result(scan, stats, len(resonances))
+        return resonances
+
+    def count_resonances(
+        self,
+        embeddings: dict[str, list[float]],
+        fragments: Mapping[str, Fragment] | None = None,
+        *,
+        sibling_skip_window: int = 2,
+    ) -> int:
+        """Count the resonances :meth:`find_resonances` would return.
+
+        Returns exactly ``len(find_resonances(...))`` for the same inputs,
+        including identical hierarchy suppression, discovery strategy and
+        failure modes — both entry points derive their inputs from the same
+        :meth:`_prepare_scan` and walk the same generator.
+
+        It exists because the count is sometimes all a caller wants.
+        ``creek link --method embeddings`` reports the similarity-edge
+        total and then discards the edges: nothing in the codebase persists
+        a :class:`Resonance`. Materialising one Pydantic model per edge just
+        to call :func:`len` on the list costs a measured ~1,017 bytes per
+        edge, which extrapolates to tens of gigabytes of heap at the
+        documented 35k-fragment scale. This path allocates nothing per edge
+        (#1337).
+
+        Args:
+            embeddings: Mapping of fragment IDs to their embedding vectors.
+            fragments: Optional mapping of fragment ID to :class:`Fragment`
+                used for hierarchy-aware suppression.
+            sibling_skip_window: Adjacent-sibling suppression radius;
+                ``0`` disables sibling suppression (ancestor suppression
+                still applies).
+
+        Returns:
+            The number of qualifying resonance edges.
+        """
+        scan = self._prepare_scan(embeddings, fragments, sibling_skip_window)
+        if scan is None:
+            return 0
+
+        stats = _ScanStats()
+        count = sum(1 for _ in self._scan_pairs(scan, stats))
+        _log_scan_result(scan, stats, count)
+        return count
+
+    def _prepare_scan(
+        self,
+        embeddings: dict[str, list[float]],
+        fragments: Mapping[str, Fragment] | None,
+        sibling_skip_window: int,
+    ) -> _ResonanceScan | None:
+        """Derive the inputs both resonance entry points traverse.
+
+        Shared so :meth:`find_resonances` and :meth:`count_resonances`
+        cannot drift on normalisation, hierarchy indexing, the threshold or
+        the too-small-to-pair guard — and so a malformed corpus (vectors of
+        unequal length) raises from the same place on both (#1337).
+
+        Args:
+            embeddings: Mapping of fragment IDs to their embedding vectors.
+            fragments: Optional mapping of fragment ID to :class:`Fragment`.
+            sibling_skip_window: Adjacent-sibling suppression radius.
+
+        Returns:
+            A :class:`_ResonanceScan`, or ``None`` when fewer than two
+            embeddings were supplied — no pair can exist, so the caller
+            returns its empty answer without logging a traversal.
+        """
         ids = list(embeddings.keys())
         if len(ids) < 2:
-            return []
+            return None
 
         logger.info(
             "Finding resonances among %d embedding(s) with threshold %.2f",
@@ -752,153 +1024,36 @@ class EmbeddingLinker:
         normalized = vectors / norms
 
         ancestors, sibling_positions = _hierarchy_index(fragments)
-        levels = _level_lookup(ids, fragments)
-        threshold = self.config.similarity_threshold
+        return _ResonanceScan(
+            ids=ids,
+            normalized=normalized,
+            threshold=self.config.similarity_threshold,
+            ancestors=ancestors,
+            sibling_positions=sibling_positions,
+            levels=_level_lookup(ids, fragments),
+            sibling_skip_window=sibling_skip_window,
+        )
 
-        # ``exact`` (default) emits every above-threshold pair; ``topk`` keeps
-        # only each fragment's k best neighbours. Both compute similarities one
-        # row-block at a time via vectorized matmul (never the full NxN matrix)
-        # and emit pairs in ascending ``(i, j)`` index order.
+    def _scan_pairs(
+        self,
+        scan: _ResonanceScan,
+        stats: _ScanStats,
+    ) -> Iterator[tuple[int, int, float]]:
+        """Dispatch to the configured pair-discovery strategy.
+
+        ``exact`` (default) emits every above-threshold pair; ``topk`` keeps
+        only each fragment's k best neighbours. Both compute similarities one
+        row-block at a time via vectorized matmul (never the full NxN matrix)
+        and emit pairs in ascending ``(i, j)`` index order.
+
+        Args:
+            scan: Prepared inputs from :meth:`_prepare_scan`.
+            stats: Mutable tally the chosen strategy writes suppression
+                counts into.
+
+        Returns:
+            An iterator of ``(i, j, similarity)`` triples.
+        """
         if self.config.resonance_method == "topk":
-            resonances, suppressed = self._resonances_topk(
-                ids=ids,
-                normalized=normalized,
-                threshold=threshold,
-                top_k=self.config.resonance_top_k,
-                ancestors=ancestors,
-                sibling_positions=sibling_positions,
-                levels=levels,
-                sibling_skip_window=sibling_skip_window,
-            )
-        else:
-            resonances, suppressed = self._resonances_exact(
-                ids=ids,
-                normalized=normalized,
-                threshold=threshold,
-                ancestors=ancestors,
-                sibling_positions=sibling_positions,
-                levels=levels,
-                sibling_skip_window=sibling_skip_window,
-            )
-
-        if suppressed:
-            logger.info(
-                "Suppressed %d hierarchy-trivial resonance(s) "
-                "(ancestor/descendant or adjacent siblings within %d)",
-                suppressed,
-                sibling_skip_window,
-            )
-        logger.info("Found %d resonance(s)", len(resonances))
-        return resonances
-
-    def _resonances_exact(
-        self,
-        *,
-        ids: list[str],
-        normalized: NDArray[np.float32],
-        threshold: float,
-        ancestors: dict[str, frozenset[str]],
-        sibling_positions: dict[str, tuple[str, int]],
-        levels: dict[str, FragmentLevel],
-        sibling_skip_window: int,
-    ) -> tuple[list[Resonance], int]:
-        """Exact all-pairs path: emit every above-*threshold* pair (i < j).
-
-        Computes the upper triangle one row-block at a time so peak memory is
-        ``block_rows x N`` rather than the full matrix. Returns the resonances
-        and the count suppressed by hierarchy rules.
-        """
-        import numpy as np  # lazy: numpy lives in the [embeddings] extra
-
-        resonances: list[Resonance] = []
-        suppressed = 0
-        n = len(ids)
-        for start in range(0, n, _RESONANCE_BLOCK_ROWS):
-            stop = min(start + _RESONANCE_BLOCK_ROWS, n)
-            block_sims = normalized[start:stop] @ normalized.T
-            for local_index, i in enumerate(range(start, stop)):
-                row = block_sims[local_index]
-                # Upper triangle only: fragment i against each j > i.
-                above = np.nonzero(row[i + 1 :] >= threshold)[0]
-                for offset in above:
-                    j = i + 1 + int(offset)
-                    if _is_hierarchy_suppressed(
-                        ids[i],
-                        ids[j],
-                        ancestors=ancestors,
-                        sibling_positions=sibling_positions,
-                        sibling_skip_window=sibling_skip_window,
-                    ):
-                        suppressed += 1
-                        continue
-                    resonances.append(
-                        Resonance(
-                            fragment_a_id=ids[i],
-                            fragment_b_id=ids[j],
-                            similarity=float(row[j]),
-                            from_level=levels[ids[i]],
-                            to_level=levels[ids[j]],
-                        ),
-                    )
-            del block_sims
-        return resonances, suppressed
-
-    def _resonances_topk(
-        self,
-        *,
-        ids: list[str],
-        normalized: NDArray[np.float32],
-        threshold: float,
-        top_k: int,
-        ancestors: dict[str, frozenset[str]],
-        sibling_positions: dict[str, tuple[str, int]],
-        levels: dict[str, FragmentLevel],
-        sibling_skip_window: int,
-    ) -> tuple[list[Resonance], int]:
-        """Top-k path: keep each fragment's *top_k* best above-*threshold* neighbours.
-
-        Bounds the edge set to O(n·k). Each directed (i -> neighbour) pick is
-        folded to its undirected ``(i < j)`` form and de-duplicated, so the
-        output is always a subset of the exact path's edges; the final list is
-        sorted into the same ascending ``(i, j)`` order the exact path emits.
-        Returns the resonances and the hierarchy-suppressed count.
-        """
-        n = len(ids)
-        seen: set[tuple[int, int]] = set()
-        picked: list[tuple[int, int, float]] = []
-        suppressed = 0
-        for start in range(0, n, _RESONANCE_BLOCK_ROWS):
-            stop = min(start + _RESONANCE_BLOCK_ROWS, n)
-            block_sims = normalized[start:stop] @ normalized.T
-            for local_index, i in enumerate(range(start, stop)):
-                row = block_sims[local_index]
-                for j in _top_k_neighbours(row, i, threshold, top_k):
-                    lo, hi = (i, j) if i < j else (j, i)
-                    if (lo, hi) in seen:
-                        continue
-                    seen.add((lo, hi))
-                    if _is_hierarchy_suppressed(
-                        ids[lo],
-                        ids[hi],
-                        ancestors=ancestors,
-                        sibling_positions=sibling_positions,
-                        sibling_skip_window=sibling_skip_window,
-                    ):
-                        suppressed += 1
-                        continue
-                    picked.append((lo, hi, float(row[j])))
-            del block_sims
-        # Tuples sort lexicographically; (lo, hi) keys are unique (deduped via
-        # ``seen``), so this yields ascending (i, j) order without a key.
-        picked.sort()
-        resonances = [
-            Resonance(
-                fragment_a_id=ids[lo],
-                fragment_b_id=ids[hi],
-                similarity=sim,
-                from_level=levels[ids[lo]],
-                to_level=levels[ids[hi]],
-            )
-            for lo, hi, sim in picked
-        ]
-        return resonances, suppressed
+            return _resonances_topk(scan, stats, top_k=self.config.resonance_top_k)
+        return _resonances_exact(scan, stats)

--- a/creek-tools/creek/link/link_engine.py
+++ b/creek-tools/creek/link/link_engine.py
@@ -116,6 +116,14 @@ class LinkSummary:
             is what lets ``creek process`` attribute local-model work to
             the run that paid for it instead of re-counting the corpus
             (#1303).
+        vectors_persisted: Rows present in
+            ``00-Creek-Meta/embeddings.parquet`` as written by *this* run.
+            Deliberately distinct from ``fragments_embedded``: the cache is
+            rewritten whole from fresh cache hits plus new vectors, so a
+            fully warm run persists the entire corpus while computing none
+            of it. ``0`` means nothing reached disk — an empty vault, or a
+            swallowed ``OSError`` from the cache write. The CLI reports
+            this rather than asserting that vectors were cached (#1337).
     """
 
     method: str
@@ -131,6 +139,7 @@ class LinkSummary:
     clusters_split: int = 0
     oversized_discarded: int = 0
     fragments_embedded: int = 0
+    vectors_persisted: int = 0
 
 
 @dataclass(frozen=True)
@@ -148,11 +157,17 @@ class EmbeddingPass:
         computed: Vectors computed by the model on this pass (cache
             misses).
         reused: Vectors served verbatim from the on-disk parquet cache.
+        persisted: Rows this pass actually wrote to the parquet — ``0``
+            when the write failed or never happened. Required, with no
+            default: the number has to be *measured* by the write, and a
+            default would let a future pass silently under-report the one
+            thing the field exists to make honest (#1337).
     """
 
     vectors: dict[str, list[float]]
     computed: int
     reused: int
+    persisted: int
 
 
 def run_link(
@@ -191,7 +206,7 @@ def run_link(
         return LinkSummary(method=method, fragment_count=0, link_count=0)
 
     if method == "embeddings":
-        link_count, embedded = _run_embeddings(
+        link_count, embedding_pass = _run_embeddings(
             fragments=fragments,
             config=config,
             cache_path=cache_path,
@@ -201,7 +216,8 @@ def run_link(
             fragment_count=len(fragments),
             link_count=link_count,
             similarity_edges=link_count,
-            fragments_embedded=embedded,
+            fragments_embedded=embedding_pass.computed,
+            vectors_persisted=embedding_pass.persisted,
         )
     if method == "temporal":
         temporal = TemporalLinker()
@@ -285,6 +301,7 @@ def _run_threads(
             clusters_split=detector.clusters_split,
             oversized_discarded=detector.oversized_discarded,
             fragments_embedded=embedding_pass.computed,
+            vectors_persisted=embedding_pass.persisted,
         )
 
     updated_fragments = detector.assign_fragments_to_threads(fragments, threads)
@@ -312,6 +329,7 @@ def _run_threads(
         clusters_split=detector.clusters_split,
         oversized_discarded=detector.oversized_discarded,
         fragments_embedded=embedding_pass.computed,
+        vectors_persisted=embedding_pass.persisted,
     )
 
 
@@ -377,6 +395,7 @@ def _run_eddies(
             clusters_split=detector.clusters_split,
             oversized_discarded=detector.oversized_discarded,
             fragments_embedded=embedding_pass.computed,
+            vectors_persisted=embedding_pass.persisted,
         )
 
     updated_fragments = detector.assign_fragments_to_eddies(fragments, eddies)
@@ -404,6 +423,7 @@ def _run_eddies(
         clusters_split=detector.clusters_split,
         oversized_discarded=detector.oversized_discarded,
         fragments_embedded=embedding_pass.computed,
+        vectors_persisted=embedding_pass.persisted,
     )
 
 
@@ -554,7 +574,7 @@ def _run_embeddings(
     fragments: list[Fragment],
     config: CreekConfig,
     cache_path: Path,
-) -> tuple[int, int]:
+) -> tuple[int, EmbeddingPass]:
     """Compute embeddings, optionally re-using the on-disk cache.
 
     Args:
@@ -563,12 +583,15 @@ def _run_embeddings(
         cache_path: Where to read/write the cached embeddings parquet.
 
     Returns:
-        ``(resonance_edges_discovered, vectors_actually_computed)``. The
-        resonance edges are computed in memory and returned to the caller
-        for reporting only — there is no ``Resonance`` writer anywhere in
-        the codebase and :class:`~creek.models.Fragment` has no
-        ``resonances`` field, so nothing about them reaches the vault
-        (#1303). Only the vectors are persisted, in the parquet cache.
+        ``(resonance_edges_discovered, embedding_pass)``. The edge count is
+        obtained from :meth:`~EmbeddingLinker.count_resonances`, which walks
+        the same traversal as ``find_resonances`` without materialising a
+        ``Resonance`` per pair — the objects were only ever built to call
+        ``len`` on them, at a measured ~1KB of heap each (#1337). Nothing
+        about the edges reaches the vault: there is no ``Resonance`` writer
+        anywhere in the codebase and :class:`~creek.models.Fragment` has no
+        ``resonances`` field (#1303). Only the vectors are persisted, in
+        the parquet cache, and the pass reports how many rows landed there.
     """
     embedding_pass = _load_or_compute_embeddings(
         fragments=fragments,
@@ -579,12 +602,12 @@ def _run_embeddings(
     # FEAT-024: hierarchy-aware filtering needs both the fragment map
     # (parent/child relations) and the configured sibling skip window.
     fragments_by_id = {f.id: f for f in fragments}
-    resonances = EmbeddingLinker(config=config.embeddings).find_resonances(
+    edges = EmbeddingLinker(config=config.embeddings).count_resonances(
         embedding_pass.vectors,
         fragments_by_id,
         sibling_skip_window=config.linking.hierarchy_sibling_skip_window,
     )
-    return len(resonances), embedding_pass.computed
+    return edges, embedding_pass
 
 
 def _load_or_compute_embeddings(
@@ -608,8 +631,9 @@ def _load_or_compute_embeddings(
         cache_path: Embedding cache path.
 
     Returns:
-        An :class:`EmbeddingPass` carrying the vectors plus the split
-        between freshly computed and cache-served entries.
+        An :class:`EmbeddingPass` carrying the vectors, the split between
+        freshly computed and cache-served entries, and the row count the
+        cache write actually landed on disk.
     """
     linker = EmbeddingLinker(config=config.embeddings)
 
@@ -623,11 +647,19 @@ def _load_or_compute_embeddings(
     }
     embeddings.update(new_vectors)
 
-    _persist_cache(linker, fragments, cached, new_vectors, fresh_ids, cache_path)
+    persisted = _persist_cache(
+        linker,
+        fragments,
+        cached,
+        new_vectors,
+        fresh_ids,
+        cache_path,
+    )
     return EmbeddingPass(
         vectors=embeddings,
         computed=len(new_vectors),
         reused=len(fresh_ids),
+        persisted=persisted,
     )
 
 
@@ -687,7 +719,7 @@ def _persist_cache(
     new_vectors: dict[str, list[float]],
     fresh_ids: set[str],
     cache_path: Path,
-) -> None:
+) -> int:
     """Write the merged cache back to disk, degrading gracefully on IO errors.
 
     Args:
@@ -697,6 +729,12 @@ def _persist_cache(
         new_vectors: Vectors produced this run.
         fresh_ids: Fragment IDs whose cached entry is still valid.
         cache_path: Cache parquet path.
+
+    Returns:
+        Rows actually written to *cache_path* — the whole merged entry set
+        on success, ``0`` when the write raised. The cache is rewritten
+        whole, so on a fully warm run this is the corpus size even though
+        no vector was computed (#1337).
     """
     new_entries = linker.build_cache_entries(fragments, new_vectors)
     entries = {frag.id: cached[frag.id] for frag in fragments if frag.id in fresh_ids}
@@ -708,11 +746,15 @@ def _persist_cache(
         # Disk full / permission denied / read-only volume. Linking
         # itself succeeded — losing the cache only costs a recompute on
         # the next run, so we degrade gracefully instead of crashing.
+        # The operator still learns about it: the zero returned here is
+        # what the CLI prints instead of claiming vectors were cached.
         logger.warning(
             "Failed to persist embeddings cache to %s: %s",
             cache_path,
             exc,
         )
+        return 0
+    return len(entries)
 
 
 def _load_fragments(vault_path: Path) -> list[Fragment]:

--- a/creek-tools/creek/link/neighbours.py
+++ b/creek-tools/creek/link/neighbours.py
@@ -5,7 +5,7 @@ Eddy DBSCAN (:mod:`creek.link.eddies`) and paradox candidate generation
 fragments whose embedding cosine similarity clears a threshold. A pure-Python
 double loop makes that O(N²) in interpreted code, which does not finish on a
 ~35k-fragment vault. This module mirrors the blocked-numpy approach used by
-:meth:`creek.link.embeddings.EmbeddingLinker._resonances_topk`: it L2-normalises
+:func:`creek.link.embeddings._resonances_topk`: it L2-normalises
 the embedding matrix once, then computes cosine similarities one row-block at a
 time (``block @ matrix.T``) so peak memory is ``block_rows x N`` rather than the
 full ``N x N`` product. The neighbour sets returned are identical (up to

--- a/creek-tools/docs/linking.md
+++ b/creek-tools/docs/linking.md
@@ -22,9 +22,23 @@ creek link --vault ~/Obsidian/Creek-Vault --method eddies
 
 ## Resonances (embeddings)
 
-`creek.link.embeddings.EmbeddingLinker` encodes each fragment's title with a sentence-transformer model and emits a resonance edge whenever the cosine similarity exceeds `EmbeddingsConfig.similarity_threshold`.
+`creek.link.embeddings.EmbeddingLinker` encodes each fragment's title with a sentence-transformer model and emits a resonance edge whenever the cosine similarity meets or exceeds `EmbeddingsConfig.similarity_threshold` — a pair sitting exactly on the threshold resonates.
 
 > **Resonance edges are not persisted.** They are computed in memory, counted, and dropped. There is no resonance writer anywhere in the codebase and `Fragment` has no `resonances` field — only `threads` and `eddies`. The only thing `--method embeddings` writes is the vector cache at `00-Creek-Meta/embeddings.parquet`, which the `threads` and `eddies` linkers then reuse. Earlier revisions of this page documented a `links: resonances:` frontmatter block; no version of Creek has ever written one. Persisting resonances is unbuilt work, not a regression.
+
+### Reading the run summary
+
+`creek link --method embeddings` reports three counts, and they legitimately differ:
+
+| Count      | Meaning                                                                        |
+|------------|---------------------------------------------------------------------------------|
+| `scanned`  | Fragments loaded from the vault — the corpus size.                              |
+| `computed` | Vectors the local model actually produced this run — cache misses only.         |
+| `cached`   | Rows in `00-Creek-Meta/embeddings.parquet` after the run.                       |
+
+`computed` is zero on a warm cache — that's normal, not a failure. It's the number this line used to report as "embedded" regardless of whether the model did anything. `cached` is the whole cache rewritten from fresh hits plus any newly-computed vectors, so a fully warm run reports the entire corpus under `cached` while `computed` sits at zero.
+
+`no vectors written` after a run that reports vectors `computed` means the cache write itself failed — check the log for the warning. Linking still succeeded and the resonance count is still accurate; the only cost is that those vectors get recomputed next run instead of served from cache. On an empty vault, `no vectors written` just means there was nothing to cache.
 
 ### Tuning
 

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -1299,6 +1299,115 @@ def test_link_rebuild_clears_embeddings_cache(tmp_path: Path) -> None:
     assert not cache_path.exists()
 
 
+# ----- Issue #1337: the embeddings sentence must match the parquet -----------
+
+_SEEDED_FRAGMENTS = 4
+"""Fragment count for the #1337 seeded-vault fixtures.
+
+Every expected number below is derived from this constant or read back off
+the parquet, so growing the fixture can never turn a test vacuous.
+"""
+
+_CACHED_VECTORS_RE = re.compile(
+    r"(\d+) vector\(s\) cached in 00-Creek-Meta/embeddings\.parquet",
+)
+"""Recovers the operator-facing cached-vector count from the CLI sentence."""
+
+_EMBEDDING_CACHE_COLUMNS = {
+    "fragment_id",
+    "content_hash",
+    "model_name",
+    "embedding",
+    "computed_at",
+}
+"""The parquet's entire schema — vectors and their freshness keys, no edges."""
+
+
+class _FlatEncoder:
+    """Deterministic stand-in for the sentence-transformer model.
+
+    Row ``i`` is ``[1.0, 0.001 * i]``, so every pair of fragments sits well
+    above the default 0.75 cosine threshold and the similarity-edge count is
+    a stable ``C(n, 2)``. The shared conftest mock returns random
+    384-dimension vectors instead, which are near-orthogonal — under it "0
+    edges" is the usual answer, which is useless for a test about the edge
+    clause. ``EmbeddingLinker.generate_embeddings`` wraps whatever ``encode``
+    returns in ``numpy.asarray``, so a nested list is an exact stand-in for
+    the real model's ndarray.
+    """
+
+    def encode(
+        self,
+        texts: str | list[str],
+        **_kwargs: object,
+    ) -> list[list[float]]:
+        """Return one deterministic vector per entry in *texts*.
+
+        Args:
+            texts: A single text, or the batch the linker passes.
+            **_kwargs: ``show_progress_bar`` / ``batch_size``; ignored.
+
+        Returns:
+            One ``[1.0, 0.001 * i]`` row per input text.
+        """
+        batch = [texts] if isinstance(texts, str) else list(texts)
+        return [[1.0, 0.001 * index] for index, _text in enumerate(batch)]
+
+
+def _seed_embeddings_vault(vault: Path, *, count: int) -> Path:
+    """Seed *vault* with *count* fragments plus the meta directory.
+
+    Args:
+        vault: Vault root to create.
+        count: Number of fragment files to write under ``01-Fragments/``.
+
+    Returns:
+        The embeddings parquet path — which does not exist yet, so a test
+        can assert on its absence as well as its contents.
+    """
+    from creek.link.embeddings import embeddings_cache_path
+    from creek.models import Fragment, FragmentSource, SourcePlatform
+    from tests.helpers import write_fragment_file
+
+    (vault / "00-Creek-Meta").mkdir(parents=True, exist_ok=True)
+    for index in range(count):
+        write_fragment_file(
+            vault=vault,
+            fragment=Fragment(
+                id=f"frag-1337vector{index:02d}",
+                title=f"Vector fragment {index}",
+                source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+            ),
+            body=f"Body of vector fragment {index}.",
+        )
+    return embeddings_cache_path(vault)
+
+
+def _run_link_embeddings(vault: Path) -> tuple[int, str]:
+    """Run ``creek link --method embeddings`` under the deterministic encoder.
+
+    Args:
+        vault: Vault root to link.
+
+    Returns:
+        ``(exit_code, output)``, the output ANSI-stripped and
+        whitespace-collapsed: the honest sentence is longer than the pinned
+        200-column test terminal, so Rich wraps it mid-clause and raw
+        substring assertions would fail for the wrong reason.
+    """
+    from unittest.mock import patch
+
+    with patch(
+        "creek.link.embeddings.EmbeddingLinker.load_model",
+        return_value=_FlatEncoder(),
+    ):
+        result = runner.invoke(
+            app,
+            ["link", "--vault", str(vault), "--method", "embeddings"],
+        )
+    return result.exit_code, " ".join(_strip_ansi(result.output).split())
+
+
 def test_link_embeddings_output_phrases_similarity_edges(tmp_path: Path) -> None:
     """Embeddings CLI output explicitly says "similarity edges", not "links".
 
@@ -1309,23 +1418,162 @@ def test_link_embeddings_output_phrases_similarity_edges(tmp_path: Path) -> None
     Issue #1303 finished the job: the #338 wording said the *edges* were
     cached in the parquet, when in fact only the *vectors* are — the
     edges are computed and dropped, because no resonance writer exists.
-    The output must therefore name both halves. The two assertions below
-    are unchanged from #338 on purpose: the accurate vocabulary has to
-    survive the rewording, not be replaced by it.
+    The output must therefore name both halves. The three vocabulary
+    assertions below are unchanged from #338/#1303 on purpose: the
+    accurate vocabulary has to survive the rewording, not be replaced by
+    it. They read the whitespace-normalised output because the honest
+    sentence no longer fits the pinned terminal width.
+
+    Issue #1337 ties the sentence to the artifact, and the tie runs both
+    ways. The vault is *seeded*, so a parquet genuinely exists (the
+    pre-#1337 version of this test ran against an empty vault where no
+    parquet was ever written, and still asserted the word
+    "embeddings.parquet" appeared — it would have passed with the cache
+    deleted from the codebase). The cached count printed to the operator
+    is compared against ``num_rows`` on disk, derived not hardcoded, and
+    the column set is asserted exactly. Add an edge column to the cache
+    later and the schema assertion fires; claim cached edges in the
+    sentence without adding that column and the wording assertion fires.
+    Neither half can move without the other.
     """
+    import pyarrow.parquet as pq
+
+    vault = tmp_path / "vault"
+    cache_path = _seed_embeddings_vault(vault, count=_SEEDED_FRAGMENTS)
+
+    exit_code, output = _run_link_embeddings(vault)
+
+    assert exit_code == 0, output
+    # #338 phrasing — accurate to what the embeddings method does.
+    assert "similarity edge" in output.lower()
+    assert "embeddings.parquet" in output
+    # #1303: and it must not claim the edges themselves were persisted.
+    assert "not persisted" in output.lower()
+
+    # #1337 tie, half one: the number the operator reads is the number of
+    # rows the artifact actually holds.
+    assert cache_path.exists(), output
+    table = pq.read_table(cache_path)
+    match = _CACHED_VECTORS_RE.search(output)
+    assert match is not None, f"no cached-vector count in output: {output}"
+    assert int(match.group(1)) == table.num_rows
+
+    # #1337 tie, half two: the cache stores vectors and freshness keys and
+    # nothing else. An added edge column fires here.
+    assert set(table.column_names) == _EMBEDDING_CACHE_COLUMNS
+
+    # Because there is no edge column, the sentence may not claim the edges
+    # were cached — only the vectors were.
+    assert "edge(s) cached" not in output
+    assert "edges cached" not in output
+
+
+def test_link_embeddings_warm_run_reports_zero_vectors_computed(
+    tmp_path: Path,
+) -> None:
+    """A second identical run must report the vectors it did *not* compute.
+
+    Issue #1337, lie one: the sentence read ``{fragment_count} fragment(s)
+    embedded``, so a fully warm cache still claimed the whole corpus had
+    been embedded even though ``LinkSummary.fragments_embedded`` was ``0``
+    and the local model was never invoked. ``N fragment(s) embedded`` is
+    the exact substring the defect printed, so its absence is asserted
+    directly rather than inferred from the replacement wording.
+
+    The cached count is still tied to ``num_rows``: a warm run rewrites the
+    same rows, so the parquet must hold the whole corpus even though this
+    run computed none of it.
+    """
+    import pyarrow.parquet as pq
+
+    vault = tmp_path / "vault"
+    cache_path = _seed_embeddings_vault(vault, count=_SEEDED_FRAGMENTS)
+
+    cold_code, cold_output = _run_link_embeddings(vault)
+    assert cold_code == 0, cold_output
+    expected_cold = (
+        f"{_SEEDED_FRAGMENTS} fragment(s) scanned, "
+        f"{_SEEDED_FRAGMENTS} vector(s) computed,"
+    )
+    assert expected_cold in cold_output
+
+    warm_code, warm_output = _run_link_embeddings(vault)
+    assert warm_code == 0, warm_output
+    expected_warm = f"{_SEEDED_FRAGMENTS} fragment(s) scanned, 0 vector(s) computed,"
+    assert expected_warm in warm_output
+    assert f"{_SEEDED_FRAGMENTS} fragment(s) embedded" not in warm_output
+
+    table = pq.read_table(cache_path)
+    assert table.num_rows == _SEEDED_FRAGMENTS
+    match = _CACHED_VECTORS_RE.search(warm_output)
+    assert match is not None, f"no cached-vector count in output: {warm_output}"
+    assert int(match.group(1)) == table.num_rows
+
+
+def test_link_embeddings_empty_vault_admits_nothing_was_cached(
+    tmp_path: Path,
+) -> None:
+    """An empty vault must not claim vectors reached the parquet.
+
+    Issue #1337, lie two: ``run_link`` returns early for a fragmentless
+    vault, so ``_persist_cache`` never runs and no parquet is created — yet
+    the sentence still ended "vectors cached in
+    00-Creek-Meta/embeddings.parquet". The disk assertion and the wording
+    assertion live in the same test on purpose: separated, one could be
+    weakened without the other noticing, which is exactly how the claim
+    and the artifact drifted apart in the first place.
+    """
+    from creek.link.embeddings import embeddings_cache_path
+
     vault = tmp_path / "vault"
     (vault / "01-Fragments").mkdir(parents=True)
+    cache_path = embeddings_cache_path(vault)
 
-    result = runner.invoke(
-        app,
-        ["link", "--vault", str(vault), "--method", "embeddings"],
+    exit_code, output = _run_link_embeddings(vault)
+
+    assert exit_code == 0, output
+    assert not cache_path.exists()
+    assert "no vectors written to 00-Creek-Meta/embeddings.parquet" in output
+    assert "vector(s) cached in" not in output
+    assert "0 fragment(s) scanned, 0 vector(s) computed," in output
+
+
+def test_link_embeddings_cache_write_failure_is_admitted(tmp_path: Path) -> None:
+    """A swallowed cache-write error must reach the operator as a zero count.
+
+    Issue #1337, lie three: ``_persist_cache`` catches ``OSError`` (disk
+    full, read-only volume) and logs a warning, so linking exits 0 with no
+    parquet on disk while the sentence claimed the vectors were cached.
+    Graceful degradation is deliberate and stays — losing the cache only
+    costs a recompute — so the exit code is pinned at 0. The fix is not to
+    fail the run but to stop lying about it: the honest count *is* the
+    remedy for the swallowed error, making it visible to the operator
+    instead of only to the log.
+
+    The run's real work is asserted too, so an implementation that reported
+    ``0 vector(s) computed`` alongside the failed write — conflating
+    "computed" with "persisted" — would fail here.
+    """
+    from unittest.mock import patch
+
+    vault = tmp_path / "vault"
+    cache_path = _seed_embeddings_vault(vault, count=_SEEDED_FRAGMENTS)
+
+    with patch(
+        "creek.link.embeddings.EmbeddingLinker.save_cache",
+        side_effect=OSError("disk full"),
+    ):
+        exit_code, output = _run_link_embeddings(vault)
+
+    assert exit_code == 0, output
+    assert not cache_path.exists()
+    assert "no vectors written to 00-Creek-Meta/embeddings.parquet" in output
+    assert "vector(s) cached in" not in output
+    expected_work = (
+        f"{_SEEDED_FRAGMENTS} fragment(s) scanned, "
+        f"{_SEEDED_FRAGMENTS} vector(s) computed,"
     )
-    assert result.exit_code == 0, result.output
-    # New phrasing — accurate to what the embeddings method does.
-    assert "similarity edge" in result.output.lower()
-    assert "embeddings.parquet" in result.output
-    # #1303: and it must not claim the edges themselves were persisted.
-    assert "not persisted" in result.output.lower()
+    assert expected_work in output
 
 
 def test_link_embeddings_model_unavailable_exits_nonzero(

--- a/creek-tools/tests/test_embeddings.py
+++ b/creek-tools/tests/test_embeddings.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import logging
 import re
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 import pytest
@@ -1010,3 +1010,320 @@ class TestHierarchyAwareFiltering:
         )
         assert edge.from_level == "document"
         assert edge.to_level == "document"
+
+
+# ---- Issue #1337: count_resonances / find_resonances parity ----------------
+
+_PARITY_CLUSTERS = 4
+"""Dense clusters in the parity corpus."""
+
+_PARITY_PER_CLUSTER = 12
+"""Vectors per cluster; 4 x 12 = 48 vectors keeps the property in the unit lane."""
+
+_PARITY_DIMS = 16
+"""Vector width — wide enough that random cluster centres stay far apart."""
+
+_PARITY_NOISE = 0.15
+"""Per-coordinate jitter around a centre; small enough to keep a cluster dense."""
+
+_PARITY_SEED = 1337
+"""Fixed RNG seed so the corpus, and therefore the edge counts, reproduce."""
+
+_PARITY_SKIP_WINDOW = 2
+"""Sibling-suppression radius passed to both callables, identically."""
+
+
+def _parity_corpus() -> dict[str, list[float]]:
+    """Build the seeded 48-vector corpus of four dense clusters.
+
+    Members of a cluster sit at cosine ~0.98 of one another and clusters
+    are mutually near-orthogonal, so at the default 0.75 threshold the
+    corpus yields hundreds of edges rather than the handful (often zero)
+    that pure standard-normal noise produces. A vacuous ``0 == 0`` parity
+    is the main way this property could rot, so the edge count is asserted
+    non-zero in every parametrisation.
+
+    Returns:
+        Mapping of fragment ID to embedding vector, IDs in cluster order.
+    """
+    rng = np.random.default_rng(_PARITY_SEED)
+    centres = rng.standard_normal((_PARITY_CLUSTERS, _PARITY_DIMS))
+    corpus: dict[str, list[float]] = {}
+    for index in range(_PARITY_CLUSTERS * _PARITY_PER_CLUSTER):
+        centre = centres[index // _PARITY_PER_CLUSTER]
+        vector = centre + _PARITY_NOISE * rng.standard_normal(_PARITY_DIMS)
+        corpus[f"frag-parity-{index:03d}"] = [float(x) for x in vector]
+    return corpus
+
+
+def _parity_hierarchy(corpus: dict[str, list[float]]) -> dict[str, Fragment]:
+    """Give each dense cluster a parent and eleven ordered children.
+
+    The hierarchy is laid over the clusters rather than across them so that
+    suppression actually bites: parent/child pairs are near-identical (and
+    therefore ancestor-suppressed) and adjacent siblings fall inside the
+    skip window. Enough non-adjacent sibling pairs survive that the edge
+    count stays comfortably above zero.
+
+    Args:
+        corpus: The parity corpus, whose IDs are in cluster order.
+
+    Returns:
+        Mapping of fragment ID to :class:`Fragment` with hierarchy fields.
+    """
+    ids = list(corpus)
+    fragments: dict[str, Fragment] = {}
+    for cluster in range(_PARITY_CLUSTERS):
+        start = cluster * _PARITY_PER_CLUSTER
+        members = ids[start : start + _PARITY_PER_CLUSTER]
+        parent_id, child_ids = members[0], members[1:]
+        fragments[parent_id] = _hier_fragment(
+            parent_id,
+            child_ids=child_ids,
+            level="document",
+        )
+        for child_id in child_ids:
+            fragments[child_id] = _hier_fragment(
+                child_id,
+                parent_id=parent_id,
+                level="paragraph",
+            )
+    return fragments
+
+
+@pytest.mark.parametrize("resonance_method", ["exact", "topk"])
+@pytest.mark.parametrize("with_hierarchy", [False, True])
+def test_count_resonances_matches_find_resonances_length(
+    resonance_method: Literal["exact", "topk"],
+    with_hierarchy: bool,
+) -> None:
+    """``count_resonances`` must never drift from ``len(find_resonances(...))``.
+
+    Issue #1337: the CLI reports the similarity-edge count next to the
+    persisted-vector count, and the edge count is the one number in that
+    sentence with no artifact behind it — nothing writes resonances to the
+    vault. Counting them without materialising ``Resonance`` objects is
+    therefore worth doing, but it forks the traversal, and a fork is a
+    place where two answers can quietly diverge.
+
+    This is the drift alarm. Both discovery strategies are exercised
+    (``exact`` emits every above-threshold pair; ``topk`` caps each
+    fragment's neighbours) and each is run with and without a hierarchy
+    mapping, so the FEAT-024 suppression branch is covered on both paths —
+    four combinations, any one of which could be the one a shortcut
+    forgets. The non-zero assertion is load-bearing: an empty corpus makes
+    the parity ``0 == 0`` and the whole property vacuous.
+    """
+    linker = EmbeddingLinker(
+        config=EmbeddingsConfig(
+            similarity_threshold=0.75,
+            resonance_method=resonance_method,
+        ),
+    )
+    corpus = _parity_corpus()
+    fragments = _parity_hierarchy(corpus) if with_hierarchy else None
+
+    edges = linker.find_resonances(
+        corpus,
+        fragments,
+        sibling_skip_window=_PARITY_SKIP_WINDOW,
+    )
+    counted = linker.count_resonances(
+        corpus,
+        fragments,
+        sibling_skip_window=_PARITY_SKIP_WINDOW,
+    )
+
+    assert len(edges) > 0, (
+        "the parity corpus must yield edges under "
+        f"{resonance_method}/hierarchy={with_hierarchy}, or 0 == 0 makes "
+        "this property vacuous"
+    )
+    assert isinstance(counted, int)
+    assert counted == len(edges)
+
+
+def test_count_resonances_builds_no_resonance_objects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Counting must not construct a ``Resonance`` per edge.
+
+    Issue #1337: the edge count reported by ``creek link --method
+    embeddings`` was ``len(find_resonances(...))``, so every above-threshold
+    pair became a Pydantic model whose only purpose was to be counted and
+    dropped. Measured at ~1KB of heap per edge, which at the documented
+    35k-fragment scale (6.9% pair density, per #338's 188-fragment sample)
+    is tens of gigabytes — an out-of-memory failure, not a slowdown.
+
+    The parity test next door pins that the two answers agree; agreement is
+    exactly what a lazy implementation risks losing, but it is also what a
+    lazy-looking implementation that quietly rebuilds the list would keep.
+    This is the assertion that separates them, and it is behavioural rather
+    than a memory measurement: a spy on the constructor counts objects,
+    which is deterministic, where a peak-heap threshold would be flaky.
+    """
+    constructed = 0
+    real_resonance = Resonance
+
+    def _spy(**kwargs: Any) -> Resonance:
+        """Count each ``Resonance`` the code under test builds."""
+        nonlocal constructed
+        constructed += 1
+        return real_resonance(**kwargs)
+
+    linker = EmbeddingLinker(
+        config=EmbeddingsConfig(similarity_threshold=0.75),
+    )
+    corpus = _parity_corpus()
+
+    monkeypatch.setattr("creek.link.embeddings.Resonance", _spy)
+
+    counted = linker.count_resonances(corpus)
+    assert counted > 0, "vacuous unless the corpus actually resonates"
+    assert constructed == 0, (
+        f"count_resonances built {constructed} Resonance object(s); "
+        "counting must allocate nothing per edge"
+    )
+
+    # The control: the same traversal via find_resonances builds exactly one
+    # object per edge, so the zero above is a property of counting and not
+    # of the spy failing to intercept.
+    edges = linker.find_resonances(corpus)
+    assert constructed == len(edges) > 0
+
+
+def test_exact_pair_scan_yields_before_finishing_the_traversal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The exact path must be a real generator, not a list behind one.
+
+    Issue #1337: returning ``list[tuple[int, int, float]]`` instead of
+    ``list[Resonance]`` looks like a fix and is not — at a measured ~120
+    bytes per tuple it is still gigabytes at 35k fragments. Laziness is
+    invisible in the return value, so it is pinned here through
+    observable work instead: every candidate pair is routed through
+    ``_is_hierarchy_suppressed``, so a lazy scan that has yielded only its
+    first triple must have consulted it strictly fewer times than a
+    completed one. An eager implementation makes the two counts equal and
+    fails, whatever its element type.
+    """
+    from creek.link import embeddings as embeddings_module
+
+    calls = 0
+    real_check = embeddings_module._is_hierarchy_suppressed
+
+    def _spy(*args: Any, **kwargs: Any) -> bool:
+        """Tally each hierarchy check the traversal performs."""
+        nonlocal calls
+        calls += 1
+        return bool(real_check(*args, **kwargs))
+
+    linker = EmbeddingLinker(
+        config=EmbeddingsConfig(similarity_threshold=0.75),
+    )
+    corpus = _parity_corpus()
+    fragments = _parity_hierarchy(corpus)
+    scan = linker._prepare_scan(corpus, fragments, _PARITY_SKIP_WINDOW)
+    assert scan is not None
+
+    monkeypatch.setattr(embeddings_module, "_is_hierarchy_suppressed", _spy)
+    stats = embeddings_module._ScanStats()
+    generator = embeddings_module._resonances_exact(scan, stats)
+    next(generator)
+    after_first = calls
+
+    remaining = sum(1 for _ in generator)
+    after_all = calls
+
+    assert remaining > 0, "vacuous unless the corpus yields more than one edge"
+    assert after_first < after_all, (
+        f"the scan consulted the hierarchy {after_first} time(s) before its "
+        f"first yield and {after_all} in total; equal counts mean the "
+        "traversal ran to completion eagerly"
+    )
+
+
+def test_count_resonances_peak_memory_does_not_hold_the_edge_set() -> None:
+    """Counting must stream the pair scan, not drain it into a list.
+
+    Issue #1337: replacing ``list[Resonance]`` with ``list[tuple[int, int,
+    float]]`` looks like the fix and is not. It kills the ~1KB-per-edge
+    Pydantic cost but keeps a per-edge allocation of its own, which at the
+    documented 35k-fragment scale is still gigabytes. The
+    ``count_resonances`` body must therefore *consume* the generator
+    lazily; ``len(list(...))`` is the mutant this test exists to kill, and
+    it is invisible to every count-based assertion because it returns the
+    right number.
+
+    Laziness has no observable return value, so it is measured. The corpus
+    is three tight seeded clusters at ~0.999 intra-cluster cosine, which
+    makes edges vastly outnumber fragments and puts the edge set — not the
+    row-block matmul — in charge of peak memory. Measured on this corpus:
+    **3.3 MB streaming versus 18.3 MB via ``list()``**, a 5.5x separation.
+    The ceiling below sits between them with roughly 2.4x headroom over the
+    streaming figure, and ``tracemalloc`` counts Python allocations rather
+    than RSS, so the number is deterministic rather than machine-dependent.
+    """
+    import tracemalloc
+
+    fragment_count = 900
+    rng = np.random.default_rng(_PARITY_SEED)
+    centres = rng.standard_normal((3, 8))
+    corpus = {
+        f"frag-dense-{index:04d}": [
+            float(value) for value in centres[index % 3] + 0.02 * rng.standard_normal(8)
+        ]
+        for index in range(fragment_count)
+    }
+    linker = EmbeddingLinker(config=EmbeddingsConfig(similarity_threshold=0.75))
+
+    tracemalloc.start()
+    tracemalloc.reset_peak()
+    counted = linker.count_resonances(corpus)
+    _, peak_bytes = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    # Vacuity guard: the property is only meaningful when the edge set is
+    # far larger than the corpus that would otherwise dominate the peak.
+    assert counted > 100 * fragment_count, (
+        f"{counted} edge(s) over {fragment_count} fragments is too sparse "
+        "for peak memory to say anything about holding the edge set"
+    )
+    ceiling_bytes = 8_000_000
+    assert peak_bytes < ceiling_bytes, (
+        f"counting {counted} edge(s) peaked at {peak_bytes / 1e6:.1f} MB, "
+        f"over the {ceiling_bytes / 1e6:.0f} MB ceiling — the edge set is "
+        "being retained rather than streamed"
+    )
+
+
+def test_similarity_threshold_is_inclusive_at_the_boundary() -> None:
+    """A pair sitting exactly on the threshold resonates.
+
+    ``EmbeddingsConfig.similarity_threshold`` is documented as the
+    *minimum* cosine similarity for linking, so the comparison is ``>=``
+    and a pair landing precisely on it must be emitted. Random corpora
+    never land exactly on a float boundary, so this case had no coverage
+    and a ``>=`` to ``>`` slip in the pair scan was invisible — the kind of
+    off-by-one that quietly drops edges at whatever threshold an operator
+    has tuned to. Identical unit vectors give an exact 1.0 with no
+    floating-point slack, which is what makes the boundary testable at all.
+
+    Pinned while #1337 rewrote this traversal into a generator; the
+    comparison itself is unchanged, and this is the assertion that says so.
+    """
+    linker = EmbeddingLinker(config=EmbeddingsConfig(similarity_threshold=1.0))
+    corpus = {"frag-boundary-a": [1.0, 0.0], "frag-boundary-b": [1.0, 0.0]}
+
+    edges = linker.find_resonances(corpus)
+
+    assert len(edges) == 1
+    assert edges[0].similarity == pytest.approx(1.0)
+    assert linker.count_resonances(corpus) == 1
+
+    # And the exclusive reading really is distinguishable here: nudge the
+    # threshold above 1.0 and the same pair drops out, so the assertion
+    # above is about the boundary and not about the pair being trivially
+    # similar.
+    above = EmbeddingLinker(config=EmbeddingsConfig(similarity_threshold=1.0001))
+    assert above.find_resonances(corpus) == []

--- a/creek-tools/tests/test_link_engine.py
+++ b/creek-tools/tests/test_link_engine.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+
+import pytest
 
 from creek.config import CreekConfig, EmbeddingsConfig
 from creek.link.embeddings import (
@@ -16,6 +18,7 @@ from creek.models import Fragment, FragmentSource, SourcePlatform
 from tests.helpers import write_fragment_file as _write_fragment
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
 
@@ -937,3 +940,240 @@ def test_run_link_reports_fragments_embedded_per_method(tmp_path: Path) -> None:
     )
     assert first.fragments_embedded == 3
     assert second.fragments_embedded == 0
+
+
+# ----- Issue #1337: report what actually reached the parquet -----------------
+
+
+def _seeded_embeddings_vault(vault: Path, *, count: int) -> list[Fragment]:
+    """Seed *vault* with *count* fragments and no embeddings cache.
+
+    Deliberately does **not** pre-write the parquet: these tests are about
+    what a run persists, so the artifact must be created by the run under
+    test and by nothing else.
+
+    Args:
+        vault: Vault root.
+        count: Number of fragment files to write.
+
+    Returns:
+        The created fragments, in creation order.
+    """
+    fragments: list[Fragment] = []
+    for index in range(count):
+        frag = Fragment(
+            id=f"frag-1337persist{index:02d}",
+            title=f"Persisted vector {index}",
+            source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+        )
+        _write_fragment(vault=vault, fragment=frag, body=f"Body {index}.")
+        fragments.append(frag)
+    return fragments
+
+
+def test_run_link_embeddings_reports_vectors_actually_persisted(
+    tmp_path: Path,
+) -> None:
+    """``vectors_persisted`` equals the rows the parquet now holds.
+
+    Issue #1337: the CLI claimed "vectors cached in
+    00-Creek-Meta/embeddings.parquet" from a hardcoded clause, with nothing
+    in the summary to contradict it. The count is now structured, and it is
+    pinned here against the artifact — ``pq.read_table(...).num_rows`` —
+    rather than a literal, so the fixture and the assertion cannot drift.
+    """
+    import pyarrow.parquet as pq
+
+    vault = tmp_path / "vault"
+    fragments = _seeded_embeddings_vault(vault, count=3)
+
+    summary = run_link(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="embeddings",
+        rebuild=False,
+    )
+
+    cache_path = embeddings_cache_path(vault)
+    assert cache_path.exists()
+    assert summary.fragment_count == len(fragments)
+    assert summary.vectors_persisted == summary.fragment_count
+    assert summary.vectors_persisted == pq.read_table(cache_path).num_rows
+
+
+def test_run_link_embeddings_empty_vault_persists_no_vectors(
+    tmp_path: Path,
+) -> None:
+    """The fragmentless early return must carry ``vectors_persisted == 0``.
+
+    Issue #1337: ``run_link`` returns a bare ``LinkSummary`` for an empty
+    vault, so the honest zero has to come from the field's default rather
+    than from a special case at the return site. If a later refactor gives
+    the field a non-zero default, or populates it unconditionally, this
+    fails — and so does the paired disk assertion, because no parquet is
+    written on this path at all.
+    """
+    vault = tmp_path / "vault"
+    (vault / "01-Fragments").mkdir(parents=True)
+
+    summary = run_link(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="embeddings",
+        rebuild=False,
+    )
+
+    assert summary.fragment_count == 0
+    assert summary.vectors_persisted == 0
+    assert not embeddings_cache_path(vault).exists()
+
+
+def test_run_link_embeddings_save_failure_reports_zero_persisted(
+    tmp_path: Path,
+) -> None:
+    """A swallowed ``OSError`` from ``save_cache`` must report zero persisted.
+
+    Issue #1337: ``_persist_cache`` degrades gracefully on a full disk or a
+    read-only volume, which is the right behaviour and is preserved (the
+    run still completes). What was wrong is that the operator was told the
+    vectors had been cached anyway. Two fragments are embedded and zero
+    persisted here on purpose: an implementation that aliased
+    ``vectors_persisted`` to ``fragments_embedded`` would pass a
+    single-fragment version of this test's disk check but dies on the
+    counter comparison.
+    """
+    from unittest.mock import patch
+
+    vault = tmp_path / "vault"
+    fragments = _seeded_embeddings_vault(vault, count=2)
+
+    with patch(
+        "creek.link.embeddings.EmbeddingLinker.save_cache",
+        side_effect=OSError("disk full"),
+    ):
+        summary = run_link(
+            vault_path=vault,
+            config=CreekConfig(),
+            method="embeddings",
+            rebuild=False,
+        )
+
+    assert summary.fragments_embedded == len(fragments)
+    assert summary.vectors_persisted == 0
+    assert not embeddings_cache_path(vault).exists()
+
+
+def test_embedding_pass_requires_an_explicit_persisted_count() -> None:
+    """``EmbeddingPass.persisted`` has no default; every call site must state it.
+
+    Issue #1337: a default would let a future pass under-report silently —
+    the whole point of the field is that the number is measured, not
+    assumed. The dataclass-field check kills the mutant that swaps the
+    missing default for a ``default_factory`` returning zero, which would
+    keep the constructor call from raising while restoring the hazard.
+    """
+    from dataclasses import MISSING, fields
+
+    from creek.link import link_engine
+
+    # Widened deliberately: a precisely-typed call to a constructor with a
+    # required argument omitted is a type error, and the point here is the
+    # runtime contract, not the annotation.
+    constructor: Callable[..., object] = link_engine.EmbeddingPass
+    with pytest.raises(TypeError):
+        constructor(vectors={}, computed=0, reused=0)
+
+    persisted_field = next(
+        field
+        for field in fields(link_engine.EmbeddingPass)
+        if field.name == "persisted"
+    )
+    assert persisted_field.default is MISSING
+    assert persisted_field.default_factory is MISSING
+
+    complete = link_engine.EmbeddingPass(
+        vectors={},
+        computed=0,
+        reused=0,
+        persisted=0,
+    )
+    assert complete.persisted == 0
+
+
+class _FlatEncoder:
+    """Deterministic stand-in for the sentence-transformer model.
+
+    Row ``i`` is ``[1.0, 0.001 * i]``, so every pair clears the default
+    0.75 cosine threshold and the run produces a known-non-zero edge count.
+    The shared conftest mock returns random 384-dimension vectors, which
+    are near-orthogonal and typically yield zero edges — useless for a test
+    whose whole subject is what happens per edge.
+    """
+
+    def encode(self, texts: str | list[str], **_kwargs: object) -> list[list[float]]:
+        """Return one deterministic vector per entry in *texts*.
+
+        Args:
+            texts: A single text, or the batch the linker passes.
+            **_kwargs: ``show_progress_bar`` / ``batch_size``; ignored.
+
+        Returns:
+            One ``[1.0, 0.001 * i]`` row per input text.
+        """
+        batch = [texts] if isinstance(texts, str) else list(texts)
+        return [[1.0, 0.001 * index] for index, _text in enumerate(batch)]
+
+
+def test_run_link_embeddings_counts_edges_without_building_them(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``creek link --method embeddings`` must not allocate a model per edge.
+
+    Issue #1337: ``_run_embeddings`` called ``find_resonances`` and took
+    ``len`` of the result, so every above-threshold pair became a Pydantic
+    :class:`~creek.link.embeddings.Resonance` that was counted and dropped.
+    Measured at ~1KB of heap each, which at the documented 35k-fragment
+    scale is tens of gigabytes — the run dies before it can report anything.
+
+    ``tests/test_embeddings.py`` pins that ``count_resonances`` itself
+    allocates nothing. This pins the *call site*, which is the part a
+    revert would touch: swapping ``count_resonances`` back for
+    ``find_resonances`` here leaves every count in this suite correct and
+    reinstates the whole defect, so nothing else in the codebase notices.
+    """
+    from creek.link import embeddings as embeddings_module
+
+    vault = tmp_path / "vault"
+    _seeded_embeddings_vault(vault, count=6)
+
+    constructed = 0
+    real_resonance = embeddings_module.Resonance
+
+    def _spy(**kwargs: Any) -> object:
+        """Count each Resonance the link run builds."""
+        nonlocal constructed
+        constructed += 1
+        return real_resonance(**kwargs)
+
+    monkeypatch.setattr(embeddings_module, "Resonance", _spy)
+    monkeypatch.setattr(
+        embeddings_module.EmbeddingLinker,
+        "load_model",
+        lambda _self: _FlatEncoder(),
+    )
+
+    summary = run_link(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="embeddings",
+        rebuild=False,
+    )
+
+    # Vacuity guard: 6 mutually-similar fragments must yield C(6,2) edges,
+    # so "zero objects built" is a real property and not an empty traversal.
+    assert summary.similarity_edges == 15
+    assert constructed == 0, (
+        f"the link run built {constructed} Resonance object(s) to count "
+        f"{summary.similarity_edges} edge(s); counting must allocate none"
+    )

--- a/creek-tools/tests/test_link_threads_pages.py
+++ b/creek-tools/tests/test_link_threads_pages.py
@@ -56,7 +56,13 @@ def _frequency_only_detection(
     monkeypatch.setattr(
         link_engine,
         "_load_or_compute_embeddings",
-        lambda **_kwargs: link_engine.EmbeddingPass(vectors={}, computed=0, reused=0),
+        lambda **_kwargs: link_engine.EmbeddingPass(
+            vectors={},
+            computed=0,
+            reused=0,
+            # #1337: no vectors were computed, so none were persisted either.
+            persisted=0,
+        ),
     )
     yield
 


### PR DESCRIPTION
## Summary

### The issue's headline premise is refuted at HEAD — and it says so itself, wrongly

#1337 is titled "`creek link` reports N 'similarity edge(s) cached in embeddings.parquet'". It also says "Distinct from open #1303." **#1303 is closed**, merged as PR #1383 (commit `3796c39`, in this branch's base), and that PR already reworded both sites this issue names. Observed at HEAD `26a69c9`:

```
Embeddings linker: 12 fragment(s) embedded, 66 similarity edge(s) computed in memory
(not persisted — no resonance writer exists); vectors cached in 00-Creek-Meta/embeddings.parquet.
```

The edge-caching claim is gone. `LinkSummary.similarity_edges`'s docstring (now `link_engine.py:81-85`, not the `:80` the issue cites) already reads "**Not persisted**". Every line number in the issue is stale.

**But three lies of exactly the same family survive, all inside that one sentence,** and #1383 built the field that fixes one of them without wiring it up. I ran a census of all four linker arms; the temporal, eddies and threads arms are honest and untouched here.

| # | State | What it said | What was on disk |
|---|---|---|---|
| 1 | Warm cache (2nd identical run) | `12 fragment(s) embedded` | `fragments_embedded == 0` — the model computed nothing |
| 2 | Empty vault | `vectors cached in 00-Creek-Meta/embeddings.parquet` | **no parquet exists** — `run_link` returns early at `link_engine.py:190-191` |
| 3 | Cache write fails | same caching claim, exit 0 | **no parquet exists** — `_persist_cache` swallows `OSError` into a log line |

Observed CLI sentence and observed parquet schema, side by side, at HEAD:

```
SAYS : ... 12 fragment(s) embedded ... vectors cached in 00-Creek-Meta/embeddings.parquet.
DISK : fragment_id: string | content_hash: string | model_name: string
       embedding: list<element: float> | computed_at: timestamp[us, tz=UTC]
       num_rows: 12   schema.metadata: None
```

The only existing test of this sentence, `test_link_embeddings_output_phrases_similarity_edges`, ran on an **empty vault where no parquet was ever written** and asserted `"embeddings.parquet" in result.output`. It would have passed with the cache deleted from the codebase.

### The decision on task 1: reword. Persist rejected.

The issue asks for a persist-vs-reword call. **Reword**, for five reasons — and this is not the cheap option talking, because the expensive half of "reword" (counting without materialising) is most of this diff.

1. **#1383 already made this call on the neighbouring path**, explicitly: "no writer was invented." Re-deciding it here re-forks the contract, which is the architectural-drift family #1303 closed.
2. **Invalidation is the killer.** The parquet's freshness model is per-fragment `content_hash`. An edge is a function of *two* fragments, so one edit invalidates every edge touching it. Bolting edges into this file means either a full recompute on any edit (the cache never helps) or a per-edge freshness protocol that does not exist.
3. **The parquet is documented-deletable derived data** — `--rebuild` unlinks it, `delete_embeddings_cache` exists, `creek purge vault` removes it, and `docs/cleaning-and-purge.md` / `docs/security/threat-model.md` both describe it as regenerable. A Resonance is one of the five ontological primitives. Putting a primitive inside a file whose documented lifecycle is "safe to delete" is a category error no schema version can fix.
4. **Measured scale.** Using the issue's own density datum (#338: 188 fragments → 1,212 edges = 6.9% of pairs), 35k fragments is 42,261,292 edges ≈ **0.9 GB of parquet minimum**, built from ~43 GB of intermediate objects. That artifact needs its own design — streaming writer, pruning policy, size budget — not a column bolted onto a vector cache.
5. **No consumer is wired.** `generate/synchronicity.py:441` computes over its own fragment set at its own config; reuse needs threshold agreement, which is a separate design.

**Migration answer: none is needed, and that is a property of the decision, not a gap.** The on-disk format is byte-for-byte unchanged, so there is no schema version bump, no `load_cache` compatibility branch, and no possibility of an old parquet being misread as "zero edges found" — because nothing ever reads edges from it.

### What changed

The sentence is now derived from what happened, in all four states (each observed by running the CLI and reading the parquet back):

```
cold  : 12 fragment(s) scanned, 12 vector(s) computed, 66 similarity edge(s) computed in memory
        (not persisted — no resonance writer exists); 12 vector(s) cached in 00-Creek-Meta/embeddings.parquet.
warm  : 12 fragment(s) scanned,  0 vector(s) computed, ... 12 vector(s) cached in ...
empty :  0 fragment(s) scanned,  0 vector(s) computed, ... no vectors written to ...   (parquet absent)
OSError:  4 fragment(s) scanned,  4 vector(s) computed, ... no vectors written to ...   (parquet absent, exit 0)
```

`LinkSummary` gains `vectors_persisted` (rows this run landed) and `EmbeddingPass` gains a **required** `persisted` — required, not defaulted, because the number must be measured and a default is precisely how a future call site under-reports silently. `_persist_cache` returns the count and `0` from its `except OSError`. The swallow is deliberate and stays: losing the cache only costs a recompute, and **the honest count is the fix for the swallowed error** — it is now the only operator-visible trace of a failure that previously reached the log alone.

The wording split is load-bearing: only the *edges* clause says "not persisted", so an assertion on that phrase unambiguously pins the edge claim and cannot be satisfied by the cache clause.

### The 43 GB the issue's sub-point asked about

`_run_embeddings` called `find_resonances` and took `len()` of the result, so every above-threshold pair became a Pydantic `Resonance` that was counted and dropped. Measured with `tracemalloc`, stable across three scale points:

| N | edges | bytes/edge |
|---|---|---|
| 800 | 13,953 | 1,017 |
| 1,500 | 302 | 1,019 |
| 2,000 | 87,408 | 1,016 |

At 42.3M edges that is **~43 GB of heap to call `len()`** — an out-of-memory failure, not a slowdown.

The exact pair scan is now a true generator and `count_resonances` streams it. Measured after: peak memory is **independent of edge count** (N=800 → 2.62 MB, N=2000 → 8.33 MB; the residual scales with the row-block matmul, i.e. with N, not edges), against `find_resonances`'s steady ~1,060 B/edge. Counting is also 5.7x faster (23.9 ms vs 135.7 ms at N=2000) because it skips Pydantic construction.

**Returning `list[tuple[int, int, float]]` instead would not have been a fix** — at ~120 B/edge that is still ~5 GB at 35k. The laziness is the point, and it is tested.

**Stated plainly: time is still O(n²).** This removes an OOM; it does not make 35k fragments fast. `_resonances_topk` is a generator for signature parity only — dedup-then-sort is inherently eager and its pick list is bounded at O(n·k) — and its docstring says so rather than implying it streams.

**Equivalence proved by execution, not argument.** `find_resonances` output was compared against `git show HEAD:`'s version across exact/topk × hierarchy/no-hierarchy: **identical edge tuples in identical order**, including the `float(row[j])` values. Ragged input raises `ValueError` identically from `find_resonances` and the new `count_resonances`. Wall-clock cost of the generator indirection on the list path: **+1.1% (N=2000), +2.3% (N=3000)**.

### Census of the rest of the linker's CLI output

Asked for one sentence; swept all four arms. `temporal` ("computed in memory, not persisted" — observed zero new files) and `eddies`/`threads` (which report `*_written`, never `*_detected`) are honest and are **not touched**. `vectors_persisted` is populated on the eddies and threads paths too, so the struct is never a lie for a programmatic consumer, but it is not surfaced in their sentences — they make no parquet claim, so there is no false claim to correct, and widening the diff there would buy nothing.

One adjacent lie found and **filed rather than fixed**: `creek/generate/mining.py:108-112` tells the operator that "embeddings.parquet edges do not contribute until they are written as synchronicity notes (run `creek link` to populate)" — same false framing, plus a second claim that `creek link` populates `10-Liminal/Synchronicities/`, which needs its own wiring verification. **#1438** (P2).

Also filed from self-review: **#1441** (P2) — `save_cache` rewrites the parquet in place with no temp-file-plus-rename, so a mid-write failure destroys a good cache. Pre-existing, bounded (a corrupt file forces a clean recompute), and orthogonal to this issue's honesty defect.

### One documentation correction, in the same family

`docs/linking.md:25` said a resonance is emitted when similarity "exceeds" the threshold. The code compares with `>=` and `EmbeddingsConfig.similarity_threshold`'s own docstring says "**Minimum**". A pair sitting exactly on the threshold *does* resonate. Corrected, and now pinned by a test so the doc and the code cannot drift again.

## Test plan

**RED first, proven by running it — not asserted.** Twelve failures, four of them behavioural on observed CLI output rather than a missing symbol:

```
test_link_embeddings_output_phrases_similarity_edges  AssertionError: no cached-vector count in output:
                                                      Embeddings linker: 4 fragment(s) embedded, 6 similarity edge(s) co...
test_link_embeddings_warm_run_reports_zero_vectors_computed
                                                      assert '4 fragment(s) scanned, 4 vector(s) computed,' in '...4 fragment(s) em...'
test_link_embeddings_empty_vault_admits_nothing_was_cached
                                                      assert 'no vectors written to 00-Creek-Meta/embeddings.parquet' in '...'
test_link_embeddings_cache_write_failure_is_admitted  same
test_embedding_pass_requires_an_explicit_persisted_count   Failed: DID NOT RAISE TypeError
```
The remaining seven are `AttributeError` on the new `vectors_persisted` / `count_resonances`, which a new field cannot avoid; the behavioural five are what prove the defect.

**The invariant: the claim is tied to the artifact, not to a string.** `test_link_embeddings_output_phrases_similarity_edges` was strengthened **in place** (its #338/#1303 vocabulary assertions kept verbatim — the accurate wording has to survive the rewording, not be replaced by it), moved onto a seeded vault so a parquet genuinely exists, and now:

- parses the cached count out of the CLI output with a regex and asserts it `== pq.read_table(cache).num_rows` — **derived, never hardcoded**, so growing the fixture cannot make it vacuous;
- asserts `set(table.column_names)` is **exactly** the five vector/freshness columns;
- asserts that *because* there is no edge column, the sentence must not claim edges are cached.

That is a two-way tie: **add an edge column later and the schema assertion fires; claim edge caching without adding the column and the wording assertion fires.** Neither half can move alone. The empty-vault and OSError tests each put `not cache_path.exists()` and the wording assertion **in the same test**, so they cannot be weakened independently — which is exactly how the claim and the artifact drifted apart originally.

**Mutation battery — 12 mutants, 12 killed.** Snapshot-restore by file bytes with hash verification after every mutant, never `git checkout` (that would delete this lane's own uncommitted work). Two mutants initially **survived and are the reason two tests exist**:

| Mutant | Result |
|---|---|
| CLI computed count reverts to `fragment_count` | killed |
| CLI cache clause always positive | killed |
| `scanned` reverts to `embedded` | killed |
| `_persist_cache` reports rows after a failed write | killed |
| `vectors_persisted` aliased to `fragments_embedded` | killed |
| `EmbeddingPass.persisted` gains a default | killed |
| **call site reverts to `find_resonances`** | **survived → new test → killed** |
| **`count_resonances` uses `len(list(...))`** | **survived → new test → killed** |
| exact path emits hierarchy-suppressed pairs | killed |
| `_prepare_scan` loses its `<2 ids` short-circuit | killed |
| topk loses dedup-then-sort | killed |
| threshold `>=` → `>` | **survived → new test → killed** |

The two survivors mattered. Nothing pinned that `_run_embeddings` *calls* `count_resonances` — the entire memory fix could be reverted at the call site with every count still correct — so `test_run_link_embeddings_counts_edges_without_building_them` spies on the `Resonance` constructor through a real `run_link` and asserts zero objects for 15 edges. And `len(list(...))` builds zero `Resonance` objects, so the constructor spy could not see it; `test_count_resonances_peak_memory_does_not_hold_the_edge_set` measures `tracemalloc` peak on a corpus where edges vastly outnumber fragments (**3.3 MB streaming vs 18.3 MB via `list()`**, ceiling set between them with ~2.4x headroom). The threshold survivor was a genuinely untested boundary in code this PR rewrote, now pinned inclusively to match the config docstring.

**Drift alarm.** `count_resonances(...) == len(find_resonances(...))` parametrised over `exact`/`topk` × hierarchy/no-hierarchy, each asserting `len(edges) > 0` first so the property cannot go vacuous at `0 == 0`.

**Gates, all run by me:**
- `./scripts/check-all.sh` → **exit 0**, 12/12 gates, **9687 passed / 5 skipped**, coverage **94.67%**, per-file gate green. The 5 skips are the pre-existing live-API and Ollama smokes; **zero SKIPPED** across every touched test file (asserted with `-rs`).
- Integration lane 357 passed; e2e lane 25 passed.
- `ruff check --no-cache` clean (verified without the cache — a stale one produced a false-clean here in #1119); `ruff format` clean; mypy strict clean; `xenon --max-absolute B --max-modules B --max-average A creek/` exit 0.

**Substituted for `pre-commit run --all-files`, which the issue's acceptance criteria ask for.** It silently edits unrelated files in the worktree — it has stripped the BOM from `tests/fixtures/encoding/utf8_bom.csv` before. `check-all.sh` is the gate here and covers the same ground.

**Anti-bypass sweep over the whole diff:** no `# noqa`, no `# type: ignore`, no `# pylint: disable`, no skip/xfail, no threshold touched in `pyproject.toml` or `scripts/`. Five `# type: ignore` comments the first pass introduced in my own new tests were **removed**, not justified. No test deleted: all 15 deleted lines are one rewritten docstring, the body of the one strengthened-in-place test, one stub constructor gaining `persisted=0`, and two import lines. No duplicate `def test_`/`class Test` names (checked by AST, module level and per class).

**Gate 2.5:** `code-review-orchestrator` over the diff returned **CLEAN, no blockers**. Its one actionable nit was acted on: `_ResonanceScan` is `@dataclass(frozen=True)` holding a numpy array, so the generated `__eq__`/`__hash__` advertised behaviour they could not honour — **verified by execution** (`ValueError: truth value of an array... is ambiguous` and `TypeError: unhashable type`) and fixed with `eq=False`. Its other finding became #1441.

**Not covered, stated rather than glossed:**
- Resonance persistence is not built, deliberately — see the decision above. `generate/synchronicity.py:441` still recomputes; nothing changed there.
- Time complexity is unchanged at O(n²). Only the memory failure is fixed.
- `test_exact_pair_scan_yields_before_finishing_the_traversal` is necessarily white-box (it calls the private `_prepare_scan` and monkeypatches the private `_is_hierarchy_suppressed`) because laziness has no black-box-observable return value; it is coupled to those two names.
- The `tracemalloc` ceiling is absolute. If it ever flakes on a specific interpreter in the 3.11/3.12/3.13 matrix, the fix is a wider ceiling or a relative streaming-vs-list comparison — not weakening the property.

Closes #1337
Refs #1303, #338, #1438, #1441
