### PR TITLE
fix(lint): stop reporting the index pages Creek just wrote, and survey the links it never read

### DIFF
--- a/creek-tools/README.md
+++ b/creek-tools/README.md
@@ -128,7 +128,7 @@ Every command is also documented under [`docs/`](docs/) with end-to-end examples
 |---------|---------|-----|
 | `creek clean orphans`       | Identify fragments with zero links after N days. | [cleaning-and-purge](docs/cleaning-and-purge.md) |
 | `creek clean stale-reviews` | Find review queue items older than N days. | [cleaning-and-purge](docs/cleaning-and-purge.md) |
-| `creek clean broken-links`  | Scan fragments for wiki-links pointing to nonexistent files. | [cleaning-and-purge](docs/cleaning-and-purge.md) |
+| `creek clean broken-links`  | Scan the vault for wiki-links pointing to nonexistent files. | [cleaning-and-purge](docs/cleaning-and-purge.md) |
 | `creek clean duplicates`    | Run the dedup sweep and emit a review report. | [cleaning-and-purge](docs/cleaning-and-purge.md) |
 | `creek clean report`        | Summary statistics on vault health. | [cleaning-and-purge](docs/cleaning-and-purge.md) |
 

--- a/creek-tools/creek/clean/hygiene.py
+++ b/creek-tools/creek/clean/hygiene.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING
 import frontmatter
 from pydantic import BaseModel, Field
 
-from creek.vault.links import build_link_index
+from creek.vault.links import build_link_index, iter_link_sources
 
 logger = logging.getLogger(__name__)
 
@@ -508,7 +508,17 @@ class StaleReviewScanner:
 
 
 class BrokenLinkScanner:
-    """Scan fragments for wiki-links and relative links to nonexistent files.
+    """Scan the vault for wiki-links and relative links to nonexistent files.
+
+    The survey is :func:`creek.vault.links.iter_link_sources`: the whole vault
+    minus Creek's own report folders (``00-Creek-Meta/Processing-Log/``,
+    ``00-Creek-Meta/State/``, ``00-Creek-Meta/Ontology/``). Scanning
+    ``01-Fragments`` alone — the behaviour before #1344 — made a dangling link
+    on a thread, praxis or decision page invisible while ``creek lint``
+    published the count as a whole-vault verdict. Scanning the *literal* whole
+    vault is the other failure: the lint report renders every finding as
+    ``- `src` → `[[target]]` ``, so three successive runs over a vault holding
+    ONE genuine broken link reported 1, then 2, then 3.
 
     Wiki-links resolve through :func:`creek.vault.links.build_link_index`,
     which knows every name a page can be linked by — filename stem,
@@ -522,42 +532,46 @@ class BrokenLinkScanner:
         """Scan the vault for broken links.
 
         Checks wiki-links (``[[Target]]``) and relative markdown links
-        (``[text](path)``) in all fragment files.
+        (``[text](path)``) in every surveyed source file — the whole vault
+        except Creek's own report folders, which quote findings back and would
+        otherwise inflate the count run over run.
 
         Args:
             vault_path: Root of the Obsidian vault.
 
         Returns:
-            A :class:`BrokenLinkResult` with broken link details.
+            A :class:`BrokenLinkResult` whose ``total_files_scanned`` counts
+            the files actually surveyed, so the "across N file(s)" line
+            ``creek lint`` prints does not overstate its own coverage.
         """
-        fragment_files = _list_fragment_files(vault_path)
+        source_files = iter_link_sources(vault_path)
         link_index = build_link_index(vault_path)
 
         broken_links: dict[str, list[str]] = {}
         total_broken = 0
 
-        for frag_file in fragment_files:
-            file_broken = self._check_file(frag_file, link_index, vault_path)
+        for source_file in source_files:
+            file_broken = self._check_file(source_file, link_index, vault_path)
             if file_broken:
-                broken_links[str(frag_file)] = file_broken
+                broken_links[str(source_file)] = file_broken
                 total_broken += len(file_broken)
 
         return BrokenLinkResult(
             broken_links=broken_links,
-            total_files_scanned=len(fragment_files),
+            total_files_scanned=len(source_files),
             total_broken=total_broken,
         )
 
     def _check_file(
         self,
-        frag_file: Path,
+        source_file: Path,
         link_index: LinkIndex,
         vault_path: Path,
     ) -> list[str]:
         """Check a single file for broken links.
 
         Args:
-            frag_file: Path to the fragment file.
+            source_file: Path to the surveyed markdown file.
             link_index: Vault-wide name → page index. A wiki-link is broken
                 only when nothing in the vault answers to its target under
                 any of its names.
@@ -566,7 +580,7 @@ class BrokenLinkScanner:
         Returns:
             List of broken link targets found in this file.
         """
