### PR TITLE
fix(generate): stop glossing ordinary English, and make the drift guard able to fail

### DIFF
--- a/creek-tools/creek/generate/jargon.py
+++ b/creek-tools/creek/generate/jargon.py
@@ -14,6 +14,17 @@ holds any gloss signal — an em-dash, a parenthetical, an appositive comma, a
 keywords. Surface forms are matched case-sensitively on a word boundary so an
 ordinary lower-case word (``rising`` the verb) or a capitalised non-term
 (``London``) never trips the scan.
+
+Case-sensitivity only buys that where the registry holds no bare lower-case
+form to match. Every registered surface form is prose a draft writes — a label
+("Rising", "Ultraviolet") or a proper name ("Agency") — and a serialised wire
+value (``rising``, ``absorb``) can never be registered at all: constructing an
+:class:`~creek.generate.ontology_glossary.OntologyTerm` around a single
+all-lower-case word raises, in its ``__post_init__``. That guard is what stands
+between this module and the #1343 defect: re-adding a ``.value`` alias would,
+absent it, put the wire values back in the scan's path and make this module flag
+ordinary English again. Weakening the guard and re-adding the alias together is
+the one change that silently restores the bug.
 """
 
 from __future__ import annotations

--- a/creek-tools/creek/generate/ontology_glossary.py
+++ b/creek-tools/creek/generate/ontology_glossary.py
@@ -11,8 +11,20 @@ This module is the **single source of truth** for that vocabulary. Every
 :class:`OntologyTerm` is *derived* from the existing taxonomy constants — the
 ``Frequency`` / ``Phase`` / ``Mode`` enums and the ``FREQUENCY_*`` / ``PHASE_*``
 description maps — rather than re-typed by hand, so the glossary cannot silently
-drift from the taxonomy. A drift-guard test asserts every enum member resolves
-to an entry, so a new enum member without a gloss seed fails the build.
+drift from the taxonomy. Each derived term names the taxonomy member it came
+from in its ``source`` field, and the drift-guard test matches every
+non-sentinel member to the term declaring it **by identity**. Identity is
+load-bearing: all three taxonomies are ``StrEnum`` classes, so their members
+compare *and hash* as bare strings across classes, and all three
+``UNCLASSIFIED`` sentinels are the one string ``"unclassified"``. The older
+guard asserted only that ``member.value`` resolved to *some* registry key, which
+one enum's term could satisfy on another enum's behalf — that is how the
+sentinels slipped through (#1343).
+
+The three ``UNCLASSIFIED`` sentinels earn no term at all: "we could not classify
+this" is a wire value, not vocabulary a draft ever writes. Each builder excludes
+its own sentinel with ``is``, never ``==``, which would also match the other two
+taxonomies' sentinels.
 
 The seeds are short hints (a clause's worth), not dictionary definitions: they
 exist to ground the model so it can phrase the gloss *in the owner's voice* on
@@ -36,18 +48,27 @@ from creek.generate.wavelength import _PHASE_DESCRIPTIONS
 from creek.models import Frequency, Mode, Phase
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Mapping, Sequence
 
 #: Plain-English activation sense for each engagement mode, adapted from the
 #: ``_mode_activation_phrase`` base map in :mod:`creek.generate.skills`. Kept
-#: here as a short gloss seed (not the full activation phrasing).
+#: here as a short gloss seed (not the full activation phrasing). Deliberately
+#: keyed only by the modes the glossary glosses — the ``UNCLASSIFIED`` sentinel
+#: is not vocabulary and is excluded from the glossary — so a future ``Mode``
+#: member added without a gloss seed raises ``KeyError`` when the terms are
+#: built. That build-time failure is the drift detection working, not a bug.
+#:
+#: Keying a dict by an enum member is the shape #1343 warns about, and it is
+#: safe *here only* because this map is mono-taxonomy and excludes the sentinel:
+#: no two ``Mode`` members share a value, and ``UNCLASSIFIED`` — the one value
+#: that also belongs to ``Frequency`` and ``Phase`` — is not a key. Do not
+#: generalise the pattern to a map spanning more than one taxonomy.
 _MODE_SENSES: dict[Mode, str] = {
     Mode.INHABIT: "living inside the frequency rather than performing it",
     Mode.EXPRESS: "enacting the frequency outward, for others to feel",
     Mode.COLLABORATE: "working a frequency alongside other people",
     Mode.INTEGRATE: "metabolising a frequency into a coherent whole",
     Mode.ABSORB: "receiving a frequency rather than producing it",
-    Mode.UNCLASSIFIED: "no dominant engagement mode is in play",
 }
 
 #: Developmental-altitude colour terms surfaced in prose (e.g. "Ultraviolet").
@@ -93,58 +114,100 @@ class OntologyTerm:
             detector looks for nearby.
         aliases: Extra surface forms that name the same term (e.g. a frequency's
             APTITUDE label alongside its ``F``-code).
+        source: The taxonomy member this term is derived from, if any. Carried
+            so the drift guard can match a member to its term by *identity*
+            rather than by string resolution — the three taxonomies are
+            ``StrEnum`` classes whose members are interchangeable as strings.
+            ``None`` for terms with no enum behind them (altitudes and named
+            concepts). Note that it joins the frozen dataclass's generated
+            ``__eq__`` / ``__hash__``, where the same cross-taxonomy string
+            equality applies; two terms are kept distinct by their labels, which
+            :func:`_build_registry` already guarantees are unique, so never
+            lean on ``source`` alone to tell two terms apart.
     """
 
     label: str
     category: str
     gloss_seed: str
     aliases: tuple[str, ...] = ()
