### PR TITLE
docs(redact): stop promising a queue and a reversible --apply that never existed

### DIFF
--- a/.claude/skills/creek-walkthrough/stages/02-the-safety-pass.md
+++ b/.claude/skills/creek-walkthrough/stages/02-the-safety-pass.md
@@ -34,21 +34,33 @@ When the scan returns, translate the report gently:
   will be false alarms (a long git hash can look like a key). Walk them
   through what was found, in plain terms, a few examples, not a wall.
 - Explain the next move: applying redaction replaces the sensitive spans
-  with markers like `[REDACTED:api_key]` and keeps a review queue. The
+  with markers like `[REDACTED:api_key]`, rewriting the files in place. The
   original secret is never written into the vault or any log.
 
-## Apply — only with a clear yes
+## Apply — only with a clear yes, and only after a backup
 
 If there were findings and the user wants to proceed, this is the first
-genuinely changing action of the walkthrough. Get an explicit yes. You may
-still run `creek redact --apply` with `--dry-run` first to preview, then
-the real apply. Narrate each step.
+genuinely changing action of the walkthrough — and it is final. `--apply`
+rewrites the source files in place; once it runs, the original text is
+gone, with no undo. Before you get their yes, make sure they know that and
+have a copy of their source material somewhere safe (a copy, a commit,
+a backup — anything that isn't the only copy).
+
+Get an explicit yes. Always run `creek redact --apply` with `--dry-run`
+first and walk them through what it would change, then run the real apply.
+Narrate each step.
 
 ## The word for this stage
 
-**Redaction.** Not deletion — *flagging*. Nothing is silently destroyed;
-sensitive spans are masked and logged for review, and you can restore a
-false alarm later. The creek protects you without erasing you.
+**Redaction.** Not deletion of a fragment — *masking*: matched spans in
+the source files are replaced with markers like `[REDACTED:api_key]`
+before anything is written into the vault. `--scan` is completely safe and
+changes nothing; `--dry-run` lets them preview an apply before it happens;
+and a false alarm is best fixed *before* applying, by adding it to
+`false_positive_allowlist` and re-scanning. But once `--apply` runs on a
+file, that change is final — there is no queue and no restore. The creek
+protects you, but it does not keep a copy of the water it already
+carried, so a backup is the user's job, not the tool's.
 
 ## Check in
 

--- a/creek-tools/CHANGELOG.md
+++ b/creek-tools/CHANGELOG.md
@@ -65,6 +65,18 @@ to locate the originating commit for any reference below.
 
 ### Removed
 
+- **Four report surfaces on the redaction classes, none of which had a
+  production caller** (#1338): `RedactionScanner.scan_directory`,
+  `.generate_report`, `.generate_json_report`, and
+  `Redactor.log_redactions`. Every shipped read path — `creek redact
+  --scan/--apply/--review`, the `creek.redact.scan` MCP tool, and
+  `creek process` — reaches the scanner through `scan_batch`, and the
+  console report through `generate_markdown_summary`. Deleting
+  `log_redactions` also retires the only code that wrote the session
+  salt to disk in cleartext beside the hashes it exists to protect.
+  There is no longer a JSON report surface; the typed statistics
+  contract on the MCP tool is unaffected (see #1292).
+
 - The repo no longer ships empty placeholder directories for
   `01-Fragments/` … `10-Liminal/` or `00-Creek-Meta/`. User vault
   content lives outside this repository (default suggested location:
@@ -72,6 +84,30 @@ to locate the originating commit for any reference below.
 
 ### Fixed
 
+- **The redaction docs promised a queue that has never existed and an
+  `--apply` that is reversible; neither was true** (#1338). On a
+  redaction tool the docs are the operator's contract, and the most
+  dangerous line — "applying is reversible if you keep the queue
+  around" — invited an unrecoverable in-place rewrite of an
+  irreplaceable export with no backup. Corrected against executed
+  behaviour: `--scan` writes **no files at all** (`--report` prints to
+  the console; the dot-directory and JSON queue the docs named under
+  `<source>` were never created by any code path), `--apply` re-scans
+  from scratch and rewrites matching
+  files **in place with no undo**, and `--review` lists **every**
+  finding rather than filtering on a `pending_review` marker — nothing
+  in the codebase reads that key. `docs/redaction.md` gains an explicit
+  back-up-first warning covering the parts that are worse than merely
+  irreversible: structured `.yaml`/`.json` files are in scope, and a
+  vault-wide run still rewrites `creek_config.yaml` (#1398, not fixed
+  here). The sample report table no longer shows an `Excerpt` column of
+  secret text, which contradicted the module's own never-store
+  invariant. Also corrected: the previous `#1398` note claimed
+  `false_positive_allowlist` entries get redacted — they are
+  exact-string exempt and are the one value in that file the rewrite
+  cannot touch; the real hazard is `exclude_patterns`, custom
+  `patterns`, paths and comments. Two new suites pin the prose to
+  behaviour so it cannot drift back.
 - **The drift guard that refuses to overwrite a hand-edited skill file
   now covers medium contracts too, not just schema skills, and it now
   lives inside the shared deployment primitive itself** (#1306).

--- a/creek-tools/README.md
+++ b/creek-tools/README.md
@@ -60,7 +60,7 @@ creek init --vault ~/Obsidian/Creek-Vault
 # 1. Scan for secrets before anything else.
 creek redact --scan --source ~/exports --report
 
-# 2. Apply redactions (writes a queue under <source>/.creek-redactions/).
+# 2. Apply redactions (rewrites source files in place — no undo; back up first).
 creek redact --apply --source ~/exports --dry-run    # preview
 creek redact --apply --source ~/exports              # commit
 
@@ -94,8 +94,8 @@ Every command is also documented under [`docs/`](docs/) with end-to-end examples
 
 | Command | Purpose | Doc |
 |---------|---------|-----|
-| `creek redact --scan`   | Scan a source for secrets, API keys, and PII. Writes a structured report. | [redaction](docs/redaction.md) |
-| `creek redact --apply`  | Apply queued redactions to source files. Supports `--dry-run` and `--yes`. | [redaction](docs/redaction.md) |
+| `creek redact --scan`   | Scan a source for secrets, API keys, and PII. Prints a report; writes no files. | [redaction](docs/redaction.md) |
+| `creek redact --apply`  | Re-scan and rewrite matches in source files in place. No undo. Supports `--dry-run` and `--yes`. | [redaction](docs/redaction.md) |
 | `creek redact --review` | Render the review queue for a vault. | [redaction](docs/redaction.md) |
 | `creek purge fragment`  | Delete a fragment and scrub every reference (right-to-be-forgotten). | [cleaning-and-purge](docs/cleaning-and-purge.md) |
 | `creek purge source`    | Delete every fragment ingested from a given source. | [cleaning-and-purge](docs/cleaning-and-purge.md) |

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -2197,7 +2197,7 @@ def redact(
         False, "--apply", help="Apply redactions to matched files"
     ),
     review: bool = typer.Option(
-        False, "--review", help="Render the review queue for a vault"
+        False, "--review", help="Re-scan a vault and render its review queue"
     ),
     source: Path | None = typer.Option(
         None, "--source", help="Source path (scan/apply)"
@@ -2220,7 +2220,7 @@ def redact(
         False, "--yes", "-y", help="Skip the confirmation prompt (apply)"
     ),
 ) -> None:
-    """Scan for sensitive data, apply redactions, or review the queue.
+    """Scan for sensitive data, apply redactions, or review a vault.
 
     Exactly one of ``--scan``, ``--apply``, or ``--review`` must be given.
     """

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -412,7 +412,7 @@ class OCRConfig(BaseModel):
     """Tesseract language codes for OCR."""
 
     min_confidence: float = Field(default=0.6, ge=0.0, le=1.0)
-    """Minimum OCR confidence below which a fragment lands in the review queue.
+    """Minimum OCR confidence below which a fragment is tagged in frontmatter.
 
     Image and scanned-PDF ingestors compare the per-page confidence
     reported by the engine to this threshold; a fragment whose OCR

--- a/creek-tools/creek/ingest/images.py
+++ b/creek-tools/creek/ingest/images.py
@@ -404,8 +404,11 @@ class ImageIngestor(Ingestor):
                 can reconcile per-fragment language with the engine
                 that produced them.
             min_confidence: OCR-confidence threshold below which a
-                produced fragment is tagged for the review queue. Mirrors
-                :pyattr:`creek.config.OCRConfig.min_confidence`.
+                produced fragment is tagged ``review: pending_review`` in
+                its frontmatter. The tag is a marker for a human reader;
+                no command filters on it — in particular ``creek redact
+                --review`` selects by findings, not by this key (#1338).
+                Mirrors :pyattr:`creek.config.OCRConfig.min_confidence`.
         """
         self.engine = engine if engine is not None else PytesseractOcrEngine(language)
         self.language = language

--- a/creek-tools/creek/redact/redactor.py
+++ b/creek-tools/creek/redact/redactor.py
@@ -1,4 +1,4 @@
-"""Redactor — replace sensitive data with safe markers and log redactions.
+"""Redactor — replace sensitive data with safe markers.
 
 The :class:`Redactor` re-scans content to locate match positions (since
 :class:`RedactionMatch` intentionally does **not** store the matched text)
@@ -43,22 +43,16 @@ token shape rather than on a reported finding. That asymmetry is
 deliberate, fail-closed behaviour — a missed secret is unrecoverable
 once written, whereas over-redaction is visible in the output and
 fixable via ``false_positive_allowlist``.
-
-Redaction logs are written as JSON with a session salt in the header so
-that hashes can be correlated within a session but not reversed.
 """
 
-import json
 import re
-from pathlib import Path
-from typing import Any, NamedTuple
+from typing import NamedTuple
 
 from creek.config import RedactionConfig
 from creek.redact.patterns import PATTERN_METADATA, REDACTION_PATTERNS
 from creek.redact.scanner import (
     HIGH_ENTROPY_CANDIDATE,
     HIGH_ENTROPY_PATTERN_NAME,
-    RedactionMatch,
     entropy_threshold,
     has_high_entropy_region,
     post_validate,
@@ -212,7 +206,7 @@ def _select_marker_name(contributors: list[_Span]) -> str:
 
 
 class Redactor:
-    """Replace sensitive data in text and log redactions.
+    """Replace sensitive data in text with safe markers.
 
     Because :class:`RedactionMatch` never stores matched text, the
     redactor must re-scan content using the same patterns to locate
@@ -221,7 +215,8 @@ class Redactor:
     Args:
         config: Redaction configuration (allowlist, custom patterns).
         salt: The session salt used by the scanner that produced the
-            matches — stored in the log header for correlation.
+            matches, kept on the instance so hashes from that same
+            scan session can be correlated.
     """
 
     def __init__(self, config: RedactionConfig, salt: bytes) -> None:
@@ -489,34 +484,3 @@ class Redactor:
                 )
             )
         return spans
-
-    def log_redactions(
-        self,
-        matches: list[RedactionMatch],
-        log_path: Path,
-    ) -> None:
-        """Write redaction matches to a JSON log file.
-
-        If the log file already exists, appends to the ``entries`` list.
-        The log header includes the hex-encoded session salt so hashes
-        can be correlated within the same scan session.
-
-        Args:
-            matches: List of redaction matches to log.
-            log_path: Path to the JSON log file.
-        """
-        data: dict[str, Any]
-        entries: list[Any]
-
-        if log_path.exists():
-            data = json.loads(log_path.read_text())
-            entries = list(data.get("entries", []))
-        else:
-            data = {"salt_hex": self.salt.hex()}
-            entries = []
-
-        for match in matches:
-            entries.append(match.model_dump(mode="json"))
-
-        data["entries"] = entries
-        log_path.write_text(json.dumps(data, indent=2))

--- a/creek-tools/creek/redact/scanner.py
+++ b/creek-tools/creek/redact/scanner.py
@@ -14,7 +14,6 @@ Enhanced features (Issue #14):
 - File extension filtering
 - Configurable directory exclusion patterns
 - Progress bar via tqdm during directory scans
-- JSON report generation with match metadata
 - Markdown summary grouped by file and severity
 - Review queue with context for human review
 """
@@ -22,7 +21,6 @@ Enhanced features (Issue #14):
 from __future__ import annotations
 
 import hashlib
-import json
 import logging
 import math
 import os
@@ -69,6 +67,15 @@ _UNREAD_FILES_CAVEAT = (
 
 A clean result reached by *not looking* reads identically to a clean tree,
 which is the one place a silent skip in a safety scanner does real harm.
+"""
+
+FINDINGS_TABLE_HEADER = "| Line | Type | Severity |"
+"""Column header of the per-file findings table in the markdown summary.
+
+Exported rather than spelled twice: the table
+:meth:`RedactionScanner.generate_markdown_summary` renders and the copy
+of it quoted in ``docs/redaction.md`` are the same table, and two
+literals are how the two surfaces drift apart.
 """
 
 HIGH_ENTROPY_PATTERN_NAME = "high_entropy_string"
@@ -378,30 +385,6 @@ class RedactionScanner:
             )
         return results
 
-    def scan_directory(
-        self,
-        dir_path: Path,
-        *,
-        progress: bool = False,
-    ) -> list[RedactionMatch]:
-        """Recursively scan all files in a directory for sensitive data.
-
-        Skips binary files and files with unsupported extensions.
-        Respects exclusion patterns from configuration.
-
-        Args:
-            dir_path: Path to the directory to scan.
-            progress: If ``True``, display a tqdm progress bar.
-
-        Returns:
-            Aggregated list of :class:`RedactionMatch` objects.
-
-        Raises:
-            FileNotFoundError: If *dir_path* does not exist.
-        """
-        summary = self.scan_batch(dir_path, progress=progress)
-        return summary.matches
-
     def scan_batch(
         self,
         dir_path: Path,
@@ -476,43 +459,6 @@ class RedactionScanner:
             files_skipped_symlink=files_skipped_symlink,
         )
 
-    def generate_report(self, matches: list[RedactionMatch]) -> str:
-        """Generate a human-readable report from a list of matches.
-
-        Args:
-            matches: Redaction matches to summarise.
-
-        Returns:
-            Multi-line string report suitable for console output.
-        """
-        if not matches:
-            return "Redaction scan complete: 0 findings."
-
-        lines: list[str] = [
-            f"Redaction scan complete: {len(matches)} finding(s).",
-            "",
-        ]
-
-        by_type: dict[str, int] = {}
-        by_file: dict[str, list[RedactionMatch]] = {}
-
-        for match in matches:
-            by_type[match.match_type] = by_type.get(match.match_type, 0) + 1
-            file_key = str(match.file_path)
-            by_file.setdefault(file_key, []).append(match)
-
-        lines.append("By type:")
-        for match_type, count in sorted(by_type.items()):
-            lines.append(f"  {match_type}: {count}")
-
-        lines.extend(("", "By file:"))
-        for file_key, file_matches in sorted(by_file.items()):
-            lines.append(f"  {file_key}:")
-            for fm in file_matches:
-                lines.append(f"    line {fm.line_number}: {fm.match_type}")
-
-        return "\n".join(lines)
-
     @staticmethod
     def extract_context(
         file_path: Path,
@@ -542,55 +488,6 @@ class RedactionScanner:
         start = max(0, line_number - 1 - window)
         end = min(len(all_lines), line_number + window)
         return all_lines[start:end]
-
-    def generate_json_report(
-        self,
-        summary: ScanSummary,
-        output_path: Path,
-    ) -> None:
-        """Write a structured JSON report to *output_path*.
-
-        The report contains scan statistics and match details grouped
-        by file and sorted by severity.
-
-        Args:
-            summary: The scan summary to serialise.
-            output_path: Destination file path for the JSON report.
-        """
-        by_file: dict[str, list[dict[str, object]]] = defaultdict(list)
-
-        for match in summary.matches:
-            severity = _get_severity(match.match_type)
-            by_file[str(match.file_path)].append(
-                {
-                    "line_number": match.line_number,
-                    "match_type": match.match_type,
-                    "severity": severity,
-                    "salted_hash": match.salted_hash,
-                }
-            )
-
-        # Sort each file's matches by severity rank.
-        for file_matches in by_file.values():
-            file_matches.sort(key=lambda m: _severity_rank(str(m["severity"])))
-
-        report: dict[str, object] = {
-            "scan_statistics": {
-                "files_scanned": summary.files_scanned,
-                "files_skipped_binary": summary.files_skipped_binary,
-                "files_skipped_extension": summary.files_skipped_extension,
-                "total_findings": len(summary.matches),
-                "by_severity": _count_by_severity(summary.matches),
-                "by_type": _count_by_type(summary.matches),
-            },
-            "findings_by_file": dict(by_file),  # noqa: FURB123  # converts defaultdict to plain dict for JSON-serialised output.
-        }
-
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_text(
-            json.dumps(report, indent=2, default=str) + "\n",
-            encoding="utf-8",
-        )
 
     def generate_markdown_summary(self, summary: ScanSummary) -> str:
         """Generate a human-readable markdown summary of scan results.
@@ -644,7 +541,7 @@ class RedactionScanner:
                 (
                     f"### `{file_key}`",
                     "",
-                    "| Line | Type | Severity |",
+                    FINDINGS_TABLE_HEADER,
                     "|------|------|----------|",
                 )
             )
@@ -1106,19 +1003,4 @@ def _count_by_severity(matches: list[RedactionMatch]) -> dict[str, int]:
     for match in matches:
         sev = _get_severity(match.match_type)
         counts[sev] = counts.get(sev, 0) + 1
-    return counts
-
-
-def _count_by_type(matches: list[RedactionMatch]) -> dict[str, int]:
-    """Count matches grouped by pattern type.
-
-    Args:
-        matches: List of redaction matches.
-
-    Returns:
-        Dictionary mapping match type to count.
-    """
-    counts: dict[str, int] = {}
-    for match in matches:
-        counts[match.match_type] = counts.get(match.match_type, 0) + 1
     return counts

--- a/creek-tools/docs/README.md
+++ b/creek-tools/docs/README.md
@@ -6,7 +6,7 @@ Task-oriented how-to guides for the `creek-tools` pipeline. The top-level [`cree
 |-------|-----------------|
 | [getting-started.md](getting-started.md) | First time running `creek`. Walks you from a clean Obsidian vault to a fully indexed pipeline run. |
 | [ingestion.md](ingestion.md) | Picking the right `--type` for each export. Lists the 12 ingestors and their file formats. |
-| [redaction.md](redaction.md) | Scanning for secrets/PII before ingestion, applying redactions, and reviewing the queue. |
+| [redaction.md](redaction.md) | Scanning for secrets/PII before ingestion, applying redactions in place, and rendering the vault-wide review queue. |
 | [classification.md](classification.md) | Rule-based vs LLM classification, frequency / phase / privacy-tier tagging, and the review queue. |
 | [linking.md](linking.md) | Resonances (embeddings), threads (temporal), eddies (density), and how to read the resulting graph. |
 | [generation.md](generation.md) | Voice Skill Tree, idea mining, draft generation, and wavelength reports. |

--- a/creek-tools/docs/configuration.md
+++ b/creek-tools/docs/configuration.md
@@ -102,7 +102,7 @@ ocr:
 | `enabled`        | `true`         | If `false`, `creek ingest --type images` will skip OCR. |
 | `engine`         | `pytesseract`  | Engine name. (Custom engines are injected at the API level — see `creek.ingest.images.OcrEngine`.) |
 | `languages`      | `[eng]`        | Tesseract language codes. |
-| `min_confidence` | `0.6`          | Per-page OCR confidence below which the resulting fragment is tagged `review: pending_review` in frontmatter and surfaced by `creek redact --review`. Range `[0.0, 1.0]`. |
+| `min_confidence` | `0.6`          | Per-page OCR confidence below which the resulting fragment is tagged `review: pending_review` in frontmatter, as a marker for a human — no command currently filters on this key. Range `[0.0, 1.0]`. |
 
 ## `linking` — resonance / thread / eddy thresholds
 

--- a/creek-tools/docs/redaction.md
+++ b/creek-tools/docs/redaction.md
@@ -10,25 +10,23 @@ This page covers the `creek redact` CLI. For the read-only MCP tool version of t
 
 `creek redact` is dispatched by exactly one of `--scan`, `--apply`, or `--review`. Mixing them is an error.
 
-| Mode      | Reads from        | Writes to                          | Purpose |
-|-----------|-------------------|------------------------------------|---------|
-| `--scan`  | `--source`        | `<source>/.creek-redactions/queue.json` (+ optional `report.md`) | Find sensitive content. |
-| `--apply` | the queue         | the source files (and the queue)   | Replace matches with placeholders. |
-| `--review`| `--vault`         | stdout                             | Render the vault's review queue. |
+| Mode      | Reads from              | Writes to                                       | Purpose |
+|-----------|--------------------------|-------------------------------------------------|---------|
+| `--scan`  | `--source`               | nothing — `--report` prints to the console      | Find sensitive content. |
+| `--apply` | `--source` (re-scanned)  | the source files, in place, plus the audit log  | Replace matches with placeholders. |
+| `--review`| `--vault`                | stdout                                          | Render the vault's review queue. |
 
 ## Workflow
 
 ```bash
-# 1. Scan the export.
+# 1. Scan the export; --report prints a markdown summary to the console.
 creek redact --scan --source ~/exports/journal --report
 
-# 2. Read the report.
-$EDITOR ~/exports/journal/.creek-redactions/report.md
-
-# 3. Preview what would change.
+# 2. Preview what --apply would change, without touching anything.
 creek redact --apply --source ~/exports/journal --dry-run
 
-# 4. Commit the changes (skips confirmation with -y).
+# 3. Commit the changes (skips confirmation with -y). Back up first — see
+#    the warning under "What `--apply` does" below.
 creek redact --apply --source ~/exports/journal -y
 ```
 
@@ -56,7 +54,7 @@ Configuration in `RedactionConfig`:
 | Field                       | Effect |
 |-----------------------------|--------|
 | `enabled`                   | Master switch. |
-| `dry_run`                   | When `true`, `--apply` plans but doesn't write. |
+| `dry_run`                   | When `true`, `--apply` plans but never modifies a source file. It still appends dry-run-marked entries to the audit log. |
 | `custom_patterns`           | Extra regex name → pattern map merged with built-ins. |
 | `false_positive_allowlist`  | Strings whose presence cancels a match (test fixtures, sample keys). |
 | `supported_extensions`      | File extensions the scanner walks. |
@@ -64,24 +62,56 @@ Configuration in `RedactionConfig`:
 | `min_confidence`            | Generic high-entropy threshold; `0.0` flags any base64url-ish ≥20 chars, `1.0` requires near-random. Default `0.6` (3.7 bits/char), governing both the whole-run and the sub-run window gate — see [What `--apply` does](#what---apply-does). |
 | `replacement_template`      | Marker template used by `--apply`; must contain `{name}`. Default `[REDACTED:{name}]`. |
 
-## Output formats
+## What the report looks like
 
-`--scan --report` produces a markdown report with one section per file:
+`--scan --report` renders a markdown summary to the console — it writes no
+files anywhere. One table per file:
 
 ```markdown
 ## /journals/2026-04-12.md
 
-| Line | Pattern        | Excerpt           |
-|------|----------------|-------------------|
-|   42 | aws_access_key | AKIAIOSFODNN7…    |
-|   88 | email          | sgsg@example.com  |
+| Line | Type           | Severity |
+|------|----------------|----------|
+|   42 | aws_access_key | critical |
+|   88 | email          | medium   |
 ```
 
-The structured queue at `<source>/.creek-redactions/queue.json` is what `--apply` actually consumes. It records the offset, the pattern that matched, and the replacement string — so applying is reversible if you keep the queue around.
+The table never shows the matched text — only the line number, the pattern
+name, and its severity. This is deliberate, and it follows from the scanner's
+core invariant: a finding carries a salted SHA-256 hash of what matched, never
+the text, so this report has no matched content available to print.
+
+That invariant is about what the scanner *stores*. It is not a promise that no
+Creek command ever puts a secret on your screen: `--review` deliberately quotes
+the surrounding source lines — see [Reviewing inside the vault](#reviewing-inside-the-vault).
 
 ## What `--apply` does
 
-For every queued match:
+### `--apply` rewrites your files in place, and there is no undo
+
+`--apply` does not consume anything `--scan` left behind — there is nothing
+to consume. It re-scans the source from scratch and rewrites every matching
+file in place, replacing each matched span with the marker. There is no
+queue, no `.bak`, and no restore path: the original bytes are gone once the
+write lands. The audit trail at `<vault>/00-Creek-Meta/audit/redact.jsonl`
+records *that* a file was rewritten and which pattern names fired — never
+the original text, never an offset — so it is a forensic record, not an
+undo log.
+
+**Back up your source tree before you run `--apply`.** Copy it, commit it,
+or run `--dry-run` first and read the output — but assume the run is
+final.
+
+It rewrites more than fragment bodies. Every file whose extension is in
+`supported_extensions` is in scope, including structured `.yaml` and
+`.json` files, where a replacement marker can leave the file invalid or
+quietly change its meaning. In particular, a vault-wide `--apply` still
+rewrites `<vault>/00-Creek-Meta/creek_config.yaml` — an open bug, **tracked
+in #1398 and not fixed**. Only `00-Creek-Meta/audit/` and the legacy purge
+log are excluded unconditionally. Point `--source` at the narrowest tree
+that needs cleaning rather than at a whole vault.
+
+For every match found by the scan:
 
 1. Replaces the match with the marker rendered from
    `RedactionConfig.replacement_template` (default `[REDACTED:{name}]`;
@@ -109,8 +139,7 @@ For every queued match:
    #909). Strings on `false_positive_allowlist` are exempt from this
    widening — a regex match inside such a string still redacts only its
    own span.
-2. Marks the queue entry as `applied: true` and stamps the timestamp.
-3. Refuses to write through symlinks (path-traversal guard): before any
+2. Refuses to write through symlinks (path-traversal guard): before any
    file is read or rewritten the source tree is walked and the run is
    aborted if any descendant symlink resolves outside the source root.
    The same guard is applied to `creek redact --review`.
@@ -141,11 +170,15 @@ runs of 40+ characters, which measured a **0%** detection rate for a
 full 20-character secret hidden behind a 12–19 character masker — a
 constructible, total, silent leak.
 
-`--dry-run` walks the queue without modifying any source file — useful for sanity-checking a big batch before committing.
+`--dry-run` performs the same scan and shows what would change, without modifying any source file — useful for sanity-checking a big batch before committing. It does still write dry-run-marked audit entries; see [the audit trail](#the-audit-trail).
 
 ## Reviewing inside the vault
 
-Once a fragment has landed in the vault, the source-side queue is no longer the right tool. Use `creek redact --review --vault <path>` to print every fragment whose `redaction.status` is `pending_review` (typically because a match landed in non-redactable content like image OCR text and needs a human decision).
+Once a fragment has landed in the vault, use `creek redact --review --vault <path>` to re-scan the whole tree and render a **Redaction Review Queue** — every finding, with surrounding context and a checkbox, so a human can triage true positives from false alarms. It is not filtered by any frontmatter field; it lists everything the scan turns up, every time you run it. Nothing is written: the queue is printed to stdout and is gone when your terminal scrollback is.
+
+The context block quotes the file's own lines **verbatim**, which means it prints the matched secret in cleartext. That is the point — you cannot tell a real key from a git hash without seeing it — but it makes `--review` output unsafe to paste into a ticket, a chat, or an LLM prompt without reading it first.
+
+OCR ingestion (`creek/ingest/images.py`) separately tags a low-confidence fragment `review: pending_review` in its frontmatter as a marker for humans. No command reads or filters on that key — it is informational only, not a queue.
 
 ## Right-to-be-forgotten
 
@@ -229,12 +262,16 @@ Two known residuals:
   now protected. Rewriting a hash-chained log needs a chain-aware operation —
   that is purge-shaped work, tracked in #1397.
 - `<vault>/00-Creek-Meta/creek_config.yaml` **is** still rewritten by a
-  vault-wide apply, which can redact your own `false_positive_allowlist`
-  entries. Tracked in #1398.
-
-There is also a second, unrelated redaction log: `Redactor.log_redactions`
-writes an unchained file with `write_text`. It has no production caller and is
-not the audit trail; do not confuse the two.
+  vault-wide apply. The `false_positive_allowlist` entries themselves are
+  safe — the allowlist check is exact-string membership, so an allowlisted
+  string is the one class of value the rewrite cannot touch. The hazard is
+  everything *else* in the file: `exclude_patterns` tokens, custom
+  `patterns`, paths, and comments are all in scope and can be replaced
+  with `[REDACTED:…]` markers, silently changing the config's meaning or
+  breaking its YAML. Concretely, an `exclude_patterns` entry like
+  `backups-AKIAIOSFODNN7EXAMPLE` becomes
+  `[REDACTED:high_entropy_string]`. Tracked in #1398, not fixed by this
+  change.
 
 ## How `creek process` interacts with redaction
 

--- a/creek-tools/tests/test_pipeline.py
+++ b/creek-tools/tests/test_pipeline.py
@@ -273,11 +273,14 @@ class TestPipelineStages:
 
         Retargeted from ``scan_directory`` to ``scan_batch`` by #1087: the
         pipeline needs the full :class:`~creek.redact.scanner.ScanSummary` so
-        it can see ``files_skipped_symlink``, and ``scan_directory`` throws
-        the counters away. The assertion is unchanged in strength — with
-        redaction disabled the scanner must not be entered at all, and
-        ``scan_directory`` delegates to ``scan_batch``, so patching the
-        deeper call still catches a caller that went round the front door.
+        it can see ``files_skipped_symlink``, and the old wrapper threw the
+        counters away. The assertion is unchanged in strength — with
+        redaction disabled the scanner must not be entered at all.
+
+        #1338 then deleted that wrapper outright: it had no production
+        caller left once every read path had moved to ``scan_batch``, so
+        ``scan_batch`` is now the scanner's only directory entry point and
+        patching it cannot be gone round.
         """
         config = CreekConfig()
         config.redaction.enabled = False
@@ -291,8 +294,9 @@ class TestPipelineStages:
     def test_redaction_enabled_scans_directory(self, vault_path, source_path):
         """Test that redaction scanner is called when enabled.
 
-        Retargeted from ``scan_directory`` to ``scan_batch`` by #1087, for the
-        reason given on ``test_redaction_disabled``. The stand-in is a real
+        Retargeted from the deleted ``scan_directory`` wrapper to
+        ``scan_batch`` by #1087, for the reason given on
+        ``test_redaction_disabled``. The stand-in is a real
         ``ScanSummary`` rather than a ``MagicMock`` deliberately: the pipeline
         now reads ``summary.files_skipped_symlink`` off the result, and a
         ``MagicMock`` answers every attribute with a truthy object — which

--- a/creek-tools/tests/test_redact.py
+++ b/creek-tools/tests/test_redact.py
@@ -3,8 +3,8 @@
 Tests cover:
 - REDACTION_PATTERNS compilation and matching
 - RedactionMatch model (must NOT store matched text, only salted hashes)
-- RedactionScanner: scan_file, scan_directory, generate_report
-- Redactor: redact_content, log_redactions
+- RedactionScanner: scan_file, scan_batch, generate_markdown_summary
+- Redactor: redact_content
 - False positive allowlisting
 - Custom pattern support
 - Security: ensure sensitive data never leaks into match objects
@@ -12,7 +12,6 @@ Tests cover:
 - File extension filtering (Issue #14)
 - Directory exclusion patterns (Issue #14)
 - Context extraction (Issue #14)
-- JSON report generation (Issue #14)
 - Markdown summary (Issue #14)
 - Review queue generation (Issue #14)
 - Batch scanning with ScanSummary (Issue #14)
@@ -324,38 +323,6 @@ class TestRedactionScanner:
         assert ssn_match.line_number == 3
         assert email_match.line_number == 5
 
-    def test_scan_directory(self, tmp_path: Path) -> None:
-        """scan_directory should recursively scan all files."""
-        sub = tmp_path / "sub"
-        sub.mkdir()
-
-        (tmp_path / "file1.txt").write_text("SSN: 123-45-6789\n")
-        (sub / "file2.txt").write_text("email: test@example.com\n")
-
-        config = RedactionConfig()
-        scanner = RedactionScanner(config=config)
-        matches = scanner.scan_directory(tmp_path)
-
-        match_types = {m.match_type for m in matches}
-        assert "ssn" in match_types
-        assert "email" in match_types
-        assert len(matches) >= 2
-
-    def test_scan_directory_empty(self, tmp_path: Path) -> None:
-        """scan_directory on empty directory should return empty list."""
-        config = RedactionConfig()
-        scanner = RedactionScanner(config=config)
-        matches = scanner.scan_directory(tmp_path)
-        assert matches == []
-
-    def test_scan_directory_nonexistent(self) -> None:
-        """scan_directory should raise FileNotFoundError for missing directory."""
-        config = RedactionConfig()
-        scanner = RedactionScanner(config=config)
-
-        with pytest.raises(FileNotFoundError):
-            scanner.scan_directory(Path("/nonexistent/directory"))
-
     def test_false_positive_allowlist(self, tmp_path: Path) -> None:
         """Matches in the false_positive_allowlist should be excluded."""
         test_file = tmp_path / "allowed.txt"
@@ -392,49 +359,6 @@ class TestRedactionScanner:
         scanner = RedactionScanner(config=config)
         assert isinstance(scanner.salt, bytes)
         assert len(scanner.salt) == 16
-
-
-# ---------------------------------------------------------------------------
-# RedactionScanner.generate_report
-# ---------------------------------------------------------------------------
-
-
-class TestGenerateReport:
-    """Tests for RedactionScanner.generate_report."""
-
-    def test_report_empty_matches(self) -> None:
-        """Report for empty matches should indicate no findings."""
-        config = RedactionConfig()
-        scanner = RedactionScanner(config=config)
-        report = scanner.generate_report([])
-        assert "no" in report.lower() or "0" in report
-
-    def test_report_with_matches(self, tmp_path: Path) -> None:
-        """Report should include match count and types."""
-        test_file = tmp_path / "report.txt"
-        test_file.write_text("SSN: 123-45-6789\nemail: test@example.com\n")
-
-        config = RedactionConfig()
-        scanner = RedactionScanner(config=config)
-        matches = scanner.scan_file(test_file)
-        report = scanner.generate_report(matches)
-
-        assert "ssn" in report.lower()
-        assert "email" in report.lower()
-        assert isinstance(report, str)
-        assert len(report) > 0
-
-    def test_report_contains_file_paths(self, tmp_path: Path) -> None:
-        """Report should reference the file paths where matches were found."""
-        test_file = tmp_path / "report_file.txt"
-        test_file.write_text("SSN: 123-45-6789\n")
-
-        config = RedactionConfig()
-        scanner = RedactionScanner(config=config)
-        matches = scanner.scan_file(test_file)
-        report = scanner.generate_report(matches)
-
-        assert "report_file.txt" in report
 
 
 # ---------------------------------------------------------------------------
@@ -549,81 +473,6 @@ class TestRedactor:
 
         assert "4111-1111-1111-1111" not in result
         assert "[REDACTED:credit_card]" in result
-
-    def test_log_redactions_creates_file(self, tmp_path: Path) -> None:
-        """log_redactions should create or append to the log file."""
-        config = RedactionConfig()
-        scanner = RedactionScanner(config=config)
-        redactor = Redactor(config=config, salt=scanner.salt)
-
-        log_path = tmp_path / "redactions.json"
-
-        matches = [
-            RedactionMatch(
-                file_path=Path("test.txt"),
-                line_number=1,
-                match_type="ssn",
-                salted_hash="abc123",
-            ),
-        ]
-
-        redactor.log_redactions(matches, log_path)
-        assert log_path.exists()
-
-        data = json.loads(log_path.read_text())
-        assert isinstance(data, dict)
-        assert "salt_hex" in data
-        assert "entries" in data
-        assert len(data["entries"]) == 1
-        assert data["entries"][0]["match_type"] == "ssn"
-
-    def test_log_redactions_appends(self, tmp_path: Path) -> None:
-        """Calling log_redactions twice should append, not overwrite."""
-        config = RedactionConfig()
-        scanner = RedactionScanner(config=config)
-        redactor = Redactor(config=config, salt=scanner.salt)
-
-        log_path = tmp_path / "redactions.json"
-
-        matches1 = [
-            RedactionMatch(
-                file_path=Path("a.txt"),
-                line_number=1,
-                match_type="ssn",
-                salted_hash="hash1",
-            ),
-        ]
-        matches2 = [
-            RedactionMatch(
-                file_path=Path("b.txt"),
-                line_number=2,
-                match_type="email",
-                salted_hash="hash2",
-            ),
-        ]
-
-        redactor.log_redactions(matches1, log_path)
-        redactor.log_redactions(matches2, log_path)
-
-        data = json.loads(log_path.read_text())
-        assert len(data["entries"]) == 2
-
-    def test_log_redactions_no_sensitive_data(self, tmp_path: Path) -> None:
-        """Log file must NOT contain any actual sensitive data."""
-        test_file = tmp_path / "pii.txt"
-        sensitive = "123-45-6789"
-        test_file.write_text(f"SSN: {sensitive}\n")
-
-        config = RedactionConfig()
-        scanner = RedactionScanner(config=config)
-        matches = scanner.scan_file(test_file)
-
-        redactor = Redactor(config=config, salt=scanner.salt)
-        log_path = tmp_path / "redactions.json"
-        redactor.log_redactions(matches, log_path)
-
-        log_content = log_path.read_text()
-        assert sensitive not in log_content
 
 
 # ---------------------------------------------------------------------------
@@ -1063,8 +912,8 @@ class TestBinaryDetection:
         """is_binary should return False for nonexistent files."""
         assert not RedactionScanner.is_binary(tmp_path / "no_such_file")
 
-    def test_scan_directory_skips_binary(self, tmp_path: Path) -> None:
-        """scan_directory should skip binary files with supported extensions."""
+    def test_scan_batch_skips_binary(self, tmp_path: Path) -> None:
+        """scan_batch should skip binary files with supported extensions."""
         (tmp_path / "data.txt").write_text("SSN: 123-45-6789\n")
         # Use a supported extension (.txt) with binary content
         binary_file = tmp_path / "binary.txt"
@@ -1284,20 +1133,6 @@ class TestScanSummary:
         assert summary.files_skipped_extension == 0
         assert summary.matches == []
 
-    def test_scan_directory_delegates_to_scan_batch(self, tmp_path: Path) -> None:
-        """scan_directory should return the same matches as scan_batch."""
-        (tmp_path / "data.txt").write_text("SSN: 123-45-6789\n")
-
-        config = RedactionConfig()
-        scanner = RedactionScanner(config=config)
-
-        dir_matches = scanner.scan_directory(tmp_path)
-        # Re-create scanner to reset salt (hashes will differ), but check counts
-        scanner2 = RedactionScanner(config=config)
-        summary = scanner2.scan_batch(tmp_path)
-
-        assert len(dir_matches) == len(summary.matches)
-
 
 # ---------------------------------------------------------------------------
 # Progress Bar (Issue #14)
@@ -1306,16 +1141,6 @@ class TestScanSummary:
 
 class TestProgressBar:
     """Tests for tqdm progress bar during scanning."""
-
-    def test_scan_directory_with_progress(self, tmp_path: Path) -> None:
-        """scan_directory with progress=True should not raise."""
-        (tmp_path / "data.txt").write_text("SSN: 123-45-6789\n")
-
-        config = RedactionConfig()
-        scanner = RedactionScanner(config=config)
-        matches = scanner.scan_directory(tmp_path, progress=True)
-
-        assert len(matches) >= 1
 
     def test_scan_batch_with_progress(self, tmp_path: Path) -> None:
         """scan_batch with progress=True should not raise."""
@@ -1326,116 +1151,6 @@ class TestProgressBar:
         summary = scanner.scan_batch(tmp_path, progress=True)
 
         assert summary.files_scanned >= 1
-
-
-# ---------------------------------------------------------------------------
-# JSON Report Generation (Issue #14)
-# ---------------------------------------------------------------------------
-
-
-class TestJsonReport:
-    """Tests for JSON report generation."""
-
-    def test_json_report_created(self, tmp_path: Path) -> None:
-        """generate_json_report should create a JSON file."""
-        (tmp_path / "data.txt").write_text("SSN: 123-45-6789\n")
-
-        config = RedactionConfig()
-        scanner = RedactionScanner(config=config)
-        summary = scanner.scan_batch(tmp_path)
-
-        report_path = tmp_path / "report" / "redaction-report.json"
-        scanner.generate_json_report(summary, report_path)
-
-        assert report_path.exists()
-
-    def test_json_report_structure(self, tmp_path: Path) -> None:
-        """JSON report should contain scan_statistics and findings_by_file."""
-        (tmp_path / "data.txt").write_text("SSN: 123-45-6789\n")
-
-        config = RedactionConfig()
-        scanner = RedactionScanner(config=config)
-        summary = scanner.scan_batch(tmp_path)
-
-        report_path = tmp_path / "redaction-report.json"
-        scanner.generate_json_report(summary, report_path)
-
-        data = json.loads(report_path.read_text())
-        assert "scan_statistics" in data
-        assert "findings_by_file" in data
-
-        stats = data["scan_statistics"]
-        assert "files_scanned" in stats
-        assert "files_skipped_binary" in stats
-        assert "files_skipped_extension" in stats
-        assert "total_findings" in stats
-        assert "by_severity" in stats
-        assert "by_type" in stats
-
-    def test_json_report_match_metadata(self, tmp_path: Path) -> None:
-        """JSON report findings should contain match metadata."""
-        (tmp_path / "data.txt").write_text("SSN: 123-45-6789\n")
-
-        config = RedactionConfig()
-        scanner = RedactionScanner(config=config)
-        summary = scanner.scan_batch(tmp_path)
-
-        report_path = tmp_path / "redaction-report.json"
-        scanner.generate_json_report(summary, report_path)
-
-        data = json.loads(report_path.read_text())
-        findings = data["findings_by_file"]
-        assert len(findings) > 0
-
-        for _file, file_matches in findings.items():
-            for match in file_matches:
-                assert "line_number" in match
-                assert "match_type" in match
-                assert "severity" in match
-                assert "salted_hash" in match
-
-    def test_json_report_creates_parent_dirs(self, tmp_path: Path) -> None:
-        """generate_json_report should create parent directories."""
-        summary = ScanSummary()
-        config = RedactionConfig()
-        scanner = RedactionScanner(config=config)
-
-        deep_path = tmp_path / "a" / "b" / "c" / "report.json"
-        scanner.generate_json_report(summary, deep_path)
-
-        assert deep_path.exists()
-
-    def test_json_report_empty_summary(self, tmp_path: Path) -> None:
-        """JSON report for empty summary should have zero totals."""
-        summary = ScanSummary()
-        config = RedactionConfig()
-        scanner = RedactionScanner(config=config)
-
-        report_path = tmp_path / "empty-report.json"
-        scanner.generate_json_report(summary, report_path)
-
-        data = json.loads(report_path.read_text())
-        assert data["scan_statistics"]["total_findings"] == 0
-        assert data["findings_by_file"] == {}
-
-    def test_json_report_severity_sorted(self, tmp_path: Path) -> None:
-        """Findings in JSON report should be sorted by severity."""
-        f = tmp_path / "mixed.txt"
-        f.write_text("email: test@example.com\nSSN: 123-45-6789\n")
-
-        config = RedactionConfig()
-        scanner = RedactionScanner(config=config)
-        summary = scanner.scan_batch(tmp_path)
-
-        report_path = tmp_path / "report.json"
-        scanner.generate_json_report(summary, report_path)
-
-        data = json.loads(report_path.read_text())
-        for _file, file_matches in data["findings_by_file"].items():
-            severities = [m["severity"] for m in file_matches]
-            order = {"critical": 0, "high": 1, "medium": 2, "low": 3, "unknown": 4}
-            ranks = [order.get(s, 4) for s in severities]
-            assert ranks == sorted(ranks)
 
 
 # ---------------------------------------------------------------------------
@@ -3305,7 +3020,7 @@ class TestHighEntropyMaskedRunLeak:
 # target resolves *outside* it is opened, matched, reported, and counted in
 # ``files_scanned``. Three callers inherit the hole (``creek redact
 # --scan/--apply/--review`` via ``_scan_source``, ``creek.redact.scan`` over
-# MCP, and ``creek process`` via ``scan_directory``), which is why the tests
+# MCP, and ``creek process`` via ``scan_batch``), which is why the tests
 # below sit on the chokepoint rather than on any one caller.
 #
 # The admission policy under test is the one the shipped SEC-003 *write* guard

--- a/creek-tools/tests/test_redact_documented_behaviour.py
+++ b/creek-tools/tests/test_redact_documented_behaviour.py
@@ -1,0 +1,425 @@
+"""Pins for what the three ``creek redact`` modes actually do.
+
+Issue #1338. The redaction documentation describes behaviour the code does
+not have, so before the prose can be rewritten the true behaviour has to be
+nailed down — otherwise the rewrite is one more unverified claim and the
+next reader has no way to tell which of the two is lying.
+
+Four properties are pinned here:
+
+* ``--scan`` writes **nothing**. Not a queue, not a report, not a directory.
+  ``--report`` renders the markdown summary to the console.
+* ``generate_markdown_summary`` never reproduces matched secret text. This
+  is the ``creek/redact/__init__.py`` "sensitive matched text is never
+  stored" invariant, observed at the rendering layer.
+* ``generate_review_queue`` **does** quote the operator's own source lines,
+  verbatim and deliberately. Stated here so the doc rewrite cannot
+  over-correct into a new misconception that redaction output is
+  excerpt-free everywhere.
+* ``--review`` selects fragments by *findings*, not by any
+  ``pending_review`` marker. The documented filter is inverted.
+
+The documentation-side guard lives in ``tests/test_redaction_docs_drift.py``.
+A new file rather than an append to ``tests/test_redact.py`` so that not one
+line of that 3927-line suite is disturbed.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Final
+
+import pytest
+from typer.testing import CliRunner
+
+from creek.cli import app
+from creek.config import RedactionConfig
+from creek.redact import RedactionScanner
+from creek.redact import scanner as scanner_module
+
+if TYPE_CHECKING:
+    from creek.redact import ScanSummary
+
+runner = CliRunner()
+
+EXPECTED_TABLE_HEADER: Final[str] = "| Line | Type | Severity |"
+"""The per-file table header this test requires, spelled independently.
+
+Deliberately *not* imported from :data:`creek.redact.scanner`. The
+production constant and ``docs/redaction.md`` must agree with each other,
+and :func:`test_the_exported_header_constant_matches_the_documented_one`
+below asserts they do. If this test simply imported the constant it would
+assert only that the renderer is self-consistent — which stays true when
+someone widens the header to reintroduce an ``Excerpt`` column, the exact
+regression issue #1338 removed from the docs.
+"""
+
+EMAIL_LINE: Final[str] = "Contact sgsg@example.com for details."
+"""One seeded source line, asserted verbatim in the review queue."""
+
+SEEDED_SECRETS: Final[tuple[str, ...]] = (
+    "AKIAIOSFODNN7EXAMPLE",
+    "sgsg@example.com",
+    "123-45-6789",
+    "4111111111111111",
+)
+"""Four distinct literals, one per pattern family, none of which may be
+reproduced by the markdown summary."""
+
+SEEDED_DOCUMENT: Final[str] = (
+    f"{EMAIL_LINE}\n"
+    "AWS key: AKIAIOSFODNN7EXAMPLE\n"
+    "SSN: 123-45-6789\n"
+    "Card number: 4111111111111111\n"
+)
+"""The scanned file's content — every entry of :data:`SEEDED_SECRETS`."""
+
+PENDING_REVIEW_FRAGMENT: Final[str] = (
+    "---\nredaction:\n  status: pending_review\n---\n\nNothing sensitive.\n"
+)
+"""A fragment carrying the marker the docs claim ``--review`` filters on,
+and carrying no findings whatsoever."""
+
+
+@pytest.fixture(autouse=True)
+def _isolate_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Run each test in its own directory with no ambient Creek config.
+
+    ``chdir`` keeps every relative path in this module — and anything a
+    command might unexpectedly write — inside ``tmp_path`` rather than the
+    source tree, which matters most for the ``--scan`` test, whose whole
+    claim is that nothing is written. Clearing ``CREEK_CONFIG`` stops a
+    developer's own exported config from being loaded in place of the
+    defaults these expectations are written against.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.delenv("CREEK_CONFIG", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+
+@pytest.fixture
+def seeded_summary(tmp_path: Path) -> ScanSummary:
+    """Scan one file containing every literal in :data:`SEEDED_SECRETS`.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+
+    Returns:
+        The summary of that scan.
+
+    Raises:
+        AssertionError: If the scan found nothing. Every "the secret is
+            absent from the output" assertion downstream would then hold
+            trivially, because there would be no findings to render.
+    """
+    source = tmp_path / "seeded"
+    source.mkdir()
+    (source / "leaky.md").write_text(SEEDED_DOCUMENT, encoding="utf-8")
+
+    summary = RedactionScanner(config=RedactionConfig()).scan_batch(source)
+
+    assert summary.matches, (
+        "the scanner found nothing in a file seeded with an AWS key, an "
+        "email address, an SSN and a card number; the absence assertions "
+        "in this module would pass over an empty report."
+    )
+    return summary
+
+
+def squashed(text: str) -> str:
+    """Return *text* with every run of whitespace removed.
+
+    Console assertions go through this. Rich wraps, centres and folds its
+    output to the terminal width, so a path or heading can be split across
+    lines at any column; removing whitespace restores the contiguity the
+    substring checks need without weakening them into "some of the
+    characters appear somewhere".
+
+    Args:
+        text: Captured console output.
+
+    Returns:
+        The same text with all whitespace stripped out.
+    """
+    return "".join(text.split())
+
+
+def relative_tree(root: Path) -> set[str]:
+    """Return every path under *root*, relative to *root*.
+
+    Directories and dotfiles included: the artifact the documentation
+    promises is a hidden *directory*, so a listing that skipped either
+    would miss the very thing being looked for.
+
+    Args:
+        root: Directory to enumerate.
+
+    Returns:
+        Repo-relative POSIX strings for every descendant of *root*.
+    """
+    entries: set[str] = set()
+    for dirpath, dirnames, filenames in os.walk(root):
+        base = Path(dirpath)
+        for name in (*dirnames, *filenames):
+            entries.add((base / name).relative_to(root).as_posix())
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# (a) generate_markdown_summary never reproduces matched text
+# ---------------------------------------------------------------------------
+
+
+def test_every_seeded_secret_appears_in_the_document_that_gets_scanned() -> None:
+    """The seeds must be in the file, or "absent from the output" is free.
+
+    The cheapest way for the invariant below to rot into a tautology is
+    for a literal to stop being seeded. Pinned as its own test so that
+    failure reads as "the fixture is wrong", not "the scanner leaked".
+    """
+    assert len(SEEDED_SECRETS) == 4, (
+        f"expected four seeded literals, found {len(SEEDED_SECRETS)}; "
+        "the parametrised absence checks cover only what is listed here."
+    )
+    for secret in SEEDED_SECRETS:
+        assert secret in SEEDED_DOCUMENT, (
+            f"{secret!r} is asserted absent from the rendered summary but "
+            "was never written into the scanned document."
+        )
+
+
+def test_the_exported_header_constant_matches_the_documented_one() -> None:
+    """``scanner.FINDINGS_TABLE_HEADER`` is the header the docs may quote.
+
+    #1338 exported the header as a constant so the renderer and
+    ``docs/redaction.md`` stop being two independent copies of one string —
+    the same reasoning as :data:`creek.redact.scanner.SYMLINK_SKIP_LABEL`.
+    A constant only prevents drift while something checks it against an
+    independently-spelled expectation, which is what this asserts.
+    """
+    assert scanner_module.FINDINGS_TABLE_HEADER == EXPECTED_TABLE_HEADER, (
+        "creek.redact.scanner.FINDINGS_TABLE_HEADER is "
+        f"{scanner_module.FINDINGS_TABLE_HEADER!r}, but the documented "
+        f"header is {EXPECTED_TABLE_HEADER!r}. Whichever moved, the sample "
+        "table in docs/redaction.md now describes output nobody emits."
+    )
+
+
+def test_markdown_summary_renders_the_findings_table_header(
+    seeded_summary: ScanSummary,
+) -> None:
+    """The per-file table is rendered, with its exact documented header.
+
+    The positive half of the never-store invariant: the summary describes
+    each finding by line, pattern name and severity. Any documentation of
+    this output must quote this header and no other.
+
+    Asserted as **whole-line equality**, not containment. A substring check
+    passes against ``| Line | Type | Severity | Excerpt |`` — the mutant
+    that reintroduces the very column issue #1338 removed from the docs —
+    because the true header is a prefix of it. Only the seeded-secret
+    assertions below caught that mutant; this one now catches it too, so
+    the widening is refused at the header rather than only at the leak.
+
+    Args:
+        seeded_summary: Scan of the file holding the seeded literals.
+    """
+    scanner = RedactionScanner(config=RedactionConfig())
+
+    markdown = scanner.generate_markdown_summary(seeded_summary)
+
+    header_lines = [
+        line for line in markdown.splitlines() if line.startswith("| Line ")
+    ]
+    assert header_lines, (
+        f"the summary rendered no findings-table header at all.\n\n{markdown}"
+    )
+    assert set(header_lines) == {EXPECTED_TABLE_HEADER}, (
+        "the per-file findings table header is not exactly "
+        f"{EXPECTED_TABLE_HEADER!r}; got {sorted(set(header_lines))!r}. The "
+        "docs quote it verbatim, and a widened header is how an Excerpt "
+        f"column of secret text gets back in.\n\n{markdown}"
+    )
+    assert "### `" in markdown, (
+        f"the summary rendered no per-file section at all.\n\n{markdown}"
+    )
+
+
+@pytest.mark.parametrize("secret", SEEDED_SECRETS)
+def test_markdown_summary_never_renders_a_seeded_secret_literal(
+    secret: str,
+    seeded_summary: ScanSummary,
+) -> None:
+    """The markdown summary reproduces none of the text it matched on.
+
+    ``creek/redact/__init__.py`` promises that sensitive matched text is
+    never stored; a :class:`RedactionMatch` carries only a salted hash.
+    This is that promise observed where it is easiest to break by
+    accident — the document a human is handed, pastes into a ticket, or
+    (via CrawDad) posts into a Discord channel.
+
+    Asserted per literal rather than by looking for a column named
+    "Excerpt": renaming a column would defeat that, and the property is
+    the absence of the *text*, not of a heading.
+
+    Args:
+        secret: One seeded literal.
+        seeded_summary: Scan of the file holding the seeded literals.
+    """
+    scanner = RedactionScanner(config=RedactionConfig())
+
+    markdown = scanner.generate_markdown_summary(seeded_summary)
+
+    assert secret not in markdown, (
+        f"generate_markdown_summary reproduced the matched literal "
+        f"{secret!r} in its output. The summary may name the file, the "
+        "line, the pattern and the severity — never the matched "
+        f"text.\n\n{markdown}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (a2) generate_review_queue deliberately DOES quote the source
+# ---------------------------------------------------------------------------
+
+
+def test_review_queue_does_quote_the_operators_own_source_line(
+    seeded_summary: ScanSummary,
+) -> None:
+    """The review queue quotes source lines verbatim, and that is correct.
+
+    The complement to the test above, and the reason the never-store
+    invariant must not be documented as "redaction output never shows
+    sensitive text". A reviewer cannot classify a finding as a false
+    positive without seeing it, so
+    :meth:`RedactionScanner.generate_review_queue` calls
+    :meth:`RedactionScanner.extract_context`, which **re-reads the
+    operator's own file** at review time. Nothing is retained: the excerpt
+    is never carried on a :class:`RedactionMatch`, never written to the
+    audit log, and never survives the call.
+
+    Anyone tempted to strip the excerpt to satisfy the invariant is
+    breaking review, not fixing a leak.
+
+    Args:
+        seeded_summary: Scan of the file holding the seeded literals.
+    """
+    scanner = RedactionScanner(config=RedactionConfig())
+
+    queue = scanner.generate_review_queue(seeded_summary)
+
+    assert EMAIL_LINE in queue, (
+        "the review queue no longer quotes the source line "
+        f"{EMAIL_LINE!r}. Without the surrounding context a reviewer "
+        "cannot tell a real secret from a false positive."
+    )
+    assert "```" in queue, (
+        "the quoted context is not inside a fenced block, so the queue "
+        "no longer renders as reviewable markdown."
+    )
+
+
+# ---------------------------------------------------------------------------
+# (b) --scan writes nothing
+# ---------------------------------------------------------------------------
+
+
+def test_scan_with_report_creates_no_artifact_under_the_source_tree(
+    tmp_path: Path,
+) -> None:
+    """``--scan --report`` leaves the source tree byte-for-byte unchanged.
+
+    The docs send operators to ``<source>/.creek-redactions/queue.json``
+    and to a sibling ``report.md``; ``--scan`` has never written either,
+    and ``--report`` prints its markdown to the console instead.
+
+    The whole tree is compared as a set rather than probing for the two
+    documented names, because a name-only check ("the queue directory does
+    not exist") would be satisfied by any future code that writes the same
+    artifact under a different name. ``--vault`` is deliberately not
+    passed, so the audit log is not implicated in the result either way.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory (also the cwd).
+    """
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "leaky.md").write_text(SEEDED_DOCUMENT, encoding="utf-8")
+    before = relative_tree(source)
+
+    result = runner.invoke(
+        app,
+        ["redact", "--scan", "--source", "source", "--report"],
+    )
+
+    assert result.exit_code == 0, result.output
+    rendered = squashed(result.output)
+    assert "Totalfindings" in rendered, (
+        f"the scan printed no statistics block.\n\n{result.output}"
+    )
+    assert "FindingsbyFile" in rendered, (
+        "--report did not render the per-file markdown report, so this "
+        f"test proves nothing about what --report writes.\n\n{result.output}"
+    )
+    after = relative_tree(source)
+    assert after == before, (
+        "`creek redact --scan --report` created "
+        f"{sorted(after - before)} under the source tree (and removed "
+        f"{sorted(before - after)}). The scan is read-only: it writes no "
+        "queue, no report file, and no directory."
+    )
+
+
+# ---------------------------------------------------------------------------
+# (c) --review selects on findings, not on a pending_review marker
+# ---------------------------------------------------------------------------
+
+
+def test_review_lists_a_fragment_with_findings_not_one_marked_pending_review() -> None:
+    """``--review`` is driven by findings; the marker plays no part at all.
+
+    The documented behaviour is exactly inverted. ``--review`` re-scans the
+    vault and renders the queue for whatever the scanner finds:
+
+    * ``a.md`` carries an email address and **no** marker — it is listed.
+    * ``b.md`` carries ``redaction.status: pending_review`` in its
+      frontmatter and **no** sensitive content — it is not listed.
+
+    A ``pending_review`` marker neither adds a fragment to the queue nor
+    removes one from it. Nothing in ``creek/`` or ``creek_mcp/`` reads that
+    field; the only writer is ``creek/ingest/images.py``. Documenting the
+    marker as the filter sends an operator hunting for a switch that is not
+    wired to anything.
+
+    The vault is named relatively so the rendered paths stay short and
+    Rich has no reason to fold them; :func:`squashed` covers the residual.
+    """
+    vault = Path("vault")
+    vault.mkdir()
+    (vault / "a.md").write_text(f"{EMAIL_LINE}\n", encoding="utf-8")
+    (vault / "b.md").write_text(PENDING_REVIEW_FRAGMENT, encoding="utf-8")
+
+    result = runner.invoke(app, ["redact", "--review", "--vault", "vault"])
+
+    assert result.exit_code == 0, result.output
+    rendered = squashed(result.output)
+    assert "RedactionReviewQueue" in rendered, (
+        f"the review queue was not rendered at all.\n\n{result.output}"
+    )
+    assert "Finding1" in rendered, (
+        f"the queue rendered no findings at all.\n\n{result.output}"
+    )
+    assert "a.md" in rendered, (
+        "--review omitted a.md, which has a finding and no "
+        "`pending_review` marker. Findings are what put a fragment in the "
+        f"queue; the marker is not consulted.\n\n{result.output}"
+    )
+    assert "b.md" not in rendered, (
+        "--review listed b.md, which carries the `pending_review` marker "
+        "and no findings. The marker does not pull a clean fragment into "
+        f"the queue — nothing in creek/ reads it.\n\n{result.output}"
+    )

--- a/creek-tools/tests/test_redaction_docs_drift.py
+++ b/creek-tools/tests/test_redaction_docs_drift.py
@@ -1,0 +1,180 @@
+"""Guard against docs that name redaction artifacts the code never creates.
+
+Issue #1338. ``creek redact`` has three modes and the prose describing them
+drifted from the code. The two most concrete drifts are filesystem paths:
+``docs/redaction.md`` and ``README.md`` tell operators that ``--scan``
+deposits a queue at ``<source>/.creek-redactions/queue.json`` and that
+``--apply`` consumes it. Neither name has ever been produced by anything
+under ``creek/`` or ``creek_mcp/`` — ``--scan`` writes no files at all, and
+``--report`` renders its summary to the console — so an operator who follows
+the documentation goes looking for a file that cannot exist, and concludes
+the scan silently failed.
+
+Only those two literals are pinned. Wordings such as "reversible" or
+"applied: true" are ordinary English with legitimate uses elsewhere in the
+tree; a grep gate over them would be brittle and could be satisfied by
+rephrasing rather than by correcting the claim. A filesystem path that the
+production code has never created is a defect by construction, which is what
+makes it safe to forbid outright.
+
+The behavioural complements — what the three modes actually do — live in
+``tests/test_redact_documented_behaviour.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Final
+
+import pytest
+
+from tests.markdown_integrity_support import tracked_markdown_files
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+# ``Path(__file__)`` is ``<root>/creek-tools/tests/test_redaction_docs_drift.py``:
+# parents[0] is ``tests``, parents[1] is ``creek-tools``, parents[2] is the
+# repository root. The sweep must run from the root — the CI ``quality`` job
+# works from ``creek-tools/``, and a root-relative sweep is the only way the
+# gate sees the repository-root ``README.md`` and ``docs/`` trees too.
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[2]
+
+PHANTOM_REDACTION_ARTIFACTS: Final[tuple[str, str]] = (
+    ".creek-redactions",
+    "queue.json",
+)
+"""Path names the documentation promises and the code has never written.
+
+Deliberately exactly two entries, and deliberately both filesystem paths.
+See the module docstring for why the vaguer doc claims are not pinned here.
+"""
+
+_CREEK_TOOLS_PREFIX: Final[str] = "creek-tools/"
+"""Repo-relative prefix of the Python subproject, for the span check."""
+
+
+def documents_naming(
+    literal: str,
+    documents: Sequence[tuple[str, str]],
+) -> list[str]:
+    """Return the labels of the documents whose text contains *literal*.
+
+    Factored out so the repository-wide sweep and its non-vacuity control
+    run the *same* matcher. A detector that quietly stopped matching
+    anything would otherwise turn the sweep into a pass over nothing.
+
+    Args:
+        literal: The exact substring to look for.
+        documents: ``(label, text)`` pairs, where the label is what a
+            failure message should name.
+
+    Returns:
+        The labels of the matching documents, in the order supplied.
+    """
+    return [label for label, text in documents if literal in text]
+
+
+@pytest.fixture(scope="module")
+def tracked_documents() -> tuple[tuple[str, str], ...]:
+    """Read every git-tracked Markdown file in the repository.
+
+    Module-scoped because the sweep is run once per forbidden literal and
+    re-reading a few hundred files per parameter buys nothing.
+
+    Returns:
+        ``(repo-relative POSIX path, file text)`` for each tracked
+        ``*.md`` file. ``errors="replace"`` so one undecodable byte
+        somewhere in the tree cannot disable the whole gate.
+    """
+    return tuple(
+        (
+            path.relative_to(REPO_ROOT).as_posix(),
+            path.read_text(encoding="utf-8", errors="replace"),
+        )
+        for path in tracked_markdown_files(REPO_ROOT)
+    )
+
+
+def test_the_tracked_markdown_sweep_spans_the_whole_repository(
+    tracked_documents: tuple[tuple[str, str], ...],
+) -> None:
+    """Discovery must reach both halves of the monorepo, not one subtree.
+
+    ``tracked_markdown_files`` already raises on a totally empty sweep.
+    The failure mode left over is a sweep that collapses to a single
+    subtree — which is exactly what a bare ``git ls-files`` run from
+    ``creek-tools/`` produces — and that would let the assertions below
+    pass while never looking at half the documentation. No filename is
+    pinned, so an ordinary rename cannot break this.
+
+    Args:
+        tracked_documents: The gathered ``(path, text)`` pairs.
+    """
+    labels = [label for label, _ in tracked_documents]
+
+    assert labels, (
+        f"the tracked-Markdown sweep under {REPO_ROOT} came back empty; "
+        "every assertion in this module would pass over nothing."
+    )
+    assert any(label.startswith(_CREEK_TOOLS_PREFIX) for label in labels), (
+        f"the sweep found no Markdown under {_CREEK_TOOLS_PREFIX}; "
+        f"discovery has collapsed to a subtree. Found: {labels[:10]}"
+    )
+    assert any(not label.startswith(_CREEK_TOOLS_PREFIX) for label in labels), (
+        "the sweep found Markdown only under "
+        f"{_CREEK_TOOLS_PREFIX}; the repository-root documentation is "
+        f"not being checked. Found: {labels[:10]}"
+    )
+
+
+@pytest.mark.parametrize("literal", PHANTOM_REDACTION_ARTIFACTS)
+def test_the_phantom_artifact_detector_fires_on_a_synthetic_document(
+    literal: str,
+) -> None:
+    """The matcher really does flag the literal — and only where it appears.
+
+    The non-vacuity control for the repository sweep. Without it, a
+    matcher that had stopped matching (or a sweep that had stopped
+    sweeping) would report a clean repository forever.
+
+    Args:
+        literal: One forbidden artifact name.
+    """
+    named = f"# Redaction\n\nThe queue lands at `<source>/{literal}` here.\n"
+    clean = "# Redaction\n\nThe scan writes nothing; the report is printed.\n"
+
+    flagged = documents_naming(
+        literal,
+        [("synthetic-names-it.md", named), ("synthetic-clean.md", clean)],
+    )
+
+    assert flagged == ["synthetic-names-it.md"], (
+        f"the detector for {literal!r} did not behave: it should flag the "
+        "one synthetic document that names the artifact and leave the "
+        f"clean one alone, but it returned {flagged!r}."
+    )
+
+
+@pytest.mark.parametrize("literal", PHANTOM_REDACTION_ARTIFACTS)
+def test_no_tracked_markdown_names_a_phantom_redaction_artifact(
+    literal: str,
+    tracked_documents: tuple[tuple[str, str], ...],
+) -> None:
+    """No documentation may promise a redaction path the code never writes.
+
+    Args:
+        literal: One forbidden artifact name.
+        tracked_documents: The gathered ``(path, text)`` pairs.
+    """
+    offenders = documents_naming(literal, tracked_documents)
+
+    assert offenders == [], (
+        f"{len(offenders)} tracked Markdown file(s) still document "
+        f"{literal!r} as a redaction artifact: {', '.join(offenders)}. "
+        "Nothing under creek/ or creek_mcp/ has ever created that path: "
+        "`creek redact --scan` writes no files at all, and `--report` "
+        "renders the summary to the console. Correct the prose to "
+        "describe what the code does — do not create the file to match "
+        "the prose."
+    )


### PR DESCRIPTION
## Summary

`docs/redaction.md` documented a persistent redaction queue that has never existed, and told operators that `--apply` "is reversible if you keep the queue around". On a redaction tool the docs *are* the operator's contract, so this PR treats them as the deliverable.

**I verified every claim by executing the CLI, not by reading it.** Observed against `b81808e`:

| Doc claimed | Actually observed |
|---|---|
| `--scan` writes a queue + optional `report.md` under `<source>` | **Creates no files at all.** I inventoried the source tree before and after `--scan --report`: unchanged. `--report` renders to the console. |
| `--apply` "reads the queue"; reversible if you keep it | Reads no queue. Re-scans from scratch and rewrites **in place**. `My key is AKIA…EXAMPLE and email sgsg@example.com.` → `My key is [REDACTED:api_key] and email [REDACTED:email].` |
| the queue "records the offset … and the replacement string" | I dumped the audit log: it holds `phase`, `operation_id`, paths, `pattern_names`, `match_counts`, hash chain, timestamps. **No original text, no offsets — no undo is reconstructable.** |
| `--review` prints fragments whose `redaction.status` is `pending_review` | **Exactly inverted.** Seeded `a.md` (email, *no* marker) and `b.md` (`redaction.status: pending_review`, *no* PII). Output listed **a.md**, omitted **b.md**. `review: pending_review` is written by `creek/ingest/images.py` and read by nothing. |
| sample report has an `\| Excerpt \|` column of secret text | Real header is `\| Line \| Type \| Severity \|`. I seeded four secrets and confirmed none appears in the rendered summary. |

## The `--apply` warning says more than "irreversible"

Per the issue this needed a back-up warning, but "irreversible" understates it. The new section states that `--apply` rewrites *every* matching file in place, that structured `.yaml`/`.json` are in scope where a marker can leave the file invalid, and that a vault-wide run still rewrites `creek_config.yaml`.

**Left deliberately to #1398:** the config-rewrite bug itself. I reproduced it (an `exclude_patterns` token `backups-AKIAIOSFODNN7EXAMPLE` became `[REDACTED:high_entropy_string]`) and documented it as an open, unfixed bug rather than widening scope.

**I also corrected the old `#1398` cross-reference, which was itself false.** It claimed the rewrite "can redact your own `false_positive_allowlist` entries". `_is_allowlisted` is exact-string membership, so allowlist entries are the one class of value the rewrite *cannot* touch — in my run the allowlist entry was byte-identical while the `exclude_patterns` token beside it was destroyed. [Posted on #1398](https://github.com/Geoffe-Ga/Creek-Vault/issues/1398#issuecomment-5264319656), including that its stated acceptance test passes against today's unfixed code and is therefore vacuous.

## What a reader can now infer

Removing false sentences isn't sufficient, so I re-read the result for wrong inferences and fixed two:

- The never-store invariant was overstated into "no matched content anywhere, on screen or on disk". `--review` **does** print secrets verbatim (`extract_context` re-reads the file). Now scoped explicitly, with a warning that `--review` output is unsafe to paste into a ticket, chat, or LLM prompt.
- The `dry_run` config row said "plans but doesn't write" — it does still append dry-run-marked audit entries.

## Wire-or-delete: `generate_json_report` → **delete**

Wiring it meant inventing an unrequested CLI flag that writes a findings inventory (absolute paths, line numbers, severities) to a caller-supplied path with no containment story — a *new* persistence surface, inside the PR whose whole point is that the docs promised persistence that doesn't exist. Its `scan_statistics` was already one key behind the live MCP copy.

**#1292 is neither narrowed nor invalidated — it's unblocked.** This PR doesn't touch `creek_mcp/tools/redact.py`, add the key, or bump `CONTRACT_VERSION`. There is now exactly *one* site emitting that statistics shape instead of two that can drift. [Noted on #1292](https://github.com/Geoffe-Ga/Creek-Vault/issues/1292#issuecomment-5264322821).

## Caller census before deleting anything

AST walk over every public method of both classes, cross-referenced against grep of `creek/`, `creek_mcp/`, `crawdad/`, `scripts/`, plus sweeps for `getattr` indirection and for the names as string literals (zero of either; `__all__` exports classes, not methods):

```
RedactionScanner.scan_directory        0 external | 0 in-module   -> DELETED
RedactionScanner.generate_report       0 external | 0 in-module   -> DELETED
RedactionScanner.generate_json_report  0 external | 0 in-module   -> DELETED
Redactor.log_redactions                0 external | 0 in-module   -> DELETED
RedactionScanner.scan_batch            3 external | 1 in-module   -> kept
RedactionScanner.generate_markdown_summary  2 external            -> kept
RedactionScanner.generate_review_queue      1 external            -> kept
RedactionScanner.scan_file             2 external | 1 in-module   -> kept
RedactionScanner.extract_context       0 external | 1 in-module   -> kept
RedactionScanner.is_binary             0 external | 1 in-module   -> kept
Redactor.redact_content                1 external                 -> kept
```

This satisfies the acceptance criterion exactly: every remaining public method on either class now has a caller.

Cascade: `import json` from both modules, `pathlib.Path` / `typing.Any` / `RedactionMatch` from `redactor.py`, the now-unreachable `_count_by_type`, and a `# noqa: FURB123` — **one fewer escape hatch in the tree.** Deleting `log_redactions` is also a small hardening: it wrote the session salt to disk in cleartext next to the hashes that salt exists to protect.

## Every deleted test, by name

17 deleted, each because its subject was deleted:

- `test_scan_directory`, `test_scan_directory_empty`, `test_scan_directory_nonexistent`, `test_scan_directory_delegates_to_scan_batch`, `test_scan_directory_with_progress` — subject `scan_directory`
- `test_report_empty_matches`, `test_report_with_matches`, `test_report_contains_file_paths` (class `TestGenerateReport`) — subject `generate_report`
- `test_json_report_created`, `test_json_report_structure`, `test_json_report_match_metadata`, `test_json_report_creates_parent_dirs`, `test_json_report_empty_summary`, `test_json_report_severity_sorted` (class `TestJsonReport`) — subject `generate_json_report`
- `test_log_redactions_creates_file`, `test_log_redactions_appends`, `test_log_redactions_no_sensitive_data` — subject `log_redactions`

**Not deleted — renamed:** `test_scan_directory_skips_binary` → `test_scan_batch_skips_binary`. Its name said `scan_directory` but its body calls `scan_batch`; its subject is alive, so deleting it would have been deleting a live test. Body preserved verbatim, all three assertions intact.

`test_log_redactions_no_sensitive_data` was the one security-flavoured casualty. Its invariant is not lost — it is strengthened onto the *live* surface by the new `test_markdown_summary_never_renders_a_seeded_secret_literal`, which asserts per-literal against the renderer operators actually see.

**Proof no surviving test was touched:** AST-compared every test present in both revisions — `SURVIVING TESTS WITH A CHANGED BODY: NONE`. Assertion arithmetic closes exactly: 41 assertions inside removed tests − 3 restored under the rename = the 38-line file delta.

## Tests that stop the drift recurring

Rather than a prose-only fix:

- `tests/test_redaction_docs_drift.py` — no git-tracked Markdown may name the phantom artifacts. **This was genuinely RED** (3 hits across `README.md` and `docs/redaction.md`) and is what turns green. Pins only the two filesystem-path literals, not words like "reversible": a path the code has never created is a defect by construction, whereas a prose grep is brittle and gameable. Includes a non-vacuity control and asserts the sweep spans the whole repo. **It caught me mid-PR** — my first CHANGELOG draft named the phantom path and the gate failed the build.
- `tests/test_redact_documented_behaviour.py` — pins `--scan` writes nothing (set-equality of the source tree, not a name check), the never-store invariant per-literal, the deliberate exception that `--review` *does* quote source lines, and the inverted `--review` filter.

**Mutation-proved non-vacuous** (characterization tests are green on arrival, so I mutated the source and watched each go red, restoring from hash-verified snapshots):

| Mutant | Result |
|---|---|
| add an `Excerpt` column to `generate_markdown_summary` | 4 failures, one per seeded literal |
| make `run_scan` write a queue dir under `--source` | no-artifact test fails |
| make `generate_review_queue` honour the *documented* `pending_review` filter | 2 failures |

The header assertion initially *survived* mutant 1 (the true header is a prefix of the widened one), so I tightened it from containment to whole-line equality and re-ran: it now kills the mutant alone.

## Census beyond the lines the issue listed

The issue named 8 lines. The sweep found 6 more, including three outside its file table:

- `README.md:97` — "`--scan` … Writes a structured report." It writes nothing.
- `README.md:98` — "Apply **queued** redactions."
- `docs/README.md:9` — "and reviewing the queue."
- `creek/cli.py:2223` — the `creek redact --help` text itself: "or review the queue."
- `creek/config.py:415` — "a fragment lands in the review queue." It lands in no queue.
- `creek/ingest/images.py:407` — the same false claim, self-described as a mirror of the above.
- **`.claude/skills/creek-walkthrough/stages/02-the-safety-pass.md`** — a user-facing conversational script, outside `creek-tools/`, containing the single most dangerous sentence in the repo on this topic: *"sensitive spans are masked and logged for review, and **you can restore a false alarm later**."* Rewritten honestly while keeping its calm register. Its neighbouring claim "the original secret is never written into the vault or any log" I verified **true**, and kept.

## Test plan

- `./scripts/check-all.sh` → **exit 0**, 12/12 checks, **9685 passed, 5 skipped** (all pre-existing environmental: Ollama absent, no live API keys). No test skipped or weakened by this change.
- `ruff check --no-cache` clean, verified independently of the gate.
- **Coverage 94.67% → 94.66%, and the direction is correct.** Statements 28161 → 28113 (−48) with **Miss unchanged at 1227** — i.e. *every* deleted statement was covered. Removing code covered at ~98.5% from a pool averaging 94.67% lowers the mean; that is arithmetic, not a regression, and the flat Miss count is the proof nothing else changed. Per-file gate passes (both redact modules ~98.5%); **no waiver added**.
- Bypass sweep over the full diff: zero `# noqa` / `type: ignore` / `skip` / `xfail` added; no `pyproject.toml`, `scripts/`, or CI config touched. Net −1 `# noqa`.

**Substitution to note:** the issue's acceptance criteria ask for `pre-commit run --all-files`. I did not run it — it silently edits unrelated files in the worktree (it has previously stripped the BOM from `tests/fixtures/encoding/utf8_bom.csv`). `check-all.sh` is the gate and it passes.

## Follow-ups filed

- **#1443** (`P3`) — `Redactor` still takes a *required* `salt` that nothing reads now that `log_redactions` is gone. Removing it is a public-constructor change, out of scope here.

Closes #1338
Refs #1398, #1292, #1443, #1087