-        content = frag_file.read_text(encoding="utf-8", errors="replace")
+        content = source_file.read_text(encoding="utf-8", errors="replace")
         broken: list[str] = [
             f"[[{target}]]"
             for target in _extract_wikilinks(content)
@@ -576,7 +590,7 @@ class BrokenLinkScanner:
         broken.extend(
             target
             for target in _extract_relative_links(content)
-            if self._is_broken_local_link(target, frag_file, vault_path)
+            if self._is_broken_local_link(target, source_file, vault_path)
         )
 
         return broken
@@ -584,7 +598,7 @@ class BrokenLinkScanner:
     @staticmethod
     def _is_broken_local_link(
         target: str,
-        frag_file: Path,
+        source_file: Path,
         vault_path: Path,
     ) -> bool:
         """Check whether a relative target resolves to no existing file.
@@ -597,15 +611,15 @@ class BrokenLinkScanner:
 
         Args:
             target: A relative link target (no URL scheme).
-            frag_file: The fragment file containing the link.
+            source_file: The surveyed file containing the link.
             vault_path: Root of the vault for resolving relative paths.
 
         Returns:
             True if the target resolves to no existing file under either
-            the fragment's directory or the vault root.
+            the source file's directory or the vault root.
         """
         try:
-            resolved = (frag_file.parent / target).resolve()
+            resolved = (source_file.parent / target).resolve()
             vault_resolved = (vault_path / target).resolve()
             missing = not resolved.exists() and not vault_resolved.exists()
         except OSError:

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -6294,7 +6294,12 @@ def clean_stale_reviews(
 def clean_broken_links(
     vault: Path | None = typer.Option(None, help="Obsidian vault path"),
 ) -> None:
-    """Scan fragments for wiki-links pointing to nonexistent files."""
+    """Scan the vault for wiki-links pointing to nonexistent files.
+
+    Surveys every markdown file except Creek's own report folders
+    (``00-Creek-Meta/Processing-Log/``, ``State/``, ``Ontology/``), which
+    quote findings back and would inflate the count on each rerun.
+    """
     from creek.clean.hygiene import BrokenLinkScanner
 
     vault_path = _resolve_vault(vault)

--- a/creek-tools/creek/generate/indexes.py
+++ b/creek-tools/creek/generate/indexes.py
@@ -22,7 +22,7 @@ never ran.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 from creek.models import Frequency
 from creek.scaffold import VAULT_TEMPLATE_DIR
@@ -32,6 +32,44 @@ if TYPE_CHECKING:
 
 _FREQUENCY_ROOT = "06-Frequencies"
 """Vault-relative folder holding the per-frequency subdirectories."""
+
+FREQUENCY_INDEX_TYPE: Final[str] = "frequency-index"
+"""Frontmatter ``type`` written to each ``06-Frequencies/F*/F*-Index.md``."""
+
+THREAD_INDEX_TYPE: Final[str] = "thread-index"
+"""Frontmatter ``type`` written to ``02-Threads/Thread-Index.md``."""
+
+EDDY_MAP_TYPE: Final[str] = "eddy-map"
+"""Frontmatter ``type`` written to ``03-Eddies/Eddy-Map.md``."""
+
+TEMPORAL_INDEX_TYPE: Final[str] = "temporal-index"
+"""Frontmatter ``type`` written to ``00-Creek-Meta/Temporal-Index.md``."""
+
+SOURCE_INDEX_TYPE: Final[str] = "source-index"
+"""Frontmatter ``type`` written to ``00-Creek-Meta/Source-Index.md``."""
+
+GENERATED_INDEX_TYPES: frozenset[str] = frozenset(
+    {
+        FREQUENCY_INDEX_TYPE,
+        THREAD_INDEX_TYPE,
+        EDDY_MAP_TYPE,
+        TEMPORAL_INDEX_TYPE,
+        SOURCE_INDEX_TYPE,
+    }
+)
+"""The definition of "a page Creek generated as navigation".
+
+A page declaring one of these types is a Dataview *query* — something nothing
+is ever expected to wiki-link. ``orphan-compiled`` therefore excludes them from
+candidacy: reporting them tells the operator to review pages Creek itself wrote
+moments earlier (#1344 measured twelve such false positives out of thirteen).
+
+The generator methods below consume these same constants, so the set and the
+frontmatter actually written cannot drift. All five are listed even though only
+``frequency-index``, ``thread-index`` and ``eddy-map`` land inside the compiled
+directories the check inspects — the set answers "did Creek generate this as
+navigation", not "is it in a compiled folder".
+"""
 
 
 def _canonical_frequency_dirname(freq_code: str) -> str:
@@ -547,7 +585,7 @@ class IndexGenerator:
 
             color = FREQUENCY_COLORS[freq]
             frontmatter = {
-                "type": "frequency-index",
+                "type": FREQUENCY_INDEX_TYPE,
                 "frequency": freq_code,
                 "color": color,
                 "title": f'"{freq_code} — {name} Index"',
@@ -571,7 +609,7 @@ class IndexGenerator:
             Path to the generated thread index file.
         """
         frontmatter = {
-            "type": "thread-index",
+            "type": THREAD_INDEX_TYPE,
             "title": '"Thread Index"',
         }
 
@@ -613,7 +651,7 @@ class IndexGenerator:
             Path to the generated eddy map file.
         """
         frontmatter = {
-            "type": "eddy-map",
+            "type": EDDY_MAP_TYPE,
             "title": '"Eddy Map"',
         }
 
@@ -648,7 +686,7 @@ class IndexGenerator:
             Path to the generated temporal index file.
         """
         frontmatter = {
-            "type": "temporal-index",
+            "type": TEMPORAL_INDEX_TYPE,
             "title": '"Temporal Index"',
         }
 
@@ -690,7 +728,7 @@ class IndexGenerator:
             Path to the generated source index file.
         """
         frontmatter = {
-            "type": "source-index",
+            "type": SOURCE_INDEX_TYPE,
             "title": '"Source Index"',
         }
 

--- a/creek-tools/creek/lint/checks/broken_links.py
+++ b/creek-tools/creek/lint/checks/broken_links.py
@@ -1,4 +1,9 @@
-"""Deterministic check: wiki-links and relative links must resolve."""
+"""Deterministic check: wiki-links and relative links must resolve.
+
+Surveyed across the whole vault minus Creek's own machine-written reports —
+see :func:`creek.vault.links.iter_link_sources` for the three withheld
+directories and the argument for each.
+"""
 
 from __future__ import annotations
 
@@ -10,11 +15,16 @@ from creek.lint._result import CheckResult
 
 
 def run(vault_path: Path, *, since: datetime | None = None) -> CheckResult:
-    """Scan fragments for broken wiki-links / relative markdown links.
+    """Scan the surveyed vault for broken wiki-links / relative markdown links.
 
-    Wraps :class:`creek.clean.hygiene.BrokenLinkScanner`. The ``since``
-    parameter is accepted for interface consistency but ignored — the
-    scanner is already fast enough that filtering by mtime adds little.
+    Wraps :class:`creek.clean.hygiene.BrokenLinkScanner`, whose survey is
+    :func:`creek.vault.links.iter_link_sources` — every ``*.md`` in the vault
+    except Creek's own report folders, which quote findings back and would
+    inflate the count on each successive run (#1344).
+
+    The ``since`` parameter is accepted for interface consistency but
+    ignored — the scanner is already fast enough that filtering by mtime adds
+    little.
 
     The source is rendered **vault-relative**, matching every sibling check
     (``compost``, ``unnamed``, ``skill_size_budget``, ``orphan_compiled``).
@@ -28,8 +38,10 @@ def run(vault_path: Path, *, since: datetime | None = None) -> CheckResult:
     falsified the standing "no path in the artefact is absolute" claim in
     ``docs/generation.md``.
 
-    ``relative_to`` cannot raise: the scanner builds every key from
-    ``vault_path / "01-Fragments"`` by the same lexical join used here.
+    ``relative_to`` cannot raise: every key the scanner emits comes from
+    :func:`~creek.vault.links.iter_link_sources`, which enumerates
+    ``vault_path.rglob("*.md")`` — the same lexical join off ``vault_path``
+    used here.
     """
     del since  # interface symmetry only
     scan = BrokenLinkScanner().scan(vault_path)

--- a/creek-tools/creek/lint/checks/orphan_compiled.py
+++ b/creek-tools/creek/lint/checks/orphan_compiled.py
@@ -1,16 +1,36 @@
 """Deterministic check: compiled pages with zero inbound wiki-links.
 
-Orphan *fragments* are normal — only orphan *compiled* pages
-(Threads, Eddies, Praxis, Frequency-indexes) are surfaced, per
-ADOPT-002 and FEAT-008. The check emits suggestions only; it never
-deletes anything.
+Orphan *fragments* are normal — only orphan *compiled* pages (Threads,
+Eddies, Praxis, Frequency-indexes) are surfaced, per ADOPT-002 and FEAT-008.
+The check emits suggestions only; it never deletes anything.
 
-Inbound links are counted through :func:`creek.vault.links.build_link_index`,
-so a page is credited for links naming it by any of its names. Comparing
-filename stems alone (the behaviour before #887) reported
+**Candidates.** A ``*.md`` file under :data:`_COMPILED_DIRS` whose declared
+frontmatter ``type`` is *not* in
+:data:`~creek.generate.indexes.GENERATED_INDEX_TYPES`. Those excluded types
+name Dataview index notes Creek itself writes; nothing is ever expected to
+link them, so reporting one asks the operator to review a page Creek created
+moments earlier. Everything else stays a candidate — a page with no ``type``
+key, an unknown ``type``, no frontmatter at all, or a header YAML cannot
+parse. The exclusion defaults to *included* on purpose: were the default the
+other way, any page could exempt itself from the check by writing a broken
+header, and a check that falls silent is the same end state as the bug it
+replaces.
+
+**Inbound sources.** :func:`~creek.vault.links.iter_link_sources` — the whole
+vault minus Creek's own report folders — rather than a hard-coded fragment
+list. Each target is resolved through
+:func:`~creek.vault.links.build_link_index`, so a page is credited for links
+naming it by filename stem, ``title``, or any ``aliases`` entry. Comparing
+stems alone (the behaviour before #887) reported
 ``02-Threads/Dormant/2020-09-26-Messages.md`` as orphaned despite roughly
-30,000 inbound ``[[Messages]]`` links, because the human-readable name lives
-in ``aliases`` while the filename carries a date prefix.
+30,000 inbound ``[[Messages]]`` links.
+
+**The #1344 measurement.** On a vault carrying ``generate_all()``, one praxis
+page, and an ``08-Decisions`` brief linking it, the check reported ``13 orphan
+compiled page(s)`` — all thirteen false. Twelve needed the generated-index
+exclusion; the thirteenth needed the widened survey, because ``08-Decisions``
+was simply never read. The two remedies fix disjoint subsets, which is why
+both ship: either alone leaves that vault dirty.
 """
 
 from __future__ import annotations
@@ -18,9 +38,14 @@ from __future__ import annotations
 import re
 from datetime import datetime  # noqa: TC003  # used at runtime as a parameter type
 from pathlib import Path  # noqa: TC003  # plain stdlib import; no lazy benefit
+from typing import TYPE_CHECKING
 
+from creek.generate.indexes import GENERATED_INDEX_TYPES
 from creek.lint._result import CheckResult
-from creek.vault.links import build_link_index
+from creek.vault.links import build_link_index, iter_link_sources, read_header_meta
+
+if TYPE_CHECKING:
+    from creek.vault.links import LinkIndex
 
 _COMPILED_DIRS: tuple[str, ...] = (
     "02-Threads",
@@ -29,12 +54,6 @@ _COMPILED_DIRS: tuple[str, ...] = (
     "06-Frequencies",
 )
 """Directories whose markdown files count as compiled-layer pages."""
-
-_FRAGMENT_DIRS: tuple[str, ...] = (
-    "01-Fragments",
-    "10-Liminal",
-)
-"""Directories whose markdown files may carry inbound links to compiled pages."""
 
 _WIKILINK_RE = re.compile(r"\[\[([^\]|#]+?)(?:[#|][^\]]*?)?\]\]")
 
@@ -49,45 +68,117 @@ def _stems_in(vault_path: Path, subdirs: tuple[str, ...]) -> list[Path]:
     return paths
 
 
-def _inbound_targets(fragment_files: list[Path]) -> set[str]:
-    """Extract the union of every wiki-link target name across *fragment_files*."""
-    targets: set[str] = set()
-    for path in fragment_files:
-        try:
-            text = path.read_text(encoding="utf-8", errors="replace")
-        except OSError:
-            continue
-        targets.update(_WIKILINK_RE.findall(text))
-    return targets
+def _is_generated_index(path: Path) -> bool:
+    """Return whether *path* declares a type Creek's index generators write.
+
+    Read header-only: a compiled layer can be large, and the body says
+    nothing about what generated the page.
+
+    Args:
+        path: Compiled-layer markdown file.
+
+    Returns:
+        True only for an explicitly declared generated-index ``type``. Every
+        other outcome — missing key, unknown value, unparseable header —
+        returns False and keeps the page a candidate.
+    """
+    return read_header_meta(path).get("type") in GENERATED_INDEX_TYPES
+
+
+def _candidate_pages(vault_path: Path) -> list[Path]:
+    """Return the compiled-layer pages an orphan verdict may be passed on.
+
+    Args:
+        vault_path: Root of the Obsidian vault.
+
+    Returns:
+        Sorted compiled-layer paths, minus Creek's own generated index notes.
+    """
+    return [
+        page
+        for page in sorted(_stems_in(vault_path, _COMPILED_DIRS))
+        if not _is_generated_index(page)
+    ]
+
+
+def _credited_pages(source: Path, link_index: LinkIndex) -> set[Path]:
+    """Resolve *source*'s outbound wiki-links to the pages they credit.
+
+    A link resolving back to *source* itself is dropped. That guard is new
+    with #1344 and newly necessary: while the source set was fragments-only a
+    compiled page could never credit itself, but a survey that reads the
+    compiled layer would otherwise let any self-referencing page exempt
+    itself from the check.
+
+    Args:
+        source: Markdown file whose outbound links are being read.
+        link_index: Vault-wide name → page index.
+
+    Returns:
+        The set of pages *source* links to, excluding itself. An unreadable
+        file credits nothing rather than aborting the walk.
+    """
+    try:
+        text = source.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return set()
+    return {
+        page
+        for target in _WIKILINK_RE.findall(text)
+        if (page := link_index.resolve(target)) is not None and page != source
+    }
+
+
+def _inbound_pages(sources: list[Path], link_index: LinkIndex) -> set[Path]:
+    """Return every vault page credited with an inbound link by *sources*.
+
+    Both *sources* and the index's resolved targets are built by ``rglob``
+    from the same vault root, so the two are the same lexical form and the
+    self-link comparison in :func:`_credited_pages` is sound without calling
+    ``Path.resolve`` on either side.
+
+    Args:
+        sources: Files whose outbound links count, per
+            :func:`~creek.vault.links.iter_link_sources`.
+        link_index: Vault-wide name → page index.
+
+    Returns:
+        The set of linked-to pages.
+    """
+    credited: set[Path] = set()
+    for source in sources:
+        credited.update(_credited_pages(source, link_index))
+    return credited
 
 
 def run(vault_path: Path, *, since: datetime | None = None) -> CheckResult:
-    """Find compiled-layer pages that no fragment links to.
+    """Find compiled-layer pages that nothing in the vault links to.
 
-    The ``since`` parameter is accepted for interface symmetry but
-    ignored — the orphan check is cheap.
+    A page is reported when it is a candidate — under a compiled directory
+    and not one of Creek's own generated index notes — and no *other* page in
+    the surveyed source set resolves a wiki-link to it.
 
-    Every inbound wiki-link target is resolved to the page it actually names
-    before the comparison, so a page counts as linked when a fragment
-    references it by alias or title. Resolution is per-page: a link that
-    resolves *somewhere* credits only that page, never the whole compiled
-    layer — otherwise the check would fall silent, which is the same end
-    state as the bug it fixes.
+    Resolution is per-page: a link that resolves *somewhere* credits only that
+    page, never the whole compiled layer — otherwise the check would fall
+    silent, which is the same end state as the bug it fixes.
+
+    Args:
+        vault_path: Root of the Obsidian vault.
+        since: Accepted for interface symmetry with the other checks and
+            ignored — the orphan check is cheap.
+
+    Returns:
+        A :class:`~creek.lint._result.CheckResult` naming each orphan page
+        vault-relative, in sorted path order.
     """
     del since
-    compiled_files = _stems_in(vault_path, _COMPILED_DIRS)
-    fragment_files = _stems_in(vault_path, _FRAGMENT_DIRS)
     link_index = build_link_index(vault_path)
-    linked_pages = {
-        resolved
-        for target in _inbound_targets(fragment_files)
-        if (resolved := link_index.resolve(target)) is not None
-    }
+    linked_pages = _inbound_pages(iter_link_sources(vault_path), link_index)
 
-    findings: list[str] = []
-    for compiled in sorted(compiled_files):
-        if compiled not in linked_pages:
-            rel = compiled.relative_to(vault_path)
-            findings.append(f"- `{rel}` (suggestion: review; never auto-deleted)")
+    findings = [
+        f"- `{page.relative_to(vault_path)}` (suggestion: review; never auto-deleted)"
+        for page in _candidate_pages(vault_path)
+        if page not in linked_pages
+    ]
     summary = f"{len(findings)} orphan compiled page(s)"
     return CheckResult(name="orphan-compiled", summary=summary, findings=findings)

--- a/creek-tools/creek/vault/links.py
+++ b/creek-tools/creek/vault/links.py
@@ -24,7 +24,32 @@ this index in #1225.
 Resolution follows Obsidian: an exact-case match wins, and a case-insensitive
 match is the fallback. The frontmatter is read **header-only** — a 35k-file
 vault must never pay to load every body into memory just to learn a page's
-aliases.
+aliases. :func:`read_header_meta` exposes that same header-only read to
+callers who need more of the header than its linkable names.
+
+Targets and sources are deliberately asymmetric (#1344)
+-------------------------------------------------------
+
+Every ``*.md`` in the vault remains a valid link **target**:
+:func:`build_link_index` walks the whole tree and is unchanged. The set
+surveyed as link **sources** — :func:`iter_link_sources` — is a strict named
+subset that withholds Creek's own machine-written documents *about* the vault.
+The asymmetry is the point, not an oversight to be simplified away: a scanner
+that reads its own report back as content inflates its findings on every run
+(measured 1 → 2 → 3 over three ``creek lint`` passes on a vault holding one
+genuine broken link).
+
+A fourth prefix is admissible only if a file there **quotes the scanner's own
+output, or documents the link syntax rather than using it**. That criterion
+deliberately excludes generated pages that quote *fragment body text* — an
+``08-Decisions`` brief, say. A dangling link inside a quoted excerpt is
+genuinely dangling and worth reporting, and the duplication it causes is
+bounded by the number of quoting pages rather than compounding run over run.
+
+The ``Ontology`` prefix is the weakest of the three: it is withheld only
+because link extraction is not code-span aware, so a backticked
+``[[note-name]]`` example reads as a link. Issue #1460 tracks that root-cause
+fix, after which the prefix can be dropped.
 """
 
 from __future__ import annotations
@@ -50,6 +75,19 @@ module exists to avoid.
 
 _MAX_HEADER_BYTES: int = 64 * 1024
 """Byte ceiling on a single header, for the same reason as the line cap."""
+
+_UNSURVEYED_PREFIXES: tuple[tuple[str, ...], ...] = (
+    ("00-Creek-Meta", "Processing-Log"),
+    ("00-Creek-Meta", "State"),
+    ("00-Creek-Meta", "Ontology"),
+)
+"""Vault-relative directories whose files are never surveyed as link sources.
+
+Each entry is a tuple of **path components**, not a string prefix, so a
+sibling whose name merely starts the same way — ``State-Machine-Notes.md``,
+``Processing-Logs-Archive.md`` — keeps its links surveyed. See
+:func:`iter_link_sources` for the argument admitting each one.
+"""
 
 
 @dataclass(frozen=True)
@@ -138,6 +176,51 @@ def _declared_names(meta: dict[str, object]) -> list[str]:
     return names
 
 
+def read_header_meta(path: Path) -> dict[str, object]:
+    """Return the YAML frontmatter mapping of *path*, header-only.
+
+    This is the one frontmatter reader in this module, and it reads no
+    further than the closing ``---`` fence. Callers that want a page's
+    declared ``type`` must use this rather than ``frontmatter.load``, which
+    parses the body too — on a 35k-file vault that is precisely the expense
+    this module exists to avoid.
+
+    Args:
+        path: Markdown file to read.
+
+    "Malformed YAML" is caught wider than ``yaml.YAMLError``, because PyYAML
+    does not raise one for every way a header can be malformed: its
+    constructors call ``int()`` and ``datetime.date()`` on the scanned text
+    and let those raise ``ValueError`` straight through. ``n: <5000 digits>``
+    trips CPython's 4300-digit int-parsing limit and ``created: 2020-13-45``
+    resolves as a timestamp and then fails to construct — both well inside the
+    size caps, and ``created`` is written by the ingest parsers from export
+    metadata nobody in this system authored. Since :func:`build_link_index`
+    reads the header of every ``*.md`` in the vault, one such file aborted the
+    whole of ``creek lint`` and ``creek state`` rather than costing itself its
+    aliases (#1344).
+
+    Args:
+        path: Markdown file to read.
+
+    Returns:
+        The parsed header mapping, or an empty dict for any of: an unreadable
+        file, no opening fence, an unterminated header, a header past the size
+        caps, malformed YAML, or a header that parses to something other than
+        a mapping. A whole-vault walk must not lose its run to one bad file.
+    """
+    block = _read_header_block(path)
+    if block is None:
+        return {}
+    try:
+        meta = yaml.safe_load(block)
+    except (yaml.YAMLError, ValueError, OverflowError, RecursionError):
+        return {}
+    if not isinstance(meta, dict):
+        return {}
+    return meta
+
+
 def _header_names(path: Path) -> list[str]:
     """Return the ``title`` and ``aliases`` names declared by *path*.
 
@@ -145,16 +228,68 @@ def _header_names(path: Path) -> list[str]:
     mapping — yields no names rather than raising. Lint walks every file in
     the vault, so one bad header must not cost the whole run its index.
     """
-    block = _read_header_block(path)
-    if block is None:
+    return _declared_names(read_header_meta(path))
+
+
+def _is_unsurveyed(relative: Path) -> bool:
+    """Return whether *relative* lies under a withheld source directory.
+
+    Args:
+        relative: A path relative to the vault root.
+
+    Returns:
+        True when the path's leading components match any entry of
+        :data:`_UNSURVEYED_PREFIXES`.
+    """
+    parts = relative.parts
+    return any(parts[: len(prefix)] == prefix for prefix in _UNSURVEYED_PREFIXES)
+
+
+def iter_link_sources(vault_path: Path) -> list[Path]:
+    """List every vault page whose **outbound** links Creek surveys.
+
+    The whole vault, minus three vault-relative directories holding Creek's
+    own machine-written documents *about* the vault:
+
+    ``00-Creek-Meta/Processing-Log/``
+        ``creek lint`` writes its report here and renders every finding as
+        ``- `src` → `[[target]]` ``, so the next run reads its own output back
+        as vault content. Measured on a vault with ONE genuine broken link:
+        three successive runs reported 1, then 2, then 3.
+
+    ``00-Creek-Meta/State/``
+        ``creek state`` echoes the same targets (``section_drift_warnings``)
+        and appends the whole lint report verbatim
+        (``section_lint_summary``).
+
+    ``00-Creek-Meta/Ontology/``
+        The canonical spec ``creek init`` deploys; its line 746 *documents*
+        wiki-link syntax with a backticked ``[[note-name]]`` example. Measured:
+        the single finding a whole-vault scan produces on a fresh 32-file
+        ``creek init`` vault. Issue #1460 tracks the code-span-aware extraction
+        that would let this prefix be dropped.
+
+    Nothing else is withheld. ``00-Creek-Meta/Tag-Garden.md`` emits real
+    ``[[fragment-id]]`` links (``creek/generate/tags.py``) and must stay a
+    source; ``00-Creek-Meta/Skills/``, ``AGENTS.md`` and ``11-Other-Authors/``
+    carry no links today and stay in scope regardless.
+
+    Args:
+        vault_path: Root of the Obsidian vault. A path that does not exist
+            yields no sources rather than raising.
+
+    Returns:
+        A sorted list of ``*.md`` paths — materialised, matching the contract
+        of the fragment listing it replaces, and deterministic so two runs on
+        one vault report identically.
+    """
+    if not vault_path.is_dir():
         return []
-    try:
-        meta = yaml.safe_load(block)
-    except yaml.YAMLError:
-        return []
-    if not isinstance(meta, dict):
-        return []
-    return _declared_names(meta)
+    return [
+        path
+        for path in sorted(vault_path.rglob("*.md"))
+        if not _is_unsurveyed(path.relative_to(vault_path))
+    ]
 
 
 def build_link_index(vault_path: Path) -> LinkIndex:

--- a/creek-tools/docs/cleaning-and-purge.md
+++ b/creek-tools/docs/cleaning-and-purge.md
@@ -37,13 +37,13 @@ creek clean stale-reviews --vault ~/Obsidian/Creek-Vault --age-days 14
 
 ### `creek clean broken-links`
 
-Scans every fragment for wiki-links pointing to nonexistent files. Common causes: a target was renamed, a target was purged, a typo.
+Scans the vault for wiki-links pointing to nonexistent files — the same scanner and vault-wide scope as `creek lint`'s `broken-links` check; see [`lint.md`](lint.md#check-names) for the withheld report folders and why. Common causes: a target was renamed, a target was purged, a typo.
 
 ```bash
 creek clean broken-links --vault ~/Obsidian/Creek-Vault
 ```
 
-The report groups broken links by source fragment so you can fix them in batches.
+The report groups broken links by source file so you can fix them in batches. A source is any surveyed page, not only a fragment — a thread, a decision brief or a wavelength observation can carry a stale link too.
 
 ### `creek clean duplicates`
 

--- a/creek-tools/docs/cleaning-pipeline.md
+++ b/creek-tools/docs/cleaning-pipeline.md
@@ -105,7 +105,7 @@ Drives the `creek clean *` CLI commands:
 
 - `OrphanScanner` — fragments with zero links after `cleaning.hygiene.orphan_age_days`.
 - `StaleReviewScanner` — review-queue items older than `cleaning.hygiene.stale_review_days`.
-- `BrokenLinkScanner` — wiki-links pointing at nonexistent files.
+- `BrokenLinkScanner` — wiki-links pointing at nonexistent files, surveyed vault-wide except Creek's own report folders; see [`lint.md`](lint.md#check-names) for the withheld set and why.
 - `DuplicateScanner` — runs normalised + semantic dedup against the saved vault.
 - `HygieneReporter` — aggregate report of vault health.
 

--- a/creek-tools/docs/lint.md
+++ b/creek-tools/docs/lint.md
@@ -44,8 +44,37 @@ creek lint --since 7d                       # include semantic checks
 Deterministic (always run by default):
 
 - `broken-links` — wiki-links / relative links that do not resolve.
-- `orphan-compiled` — Threads / Eddies / Praxis / Frequency-indexes
-  that no fragment links to.
+  Surveys every `*.md` in the vault except three directories holding
+  Creek's own machine-written documents *about* the vault:
+  `00-Creek-Meta/Processing-Log/` and `00-Creek-Meta/State/` both
+  render findings back as vault content — three successive `creek
+  lint` runs over a vault holding ONE genuine broken link reported 1,
+  then 2, then 3 — and `00-Creek-Meta/Ontology/` (the deployed spec,
+  whose line 746 *documents* wiki-link syntax with a backticked
+  `[[note-name]]` example: the one finding a whole-vault scan produces
+  on a fresh 32-file `creek init` vault; #1460 tracks the code-span-
+  aware fix that would let this prefix be dropped). Nothing else is
+  withheld — `00-Creek-Meta/Tag-Garden.md` stays surveyed, since it
+  emits real `[[fragment-id]]` links. `creek clean broken-links`
+  shares this same scanner and scope.
+- `orphan-compiled` — Threads / Eddies / Praxis pages that nothing in
+  that same surveyed set links to (a page's link to itself does not
+  count). A page is never a candidate when its frontmatter `type` is
+  one Creek's own `IndexGenerator` writes (`frequency-index`,
+  `thread-index`, `eddy-map`, `temporal-index`, `source-index` — the
+  set `creek.generate.indexes.GENERATED_INDEX_TYPES`): these are
+  Dataview query notes nothing is ever expected to link. Before this
+  exclusion existed, a vault that had run `creek index` reported `13
+  orphan compiled page(s)`, all thirteen false — twelve of them
+  generated-index pages, the thirteenth cited only from an
+  `08-Decisions` brief the old fragments-only survey never read.
+  The exclusion needs an *explicit* declaration: a page with no `type`
+  key, an unrecognised `type`, no frontmatter at all, or a header YAML
+  cannot parse stays a candidate and is still reported when nothing
+  links it. The default has to fall that way — were it the other way,
+  any page could exempt itself from the check by writing a broken
+  header, and a check that falls silent is the same end state as the
+  false-positive storm it replaces.
 - `skill-size` — `.SKILL.md` files over their declared word budget
   (proxy for the ≤1500-token limit pinned by `lint.SKILL.md`); also
   enforces ≤3000 words on root `AGENTS.md`.

--- a/creek-tools/tests/test_hygiene.py
+++ b/creek-tools/tests/test_hygiene.py
@@ -593,6 +593,65 @@ class TestBrokenLinkScanner:
         broken_targets = next(iter(result.broken_links.values()))
         assert broken_targets == ["[[missing]]"]
 
+    def test_scan_covers_non_fragment_sources(self, tmp_path: Path) -> None:
+        """Threads, praxis and decisions carry links too (#1344).
+
+        The scanner surveyed ``01-Fragments`` alone while ``creek lint``
+        reported its count as a whole-vault verdict, so a dangling link on a
+        compiled page was invisible no matter how many times it ran.
+        """
+        vault = _make_vault(tmp_path)
+        source = _write_md_file(
+            vault / "02-Threads" / "Active" / "t.md",
+            "See [[ghost-thread]] here.",
+        )
+        scanner = BrokenLinkScanner()
+        result = scanner.scan(vault)
+        assert result.total_broken == 1
+        assert result.broken_links[str(source)] == ["[[ghost-thread]]"]
+
+    def test_total_files_scanned_counts_every_surveyed_file(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The count reports the survey, which is no longer fragments-only.
+
+        ``creek lint`` renders this number as "across N file(s)", so leaving
+        it at the fragment count would keep the verdict overstating its own
+        coverage even after the survey widened (#1344).
+        """
+        vault = _make_vault(tmp_path)
+        _write_fragment(vault, "f1", content="No links at all.")
+        _write_md_file(vault / "02-Threads" / "Active" / "t.md", "Thread body.")
+        _write_md_file(vault / "00-Creek-Meta" / "Tag-Garden.md", "Garden body.")
+        scanner = BrokenLinkScanner()
+        result = scanner.scan(vault)
+        assert result.total_files_scanned == 3
+        assert result.total_broken == 0
+
+    def test_scan_skips_creek_report_directories(self, tmp_path: Path) -> None:
+        """Creek's own reports echo findings; reading them back inflates them.
+
+        ``lint-<date>.md`` renders each finding as ``- `src` → `[[target]]` ``
+        and ``State/latest.md`` echoes the same lines, so a literal
+        whole-vault survey grew one genuine broken link into 1, then 2, then 3
+        over three successive runs (#1344).
+        """
+        vault = _make_vault(tmp_path)
+        _write_md_file(
+            vault / "00-Creek-Meta" / "Processing-Log" / "lint-2026-08-09.md",
+            "- `01-Fragments/Conversations/a.md` → `[[ghost]]`\n",
+        )
+        _write_md_file(
+            vault / "00-Creek-Meta" / "State" / "latest.md",
+            "- Broken links in `x`: [[phantom]]\n",
+        )
+        scanner = BrokenLinkScanner()
+        result = scanner.scan(vault)
+        assert result.broken_links == {}
+        assert result.total_broken == 0
+        assert result.total_files_scanned == 0
+
 
 # ---------------------------------------------------------------------------
 # DuplicateScanner tests

--- a/creek-tools/tests/test_lint_generated_index_pages.py
+++ b/creek-tools/tests/test_lint_generated_index_pages.py
@@ -1,0 +1,471 @@
+"""Generated index pages are not orphans; lint reports are not link sources.
+
+Regression tests for issue #1344, which recorded two independent defects that
+compound into one unusable report.
+
+*The 13/13.* On a temp vault carrying nothing but
+``IndexGenerator(vault).generate_all()``, a ``04-Praxis/praxis-1.md`` page, and
+an ``08-Decisions/brief-1.md`` containing ``- [[praxis-1]]``,
+``orphan-compiled`` reported ``13 orphan compiled page(s)`` — every one of the
+thirteen a false positive: ``02-Threads/Thread-Index.md``,
+``03-Eddies/Eddy-Map.md``, ``04-Praxis/praxis-1.md``, and the ten
+``06-Frequencies/F*/F*-Index.md`` pages. Twelve of them are Dataview index
+notes Creek itself writes and that nothing is ever expected to link; the
+thirteenth is linked from ``08-Decisions``, a directory the check never
+surveyed because its inbound-link sources were hard-coded to ``01-Fragments``
+and ``10-Liminal``. A check that is 100% wrong is worse than no check at all,
+because its output still has to be read.
+
+*The 1 → 2 → 3.* ``broken-links`` surveys only ``01-Fragments`` while
+reporting a whole-vault verdict, so the obvious remedy is to survey the whole
+vault. Done naively, the check then eats its own output: ``creek lint`` writes
+``00-Creek-Meta/Processing-Log/lint-<date>.md``, which renders every finding
+as ``- `src` → `[[target]]` ``. On a vault holding exactly ONE genuine broken
+link, three successive ``creek lint`` runs reported 1, then 2, then 3 broken
+links. ``00-Creek-Meta/State/`` is the same hazard, and
+``00-Creek-Meta/Ontology/creek_ontology_agent_prompt.md`` carries the deployed
+spec's own syntax example (``[[note-name]]``, line 746) — the single finding a
+whole-vault scan produces on a fresh 32-file ``creek init`` vault. Those three
+path prefixes are carved out and nothing else is, because
+``00-Creek-Meta/Tag-Garden.md`` emits real ``[[fragment-id]]`` links and has to
+remain a surveyed source.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import frontmatter
+import pytest
+from typer.testing import CliRunner
+
+from creek.cli import app
+from creek.generate.indexes import GENERATED_INDEX_TYPES, IndexGenerator
+from creek.lint import LintRunner
+from creek.lint.checks import broken_links, orphan_compiled
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write(vault: Path, relpath: str, text: str) -> Path:
+    """Write *text* to *relpath* under *vault*, creating parent folders.
+
+    Args:
+        vault: Vault root.
+        relpath: Vault-relative path of the file to write.
+        text: Full file contents.
+
+    Returns:
+        The path written.
+    """
+    path = vault / relpath
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _page(vault: Path, relpath: str, page_type: str, body: str = "Body.") -> Path:
+    """Write a page whose frontmatter declares ``type: <page_type>``.
+
+    Args:
+        vault: Vault root.
+        relpath: Vault-relative path of the page.
+        page_type: Value of the frontmatter ``type`` key.
+        body: Markdown body beneath the header.
+
+    Returns:
+        The path written.
+    """
+    return _write(vault, relpath, f"---\ntype: {page_type}\n---\n\n{body}\n")
+
+
+# ---------------------------------------------------------------------------
+# orphan-compiled: the twelve generated index pages
+# ---------------------------------------------------------------------------
+
+
+def test_generated_index_pages_are_not_orphans(tmp_path: Path) -> None:
+    """Nothing links a Dataview index note, and nothing ever will.
+
+    ``generate_all`` writes twelve pages into the compiled directories. Each
+    one is a query, not a destination; flagging them as orphans is telling the
+    operator to review pages Creek itself created moments earlier.
+    """
+    IndexGenerator(tmp_path).generate_all()
+
+    result = orphan_compiled.run(tmp_path)
+
+    assert result.findings == []
+    assert "0 orphan compiled page(s)" in result.summary
+
+
+def test_the_thirteen_false_positives_are_all_gone(tmp_path: Path) -> None:
+    """The measured repro from #1344, reported as ``13 orphan compiled page(s)``.
+
+    This is the disjointness proof: twelve findings need the generated-index
+    exclusion and the thirteenth (``04-Praxis/praxis-1.md``, linked from
+    ``08-Decisions``) needs the widened inbound-source survey. Either remedy
+    alone leaves this vault dirty.
+    """
+    IndexGenerator(tmp_path).generate_all()
+    _page(tmp_path, "04-Praxis/praxis-1.md", "praxis", body="A practice.")
+    _page(tmp_path, "08-Decisions/brief-1.md", "decision", body="- [[praxis-1]]")
+
+    result = orphan_compiled.run(tmp_path)
+
+    assert result.findings == []
+    assert "0 orphan compiled page(s)" in result.summary
+
+
+def test_a_genuinely_orphaned_thread_is_still_reported_after_generate_all(
+    tmp_path: Path,
+) -> None:
+    """The check must stay loud about a real orphan among the index pages.
+
+    Excluding the generated pages by decorating the whole compiled layer as
+    "linked" would silence the check — the same end state as the bug, reached
+    from the other side. The unlinked thread is the ONLY finding here.
+    """
+    IndexGenerator(tmp_path).generate_all()
+    _page(tmp_path, "02-Threads/Dormant/lonely-thread.md", "thread")
+
+    result = orphan_compiled.run(tmp_path)
+
+    assert len(result.findings) == 1
+    assert "02-Threads/Dormant/lonely-thread.md" in result.findings[0]
+    assert "1 orphan compiled page(s)" in result.summary
+
+
+def test_generated_index_types_matches_what_the_generators_write(
+    tmp_path: Path,
+) -> None:
+    """Drift guard: the constant set must equal the types actually written.
+
+    ``generate_all`` returns fourteen paths whose frontmatter ``type`` values
+    are ten ``frequency-index`` plus ``thread-index``, ``eddy-map``,
+    ``temporal-index`` and ``source-index``. If a generator ever renames or
+    adds a type without updating :data:`GENERATED_INDEX_TYPES`, the exclusion
+    silently stops applying and the false positives come back.
+    """
+    generated = IndexGenerator(tmp_path).generate_all()
+
+    assert len(generated) == 14
+    collected: set[str] = set()
+    for path in generated:
+        declared = frontmatter.load(str(path)).get("type")
+        assert isinstance(declared, str)
+        collected.add(declared)
+
+    assert collected == GENERATED_INDEX_TYPES
+
+
+# ---------------------------------------------------------------------------
+# orphan-compiled: inbound links from every content directory
+# ---------------------------------------------------------------------------
+
+
+def test_praxis_linked_only_from_08_decisions_is_not_orphaned(
+    tmp_path: Path,
+) -> None:
+    """A decision brief citing a praxis is an inbound link.
+
+    No index pages here at all — this isolates the source-survey remedy from
+    the generated-index remedy.
+    """
+    _page(tmp_path, "04-Praxis/praxis-1.md", "praxis", body="A practice.")
+    _page(tmp_path, "08-Decisions/brief-1.md", "decision", body="- [[praxis-1]]")
+
+    result = orphan_compiled.run(tmp_path)
+
+    assert result.findings == []
+
+
+def test_praxis_linked_only_from_05_wavelength_is_not_orphaned(
+    tmp_path: Path,
+) -> None:
+    """A wavelength observation citing a praxis is an inbound link."""
+    _page(tmp_path, "04-Praxis/praxis-2.md", "praxis", body="A practice.")
+    _page(
+        tmp_path,
+        "05-Wavelength/Observations/obs-1.md",
+        "wavelength-observation",
+        body="- [[praxis-2]]",
+    )
+
+    result = orphan_compiled.run(tmp_path)
+
+    assert result.findings == []
+
+
+def test_praxis_linked_only_from_07_voice_is_not_orphaned(tmp_path: Path) -> None:
+    """A voice draft citing a praxis is an inbound link."""
+    _page(tmp_path, "04-Praxis/praxis-3.md", "praxis", body="A practice.")
+    _page(
+        tmp_path,
+        "07-Voice/Drafts/draft-1.md",
+        "voice-draft",
+        body="- [[praxis-3]]",
+    )
+
+    result = orphan_compiled.run(tmp_path)
+
+    assert result.findings == []
+
+
+def test_thread_linked_only_from_tag_garden_is_not_orphaned(tmp_path: Path) -> None:
+    """``00-Creek-Meta/Tag-Garden.md`` emits real links and is a real source.
+
+    Carving out the whole of ``00-Creek-Meta`` to escape the report/state
+    feedback loop would silently discard the tag garden's links, which
+    ``creek/generate/tags.py`` writes as ``[[fragment-id]]``.
+    """
+    _page(tmp_path, "02-Threads/Active/thread-1.md", "thread")
+    _write(
+        tmp_path,
+        "00-Creek-Meta/Tag-Garden.md",
+        "# Tag Garden\n\n## sourdough\n\n- [[thread-1]]\n",
+    )
+
+    result = orphan_compiled.run(tmp_path)
+
+    assert result.findings == []
+
+
+# ---------------------------------------------------------------------------
+# orphan-compiled: the exclusion is by declared type, and nothing wider
+# ---------------------------------------------------------------------------
+
+
+def test_compiled_page_with_no_type_key_is_still_reported(tmp_path: Path) -> None:
+    """A header without ``type`` earns no exclusion.
+
+    The generated ``Thread-Index.md`` alongside it must still drop out, so the
+    single finding proves the exclusion is narrow rather than absent.
+    """
+    IndexGenerator(tmp_path).generate_thread_index()
+    _write(tmp_path, "03-Eddies/no-type.md", "---\ntitle: No Type\n---\n\nBody.\n")
+
+    result = orphan_compiled.run(tmp_path)
+
+    assert len(result.findings) == 1
+    assert "03-Eddies/no-type.md" in result.findings[0]
+
+
+def test_compiled_page_with_unknown_type_is_still_reported(tmp_path: Path) -> None:
+    """A type Creek's generators never write is not a generated index."""
+    IndexGenerator(tmp_path).generate_thread_index()
+    _page(tmp_path, "03-Eddies/eddy-atlas.md", "eddy-atlas")
+
+    result = orphan_compiled.run(tmp_path)
+
+    assert len(result.findings) == 1
+    assert "03-Eddies/eddy-atlas.md" in result.findings[0]
+
+
+def test_compiled_page_with_no_frontmatter_at_all_is_still_reported(
+    tmp_path: Path,
+) -> None:
+    """A bare markdown page has no declared type, so it stays a candidate."""
+    IndexGenerator(tmp_path).generate_thread_index()
+    _write(tmp_path, "02-Threads/plain.md", "Just a body, no header.\n")
+
+    result = orphan_compiled.run(tmp_path)
+
+    assert len(result.findings) == 1
+    assert "02-Threads/plain.md" in result.findings[0]
+
+
+def test_compiled_page_with_malformed_yaml_header_is_still_reported(
+    tmp_path: Path,
+) -> None:
+    """Unparseable YAML yields no type — and no exception out of the check.
+
+    Failing open here would hand any page an exclusion by writing a broken
+    header; failing loudly would cost the whole run over one bad file.
+    """
+    IndexGenerator(tmp_path).generate_thread_index()
+    _write(tmp_path, "03-Eddies/malformed.md", "---\ntype: [unclosed\n---\n\nBody.\n")
+
+    result = orphan_compiled.run(tmp_path)
+
+    assert len(result.findings) == 1
+    assert "03-Eddies/malformed.md" in result.findings[0]
+
+
+def test_a_page_cannot_credit_itself(tmp_path: Path) -> None:
+    """A page's wiki-link to its own name is not an inbound link.
+
+    Widening the inbound-source survey to the compiled layer means a page's
+    own body is now read. Self-credit would let every self-referencing page
+    exempt itself from the check.
+    """
+    IndexGenerator(tmp_path).generate_thread_index()
+    _page(tmp_path, "02-Threads/Self.md", "thread", body="See [[Self]] for more.")
+
+    result = orphan_compiled.run(tmp_path)
+
+    assert len(result.findings) == 1
+    assert "02-Threads/Self.md" in result.findings[0]
+
+
+# ---------------------------------------------------------------------------
+# broken-links: the survey covers every content directory
+# ---------------------------------------------------------------------------
+
+
+def test_broken_link_in_08_decisions_is_reported(tmp_path: Path) -> None:
+    """A dangling link in a decision brief is a whole-vault finding."""
+    _page(
+        tmp_path,
+        "08-Decisions/brief-2.md",
+        "decision",
+        body="See [[ghost-decision]].",
+    )
+
+    result = broken_links.run(tmp_path)
+
+    assert len(result.findings) == 1
+    assert "08-Decisions/brief-2.md" in result.findings[0]
+    assert "[[ghost-decision]]" in result.findings[0]
+
+
+def test_broken_link_in_05_wavelength_is_reported(tmp_path: Path) -> None:
+    """A dangling link in a wavelength observation is a whole-vault finding."""
+    _page(
+        tmp_path,
+        "05-Wavelength/Observations/obs-2.md",
+        "wavelength-observation",
+        body="See [[ghost-phase]].",
+    )
+
+    result = broken_links.run(tmp_path)
+
+    assert len(result.findings) == 1
+    assert "05-Wavelength/Observations/obs-2.md" in result.findings[0]
+    assert "[[ghost-phase]]" in result.findings[0]
+
+
+def test_broken_link_in_07_voice_is_reported(tmp_path: Path) -> None:
+    """A dangling link in a voice draft is a whole-vault finding."""
+    _page(
+        tmp_path,
+        "07-Voice/Drafts/draft-2.md",
+        "voice-draft",
+        body="See [[ghost-lexeme]].",
+    )
+
+    result = broken_links.run(tmp_path)
+
+    assert len(result.findings) == 1
+    assert "07-Voice/Drafts/draft-2.md" in result.findings[0]
+    assert "[[ghost-lexeme]]" in result.findings[0]
+
+
+def test_broken_link_in_a_compiled_thread_page_is_reported(tmp_path: Path) -> None:
+    """A dangling link on a thread page is a whole-vault finding."""
+    _page(
+        tmp_path,
+        "02-Threads/Active/thread-2.md",
+        "thread",
+        body="See [[ghost-thread]].",
+    )
+
+    result = broken_links.run(tmp_path)
+
+    assert len(result.findings) == 1
+    assert "02-Threads/Active/thread-2.md" in result.findings[0]
+    assert "[[ghost-thread]]" in result.findings[0]
+
+
+# ---------------------------------------------------------------------------
+# broken-links: Creek's own artefacts are not vault content
+# ---------------------------------------------------------------------------
+
+
+def test_lint_report_does_not_feed_its_own_next_scan(tmp_path: Path) -> None:
+    """Three successive lint runs must report the same one broken link.
+
+    Measured on the naive whole-vault scan: 1, then 2, then 3, because
+    ``lint-<date>.md`` renders each finding as ``- `src` → `[[target]]` `` and
+    the next run reads it back as vault content. The report is asserted to
+    exist on disk between passes, so the test cannot pass by never writing it.
+    """
+    _page(
+        tmp_path,
+        "01-Fragments/Notes/frag-1.md",
+        "fragment",
+        body="See [[ghost]] for context.",
+    )
+    expected = "1 broken link(s) across 1 file(s)"
+    finding = "- `01-Fragments/Notes/frag-1.md` → `[[ghost]]`"
+
+    summaries: list[str] = []
+    report_path: Path | None = None
+    for _ in range(3):
+        if report_path is not None:
+            assert report_path.exists()
+        lint = LintRunner(tmp_path)
+        report = lint.run(["broken-links"])
+        summaries.append(report.results[0].summary)
+        report_path = lint.write(report)
+        assert report_path.exists()
+        assert finding in report_path.read_text(encoding="utf-8")
+
+    assert summaries == [expected, expected, expected]
+
+
+def test_state_artifact_does_not_feed_the_broken_link_scan(tmp_path: Path) -> None:
+    """``00-Creek-Meta/State/latest.md`` echoes findings; it is not a source."""
+    _write(
+        tmp_path,
+        "00-Creek-Meta/State/latest.md",
+        "## Drift warnings\n\n- Broken links in `x`: [[ghost]]\n",
+    )
+
+    result = broken_links.run(tmp_path)
+
+    assert result.findings == []
+    assert "0 broken link(s)" in result.summary
+
+
+def test_deployed_ontology_syntax_example_is_not_a_broken_link(
+    tmp_path: Path,
+) -> None:
+    """The deployed spec documents wiki-link syntax; it does not link a page.
+
+    Line 746 of ``creek_ontology_agent_prompt.md`` is the only finding a
+    whole-vault scan produces on a fresh ``creek init`` vault, which is why
+    ``00-Creek-Meta/Ontology/`` is carved out.
+    """
+    _write(
+        tmp_path,
+        "00-Creek-Meta/Ontology/creek_ontology_agent_prompt.md",
+        "Generate wiki-links (`[[note-name]]`) between related fragments and"
+        " add them to the appropriate frontmatter arrays.\n",
+    )
+
+    result = broken_links.run(tmp_path)
+
+    assert result.findings == []
+
+
+@pytest.mark.integration
+def test_fresh_init_vault_lints_clean(tmp_path: Path) -> None:
+    """The tripwire bounding the deny-list: a scaffolded vault lints clean.
+
+    Every path component excluded from the survey costs coverage, so the
+    carve-out is bounded by this: canonical material plus the generated index
+    notes must produce zero findings from both checks. A wider deny-list would
+    still pass; a narrower one would fail here, which is where the argument
+    for each excluded prefix has to be made.
+    """
+    vault = tmp_path / "vault"
+
+    result = CliRunner().invoke(app, ["init", "--vault", str(vault)])
+    assert result.exit_code == 0
+
+    IndexGenerator(vault).generate_all()
+
+    assert broken_links.run(vault).findings == []
+    assert orphan_compiled.run(vault).findings == []

--- a/creek-tools/tests/test_state.py
+++ b/creek-tools/tests/test_state.py
@@ -1652,3 +1652,57 @@ def test_cli_state_budget_fails_when_over_budget(populated_vault: Path) -> None:
 
     assert result.exit_code != 0
     assert "budget" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# #1344: the drift section stays fragment-scoped as the link survey widens
+# ---------------------------------------------------------------------------
+
+
+def test_section_drift_warnings_omits_non_fragment_sources(
+    empty_vault: Path,
+) -> None:
+    """A broken link on a thread page must not reach the drift section.
+
+    ``BrokenLinkScanner`` now surveys the whole vault minus Creek's own
+    report folders (#1344), but ``## Drift warnings`` renders only sources in
+    ``admitted_paths`` — which holds admitted *fragments*. #969 gates this
+    section by source precisely so an above-ceiling path never lands in a
+    committable artefact; widening the scanner must not widen the section.
+    """
+    base = datetime(2026, 4, 1, tzinfo=UTC)
+    _write_fragment(
+        empty_vault,
+        frag_id="frag-link",
+        title="Linker",
+        created=base,
+        body="See [[Missing Fragment Target]] for context.",
+    )
+    thread_meta = {
+        "type": "thread",
+        "id": "thread-link",
+        "title": "Thread Link",
+        "status": "active",
+        "first_seen": date(2026, 4, 1).isoformat(),
+        "last_seen": date(2026, 4, 15).isoformat(),
+        "fragment_count": 1,
+    }
+    thread = empty_vault / "02-Threads" / "Active" / "thread-link.md"
+    thread.write_text(
+        frontmatter.dumps(
+            frontmatter.Post(
+                content="See [[Nonexistent Thread Target]] for context.",
+                **thread_meta,
+            ),
+        ),
+        encoding="utf-8",
+    )
+
+    section = StateReportGenerator(
+        vault_path=empty_vault,
+    ).section_drift_warnings()
+
+    assert section.startswith("## Drift warnings")
+    assert "Missing Fragment Target" in section
+    assert "Nonexistent Thread Target" not in section
+    assert "thread-link" not in section

--- a/creek-tools/tests/test_vault_links.py
+++ b/creek-tools/tests/test_vault_links.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from creek.vault.links import build_link_index
+from creek.vault.links import build_link_index, iter_link_sources, read_header_meta
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -200,3 +200,233 @@ def test_empty_vault_yields_an_empty_index(vault: Path) -> None:
 
     assert index.resolve("anything") is None
     assert "anything" not in index
+
+
+# ---------------------------------------------------------------------------
+# iter_link_sources — whose outbound links Creek surveys (#1344)
+# ---------------------------------------------------------------------------
+#
+# ``broken-links`` surveyed ``01-Fragments`` alone while reporting a
+# whole-vault verdict, and ``orphan-compiled`` counted inbound links from
+# ``01-Fragments`` and ``10-Liminal`` alone. Widening either to the literal
+# whole vault makes Creek read its own output back as content: three
+# successive ``creek lint`` runs over a vault with ONE genuine broken link
+# reported 1, then 2, then 3, because ``lint-<date>.md`` renders every finding
+# as ``- `src` → `[[target]]` ``. This is the one definition of the surveyed
+# set, and of the three prefixes it withholds.
+
+
+def _relative(vault: Path, paths: list[Path]) -> list[str]:
+    """Render *paths* as POSIX, vault-relative strings, order preserved."""
+    return [path.relative_to(vault).as_posix() for path in paths]
+
+
+def test_iter_link_sources_includes_every_content_directory(vault: Path) -> None:
+    """Every folder a human or a generator writes links into is surveyed.
+
+    ``00-Creek-Meta/Tag-Garden.md`` is in the list deliberately: it emits real
+    ``[[fragment-id]]`` links, so carving out the whole of ``00-Creek-Meta``
+    to escape the report feedback loop would be a weakening.
+    """
+    expected = [
+        "00-Creek-Meta/Tag-Garden.md",
+        "01-Fragments/Notes/f.md",
+        "02-Threads/Active/t.md",
+        "04-Praxis/Daily/p.md",
+        "05-Wavelength/Observations/w.md",
+        "07-Voice/Drafts/v.md",
+        "08-Decisions/Active/d.md",
+        "10-Liminal/Compost/l.md",
+    ]
+    for relpath in expected:
+        _page(vault, relpath)
+
+    assert _relative(vault, iter_link_sources(vault)) == expected
+
+
+def test_iter_link_sources_excludes_processing_log(vault: Path) -> None:
+    """``creek lint`` writes its report here; re-reading it doubles findings."""
+    _page(vault, "01-Fragments/Notes/f.md")
+    _page(vault, "00-Creek-Meta/Processing-Log/lint-2026-08-09.md")
+    _page(vault, "00-Creek-Meta/Processing-Log/2026/archived-lint.md")
+
+    assert _relative(vault, iter_link_sources(vault)) == ["01-Fragments/Notes/f.md"]
+
+
+def test_iter_link_sources_excludes_state(vault: Path) -> None:
+    """``creek state`` echoes findings into ``latest.md``; same feedback loop."""
+    _page(vault, "01-Fragments/Notes/f.md")
+    _page(vault, "00-Creek-Meta/State/latest.md")
+
+    assert _relative(vault, iter_link_sources(vault)) == ["01-Fragments/Notes/f.md"]
+
+
+def test_iter_link_sources_excludes_ontology(vault: Path) -> None:
+    """The deployed spec documents wiki-link syntax rather than linking pages.
+
+    Its ``[[note-name]]`` example is the only finding a whole-vault scan
+    produces on a fresh 32-file ``creek init`` vault.
+    """
+    _page(vault, "01-Fragments/Notes/f.md")
+    _page(vault, "00-Creek-Meta/Ontology/creek_ontology_agent_prompt.md")
+
+    assert _relative(vault, iter_link_sources(vault)) == ["01-Fragments/Notes/f.md"]
+
+
+def test_iter_link_sources_is_sorted(vault: Path) -> None:
+    """Deterministic order: two runs on one vault must report identically."""
+    for relpath in (
+        "03-Eddies/mmm.md",
+        "02-Threads/zzz.md",
+        "01-Fragments/aaa.md",
+    ):
+        _page(vault, relpath)
+
+    assert _relative(vault, iter_link_sources(vault)) == [
+        "01-Fragments/aaa.md",
+        "02-Threads/zzz.md",
+        "03-Eddies/mmm.md",
+    ]
+
+
+def test_iter_link_sources_on_a_missing_vault_returns_empty(tmp_path: Path) -> None:
+    """A path that does not exist yields no sources and does not raise."""
+    assert iter_link_sources(tmp_path / "no-such-vault") == []
+
+
+def test_iter_link_sources_keeps_similarly_named_siblings(vault: Path) -> None:
+    """The carve-out matches path components, not string prefixes.
+
+    ``str(path).startswith("00-Creek-Meta/State")`` would swallow
+    ``State-Machine-Notes.md`` and ``Processing-Logs-Archive.md`` — operator
+    notes that live beside the excluded folders and carry real links.
+    """
+    _page(vault, "00-Creek-Meta/State-Machine-Notes.md")
+    _page(vault, "00-Creek-Meta/Processing-Logs-Archive.md")
+    _page(vault, "00-Creek-Meta/State/latest.md")
+    _page(vault, "00-Creek-Meta/Processing-Log/lint-2026-08-09.md")
+
+    assert _relative(vault, iter_link_sources(vault)) == [
+        "00-Creek-Meta/Processing-Logs-Archive.md",
+        "00-Creek-Meta/State-Machine-Notes.md",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# read_header_meta — the public, header-only frontmatter read (#1344)
+# ---------------------------------------------------------------------------
+
+
+def test_read_header_meta_returns_the_frontmatter_mapping(vault: Path) -> None:
+    """The parsed header comes back whole, not just the names it declares."""
+    page = _page(vault, "02-Threads/Meta.md", title="Long Walks", aliases=["Walks"])
+
+    assert read_header_meta(page) == {"title": "Long Walks", "aliases": ["Walks"]}
+
+
+def test_read_header_meta_returns_empty_without_frontmatter(vault: Path) -> None:
+    """A bare markdown page declares nothing; it does not raise."""
+    page = vault / "02-Threads" / "Plainer.md"
+    page.write_text("Just a body, no header.\n", encoding="utf-8")
+
+    assert read_header_meta(page) == {}
+
+
+def test_read_header_meta_returns_empty_on_malformed_yaml(vault: Path) -> None:
+    """One unparseable header must not cost a whole-vault walk its run."""
+    page = vault / "02-Threads" / "Malformed.md"
+    page.write_text("---\ntype: [unclosed\n---\n\nBody.\n", encoding="utf-8")
+
+    assert read_header_meta(page) == {}
+
+
+def test_read_header_meta_stops_at_the_closing_fence(vault: Path) -> None:
+    """The body is never read, so a second fence in it cannot forge a type.
+
+    This is the observable consequence of the header-only bound: a 35k-file
+    vault must not pay to load every body just to learn a page's type.
+    """
+    page = vault / "02-Threads" / "Fenced.md"
+    page.write_text(
+        "---\ntype: thread\n---\n\nBody text.\n\n---\ntype: forged\n---\n",
+        encoding="utf-8",
+    )
+
+    assert read_header_meta(page) == {"type": "thread"}
+
+
+# ---------------------------------------------------------------------------
+# read_header_meta — "malformed YAML" means every way YAML can be malformed
+# ---------------------------------------------------------------------------
+#
+# ``yaml.safe_load`` does not funnel every failure through ``YAMLError``. Its
+# constructors call ``int()`` and ``datetime.date()`` on the scanned text and
+# let those raise ``ValueError`` straight through. Catching ``YAMLError``
+# alone therefore kept the promise for a broken *fence* and broke it for a
+# broken *value* — and because ``build_link_index`` reads the header of every
+# file in the vault, one such file aborted the whole of ``creek lint`` and
+# ``creek state``. Measured before the fix: ``ValueError: month must be in
+# 1..12`` propagating out of ``build_link_index``.
+
+
+def test_read_header_meta_returns_empty_on_an_oversized_integer(vault: Path) -> None:
+    """A 5000-digit scalar exceeds CPython's int-parsing limit, and is not YAML's.
+
+    Well inside the 64 KiB header cap, so no size guard catches it first:
+    ``int()`` raises ``ValueError`` from inside PyYAML's own constructor.
+    """
+    page = vault / "02-Threads" / "Bigint.md"
+    page.write_text(f"---\nn: {'1' * 5000}\n---\n\nBody.\n", encoding="utf-8")
+
+    assert read_header_meta(page) == {}
+
+
+def test_read_header_meta_returns_empty_on_an_impossible_date(vault: Path) -> None:
+    """``created: 2020-13-45`` resolves as a timestamp, then fails to construct.
+
+    ``created`` is written by the ingest parsers from export metadata nobody
+    in this system authored, so an impossible date is a reachable input rather
+    than a contrived one.
+    """
+    page = vault / "02-Threads" / "Baddate.md"
+    page.write_text("---\ncreated: 2020-13-45\n---\n\nBody.\n", encoding="utf-8")
+
+    assert read_header_meta(page) == {}
+
+
+def test_build_link_index_survives_a_header_that_breaks_the_constructor(
+    vault: Path,
+) -> None:
+    """One poisoned header must not cost the whole vault its index.
+
+    This is the consequence that matters: the index is built once per lint or
+    state run over every ``*.md`` in the vault, so a single unlucky file took
+    down both commands entirely rather than costing itself its aliases.
+    """
+    (vault / "02-Threads" / "Poison.md").write_text(
+        "---\ncreated: 2020-13-45\n---\n\nBody.\n",
+        encoding="utf-8",
+    )
+    _page(vault, "02-Threads/Healthy.md", title="Long Walks")
+
+    index = build_link_index(vault)
+
+    assert index.resolve("Long Walks") == vault / "02-Threads" / "Healthy.md"
+    assert index.resolve("Poison") == vault / "02-Threads" / "Poison.md"
+
+
+def test_unsurveyed_prefixes_track_the_writers_own_constants() -> None:
+    """The deny list must name the directories the writers actually write to.
+
+    ``_UNSURVEYED_PREFIXES`` restates paths that ``creek lint`` and
+    ``creek state`` define for themselves. If either writer's constant moves
+    and this one does not, the guard silently stops matching, the report
+    becomes a link source again, and the feedback loop reopens with the whole
+    suite still green — the failure mode this test exists to make loud.
+    """
+    from creek.generate.state import _STATE_SUBPATH
+    from creek.lint.runner import _PROCESSING_LOG
+    from creek.vault.links import _UNSURVEYED_PREFIXES
+
+    assert _PROCESSING_LOG in _UNSURVEYED_PREFIXES
+    assert _STATE_SUBPATH in _UNSURVEYED_PREFIXES


### PR DESCRIPTION
## Summary

`orphan-compiled` reported **13 findings on a vault that had just run `creek index`, and all thirteen were false**. `broken-links` surveyed `01-Fragments` alone while printing `N broken link(s) across M file(s)` as a whole-vault verdict.

### The issue's "or" is wrong — the two remedies fix disjoint subsets

Task 1 offered "extend `_FRAGMENT_DIRS` … **or** invert the check to exclude machine-generated index pages". I reproduced the 13 and attributed each:

| Findings | Cause | Which remedy fixes it |
|---|---|---|
| `02-Threads/Thread-Index.md`, `03-Eddies/Eddy-Map.md`, 10× `06-Frequencies/F*/F*-Index.md` | Dataview index notes `IndexGenerator` writes. Nothing in `creek/` ever emits a wiki-link naming one. | **Only exclusion.** There are no inbound links to find, so widening the survey cannot help. |
| `04-Praxis/praxis-1.md` | Linked by `- [[praxis-1]]` from `08-Decisions/brief-1.md` — a real inbound link the check never read. | **Only widening.** Its `type` is `praxis`, so exclusion cannot touch it. |

So both ship. Either alone leaves that vault dirty.

### Surveying the literal whole vault is unshippable

Task 2 asks `broken-links` to survey "the same set `build_link_index` already walks". Taken literally that is the whole vault, and I measured why it cannot ship. `creek lint` writes its own report to `00-Creek-Meta/Processing-Log/lint-<date>.md`, rendering each finding as ``- `src` → `[[target]]` ``. On a vault holding **one** genuine broken link, three successive runs reported:

```
pass 1: 1 broken link(s) across 1 file(s)
pass 2: 2 broken link(s) across 2 file(s)   <- + Processing-Log/lint-2026-08-12.md
pass 3: 3 broken link(s) across 2 file(s)   <- the artefact now quotes it twice
```

One extra finding per run, forever — the same Family-0 storm the issue is about, self-inflicted by the fix. `00-Creek-Meta/State/` is the same loop (`section_drift_warnings` quotes targets; `section_lint_summary` appends the whole report verbatim). And on a fresh 32-file `creek init` vault a whole-vault scan produces exactly one finding:

```
- `00-Creek-Meta/Ontology/creek_ontology_agent_prompt.md` → `[[note-name]]`
```

— the deployed spec's own backticked syntax example at line 746. Permanent, and nothing an operator can do clears it.

New `creek.vault.links.iter_link_sources` is therefore the whole vault **minus those three prefixes and nothing else**. `00-Creek-Meta/Tag-Garden.md` stays surveyed: it emits real `[[fragment-id]]` links, so carving out all of `00-Creek-Meta` would have been a weakening. The admission criterion for any fourth prefix is recorded in the docstring — *quotes the scanner's own output, or documents the link syntax rather than using it* — which deliberately keeps in scope generated pages that quote fragment **body** text, like `08-Decisions` briefs, where a dangling link is genuinely dangling and the duplication is bounded rather than compounding.

`links.py` now names the asymmetry a future reader would otherwise simplify away: **every page remains a valid link *target* (`build_link_index` is unchanged); the set surveyed as *sources* is a strict named subset.**

### The check must not become decoration

- **Exclusion requires an explicit declaration.** No `type` key, an unknown `type`, no frontmatter, or a header YAML cannot parse → still a candidate, still reported. Were the default the other way, any page could exempt itself by writing a broken header, and a silent check is the same end state as the storm it replaces. Four tests pin this.
- **Self-links no longer credit.** Widening the source set to include the compiled layer opened a hole that could not exist when sources were fragments-only.
- **The five `type` literals now live beside the frozenset the generators themselves consume**, so `GENERATED_INDEX_TYPES` and the frontmatter actually written cannot drift (`test_generated_index_types_matches_what_the_generators_write`).
- **End-to-end proof.** Fresh `creek init` + `generate_all()` → `0 orphan compiled page(s)` / `0 broken link(s) across 31 file(s)`. Add one unreferenced thread page and one dangling link in `08-Decisions` → exactly those two reported, nothing else.

### One bug found while promoting the header reader

`read_header_meta` publishes "malformed YAML yields `{}`". Catching `yaml.YAMLError` alone did not keep that promise: PyYAML's constructors call `int()` and `datetime.date()` on the scanned text and let `ValueError` through. `created: 2020-13-45` — a date the ingest parsers can read straight out of an export — propagated out of `build_link_index` and aborted **all of `creek lint` and `creek state`** over one file. Fixed with a failing test first; pre-existing on `main`, but this PR is what makes the promise public.

### Scope

The 14 files are the two checks plus what they mechanically forced and what they made untrue:

| File | Why |
|---|---|
| `clean/hygiene.py`, `tests/test_hygiene.py` | `broken_links.py` is a wrapper; the survey lives in `BrokenLinkScanner.scan`. `OrphanScanner` and `_list_fragment_files` are untouched — there the helper means "candidate orphan fragments", a different question. |
| `tests/test_state.py` | `state.py:1440` is the scanner's third caller and writes a committable artefact. One appended test pins that `## Drift warnings` still filters to `admitted_paths` (fragments only). No production change to `state.py`. |
| `README.md:131`, `docs/cleaning-and-purge.md`, `docs/cleaning-pipeline.md`, `cli.py` docstring | Four more copies of the same false claim as `docs/lint.md:46`: "Scan **fragments** for wiki-links…". |

`docs/lint.md` carries the full argument once; the others point at it (§1.2, no second copies).

## Test plan

- **`./scripts/check-all.sh` → exit 0**, 12/12 gates, coverage 94.64%, per-file gate 261 files ≥ 80%.
- Unit **10057 passed / 5 skipped** (all pre-existing env skips: Ollama, live API keys); integration **358 passed**; e2e **25 passed**. Zero skips in the new module.
- ruff re-verified with `--no-cache` (#1119): clean, 580 files formatted.
- 36 new tests, zero existing tests deleted or renamed (`git diff --numstat` shows `0` deletions in all three appended files; the single deleted line in `test_vault_links.py` is its import line, which I widened when hoisting 11 function-local imports).
- **Mutation battery, 6/6 killed**, every file restored and SHA-256 verified (snapshot/restore, never `git checkout`):

  | Mutation | Tests turned red |
  |---|---|
  | restore `_FRAGMENT_DIRS` | 5 |
  | empty `GENERATED_INDEX_TYPES` | 10 |
  | default a missing marker to *excluded* | 4 |
  | drop the self-link guard | 1 |
  | remove the carve-out (literal whole vault) | 9 |
  | widen the carve-out to all of `00-Creek-Meta` | 3 |
  | rename `State` in the deny list | 1 (the writer-constant drift guard) |

- Path-form robustness checked by hand: absolute, trailing-slash, dot-segment and relative vault paths all give identical results, so the self-link `Path` comparison across two `rglob` walks is sound.
- `pre-commit run --all-files` was **not** run — it silently edits unrelated files. `check-all.sh` is the gate and was substituted for it.

## Known limits, disclosed

- The deny list is a path prefix, so a symlink or copy of a lint report placed elsewhere in the vault would be surveyed. The real invariant is "do not survey a document that quotes findings", which a prefix only approximates; a marker in the report's own frontmatter would be exact, but the report format is out of scope per the issue.
- `docs/linking.md:183` names `broken-links` as the detector for orphaned re-minted eddy/thread pages. That is `orphan-compiled`'s job and the sentence looks wrong, but it was wrong before this change and this change does not alter its truth value, so I left it.

## Follow-ups filed

- **#1460** (P2) — link extraction is not code-span aware, which is the root cause behind the `Ontology` carve-out. Fixing it would let that prefix be dropped; it also touches `OrphanScanner` and the purge sweeps, where losing a match is a *privacy* regression, so it needs its own audit.
- **#1461** (P3) — `lint.SKILL.md:85` points agents at `Processing-Log/lint/YYYY-MM-DD.md`; the runner writes `Processing-Log/lint-<date>.md`.

Closes #1344