+    source: Frequency | Phase | Mode | None = None
+
+    def __post_init__(self) -> None:
+        """Reject any surface form that is a bare serialised wire value.
+
+        A single all-lower-case word (``"rising"``, ``"bottoming_out"``) is an
+        enum's ``.value``, indistinguishable from ordinary English — the
+        detector matches surface forms case-sensitively on a word boundary, so
+        registering one makes it flag prose (#1343). A lower-case *phrase*
+        (``"non-dual substrate"``) is real vocabulary and stays legal, as does
+        anything carrying a capital (``"F1"``, ``"Rising"``, ``"APTITUDE"``).
+
+        Raises:
+            ValueError: If ``label`` or any entry of ``aliases`` is a single
+                all-lower-case word.
+        """
+        for surface in (self.label, *self.aliases):
+            if surface.islower() and " " not in surface:
+                msg = (
+                    f"ontology surface form {surface!r} is a bare lower-case "
+                    "word — a serialised wire value, indistinguishable from "
+                    "ordinary English; register the prose form a draft writes"
+                )
+                raise ValueError(msg)
 
 
 def _frequency_terms() -> list[OntologyTerm]:
-    """Build a term per ``Frequency`` member from the theme/name maps."""
-    terms: list[OntologyTerm] = []
-    for freq in Frequency:
-        if freq is Frequency.UNCLASSIFIED:
-            seed = "no dominant frequency signal is present"
-            aliases: tuple[str, ...] = ()
-        else:
-            seed = FREQUENCY_THEMES[freq]
-            aliases = (CANONICAL_FREQUENCY_NAMES[freq],)
-        terms.append(
-            OntologyTerm(
-                label=freq.value,
-                category="frequency",
-                gloss_seed=seed,
-                aliases=aliases,
-            )
+    """Build a term per real ``Frequency`` member from the theme/name maps.
+
+    The canonical APTITUDE name is kept as an alias: unlike a wire value, it is
+    a capitalised proper name ("Agency", "Pluralism") a draft genuinely writes.
+    """
+    return [
+        OntologyTerm(
+            label=freq.value,
+            category="frequency",
+            gloss_seed=FREQUENCY_THEMES[freq],
+            aliases=(CANONICAL_FREQUENCY_NAMES[freq],),
+            source=freq,
         )
-    return terms
+        for freq in Frequency
+        if freq is not Frequency.UNCLASSIFIED
+    ]
 
 
 def _phase_terms() -> list[OntologyTerm]:
-    """Build a term per ``Phase`` member from the phase-description map."""
+    """Build a term per real ``Phase`` member from the phase-description map.
+
+    The title-cased label ("Rising", "Bottoming Out") is the only surface form a
+    draft writes; the ``.value`` behind it is a wire value, never registered.
+    """
     return [
         OntologyTerm(
             label=phase.name.replace("_", " ").title(),
             category="phase",
             gloss_seed=_PHASE_DESCRIPTIONS[phase.value],
-            aliases=(phase.value,),
+            source=phase,
         )
         for phase in Phase
+        if phase is not Phase.UNCLASSIFIED
     ]
 
 
 def _mode_terms() -> list[OntologyTerm]:
-    """Build a term per ``Mode`` member from the activation-sense map."""
+    """Build a term per real ``Mode`` member from the activation-sense map.
+
+    As with phases, only the title-cased label is a surface form — "absorb" and
+    "express" as bare wire values are ordinary English verbs.
+    """
     return [
         OntologyTerm(
             label=mode.value.title(),
             category="mode",
             gloss_seed=_MODE_SENSES[mode],
-            aliases=(mode.value,),
+            source=mode,
         )
         for mode in Mode
+        if mode is not Mode.UNCLASSIFIED
     ]
 
 
@@ -192,14 +255,93 @@ def iter_ontology_terms() -> list[OntologyTerm]:
     ]
 
 
