### PR TITLE
fix(config): delete the timezone key nothing read, and declare LA_TZ once

### DIFF
--- a/creek-tools/creek/classify/review_runner.py
+++ b/creek-tools/creek/classify/review_runner.py
@@ -28,8 +28,8 @@ from creek.classify.constants import (
     MANUAL_METHOD,
 )
 from creek.classify.review import ReviewQueueGenerator
-from creek.ingest.base import LA_TZ
 from creek.models import Fragment, Frequency, FrequencyClassification
+from creek.time import LA_TZ
 from creek.vault.reader import try_load_fragment
 
 if TYPE_CHECKING:

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -15,7 +15,6 @@ import re
 from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
-from zoneinfo import ZoneInfo
 
 import yaml
 from pydantic import BaseModel, Field, field_validator, model_validator
@@ -1746,12 +1745,22 @@ class DiscordSourceConfig(BaseModel):
         return value
 
 
+_OBSOLETE_TIMEZONE_KEY = "timezone"
+"""Config key deleted by #1339, still present in every pre-#1339 vault config.
+
+Creek anchors every timestamp it writes to America/Los_Angeles by ontology
+mandate §8.3 (:data:`creek.time.LA_TZ`); the knob had no production reader, and
+wiring one would have made fragment ids config-dependent (see
+:meth:`CreekConfig._drop_obsolete_timezone`).
+"""
+
+
 class CreekConfig(BaseSettings):
     """Top-level Creek configuration.
 
     Values are loaded from a YAML file and can be overridden by
     environment variables prefixed with ``CREEK_`` (e.g.
-    ``CREEK_VAULT_PATH``, ``CREEK_TIMEZONE``).
+    ``CREEK_VAULT_PATH``, ``CREEK_SOURCE_DRIVE``).
     """
 
     model_config = SettingsConfigDict(
@@ -1763,9 +1772,6 @@ class CreekConfig(BaseSettings):
 
     source_drive: Path = Path()
     """Path to the mounted source drive containing raw exports."""
-
-    timezone: str = "America/Los_Angeles"
-    """IANA timezone for timestamp normalisation."""
 
     llm: LLMRoutingConfig = Field(default_factory=LLMRoutingConfig)
     """Per-stage LLM routing (#642). A legacy flat ``llm`` block is promoted to
@@ -1832,26 +1838,61 @@ class CreekConfig(BaseSettings):
     discord: DiscordSourceConfig = Field(default_factory=DiscordSourceConfig)
     """Discord ingest mode toggles (data_package | exporter | bot_capture)."""
 
-    @field_validator("timezone")
+    @model_validator(mode="before")
     @classmethod
-    def validate_timezone(cls, v: str) -> str:
-        """Validate that *v* is a recognised IANA timezone.
+    def _drop_obsolete_timezone(cls, data: object) -> object:
+        """Discard the pre-#1339 ``timezone:`` key, loudly (#1339).
+
+        The field was deleted rather than wired: it had no production reader,
+        and :func:`creek.ingest.base.generate_fragment_id` hashes
+        ``timestamp.isoformat()`` — whose rendered UTC offset changes with the
+        zone — so an operator-settable anchor would mint a second id for every
+        fragment on re-ingest, reopening the bug #1329 had to migrate vaults
+        out of.
+
+        A shim is required because this model forbids extra keys while
+        :func:`generate_default_config` dumps the whole model, so every
+        ``creek_config.yaml`` ``creek init`` has ever written carries a
+        ``timezone:`` line. Without this, deletion would turn every existing
+        config into a hard ``ValidationError`` at load. It lives on the model
+        rather than in :func:`load_config` because direct construction reaches
+        validation without passing through that loader's YAML dict —
+        :func:`generate_default_config` builds its own ``CreekConfig()``, and
+        the environment-variable settings source populates the model whether or
+        not a config file was ever read.
+
+        Exactly one key is removed, by name: ``extra='forbid'`` still rejects
+        everything else, so a typo stays a loud error rather than a silent
+        no-op.
 
         Args:
-            v: Timezone string to validate.
+            data: The raw input to validation — a ``dict`` for YAML and
+                settings-source loads, but any object at all when a caller
+                hands one straight to ``model_validate``.
 
         Returns:
-            The validated timezone string.
-
-        Raises:
-            ValueError: If the timezone is not recognised by ``zoneinfo``.
+            *data* unchanged, or a new ``dict`` without the obsolete key.
+            Anything that is not a ``dict`` passes straight through, so it
+            still fails with pydantic's own ``ValidationError`` rather than
+            an ``AttributeError`` raised from inside this validator.
         """
-        try:
-            ZoneInfo(v)
-        except KeyError as exc:
-            msg = f"Invalid timezone: {v}"
-            raise ValueError(msg) from exc
-        return v
+        if not isinstance(data, dict) or _OBSOLETE_TIMEZONE_KEY not in data:
+            return data
+        logger.warning(
+            "Ignoring obsolete `%s` key in your Creek config: it is no longer "
+            "a setting. Creek anchors every timestamp it writes to "
+            "America/Los_Angeles by design, so the key had no effect and can "
+            "be deleted from your config file (issue #1339).",
+            _OBSOLETE_TIMEZONE_KEY,
+        )
+        # A copy, not a pop. As a ``BaseSettings``, this model is handed a
+        # dict its settings sources freshly merged, so an in-place ``del``
+        # would not actually reach the caller's parsed YAML today — but that
+        # is an implementation detail of pydantic-settings, not a promise.
+        # Copying keeps the validator side-effect-free regardless.
+        remaining = dict(data)
+        del remaining[_OBSOLETE_TIMEZONE_KEY]
+        return remaining
 
     @cached_property
     def model_router(self) -> "ModelRouter":

--- a/creek-tools/creek/consent.py
+++ b/creek-tools/creek/consent.py
@@ -39,7 +39,7 @@ from pathlib import Path
 from pydantic import BaseModel, Field, ValidationError
 
 from creek._fsio import atomic_write_text
-from creek.ingest.base import LA_TZ
+from creek.time import LA_TZ
 
 logger = logging.getLogger(__name__)
 

--- a/creek-tools/creek/ingest/base.py
+++ b/creek-tools/creek/ingest/base.py
@@ -31,12 +31,13 @@ from creek.classify.tags_pass import apply_tags
 from creek.ingest.source_unit import compose_source_unit
 from creek.models import Fragment, FragmentLevel
 
+# ``LA_TZ`` — the target timezone for all normalized timestamps — is declared
+# once in :mod:`creek.time` and imported here (#1339). This module re-exports
+# it so the historical ``from creek.ingest.base import LA_TZ`` path keeps
+# resolving for out-of-tree callers.
+from creek.time import LA_TZ
+
 logger = logging.getLogger(__name__)
-
-# ---- Constants ----
-
-LA_TZ = ZoneInfo("America/Los_Angeles")
-"""Target timezone for all normalized timestamps."""
 
 # ---- Pydantic Models ----
 

--- a/creek-tools/creek/ingest/chatgpt.py
+++ b/creek-tools/creek/ingest/chatgpt.py
@@ -22,7 +22,6 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from creek.ingest.base import (
-    LA_TZ,
     Ingestor,
     ParsedFragment,
     RawDocument,
@@ -30,6 +29,7 @@ from creek.ingest.base import (
 )
 from creek.ingest.turns import group_turn_runs, merge_turn_texts
 from creek.models import Authorship
+from creek.time import LA_TZ
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/creek-tools/creek/ingest/code.py
+++ b/creek-tools/creek/ingest/code.py
@@ -415,7 +415,7 @@ def _get_file_timestamp(path: Path) -> datetime:
     Returns:
         A timezone-aware datetime from the file's modification time.
     """
-    from creek.ingest.base import LA_TZ
+    from creek.time import LA_TZ
 
     mtime = path.stat().st_mtime
     return datetime.fromtimestamp(mtime, tz=LA_TZ)

--- a/creek-tools/creek/ingest/discord.py
+++ b/creek-tools/creek/ingest/discord.py
@@ -665,7 +665,8 @@ class DiscordIngestor(Ingestor):
             ts_str: The ISO 8601 timestamp string.
 
         Returns:
-            A timezone-aware datetime in the configured timezone.
+            A timezone-aware datetime in America/Los_Angeles, the anchor
+            every normalized Creek timestamp uses (:data:`creek.time.LA_TZ`).
         """
         if not ts_str:
             return normalize_timestamp("1970-01-01T00:00:00Z", None)

--- a/creek-tools/creek/ingest/generic.py
+++ b/creek-tools/creek/ingest/generic.py
@@ -23,7 +23,6 @@ from typing import Any
 import chardet
 
 from creek.ingest.base import (
-    LA_TZ,
     Ingestor,
     ParsedFragment,
     RawDocument,
@@ -31,6 +30,7 @@ from creek.ingest.base import (
     normalize_encoding,
 )
 from creek.models import SourcePlatform
+from creek.time import LA_TZ
 
 logger = logging.getLogger(__name__)
 

--- a/creek-tools/creek/time.py
+++ b/creek-tools/creek/time.py
@@ -9,12 +9,14 @@ produce naive datetimes that fail to compare against tz-aware ones with
 values that arrive from outside that discipline — persisted frontmatter,
 legacy callers — making them safe to compare without moving the clock.
 
-The constant :data:`LA_TZ` is defined here as a dependency-free home
-for the timezone helpers; :mod:`creek.ingest.base` independently
-defines its own equal constant of the same name to preserve the
-historical import path some callers still use. Neither re-exports the
-other — each module owns its own definition, and the two simply agree
-on the same ``ZoneInfo("America/Los_Angeles")`` value.
+This module is the single, dependency-free home of :data:`LA_TZ`: the
+constant is declared here exactly once and imported everywhere else
+(#1339). :mod:`creek.ingest.base` is among those importers and
+re-exports it, so the historical ``from creek.ingest.base import
+LA_TZ`` path some callers still use keeps resolving to this one
+definition. The LA anchor is an ontology mandate, not a preference, so
+it gets one place to change, audit and reason about — not two constants
+that agree until somebody edits one of them.
 """
 
 from __future__ import annotations

--- a/creek-tools/docs/configuration.md
+++ b/creek-tools/docs/configuration.md
@@ -38,14 +38,24 @@ The summary is consumed by the audit report (FEAT-006).
 ```yaml
 vault_path: ~/Obsidian/Creek-Vault
 source_drive: ~/exports
-timezone: America/Los_Angeles
 ```
 
 | Field          | Default         | Notes |
 |----------------|-----------------|-------|
 | `vault_path`   | `.`             | Absolute path to the Obsidian vault. |
 | `source_drive` | `.`             | Default `--source` for `creek process` / `creek ingest`. |
-| `timezone`     | `America/Los_Angeles` | Used for every `datetime` written into frontmatter. |
+
+**`timezone` was removed in #1339.** It had zero production readers, and a
+configurable anchor would have been actively harmful: `generate_fragment_id`
+(`creek/ingest/base.py`) hashes `timestamp.isoformat()`, whose rendered UTC
+offset changes with the zone, so a settable `timezone` would mint a
+different `frag-…` id for the same instant depending on operator config —
+reopening the id-derivation bug #1329 already required a vault migration
+(`creek/ingest/pin_ids.py`) to fix. Creek anchors every timestamp it writes
+to **America/Los_Angeles** by ontology mandate §8.3 (`creek/time.py`,
+`LA_TZ`) — a design invariant, not a per-operator preference. If your
+`creek_config.yaml` still has a `timezone:` line, the file still loads, but
+you'll see a `WARNING` on load: the key is ignored and safe to delete.
 
 ## `llm` — language model provider
 

--- a/creek-tools/tests/test_config.py
+++ b/creek-tools/tests/test_config.py
@@ -1,9 +1,11 @@
 """Tests for creek.config module — configuration loader with Pydantic Settings."""
 
+import logging
 from pathlib import Path
 
 import pytest
 import yaml
+from pydantic import ValidationError
 
 from creek.config import (
     CONFIG_PATH_ENV_VAR,
@@ -589,7 +591,6 @@ class TestCreekConfig:
         cfg = CreekConfig()
         assert cfg.vault_path == Path(".")
         assert cfg.source_drive == Path(".")
-        assert cfg.timezone == "America/Los_Angeles"
         # Nested models should exist with their own defaults. ``llm`` is now a
         # per-stage LLMRoutingConfig (#646) whose ``default`` is an LLMConfig.
         assert isinstance(cfg.llm, LLMRoutingConfig)
@@ -603,27 +604,11 @@ class TestCreekConfig:
         assert isinstance(cfg.sources, SourcePaths)
         assert isinstance(cfg.cleaning, CleaningConfig)
 
-    def test_valid_timezone(self) -> None:
-        """CreekConfig should accept a valid timezone string."""
-        cfg = CreekConfig(timezone="Europe/London")
-        assert cfg.timezone == "Europe/London"
-
-    def test_invalid_timezone_rejected(self) -> None:
-        """CreekConfig must reject an invalid timezone string."""
-        with pytest.raises(ValueError, match="Invalid timezone"):
-            CreekConfig(timezone="Not/A/Timezone")
-
     def test_env_var_override_vault_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """CREEK_VAULT_PATH env var should override the default."""
         monkeypatch.setenv("CREEK_VAULT_PATH", "/tmp/my-vault")  # nosec B108
         cfg = CreekConfig()
         assert cfg.vault_path == Path("/tmp/my-vault")  # nosec B108
-
-    def test_env_var_override_timezone(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """CREEK_TIMEZONE env var should override the default."""
-        monkeypatch.setenv("CREEK_TIMEZONE", "UTC")
-        cfg = CreekConfig()
-        assert cfg.timezone == "UTC"
 
     def test_env_var_override_source_drive(
         self, monkeypatch: pytest.MonkeyPatch
@@ -646,14 +631,12 @@ class TestLoadConfig:
         """load_config() should return defaults when YAML file does not exist."""
         cfg = load_config(tmp_path / "nonexistent.yaml")
         assert cfg.vault_path == Path(".")
-        assert cfg.timezone == "America/Los_Angeles"
 
     def test_loads_yaml_file(self, tmp_path: Path) -> None:
         """load_config() should load values from a YAML file."""
         config_file = tmp_path / "creek_config.yaml"
         config_data = {
             "vault_path": "/home/user/vault",
-            "timezone": "America/New_York",
             "llm": {"provider": "anthropic", "model": "claude-3"},
             "embeddings": {"similarity_threshold": 0.85},
         }
@@ -661,7 +644,6 @@ class TestLoadConfig:
 
         cfg = load_config(config_file)
         assert cfg.vault_path == Path("/home/user/vault")
-        assert cfg.timezone == "America/New_York"
         assert cfg.llm.default.provider == "anthropic"
         assert cfg.llm.default.model == "claude-3"
         assert cfg.embeddings.similarity_threshold == 0.85
@@ -758,13 +740,13 @@ class TestLoadConfigEnvVar:
     ) -> None:
         """``CREEK_CONFIG`` is honoured when ``config_path`` is None."""
         config_file = tmp_path / "vault-config.yaml"
-        config_file.write_text(yaml.dump({"timezone": "UTC"}))
+        config_file.write_text(yaml.dump({"vault_path": "/vaults/from-env"}))
         monkeypatch.setenv(CONFIG_PATH_ENV_VAR, str(config_file))
         # Ensure cwd has no fallback creek_config.yaml that could mask the env var.
         monkeypatch.chdir(tmp_path)
 
         cfg = load_config()
-        assert cfg.timezone == "UTC"
+        assert cfg.vault_path == Path("/vaults/from-env")
 
     def test_explicit_config_path_overrides_env_var(
         self,
@@ -773,13 +755,13 @@ class TestLoadConfigEnvVar:
     ) -> None:
         """An explicit ``config_path`` argument wins over the env var."""
         env_file = tmp_path / "from-env.yaml"
-        env_file.write_text(yaml.dump({"timezone": "UTC"}))
+        env_file.write_text(yaml.dump({"vault_path": "/vaults/from-env"}))
         cli_file = tmp_path / "from-cli.yaml"
-        cli_file.write_text(yaml.dump({"timezone": "Europe/London"}))
+        cli_file.write_text(yaml.dump({"vault_path": "/vaults/from-cli"}))
         monkeypatch.setenv(CONFIG_PATH_ENV_VAR, str(env_file))
 
         cfg = load_config(cli_file)
-        assert cfg.timezone == "Europe/London"
+        assert cfg.vault_path == Path("/vaults/from-cli")
 
     def test_env_var_pointing_to_missing_file_raises(
         self,
@@ -800,11 +782,14 @@ class TestLoadConfigEnvVar:
     ) -> None:
         """An empty (or whitespace) env var behaves as if unset."""
         monkeypatch.setenv(CONFIG_PATH_ENV_VAR, "   ")
+        # A stray CREEK_VAULT_PATH in the ambient environment would otherwise
+        # override the built-in default this test is asserting.
+        monkeypatch.delenv("CREEK_VAULT_PATH", raising=False)
         monkeypatch.chdir(tmp_path)
 
         cfg = load_config()
         # No creek_config.yaml in tmp_path → defaults populated.
-        assert cfg.timezone == "America/Los_Angeles"
+        assert cfg.vault_path == Path(".")
 
     def test_unset_env_var_uses_cwd_default(
         self,
@@ -814,11 +799,11 @@ class TestLoadConfigEnvVar:
         """When the env var is unset, behaviour matches the historical contract."""
         monkeypatch.delenv(CONFIG_PATH_ENV_VAR, raising=False)
         config_file = tmp_path / "creek_config.yaml"
-        config_file.write_text(yaml.dump({"timezone": "Asia/Tokyo"}))
+        config_file.write_text(yaml.dump({"vault_path": "/vaults/from-cwd"}))
         monkeypatch.chdir(tmp_path)
 
         cfg = load_config()
-        assert cfg.timezone == "Asia/Tokyo"
+        assert cfg.vault_path == Path("/vaults/from-cwd")
 
 
 # ---------------------------------------------------------------------------
@@ -839,7 +824,11 @@ class TestGenerateDefaultConfig:
             data = yaml.safe_load(f)
         assert isinstance(data, dict)
         assert "vault_path" in data
-        assert "timezone" in data
+        # Issue #1339: the dead ``timezone`` knob was deleted, so freshly
+        # generated configs must stop shipping it — otherwise every new vault
+        # is born with a key the loader only tolerates for backwards
+        # compatibility.
+        assert "timezone" not in data
 
     def test_roundtrip(self, tmp_path: Path) -> None:
         """Generated config should round-trip back through load_config."""
@@ -848,7 +837,6 @@ class TestGenerateDefaultConfig:
 
         cfg = load_config(output)
         assert cfg.vault_path == Path(".")
-        assert cfg.timezone == "America/Los_Angeles"
         assert cfg.llm.default.provider == "ollama"
         assert cfg.embeddings.model == "all-MiniLM-L6-v2"
         assert cfg.google_drive.scopes == [
@@ -951,3 +939,207 @@ class TestVoiceConfigRoundtrip:
             config.ai_style.voice_distance_target
             <= config.ai_style.voice_distance_upper
         )
+
+
+# ---------------------------------------------------------------------------
+# Deletion of the dormant ``timezone`` field (issue #1339)
+# ---------------------------------------------------------------------------
+
+
+class TestTimezoneFieldDeleted:
+    """The dormant ``timezone`` knob is gone, behind a migration shim (#1339).
+
+    ``CreekConfig.timezone`` had zero production readers. Wiring it would have
+    made every fragment id a function of the setting — ``generate_fragment_id``
+    (``creek/ingest/base.py``) hashes ``timestamp.isoformat()``, whose rendered
+    UTC offset changes with the zone, so one instant yields a different
+    ``frag-…`` id per configured timezone. That is exactly the id-derivation
+    bug #1329 had to migrate vaults out of, so the field was **deleted**
+    instead of wired: Creek's anchor is America/Los_Angeles by ontology
+    mandate §8.3 (:data:`creek.time.LA_TZ`), not an operator knob.
+
+    Deletion needs a shim because ``CreekConfig`` forbids extra keys and
+    ``generate_default_config`` dumps the whole model — so every
+    ``creek_config.yaml`` ever written by ``creek init`` carries a
+    ``timezone:`` line. Without the shim, deleting the field would turn 100%
+    of existing operator configs into a hard ``ValidationError`` at load.
+    """
+
+    def test_timezone_is_not_a_config_field(self) -> None:
+        """``timezone`` is no longer a field on ``CreekConfig`` (#1339).
+
+        Named explicitly so a revert fails with the reason attached rather
+        than as a puzzling knock-on elsewhere: re-adding the field either
+        re-introduces a dead knob (caught by ``test_config_contract.py``) or,
+        if wired, makes fragment ids config-dependent again.
+        """
+        assert "timezone" not in CreekConfig.model_fields
+
+    def test_stale_timezone_key_still_loads(self, tmp_path: Path) -> None:
+        """A pre-#1339 config carrying ``timezone:`` still loads (#1339).
+
+        The migration path for every vault already on disk: the stale key is
+        dropped, and the rest of the file survives untouched.
+        """
+        config_file = tmp_path / "creek_config.yaml"
+        config_file.write_text(
+            yaml.dump(
+                {
+                    "timezone": "America/Los_Angeles",
+                    "vault_path": "/vaults/legacy",
+                },
+            ),
+        )
+
+        cfg = load_config(config_file)
+
+        assert not hasattr(cfg, "timezone")
+        assert "timezone" not in cfg.model_dump()
+        # The shim drops one key; it must not swallow the rest of the config.
+        assert cfg.vault_path == Path("/vaults/legacy")
+
+    def test_stale_timezone_key_warns_it_is_ignored(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Dropping the stale key is announced, not silent (#1339).
+
+        An operator who set ``timezone: Europe/London`` believed it did
+        something. Discarding that quietly would leave them believing it
+        still does, so the load emits a WARNING naming the key.
+        """
+        config_file = tmp_path / "creek_config.yaml"
+        config_file.write_text(yaml.dump({"timezone": "Europe/London"}))
+
+        with caplog.at_level(logging.WARNING, logger="creek.config"):
+            load_config(config_file)
+
+        messages = [record.getMessage() for record in caplog.records]
+        timezone_warnings = [
+            record.getMessage()
+            for record in caplog.records
+            if record.levelno == logging.WARNING and "timezone" in record.getMessage()
+        ]
+        assert timezone_warnings, (
+            f"no WARNING naming 'timezone'; records were {messages}"
+        )
+        # Substance, not prose: the operator must learn the key is dead.
+        assert any(
+            phrase in message.lower()
+            for message in timezone_warnings
+            for phrase in ("ignored", "obsolete", "no longer", "removed")
+        ), f"WARNING never says the key is ignored/obsolete: {timezone_warnings}"
+
+    def test_any_stale_timezone_value_is_tolerated(self, tmp_path: Path) -> None:
+        """A nonsense ``timezone:`` value now loads instead of raising (#1339).
+
+        Pins that the validator was *removed* rather than left half-alive: a
+        value the old ``validate_timezone`` rejected must sail through, because
+        nothing validates a key nothing reads.
+        """
+        config_file = tmp_path / "creek_config.yaml"
+        config_file.write_text(
+            yaml.dump({"timezone": "Not/A/Timezone", "vault_path": "/vaults/legacy"}),
+        )
+
+        cfg = load_config(config_file)
+
+        assert not hasattr(cfg, "timezone")
+        assert cfg.vault_path == Path("/vaults/legacy")
+
+    def test_genuinely_unknown_key_is_still_rejected(self, tmp_path: Path) -> None:
+        """The shim must not be implemented as a blanket ``extra='ignore'``.
+
+        The one-way ratchet: dropping *one* named, historically-generated key
+        is a migration; accepting *any* unknown key turns every config typo
+        into a silent no-op. ``redction:`` is a plausible ``redaction:`` typo.
+        """
+        config_file = tmp_path / "creek_config.yaml"
+        config_file.write_text(yaml.dump({"redction": {"enabled": True}}))
+
+        with pytest.raises(ValidationError) as excinfo:
+            load_config(config_file)
+
+        errors = excinfo.value.errors()
+        assert [error["type"] for error in errors] == ["extra_forbidden"]
+        assert [error["loc"] for error in errors] == [("redction",)]
+
+    def test_unknown_key_rejected_even_beside_a_stale_timezone(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Popping ``timezone`` must not amnesty its neighbours (#1339).
+
+        Guards the shim shape: it removes one key by name, rather than
+        clearing whatever the model would otherwise reject.
+        """
+        config_file = tmp_path / "creek_config.yaml"
+        config_file.write_text(
+            yaml.dump({"timezone": "UTC", "redction": {"enabled": True}}),
+        )
+
+        with pytest.raises(ValidationError) as excinfo:
+            load_config(config_file)
+
+        assert [error["loc"] for error in excinfo.value.errors()] == [("redction",)]
+
+    def test_stray_creek_timezone_env_var_is_inert(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A leftover ``CREEK_TIMEZONE`` export must not break startup (#1339).
+
+        pydantic-settings silently drops env vars that match no field, so the
+        operator whose shell profile still exports it gets defaults rather
+        than a crash. Pinned here so it cannot regress into a hard failure.
+        """
+        monkeypatch.setenv("CREEK_TIMEZONE", "Europe/London")
+
+        cfg = CreekConfig()
+
+        assert not hasattr(cfg, "timezone")
+        assert "timezone" not in cfg.model_dump()
+
+    def test_modern_config_loads_silently(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A config without the stale key warns about nothing (#1339).
+
+        The deprecation notice must be conditional on the key being present.
+        Hoisting the ``logger.warning`` above the shim's guard would make
+        every single load noisy forever, and every other test in this class
+        would still pass — so the silence is pinned explicitly.
+        """
+        config_file = tmp_path / "creek_config.yaml"
+        config_file.write_text(yaml.dump({"vault_path": "/vaults/modern"}))
+
+        with caplog.at_level(logging.WARNING, logger="creek.config"):
+            cfg = load_config(config_file)
+
+        assert cfg.vault_path == Path("/vaults/modern")
+        assert [record.getMessage() for record in caplog.records] == []
+
+    @pytest.mark.parametrize("payload", [None, 42], ids=["none", "int"])
+    def test_non_mapping_input_still_raises_a_validation_error(
+        self,
+        payload: object,
+    ) -> None:
+        """A non-``dict`` payload fails as pydantic's error, not the shim's.
+
+        The shim runs before pydantic has coerced anything, so it must not
+        assume it was handed a container. Dropping its ``isinstance`` guard
+        makes ``_OBSOLETE_TIMEZONE_KEY not in data`` raise ``TypeError:
+        argument of type 'int' is not iterable`` from *inside* validation,
+        instead of the ``ValidationError`` callers are written to handle.
+
+        Both payloads are deliberately non-iterable: a ``list`` or ``str``
+        would support ``in`` and so pass even without the guard (#1339).
+
+        Args:
+            payload: A non-mapping value handed straight to validation.
+        """
+        with pytest.raises(ValidationError):
+            CreekConfig.model_validate(payload)

--- a/creek-tools/tests/test_config_contract.py
+++ b/creek-tools/tests/test_config_contract.py
@@ -91,10 +91,6 @@ _LLM_BATCH_SIZE: Final[str] = (
 )
 
 DORMANT_CONFIG_FIELDS: Final[dict[str, str]] = {
-    "timezone": (
-        "declared dormant: no production code normalises timestamps through "
-        "it yet; wire-in tracked by #1041"
-    ),
     "ocr.enabled": "declared dormant: OCR wire-in tracked by #1041",
     "ocr.engine": "declared dormant: OCR wire-in tracked by #1041",
     "ocr.languages": "declared dormant: OCR wire-in tracked by #1041",
@@ -1062,6 +1058,46 @@ def test_dormant_reason_cites_an_issue(path: str, reason: str) -> None:
     assert _ISSUE_REFERENCE.search(reason), (
         f"DORMANT_CONFIG_FIELDS[{path!r}] must cite an issue number so the "
         f"next engineer can find the decision; got {reason!r}."
+    )
+
+
+def test_timezone_field_may_not_return_without_a_production_reader() -> None:
+    """``timezone`` may exist on ``CreekConfig`` only if production reads it.
+
+    Issue #1339 deleted ``CreekConfig.timezone``: it had zero production
+    readers, and wiring it in would have made fragment ids config-dependent,
+    because :func:`creek.ingest.base.generate_fragment_id` hashes
+    ``timestamp.isoformat()``. A vault re-ingested under a different
+    ``timezone:`` would mint a second id for every fragment it already held.
+
+    This guard deliberately does **not** consult
+    :data:`DORMANT_CONFIG_FIELDS`. The generic gate above
+    (:func:`test_every_config_field_is_consumed_or_declared_dormant`) can be
+    silenced by re-adding a dormancy entry — which is exactly how the field
+    survived from #1041 to #1339 — so it cannot express "this one never comes
+    back dead". This one can: the only way to make it pass with the field
+    present is to reintroduce it *together with a real production reader*,
+    which is what #1339 asks of anyone who wants the knob back.
+
+    The scan is trustworthy here for a specific reason: per this module's
+    docstring, ``creek/config.py`` itself is excluded from
+    :func:`_consumed_config_fields`, "it is where the fields are *defined*".
+    So the deletion's migration shim — a ``model_validator(mode="before")``
+    living in ``config.py`` that pops the stale key and warns, and which
+    necessarily mentions the string ``"timezone"`` — provably cannot fool
+    this guard into seeing a reader that does not exist.
+    """
+    if "timezone" not in model_leaf_paths(CreekConfig):
+        return
+
+    assert "timezone" in _consumed_config_fields(), (
+        "CreekConfig declares a `timezone` field again, and no production "
+        "code under creek/ or creek_mcp/ reads it (creek/config.py excluded: "
+        "the migration shim's mention of the key does not count as a reader). "
+        "Issue #1339 deleted this field precisely because it was a dormant "
+        "knob shipped into every vault. Do not re-add it to "
+        "DORMANT_CONFIG_FIELDS — that is the loophole this test exists to "
+        "close. Either wire it to a real consumer, or delete the field again."
     )
 
 

--- a/creek-tools/tests/test_discord_ingest.py
+++ b/creek-tools/tests/test_discord_ingest.py
@@ -666,7 +666,7 @@ class TestDiscordIngestorParse:
         assert "[SPOILER: secret]" in fragments[0].content
 
     def test_parse_timestamp_normalization(self) -> None:
-        """Should normalize timestamp to configured timezone."""
+        """Should normalize timestamp to America/Los_Angeles."""
         messages = [
             _make_msg(timestamp="2024-11-10T20:00:00+00:00"),
         ]

--- a/creek-tools/tests/test_ingest_generic_idempotent.py
+++ b/creek-tools/tests/test_ingest_generic_idempotent.py
@@ -37,10 +37,11 @@ import frontmatter
 import pytest
 
 from creek.ingest import INGESTOR_REGISTRY, generic
-from creek.ingest.base import LA_TZ, RawDocument, assemble_ingested_fragment
+from creek.ingest.base import RawDocument, assemble_ingested_fragment
 from creek.ingest.generic import GenericIngestor
 from creek.ingest.pipeline import run_ingest
 from creek.models import SourcePlatform
+from creek.time import LA_TZ
 from creek.vault.writer import VaultWriter
 
 if TYPE_CHECKING:

--- a/creek-tools/tests/test_mcp_server.py
+++ b/creek-tools/tests/test_mcp_server.py
@@ -528,7 +528,7 @@ def test_main_config_flag_sets_env_var_before_build_server(
     from creek_mcp import server as server_module
 
     config_file = tmp_path / "vault-config.yaml"
-    config_file.write_text("timezone: UTC\n")
+    config_file.write_text("vault_path: /vaults/x\n")
     monkeypatch.delenv(CONFIG_PATH_ENV_VAR, raising=False)
 
     captured_env: dict[str, str | None] = {}

--- a/creek-tools/tests/test_time.py
+++ b/creek-tools/tests/test_time.py
@@ -15,12 +15,18 @@ These tests pin the facts that earlier code regressed on:
    ``ingested`` / ``authored_at`` to America/Los_Angeles at validation
    time (issue #976), so offsetless YAML frontmatter cannot smuggle a
    naive datetime into a vault that also holds tz-aware ones.
+6. The LA anchor has exactly one production definition — ``LA_TZ`` in
+   :mod:`creek.time` (issue #1339). Two constants that merely *agree*
+   today are two places to change tomorrow.
 """
 
 from __future__ import annotations
 
+import re
 import time
 from datetime import UTC, datetime
+from pathlib import Path
+from typing import Final
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -88,6 +94,81 @@ def test_la_tz_constant_matches_zoneinfo() -> None:
     """The exported ``LA_TZ`` constant is the LA zoneinfo, not a tzname str."""
     sample = datetime(2026, 4, 1, tzinfo=LA_TZ)
     assert sample.utcoffset() == ZoneInfo("America/Los_Angeles").utcoffset(sample)
+
+
+_CREEK_TOOLS_ROOT: Final[Path] = Path(__file__).resolve().parents[1]
+"""The ``creek-tools`` package root — the directory holding ``creek/``."""
+
+_PRODUCTION_ROOTS: Final[tuple[Path, ...]] = (
+    _CREEK_TOOLS_ROOT / "creek",
+    _CREEK_TOOLS_ROOT / "creek_mcp",
+)
+"""Production source trees scanned for ``LA_TZ`` definitions (``tests/`` excluded).
+
+Test modules legitimately mint their own local ``LA_TZ`` for fixtures; the
+single-definition rule is about production code, where a second constant is a
+second thing to change.
+"""
+
+_LA_TZ_ASSIGNMENT: Final[re.Pattern[str]] = re.compile(
+    r"^\s*LA_TZ\s*(?::[^=\n]+)?=[^=]",
+    re.MULTILINE,
+)
+"""Matches an assignment to ``LA_TZ`` (annotated or not), never a comparison.
+
+Anchored to an assignment so that ``from creek.time import LA_TZ`` and prose
+mentions in docstrings do not count as definitions.
+"""
+
+
+def _production_files_declaring_la_tz() -> list[str]:
+    """Return the production files that assign ``LA_TZ``, as relative paths.
+
+    Returns:
+        Repo-relative POSIX paths (e.g. ``creek/time.py``), sorted, one per
+        file containing at least one ``LA_TZ = ...`` assignment.
+    """
+    return [
+        source.relative_to(_CREEK_TOOLS_ROOT).as_posix()
+        for root in _PRODUCTION_ROOTS
+        for source in sorted(root.rglob("*.py"))
+        if _LA_TZ_ASSIGNMENT.search(source.read_text(encoding="utf-8"))
+    ]
+
+
+def test_la_tz_is_declared_exactly_once_in_production() -> None:
+    """``LA_TZ`` is defined once, in ``creek/time.py``, and re-exported (#1339).
+
+    ``creek.ingest.base`` used to mint its own ``ZoneInfo("America/Los_Angeles")``
+    under the same name. The two constants happened to agree, which is precisely
+    the failure mode: the LA anchor is an ontology mandate (§8.3), so it needs
+    one definition to change, audit, and reason about — not two that agree until
+    someone edits one of them.
+
+    The source scan is the load-bearing assertion, and it has to be: an
+    *identity* check (``creek.ingest.base.LA_TZ is creek.time.LA_TZ``) cannot
+    prove single-definition, because :class:`~zoneinfo.ZoneInfo` caches its
+    instances by key — two independently constructed
+    ``ZoneInfo("America/Los_Angeles")`` objects are already the same object,
+    so such a check passes just as happily against the duplicated constant.
+    The second assertion therefore pins a different fact: the historical
+    ``from creek.ingest.base import LA_TZ`` path must keep resolving, to the
+    LA zone, so the five modules importing it from there do not break on
+    consolidation.
+    """
+    declaring = _production_files_declaring_la_tz()
+    assert declaring == ["creek/time.py"], (
+        "LA_TZ must be defined exactly once, in creek/time.py; "
+        f"found definitions in: {declaring}"
+    )
+
+    from creek.ingest.base import LA_TZ as REEXPORTED_LA_TZ
+
+    sample = datetime(2026, 4, 1, tzinfo=REEXPORTED_LA_TZ)
+    assert sample.utcoffset() == ZoneInfo("America/Los_Angeles").utcoffset(sample), (
+        "creek.ingest.base.LA_TZ must stay importable and anchored to "
+        "America/Los_Angeles; existing importers depend on that path"
+    )
 
 
 class TestFragmentDefaultTimestamps:

--- a/docs/Ontology/creek_ontology_agent_prompt.md
+++ b/docs/Ontology/creek_ontology_agent_prompt.md
@@ -897,7 +897,6 @@ pytz = "^2024.1"         # Timezone normalization
 # creek_config.yaml
 vault_path: "/path/to/Creek-Vault"
 source_drive: "/path/to/external/drive"
-timezone: "America/Los_Angeles"
 
 llm:
   # DEFAULT: Local-only processing via Ollama. No data leaves your machine.


### PR DESCRIPTION
## Summary

`CreekConfig.timezone` was validated against `ZoneInfo` at load — real work that
teaches an operator the setting matters — and then read by **nothing**. Every
timestamp the pipeline writes was anchored to a hard-coded `America/Los_Angeles`
constant, which was itself declared twice.

The issue offered a fork: wire the key through, or delete it. **This PR deletes
it**, and the reason is not "wiring was expensive" — it is that wiring would
have been actively harmful.

`generate_fragment_id` (`creek/ingest/base.py`) computes
`f"{source}:{timestamp.isoformat()}:{content}"`, and `isoformat()` renders the
UTC offset. One instant therefore hashes differently per anchor — verified by
execution:

```
2023-11-14T14:13:20-08:00  ->  frag-f8d2701a16e9   (America/Los_Angeles)
2023-11-14T22:13:20+00:00  ->  frag-b79caa69dda2   (Europe/London)
```

Same moment, two ids. A settable anchor would make every fragment's identity a
function of a mutable operator setting — reopening the exact `#1329` bug class
this repo already paid for with a dedicated vault migration module
(`creek/ingest/pin_ids.py`) and a whole regression suite
(`tests/test_ingest_id_host_independence.py`). It would also dissolve
`ensure_aware`'s correctness argument (naive frontmatter is an *LA* wall-clock
reading) and make `chatgpt.py`'s `_MISSING_TIMESTAMP_SENTINEL` a moving instant.
Deleting the key is what `creek/time.py`'s own §8.3 ontology mandate already
said.

### The migration this needed (the part the issue did not mention)

`CreekConfig` is `extra='forbid'`, and `generate_default_config` writes
`CreekConfig().model_dump()` — so **every `creek_config.yaml` `creek init` has
ever produced contains a `timezone:` line**. A naive field deletion would have
turned 100% of existing operator configs into a hard `ValidationError` at load.

So deletion ships with a deliberately narrow shim,
`CreekConfig._drop_obsolete_timezone` — a `model_validator(mode="before")` that
removes that one key **by name** (returning a copy, never mutating the caller's
parsed YAML) and logs one WARNING telling the operator the key is obsolete,
ignored, and safe to delete.

`extra='forbid'` is untouched. Flipping it to `extra='ignore'` would have been
the easy migration and a safety regression — a typo'd `redction:` block would
silently become a no-op. Two tests pin that unknown keys still hard-fail, one of
them specifically with a stale `timezone:` sitting right beside the typo.

Environment vars needed no migration: pydantic-settings never collects a
`CREEK_*` var that matches no field, so a leftover `export CREEK_TIMEZONE=...`
is inert. Pinned by test so it cannot regress into a crash.

### The guard against the key coming back

The invariant "the config cannot advertise a setting nothing honours" was
already enforced here — `tests/test_config_contract.py` (#1042) AST-scans
`creek/` + `creek_mcp/` and fails any field that is neither read nor
allowlisted. `timezone` was sitting in its `DORMANT_CONFIG_FIELDS` allowlist;
that entry is now removed, and the allowlist only ever shrinks.

On top of it this PR adds
`test_timezone_field_may_not_return_without_a_production_reader`, which
deliberately **does not consult the allowlist**, so it cannot be silenced by
re-declaring the field dormant. The only legitimate way to make it pass with the
field present is to bring it back *with a real production reader*.

Mutation-proved, not asserted:

| mutant | result |
| --- | --- |
| reintroduce `timezone` field, no reader | **7 tests fail** |
| reintroduce it *and* re-add a `DORMANT_CONFIG_FIELDS` entry | generic gate goes green, **the new guard still fails** |

Both mutants applied via byte snapshots and restored by verified SHA-256 (never
`git checkout`, which would have destroyed uncommitted lane work).

### `LA_TZ` declared once

Was two independent declarations (`creek/time.py:29`, `creek/ingest/base.py:38`)
whose duplication `creek/time.py`'s module docstring explicitly *defended*. Now
one, in `creek/time.py`; `creek/ingest/base.py` imports and re-exports it so the
historical `from creek.ingest.base import LA_TZ` path keeps working, and the
five other importers point at the declaration site. Verified:

```
$ grep -rn '^\s*LA_TZ\s*[:=]' --include='*.py' creek creek_mcp
creek/time.py:31:LA_TZ = ZoneInfo("America/Los_Angeles")
```

Note an identity check (`base.LA_TZ is time.LA_TZ`) **cannot** prove this —
`ZoneInfo` caches instances by key, so it was already `True` before the fix. The
load-bearing assertion is a source scan.

Three lying docstrings fixed along the way: `creek/time.py`'s paragraph
defending the duplicate constant, `creek/ingest/discord.py:668`'s "in the
configured timezone", and `CreekConfig`'s class docstring advertising
`CREEK_TIMEZONE` as an example env var.

### Decisions recorded

- **Consent records stay pinned.** `creek/consent.py` stamps consent evidence
  with `LA_TZ`. These must never be operator-configurable — that is an argument
  *for* this direction. The retarget there is import-source-only; record naming
  and timestamps are byte-identical.
- Deleted-vs-converted tests: several `tests/test_config.py` cases used
  `timezone` only as an arbitrary key to exercise `load_config`'s `CREEK_CONFIG`
  path resolution. Those were **converted** to `vault_path`, not deleted —
  deleting them would have been a silent coverage regression. Only three tests
  that genuinely tested the deleted field were removed.

### What Gate 2.5 review caught

Worth recording, because two of the three were *my own* new tests failing to
earn their keep:

1. **Blocker, fixed.** The shim's docstring claimed it lives on the model
   because "MCP, direct construction and the environment all bypass
   `load_config`". The MCP half is false — `creek_mcp/` has **27** `load_config`
   calls and **zero** direct `CreekConfig()` constructions. On an issue whose
   entire premise is documentation that lied, that could not ship. Reworded to
   the two bypasses that are real.
2. **A test of mine was unfalsifiable.** I had added
   `test_shim_does_not_mutate_the_callers_mapping` to pin the "copy, not a pop"
   comment. Mutation-testing it revealed the in-place `del` mutant *survives* —
   because as a `BaseSettings`, this model receives a dict its settings sources
   freshly merged, never the caller's object. The test could never fail, and the
   code comment asserting "``data`` is the caller's parsed YAML" was itself
   false. Test deleted; comment corrected to say the copy is defensive rather
   than load-bearing.
3. **A test of mine probed the wrong thing.** The non-mapping guard test passed
   `["not", "a", "mapping"]` — but `in` works fine on a list, so it survived
   removal of the `isinstance` guard. Now parametrised over `None` and `42`,
   which are genuinely non-iterable; both fail with `TypeError` when the guard
   is removed.

Every guard in this PR was mutation-verified after fixing, not just asserted.

## Test plan

- `./scripts/check-all.sh` — **exit 0**; 12/12 checks, **9693 passed**, coverage
  **94.66%** (gate 90%), per-file gate green, mypy strict clean, ruff clean
  verified with `--no-cache`.
- The 5 skips are pre-existing environmental ones (Ollama unreachable, absent
  API keys) — no test skipped by this change.
- Gate 1 RED proved by running: 9 failing tests before implementation, all
  behavioural (no missing-symbol errors).
- Mutation battery above.
- Bypass sweep over added lines: no `noqa`, `type: ignore`, `pylint: disable`,
  `skip`/`xfail`, `pragma: no cover`, `nosec`. No `pyproject.toml`, `scripts/`,
  pre-commit or CI files touched.

**Substitution noted:** the issue's acceptance criteria list
`pre-commit run --all-files`. That was **not** run — it reformats unrelated
files across the worktree. `./scripts/check-all.sh` is the repo's gate and runs
the same ruff/mypy/bandit/interrogate checks; it passed at exit 0.

Closes #1339