+def _source_key(source: Frequency | Phase | Mode) -> tuple[str, str]:
+    """Return a key that distinguishes *source* across the three taxonomies.
+
+    ``Frequency`` / ``Phase`` / ``Mode`` are ``StrEnum`` classes, so a member is
+    equal to — and hashes as — its bare value: keying by the member itself would
+    collapse the three ``UNCLASSIFIED`` sentinels into one. Pairing the class
+    name with the value keeps each member distinct.
+    """
+    return (type(source).__name__, source.value)
+
+
+def _check_source_collisions(terms: Sequence[OntologyTerm]) -> None:
+    """Raise ValueError if two *terms* derive from the same taxonomy member.
+
+    Terms with no ``source`` (altitudes, named concepts) are skipped: they
+    derive from no member, so they cannot collide on one.
+
+    Raises:
+        ValueError: If two terms declare the same taxonomy member as ``source``,
+            which would leave the drift guard matching that member to whichever
+            of them it happened to see first.
+    """
+    seen: dict[tuple[str, str], OntologyTerm] = {}
+    for term in terms:
+        if term.source is None:
+            continue
+        key = _source_key(term.source)
+        previous = seen.get(key)
+        if previous is not None:
+            msg = (
+                f"two ontology terms derive from {key[0]}.{key[1]}: "
+                f"{previous.label!r} and {term.label!r}"
+            )
+            raise ValueError(msg)
+        seen[key] = term
+
+
+def _build_registry(terms: Sequence[OntologyTerm]) -> dict[str, OntologyTerm]:
+    """Index *terms* by their exact surface forms, refusing any collision.
+
+    Kept pure and un-memoised so it can be exercised directly;
+    :func:`ontology_term_registry` is the cached, read-only view of it over
+    :func:`iter_ontology_terms`.
+
+    Args:
+        terms: The ontology terms to index.
+
+    Returns:
+        A mapping from each exact surface form (a term's ``label`` and every
+        entry of its ``aliases``) to the term that owns it.
+
+    Raises:
+        ValueError: If two terms claim the same surface form — the second would
+            silently shadow the first, leaving a term that can never be glossed
+            or detected. Source collisions raise here too, via
+            :func:`_check_source_collisions`.
+    """
+    _check_source_collisions(terms)
+    registry: dict[str, OntologyTerm] = {}
+    for term in terms:
+        for surface in (term.label, *term.aliases):
+            previous = registry.get(surface)
+            if previous is not None:
+                msg = (
+                    f"two ontology terms claim the surface form {surface!r}: "
+                    f"{previous.label!r} ({previous.category}) and "
+                    f"{term.label!r} ({term.category})"
+                )
+                raise ValueError(msg)
+            registry[surface] = term
+    return registry
+
+
 @cache
 def ontology_term_registry() -> Mapping[str, OntologyTerm]:
-    """Return a lookup of every term surface form (lower-cased) to its term.
+    """Return a lookup from each exact surface form to the term that owns it.
 
-    Both each term's ``label`` and its ``aliases`` are registered under their
-    exact surface form *and* a lower-cased form, so a drift-guard test can assert
-    ``freq.value in registry`` for every enum member while case-insensitive
-    lookups (an altitude or named concept written mid-sentence) still resolve.
+    A term's ``label`` and each of its ``aliases`` is registered under its
+    **exact** form and nothing else. This once wrote a lower-cased shadow key
+    beside each one, which is what made the detector flag ordinary English: the
+    detector matches case-sensitively, so the shadow turned every phase and mode
+    wire value (``rising``, ``absorb``) into a matchable term (#1343). Which
+    surface forms may exist at all is enforced at the source, in
+    :meth:`OntologyTerm.__post_init__`.
+
+    Two terms claiming one surface form is an error, not a last-writer-wins
+    overwrite; :func:`_build_registry` raises rather than lose a term.
 
     The registry is derived from static enums and constants, so it is built once
     and memoised. The result is wrapped in a read-only
@@ -207,15 +349,9 @@ def ontology_term_registry() -> Mapping[str, OntologyTerm]:
     instance.
 
     Returns:
-        A read-only mapping from surface form (exact and lower-cased) to
-        :class:`OntologyTerm`.
+        A read-only mapping from exact surface form to :class:`OntologyTerm`.
     """
-    registry: dict[str, OntologyTerm] = {}
-    for term in iter_ontology_terms():
-        for surface in (term.label, *term.aliases):
-            registry[surface] = term
-            registry[surface.lower()] = term
-    return MappingProxyType(registry)
+    return MappingProxyType(_build_registry(iter_ontology_terms()))
 
 
 #: Prompt steer asking the model to gloss each bespoke term in the owner's voice

--- a/creek-tools/tests/test_ontology_glossary.py
+++ b/creek-tools/tests/test_ontology_glossary.py
@@ -1,19 +1,32 @@
 """Tests for the bespoke-ontology-term glossary registry and gloss detector.
 
-Three concerns are pinned here:
+Four concerns are pinned here:
 
 * the registry is a *drift-guarded* single source of truth — every
-  ``Frequency`` / ``Phase`` / ``Mode`` enum member has a gloss-seed entry, so a
-  new enum member without a gloss fails the build;
+  non-sentinel ``Frequency`` / ``Phase`` / ``Mode`` member is matched to the
+  term that declares it as its ``source``, by **identity**, so a new enum
+  member without a gloss fails the build. Identity is load-bearing: all three
+  taxonomies are ``StrEnum`` classes, so their members compare *and hash* as
+  bare strings across classes, and all three ``UNCLASSIFIED`` sentinels are the
+  same string ``"unclassified"``. A string-resolvability guard therefore lets
+  one enum's term silently "cover" another enum's member — which is exactly
+  how the sentinel slipped through before #1343;
+* every surface form the registry holds is a form a draft actually writes: no
+  bare lower-case wire values (``rising``, ``bottoming_out``), no lower-cased
+  shadow keys, and no term silently overwritten by a duplicate key;
 * the gloss prompt-steer is present in both ``## Ask`` builders (the draft and
   voice surfaces), mirroring how the no-fabrication / no-provenance steers are
   pinned;
 * the conservative ``unglossed_jargon`` detector flags a first-mention bespoke
   term with no nearby gloss, never re-flags a second occurrence, and does not
-  over-flag a glossed term or an ordinary capitalised word.
+  over-flag a glossed term, an ordinary capitalised word, or an ordinary
+  lower-case English verb (``rising``, ``absorb``, ``collaborate``,
+  ``express``).
 """
 
 from __future__ import annotations
+
+import pytest
 
 from creek.generate.jargon import detect_unglossed_jargon
 from creek.generate.ontology_glossary import (
@@ -26,25 +39,91 @@ from creek.models import Frequency, Mode, Phase
 
 
 class TestRegistryDriftGuard:
-    """Every taxonomy enum member must carry a gloss-seed entry."""
+    """Every real taxonomy member — and only those — carries a gloss-seed entry."""
 
-    def test_every_frequency_member_has_a_registry_entry(self) -> None:
-        """Each ``Frequency`` member resolves to a registered term."""
-        registry = ontology_term_registry()
+    def test_every_non_sentinel_member_resolves_to_its_own_term(self) -> None:
+        """Each real taxonomy member owns a term of the matching category.
+
+        This one guard replaces the three per-enum guards it grew out of
+        (``test_every_{frequency,phase,mode}_member_has_a_registry_entry``),
+        which asserted only that ``member.value in registry`` — mere *string*
+        resolvability. Because ``Frequency`` / ``Phase`` / ``Mode`` are all
+        ``StrEnum`` classes, that assertion could not fail for the reason it
+        existed: ``Phase.UNCLASSIFIED`` "passed" by resolving to the **Mode**
+        term registered under the same ``"unclassified"`` string, and the
+        frequency sentinel's own term had already been overwritten in the
+        registry. A member could be entirely unglossed and still pass.
+
+        The identity-keyed form cannot be satisfied by an unrelated term: each
+        member must be the declared ``source`` of a term whose ``category``
+        matches its taxonomy. Sentinels are skipped by ``is`` — never by
+        equality, which would also match the other two enums' sentinels.
+        """
+        by_source: dict[tuple[str, str], OntologyTerm] = {
+            (type(term.source).__name__, term.source.value): term
+            for term in iter_ontology_terms()
+            if term.source is not None
+        }
+        expected: list[tuple[tuple[str, str], str]] = []
         for freq in Frequency:
-            assert freq.value in registry, f"no gloss-seed for {freq!r}"
-
-    def test_every_phase_member_has_a_registry_entry(self) -> None:
-        """Each ``Phase`` member resolves to a registered term."""
-        registry = ontology_term_registry()
+            if freq is not Frequency.UNCLASSIFIED:
+                expected.append(((Frequency.__name__, freq.value), "frequency"))
         for phase in Phase:
-            assert phase.value in registry, f"no gloss-seed for {phase!r}"
-
-    def test_every_mode_member_has_a_registry_entry(self) -> None:
-        """Each ``Mode`` member resolves to a registered term."""
-        registry = ontology_term_registry()
+            if phase is not Phase.UNCLASSIFIED:
+                expected.append(((Phase.__name__, phase.value), "phase"))
         for mode in Mode:
-            assert mode.value in registry, f"no gloss-seed for {mode!r}"
+            if mode is not Mode.UNCLASSIFIED:
+                expected.append(((Mode.__name__, mode.value), "mode"))
+
+        for key, category in expected:
+            assert key in by_source, f"no gloss-seed term sourced from {key}"
+            assert by_source[key].category == category
+
+    def test_sentinel_members_are_not_glossary_terms(self) -> None:
+        """The three ``UNCLASSIFIED`` sentinels earn no term and no key.
+
+        A sentinel is a wire value meaning "we could not classify this", not
+        vocabulary a draft ever writes, so it must not reach the registry the
+        jargon detector scans with. Each sentinel is checked with ``is``: the
+        three are equal as strings, so an equality test would pass on the
+        wrong enum's member.
+        """
+        for term in iter_ontology_terms():
+            assert term.source is not Frequency.UNCLASSIFIED
+            assert term.source is not Phase.UNCLASSIFIED
+            assert term.source is not Mode.UNCLASSIFIED
+        registry = ontology_term_registry()
+        assert "Unclassified" not in registry
+        assert "unclassified" not in registry
+
+    def test_registry_has_no_lower_cased_shadow_keys(self) -> None:
+        """Only exact surface forms are registered, never lower-cased shadows.
+
+        The shadow keys were what made the detector flag ordinary English:
+        ``"rising"`` / ``"express"`` / ``"absorb"`` / ``"collaborate"`` are
+        common verbs, and the detector matches keys case-sensitively (#1343).
+        """
+        registry = ontology_term_registry()
+        for shadow in (
+            "rising",
+            "express",
+            "absorb",
+            "collaborate",
+            "teal",
+            "aptitude",
+        ):
+            assert shadow not in registry, f"{shadow!r} is a lower-cased shadow key"
+
+    def test_no_term_is_lost_to_a_key_collision(self) -> None:
+        """Every derived term survives into the registry, unshadowed.
+
+        Two terms writing the same key means the first is unreachable — it can
+        never be glossed or detected. Counted against ``iter_ontology_terms()``
+        rather than a pinned number so adding a term cannot fail this test for
+        the wrong reason.
+        """
+        registry = ontology_term_registry()
+        assert len(set(registry.values())) == len(iter_ontology_terms())
 
     def test_every_term_carries_a_nonempty_gloss_seed(self) -> None:
         """No registered term may have a blank gloss-seed."""
@@ -53,7 +132,7 @@ class TestRegistryDriftGuard:
             assert term.gloss_seed.strip(), f"empty gloss-seed for {term.label!r}"
 
     def test_named_concepts_are_registered(self) -> None:
-        """The named bespoke concepts carry gloss seeds too."""
+        """The named bespoke concepts are registered under their exact form."""
         registry = ontology_term_registry()
         for concept in (
             "APTITUDE",
@@ -61,13 +140,15 @@ class TestRegistryDriftGuard:
             "Archetypal Wavelength",
             "non-dual substrate",
         ):
-            assert concept.lower() in registry
+            assert concept in registry
+            assert registry[concept].category == "concept"
 
     def test_altitude_terms_are_registered(self) -> None:
-        """The developmental altitudes (e.g. Teal, Ultraviolet) are registered."""
+        """The developmental altitudes (Teal, Ultraviolet) keep their exact form."""
         registry = ontology_term_registry()
         for altitude in ("Teal", "Ultraviolet"):
-            assert altitude.lower() in registry
+            assert altitude in registry
+            assert registry[altitude].category == "altitude"
 
 
 class TestRegistryMemoization:
@@ -76,6 +157,99 @@ class TestRegistryMemoization:
     def test_registry_is_memoized(self) -> None:
         """Two calls return the same cached object (identity)."""
         assert ontology_term_registry() is ontology_term_registry()
+
+
+class TestSurfaceFormInvariant:
+    """A term's surface forms must be prose a draft writes, not wire values.
+
+    ``OntologyTerm`` is the boundary the detector trusts. An all-lower-case
+    single word is a serialised enum value (``"rising"``, ``"bottoming_out"``),
+    indistinguishable from ordinary English, so constructing a term around one
+    is rejected at the source rather than filtered downstream (#1343).
+    """
+
+    def test_a_bare_lower_case_label_is_rejected(self) -> None:
+        """A single all-lower-case word as the ``label`` raises ``ValueError``."""
+        with pytest.raises(ValueError, match="rising"):
+            OntologyTerm(label="rising", category="phase", gloss_seed="x")
+
+    def test_a_bare_lower_case_alias_is_rejected(self) -> None:
+        """A bare wire value hidden in ``aliases`` is rejected just as hard.
+
+        Separate from the label case so the validation loop is exercised on
+        both arms: a legal label must not excuse an illegal alias.
+        """
+        with pytest.raises(ValueError, match="rising"):
+            OntologyTerm(
+                label="Rising",
+                category="phase",
+                gloss_seed="x",
+                aliases=("rising",),
+            )
+
+    def test_a_multi_word_lower_case_phrase_is_allowed(self) -> None:
+        """A lower-case *phrase* is real vocabulary and constructs fine."""
+        term = OntologyTerm(
+            label="non-dual substrate",
+            category="concept",
+            gloss_seed="the ground where self and world stop being two",
+        )
+        assert term.label == "non-dual substrate"
+
+
+class TestRegistryCollisionDetection:
+    """Building the registry refuses to silently drop a term.
+
+    ``_build_registry`` is the pure, un-memoised builder behind
+    ``ontology_term_registry()``, so these call it directly — no cache to
+    clear, no monkeypatching of the module.
+    """
+
+    def test_two_terms_sharing_a_surface_form_raise(self) -> None:
+        """Two terms claiming one surface form raise, naming the clash."""
+        from creek.generate.ontology_glossary import _build_registry
+
+        terms = [
+            OntologyTerm(
+                label="Peaking",
+                category="phase",
+                gloss_seed="the full expression",
+            ),
+            OntologyTerm(
+                label="Peaking",
+                category="mode",
+                gloss_seed="a wholly different sense",
+            ),
+        ]
+
+        with pytest.raises(ValueError) as excinfo:
+            _build_registry(terms)
+
+        assert "Peaking" in str(excinfo.value)
+
+    def test_two_terms_claiming_the_same_source_raise(self) -> None:
+        """Two terms deriving from one taxonomy member raise, naming it."""
+        from creek.generate.ontology_glossary import _build_registry
+
+        terms = [
+            OntologyTerm(
+                label="Rising",
+                category="phase",
+                gloss_seed="energy gathering",
+                source=Phase.RISING,
+            ),
+            OntologyTerm(
+                label="Ascending",
+                category="phase",
+                gloss_seed="energy gathering",
+                source=Phase.RISING,
+            ),
+        ]
+
+        with pytest.raises(ValueError) as excinfo:
+            _build_registry(terms)
+
+        assert "rising" in str(excinfo.value).lower()
 
 
 class TestGlossSteerPinned:
@@ -183,3 +357,22 @@ class TestUnglossedJargonDetector:
             "maximum output, abundance everywhere."
         )
         assert detect_unglossed_jargon(body) == []
+
+    def test_ordinary_lower_case_words_are_not_flagged(self) -> None:
+        """Ordinary English verbs are prose, not bespoke jargon.
+
+        ``jargon.py``'s module docstring already promises this — "an ordinary
+        lower-case word (``rising`` the verb) … never trips the scan" — but no
+        test stood behind the claim, and the lower-cased shadow keys in the
+        registry made it false for every phase and mode value (#1343).
+        """
+        body = (
+            "The bread was rising in the pan while I waited. I could not "
+            "absorb what he said. We collaborate on Tuesdays and express "
+            "ourselves badly."
+        )
+        assert detect_unglossed_jargon(body) == []
+
+    def test_a_wavelength_essay_with_the_verb_rising_is_not_flagged(self) -> None:
+        """The issue's literal acceptance criterion: one sentence, no findings."""
+        assert detect_unglossed_jargon("The bread was rising in the pan.") == []

--- a/creek-tools/tests/test_reflection.py
+++ b/creek-tools/tests/test_reflection.py
@@ -136,6 +136,29 @@ def test_glossed_jargon_raises_no_jargon_finding() -> None:
     assert not any(f.dimension == "unglossed_jargon" for f in result.findings)
 
 
+def test_ordinary_english_verbs_do_not_block_pass() -> None:
+    """Plain prose using "rising"/"absorb"/"collaborate"/"express" reaches PASS.
+
+    Issue #1343's acceptance criterion. Those four words are ordinary English
+    verbs *and* lower-cased ontology surface forms, so today each raises a MID
+    ``unglossed_jargon`` finding on this body. ``reflection.py`` turns any
+    finding into REVISE, and ``AuthorConductor`` loops REVISE until
+    ``max_rounds`` is spent and then ESCALATEs to a human — so an essay about
+    bread becomes unshippable. Asserted as the exact verdict plus an empty
+    finding list: "no jargon finding" alone would pass while some other
+    dimension quietly took over the block.
+    """
+    body = (
+        "The bread was rising in the pan while I waited. I could not absorb "
+        "what he said. We collaborate on Tuesdays and express ourselves badly."
+    )
+
+    result = ReflectionNode().review(body, _grounded())
+
+    assert result.decision == "PASS"
+    assert result.findings == []
+
+
 def test_privacy_leak_revises_with_privacy_finding(tmp_path: Path) -> None:
     """A cited intimate fragment leaked above the OPEN default → privacy finding."""
     secret = "the intimate confession nobody should publish"


### PR DESCRIPTION
## Summary

`_phase_terms` and `_mode_terms` registered each enum's raw lower-case `.value`
as a matchable alias, so `detect_unglossed_jargon` flagged ordinary English:

```
detect_unglossed_jargon("The bread was rising in the pan while I waited. I could
not absorb what he said. We collaborate on Tuesdays and express ourselves badly.")
  -> ['rising', 'absorb', 'collaborate', 'express']
```

Every `unglossed_jargon` finding is `MID` (`creek/author/checks.py:575` — the
issue's `:384` is stale), `ReflectionNode.reflect` turns *any* finding into
`REVISE` (`creek/author/reflection.py:126`), and `AuthorConductor` loops on
REVISE to `max_rounds` then rewrites the verdict to `ESCALATE`
(`creek/author/conductor.py:403-436`). I confirmed the whole chain by running
it: that bread sentence returns `decision == "REVISE"` with four findings, all
`unglossed_jargon`. An essay about the Archetypal Wavelength necessarily
contains "rising", so it could never PASS the author desk.

`jargon.py`'s own module docstring named the exact failing case as something
that could not happen: *"an ordinary lower-case word (`rising` the verb) …
never trips the scan."*

### The design fork (issue task 1)

Chose **capitalised surface forms only**, expressed as a structural invariant
rather than a per-term list: a surface form must carry a capital or be a
multi-word phrase. `OntologyTerm.__post_init__` raises on a bare all-lower-case
single word, so a *future* enum member cannot reintroduce the bug. The dropped
aliases carried no detection power the labels did not already have — "Rising"
and "Absorb" are the forms a draft actually writes; `.value` is a wire value.

**Rejected: per-term opt-in for `.value` aliases.** It makes someone adjudicate
"is `peaking` an ordinary word?" thirteen times, and whatever default a new enum
member inherits is either the bug (default on) or dead config nobody maintains
(default off). The invariant also satisfies the detector's stated bias toward
false negatives; opt-in does not, because the default decides for you.

`"non-dual substrate"` stays legal and detectable: it is multi-word, so it is
vocabulary rather than a serialised value.

### The registry collision (issue task 2)

The real numbers, counted: `iter_ontology_terms()` returned **30** terms but the
registry held only **28** distinct values across **76** keys — every surface form
was registered twice, exact and lower-cased. (The issue's "30 in, 28 out" counts
distinct terms; 76 counts keys. Both denominators are right about different
things.) Exactly **3** collisions, all on the `UNCLASSIFIED` sentinels:
`registry["unclassified"]` and `registry["Unclassified"]` both returned the
**Mode** term, silently burying the Frequency and Phase ones.

The three sentinels now earn no term at all — "we could not classify this" is a
wire value, not vocabulary. The registry holds exact surface forms only and
`_build_registry` *raises* on a duplicate rather than last-writer-wins.
Post-change: **27** terms, **37** unique surface forms, zero collisions.

### The vacuous guard — the part that mattered most

The module docstring promised "a drift-guard test asserts every enum member
resolves to an entry, so a new enum member without a gloss seed fails the
build". It asserted `member.value in registry` — mere *string* resolvability —
and `Frequency.UNCLASSIFIED` / `Phase.UNCLASSIFIED` "passed" by resolving to the
**Mode** term. Green on entries that no longer existed: a guard that could not
fail for the reason it existed.

Identity is load-bearing here in a way that is easy to get wrong. All three
taxonomies are `StrEnum`, so their members compare **and hash** as bare strings
*across classes*:

```
frozenset({Frequency.UNCLASSIFIED, Phase.UNCLASSIFIED, Mode.UNCLASSIFIED})  # len 1
{Frequency.UNCLASSIFIED: 'freq', Phase.UNCLASSIFIED: 'phase', Mode.UNCLASSIFIED: 'mode'}
  # {<Frequency.UNCLASSIFIED>: 'mode'} — one entry
```

A guard keyed by the enum member would have reproduced the exact bug it exists
to catch. So each term carries `source`, uniqueness is keyed by
`(type(source).__name__, source.value)` via `_source_key`, and every sentinel
comparison uses `is`, never `==`.

## Test plan

Gate 1 RED proved by running it: 11 failures, each for the stated reason. The
headline one is the test the docstring already promised and nobody had written —
`test_ordinary_capitalised_word_is_not_flagged` guarded the *capitalised* case
while the lower-case case had no test at all.

Mutation battery — 6 mutations, byte-snapshot restore, hash-verified after each
(never `git checkout`):

| Mutation | Detected by |
|---|---|
| re-add `aliases=(phase.value,)` | `__post_init__` refuses it at import |
| re-add the aliases **and** neuter the invariant (the exact HEAD defect) | exactly 6 tests fail, no others |
| reintroduce the Phase+Mode `Unclassified` collision | `_build_registry`: "two ontology terms claim the surface form 'Unclassified'" |
| point a Phase term at a `Mode` source | `_check_source_collisions`: "two ontology terms derive from Mode.express" |
| delete a live `_MODE_SENSES` entry | `KeyError` at build |
| silently drop `Phase.PEAKING` (no collision, no KeyError) | drift guard: "no gloss-seed term sourced from ('Phase', 'peaking')" |

The last one is the proof the guard now detects identity rather than
resolvability, and the second is the proof the new tests detect the original
defect.

Gate 2 `./scripts/check-all.sh` → **exit 0**: 12/12 checks, 9639 passed,
coverage 94.65%, per-file gate 261 files >= 80%
(`ontology_glossary.py` 97.67%, `jargon.py` 100%). ruff verified with
`--no-cache`; xenon `--max-absolute B --max-modules B --max-average A` clean.

Per this repo's standing guidance I ran `./scripts/check-all.sh` as the gate
rather than `pre-commit run --all-files` (which edits unrelated files in a
worktree); the acceptance criterion's hook list is covered by check-all's 12
gates plus the pre-commit hooks that run on the commit itself.

### Tests changed, by name

Three per-enum guards — `test_every_frequency_member_has_a_registry_entry`,
`test_every_phase_member_has_a_registry_entry`,
`test_every_mode_member_has_a_registry_entry` — were **merged into one**
strictly stronger `test_every_non_sentinel_member_resolves_to_its_own_term`,
which matches each member to the term declaring it as `source` and asserts the
category matches. `test_named_concepts_are_registered` and
`test_altitude_terms_are_registered` **keep their names**; their bodies move
from `x.lower() in registry` to the exact form plus a category assertion.
Nothing else was deleted: 22 removed lines = 21 content + 1 blank, all
accounted for above. Ten tests added.

## Out of scope

The 90-char `_GLOSS_WINDOW` and the `MID` severity are untouched, per the
issue's own Scope section.

Closes #1343
